### PR TITLE
Match some functions and values to the original binary

### DIFF
--- a/ISLE/define.cpp
+++ b/ISLE/define.cpp
@@ -3,8 +3,7 @@
 Isle *g_isle = 0;
 int g_closed = 0;
 
-const char *WNDCLASS_NAME = "Lego Island MainNoM App";
-const char *WINDOW_TITLE = "LEGO®";
+const char *WINDOW_TITLE = "LEGOÂ®";
 
 unsigned char g_mousedown = 0;
 unsigned char g_mousemoved = 0;

--- a/ISLE/define.h
+++ b/ISLE/define.h
@@ -5,7 +5,7 @@ class Isle;
 
 extern Isle *g_isle;
 extern int g_closed;
-extern const char *WNDCLASS_NAME;
+#define WNDCLASS_NAME "Lego Island MainNoM App"
 extern const char *WINDOW_TITLE;
 extern unsigned char g_mousedown;
 extern unsigned char g_mousemoved;

--- a/ISLE/isle.cpp
+++ b/ISLE/isle.cpp
@@ -234,8 +234,8 @@ void Isle::setupVideoFlags(BOOL fullScreen, BOOL flipSurfaces, BOOL backBuffers,
   m_videoParam.flags().EnableBackBuffers(backBuffers);
   m_videoParam.flags().EnableUnknown1(param_6);
   m_videoParam.flags().SetUnknown3(param_7);
-  m_videoParam.flags().EnableUnknown2();
   m_videoParam.flags().EnableWideViewAngle(wideViewAngle);
+  m_videoParam.flags().EnableUnknown2();
   m_videoParam.SetDeviceName(deviceId);
   if (using8bit) {
     m_videoParam.flags().Set8Bit();

--- a/ISLE/isle.cpp
+++ b/ISLE/isle.cpp
@@ -119,15 +119,17 @@ BOOL readReg(LPCSTR name, LPSTR outValue, DWORD outSize)
   HKEY hKey;
   DWORD valueType;
 
+  BOOL out = FALSE;
+  unsigned long size = outSize;
   if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Mindscape\\LEGO Island", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-    if (RegQueryValueExA(hKey, name, NULL, &valueType, (LPBYTE) outValue, &outSize) == ERROR_SUCCESS) {
+    if (RegQueryValueExA(hKey, name, NULL, &valueType, (LPBYTE) outValue, &size) == ERROR_SUCCESS) {
       if (RegCloseKey(hKey) == ERROR_SUCCESS) {
-        return TRUE;
+        out = TRUE;
       }
     }
   }
 
-  return FALSE;
+  return out;
 }
 
 int readRegBool(LPCSTR name, BOOL *out)

--- a/ISLE/main.cpp
+++ b/ISLE/main.cpp
@@ -19,7 +19,7 @@ BOOL findExistingInstance(void)
 
 BOOL startDirectSound(void)
 {
-  LPDIRECTSOUND lpDS;
+  LPDIRECTSOUND lpDS = 0;
   HRESULT ret = DirectSoundCreate(NULL, &lpDS, NULL);
   if (ret == DS_OK && lpDS != NULL) {
     lpDS->Release();


### PR DESCRIPTION
Matched Fully: `startDirectSound`, `WNDCLASS_NAME`, `readReg`
Partially Matched: `setupVideoFlags`

Changes:
In `startDirectSound` `lpDS` is now initialized to zero.
`WNDCLASS_NAME` is now a macro definition.
`WINDOW_TITLE` has been left untouched. However, in 1.0 it is also a macro, and it has a value of "Lego Island". The decomp already matches to 1.1, but I thought it would be good to mention that.
In `readReg` now creating and assigning an out and size variable.
In `setupVideoFlags` calling `EnableUnknown2` after `EnableWideViewAngle`.

All changes have been checked against 1.0 and 1.1 and other than `WINDOW_TITLE` they match both.

There is another difference in `setupVideoFlags` that I was unable to fix. The first line of the decompiled original binary looks like this
```
bVar2 = (*(byte *)((int)this + 100) ^ param_1) & 1 ^ *(byte *)((int)this + 100);
```
However, the decomp binary looks like this
```
bVar2 = (param_1 ^ *(byte *)((int)this + 100)) & 1 ^ *(byte *)((int)this + 100);
```
And the source (from `EnableFullScreen`) is 
```
 m_flags1 = (m_flags1 ^ (e << 0)) & FULL_SCREEN ^ m_flags1;
```
The source seems to be an exact match of the original binary, but for some reason when compiling the first xor gets flipped. This does not affect functionality, but it's different from the original binary. I haven't changed anything to do with it in these commits, but I thought I should mention it.