### PR TITLE
isle: replace other instances of ®️ with \xAE

### DIFF
--- a/ISLE/main.cpp
+++ b/ISLE/main.cpp
@@ -48,7 +48,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
   // Throw error if sound unavailable
   if (!soundReady) {
-    MessageBoxA(NULL, "\"LEGO® Island\" is not detecting a DirectSound compatible sound card.  Please quit all other applications and try again.",
+    MessageBoxA(NULL, "\"LEGO\xAE Island\" is not detecting a DirectSound compatible sound card.  Please quit all other applications and try again.",
       "Lego Island Error",0);
     return 0;
   }
@@ -58,7 +58,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
   // Create window
   if (g_isle->setupWindow(hInstance) != SUCCESS) {
-    MessageBoxA(NULL, "\"LEGO® Island\" failed to start.  Please quit all other applications and try again.", "LEGO® Island Error",0);
+    MessageBoxA(NULL, "\"LEGO\xAE Island\" failed to start.  Please quit all other applications and try again.", "LEGO\xAE Island Error",0);
     return 0;
   }
 


### PR DESCRIPTION
Noticed a couple other potential Unicode issues and thought I'd clean those up rq

In doing this I specifically excluded the `.vscode` directory that also enforces Windows-1252 encoding in the editor, let me know if that'd be a worthwhile PR on its own. 