### PR TITLE
Fix broken MxOmniCreateParam ctor interface

### DIFF
--- a/LEGO1/mxomnicreateparam.cpp
+++ b/LEGO1/mxomnicreateparam.cpp
@@ -1,9 +1,9 @@
 #include "mxomnicreateparam.h"
 
-MxOmniCreateParam::MxOmniCreateParam(const char *mediaPath, HWND windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags)
+MxOmniCreateParam::MxOmniCreateParam(const char *mediaPath, struct HWND__ * windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags)
 {
   this->m_mediaPath = mediaPath;
-  this->m_windowHandle = windowHandle;
+  this->m_windowHandle = (HWND) windowHandle;
   this->m_videoParam = vparam;
   this->m_createFlags = flags;
 }

--- a/LEGO1/mxomnicreateparam.cpp
+++ b/LEGO1/mxomnicreateparam.cpp
@@ -1,6 +1,6 @@
 #include "mxomnicreateparam.h"
 
-MxOmniCreateParam::MxOmniCreateParam(const char *mediaPath, struct HWND__ * windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags)
+MxOmniCreateParam::MxOmniCreateParam(const char *mediaPath, struct HWND__ *windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags)
 {
   this->m_mediaPath = mediaPath;
   this->m_windowHandle = (HWND) windowHandle;

--- a/LEGO1/mxomnicreateparam.h
+++ b/LEGO1/mxomnicreateparam.h
@@ -11,7 +11,7 @@
 class MxOmniCreateParam : public MxOmniCreateParamBase
 {
 public:
-  __declspec(dllexport) MxOmniCreateParam(const char *mediaPath, HWND windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags);
+  __declspec(dllexport) MxOmniCreateParam(const char *mediaPath, struct HWND__ *windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags);
   // virtual void vtable00(); seems to be a destructor
 
   const MxOmniCreateFlags& CreateFlags() const { return this->m_createFlags; }


### PR DESCRIPTION
Minor bug introduced in https://github.com/isledecomp/isle/pull/15 which lead to `ISLE.EXE` not working anymore (in conjunction with the original `LEGO1.DLL`) since a signature was changed in an incompatible way.