### PR TITLE
lego1/isle: Fix wrong video param flag interfaces

### DIFF
--- a/LEGO1/mxvideoparamflags.h
+++ b/LEGO1/mxvideoparamflags.h
@@ -1,7 +1,7 @@
 #ifndef MXVIDEOPARAMFLAGS_H
 #define MXVIDEOPARAMFLAGS_H
 
-#include "mxbool.h"
+#include "legoinc.h"
 
 class MxVideoParamFlags
 {
@@ -24,22 +24,22 @@ public:
 
   __declspec(dllexport) MxVideoParamFlags();
 
-  inline void EnableFullScreen(MxBool e)
+  inline void EnableFullScreen(BOOL e)
   {
     m_flags1 = (m_flags1 ^ (e << 0)) & FULL_SCREEN ^ m_flags1;
   }
 
-  inline void EnableFlipSurfaces(MxBool e)
+  inline void EnableFlipSurfaces(BOOL e)
   {
     m_flags1 = (m_flags1 ^ (e << 1)) & FLIP_SURFACES ^ m_flags1;
   }
 
-  inline void EnableBackBuffers(MxBool e)
+  inline void EnableBackBuffers(BOOL e)
   {
     m_flags1 = (m_flags1 ^ ((!e) << 2)) & BACK_BUFFERS ^ m_flags1;
   }
 
-  inline void SetUnknown3(MxBool e)
+  inline void SetUnknown3(BOOL e)
   {
     m_flags1 = (m_flags1 ^ (e << 7)) & UNKNOWN3 ^ m_flags1;
   }
@@ -59,17 +59,17 @@ public:
     m_flags1 = ((e << 5) ^ m_flags1) & ENABLE_16BIT ^ m_flags1;
   }
 
-  inline void EnableWideViewAngle(MxBool e)
+  inline void EnableWideViewAngle(BOOL e)
   {
     m_flags1 = (m_flags1 ^ (e << 6)) & WIDE_VIEW_ANGLE ^ m_flags1;
   }
 
-  inline void EnableUnknown1(MxBool e)
+  inline void EnableUnknown1(BOOL e)
   {
     m_flags2 = (m_flags2 ^ ((!e) << 0)) & UNKNOWN1 ^ m_flags2;
   }
 
-  inline void EnableUnknown2(MxBool e)
+  inline void EnableUnknown2(BOOL e)
   {
     m_flags2 = (m_flags2 ^ (e << 1)) & UNKNOWN2 ^ m_flags2;
   }


### PR DESCRIPTION
This commit broke `ISLE.EXE`: https://github.com/isledecomp/isle/commit/f8263a3ef86cfd3623bd933807915e00ebe46687

`MxBool` is a 1-byte char, the Windows-defined `BOOL` is a 4-byte int. Easy to mix up for sure.