### PR TITLE
isle: Match Isle::SetupCursor

### DIFF
--- a/ISLE/isle.cpp
+++ b/ISLE/isle.cpp
@@ -290,7 +290,7 @@ void Isle::SetupCursor(WPARAM wParam)
   case 7:
   case 8:
   case 9:
-  case 0xa:
+  case 0xA:
     break;
   }
 

--- a/ISLE/isle.cpp
+++ b/ISLE/isle.cpp
@@ -283,6 +283,14 @@ void Isle::SetupCursor(WPARAM wParam)
     break;
   case 0xB:
     m_cursorCurrent = NULL;
+  case 3:
+  case 4:
+  case 5:
+  case 6:
+  case 7:
+  case 8:
+  case 9:
+  case 0xa:
     break;
   }
 


### PR DESCRIPTION
Making a separate PR for this one since the accuracy checker has a problem with detecting a 100% match with this function. Maybe because of the jump table? Not sure. As far as I can tell it does match the original assembly completely.

I don't mind that the check isn't perfect in all cases, just wanting to give you the opportunity to further improve it using this example @itsmattkc 