### PR TITLE
lego1: MxString matching

### DIFF
--- a/LEGO1/mxstring.cpp
+++ b/LEGO1/mxstring.cpp
@@ -11,6 +11,60 @@ MxString::MxString()
   this->m_length = 0;
 }
 
+// OFFSET: LEGO1 0x100ae2a0
+MxString::MxString(const MxString &str)
+{
+  this->m_length = str.m_length;
+  this->m_data = (char *)malloc(this->m_length + 1);
+  strcpy(this->m_data, str.m_data);
+}
+
+// OFFSET: LEGO1 0x100ae350
+MxString::MxString(const char *str)
+{
+  if (str) {
+    this->m_length = strlen(str);
+    this->m_data = (char *)malloc(this->m_length + 1);
+    strcpy(this->m_data, str);
+  } else {
+    this->m_data = (char *)malloc(1);
+    this->m_data[0] = 0;
+    this->m_length = 0;
+  }
+}
+
+// OFFSET: LEGO1 0x100ae420
+MxString::~MxString()
+{
+  free(this->m_data);
+}
+
+// OFFSET: LEGO1 0x100ae490
+void MxString::ToUpperCase()
+{
+  strupr(this->m_data);
+}
+
+// OFFSET: LEGO1 0x100ae4a0
+void MxString::ToLowerCase()
+{
+  strlwr(this->m_data);
+}
+
+// OFFSET: LEGO1 0x100ae4b0
+const MxString &MxString::operator=(MxString *param)
+{
+  if (this->m_data != param->m_data)
+  {
+    free(this->m_data);
+    this->m_length = param->m_length;
+    this->m_data = (char *)malloc(this->m_length + 1);
+    strcpy(this->m_data, param->m_data);
+  }
+
+  return *this;
+}
+
 // TODO: this *mostly* matches, again weird with the comparison
 // OFFSET: LEGO1 0x100ae510
 const MxString &MxString::operator=(const char *param)
@@ -24,10 +78,4 @@ const MxString &MxString::operator=(const char *param)
   }
 
   return *this;
-}
-
-// OFFSET: LEGO1 0x100ae420
-MxString::~MxString()
-{
-  free(this->m_data);
 }

--- a/LEGO1/mxstring.h
+++ b/LEGO1/mxstring.h
@@ -11,6 +11,10 @@ public:
   __declspec(dllexport) const MxString &operator=(const char *);
 
   MxString();
+  MxString(const char *);
+  void ToUpperCase();
+  void ToLowerCase();
+  const MxString &operator=(MxString *);
 
 private:
   char *m_data;


### PR DESCRIPTION
Added some missing functions to MxString. The function at 0x100ae580 looks like a constructor for something else, so this may be all of it.

Everything matches except the swapped regs for `cmp eax, esi` in the MxString to char* comparator. What's odd is that other functions in the class can influence this order. For example, if I comment out one of the newly added ToUpperCase or ToLowerCase functions.