### PR TITLE
Hotfix: messed up structure due to windows.h

### DIFF
--- a/ISLE/define.h
+++ b/ISLE/define.h
@@ -1,7 +1,7 @@
 #ifndef DEFINE_H
 #define DEFINE_H
 
-#include <Windows.h>
+#include "legoinc.h"
 
 class Isle;
 

--- a/ISLE/isle.h
+++ b/ISLE/isle.h
@@ -1,8 +1,7 @@
 #ifndef ISLE_H
 #define ISLE_H
 
-#include <windows.h>
-
+#include "legoinc.h"
 #include "define.h"
 
 #include "legoomni.h"

--- a/ISLE/main.cpp
+++ b/ISLE/main.cpp
@@ -1,9 +1,10 @@
 #include <dsound.h>
-#include <windows.h>
 
+#include "legoinc.h"
 #include "define.h"
-#include "isle.h"
+
 #include "legoomni.h"
+#include "isle.h"
 
 // OFFSET: ISLE 0x401ca0
 BOOL FindExistingInstance(void)


### PR DESCRIPTION
This PR: https://github.com/isledecomp/isle/pull/32 accidentally broke `ISLE.EXE` - not so much because of the code changes, but because of a `Windows.h` include that sneaked `GetClassName` in and lead to immediate crashes.

I removed all remaining instances of `windows.h` includes and replaced them with `legoinc.h`