### PR TITLE
Use bitfield for MxVideoParamFlags

### DIFF
--- a/ISLE/isle.cpp
+++ b/ISLE/isle.cpp
@@ -36,7 +36,7 @@ Isle::Isle()
   m_windowActive = 1;
 
   m_videoParam = MxVideoParam(MxRect32(0, 0, 639, 479), NULL, 1, MxVideoParamFlags());
-  m_videoParam.flags().Enable16Bit(MxDirectDraw::GetPrimaryBitDepth() == 16);
+  m_videoParam.flags().Set16Bit(MxDirectDraw::GetPrimaryBitDepth() == 16);
 
   m_windowHandle = NULL;
   m_cursorArrow = NULL;
@@ -228,22 +228,22 @@ void Isle::LoadConfig()
 
 // OFFSET: ISLE 0x401560
 void Isle::SetupVideoFlags(BOOL fullScreen, BOOL flipSurfaces, BOOL backBuffers,
-                           BOOL using8bit, BOOL m_using16bit, BOOL param_6, BOOL param_7,
+                           BOOL using8bit, BOOL using16bit, BOOL param_6, BOOL param_7,
                            BOOL wideViewAngle, char *deviceId)
 {
-  m_videoParam.flags().EnableFullScreen(fullScreen);
-  m_videoParam.flags().EnableFlipSurfaces(flipSurfaces);
-  m_videoParam.flags().EnableBackBuffers(backBuffers);
-  m_videoParam.flags().EnableUnknown1(param_6);
-  m_videoParam.flags().SetUnknown3(param_7);
-  m_videoParam.flags().EnableWideViewAngle(wideViewAngle);
-  m_videoParam.flags().EnableUnknown2();
+  m_videoParam.flags().SetFullScreen(fullScreen);
+  m_videoParam.flags().SetFlipSurfaces(flipSurfaces);
+  m_videoParam.flags().SetBackBuffers(!backBuffers);
+  m_videoParam.flags().Set_f2bit0(!param_6);
+  m_videoParam.flags().Set_f1bit7(param_7);
+  m_videoParam.flags().SetWideViewAngle(wideViewAngle);
+  m_videoParam.flags().Set_f2bit1(1);
   m_videoParam.SetDeviceName(deviceId);
   if (using8bit) {
-    m_videoParam.flags().Set8Bit();
+    m_videoParam.flags().Set16Bit(0);
   }
-  if (m_using16bit) {
-    m_videoParam.flags().Set16Bit();
+  if (using16bit) {
+    m_videoParam.flags().Set16Bit(1);
   }
 }
 

--- a/ISLE/isle.h
+++ b/ISLE/isle.h
@@ -27,7 +27,7 @@ public:
   BOOL SetupLegoOmni();
   void LoadConfig();
   void SetupVideoFlags(BOOL fullScreen, BOOL flipSurfaces, BOOL backBuffers,
-                       BOOL using8bit, BOOL m_using16bit, BOOL param_6, BOOL param_7,
+                       BOOL using8bit, BOOL using16bit, BOOL param_6, BOOL param_7,
                        BOOL wideViewAngle, char *deviceId);
 
   void SetupCursor(WPARAM wParam);

--- a/LEGO1/mxvideoparamflags.cpp
+++ b/LEGO1/mxvideoparamflags.cpp
@@ -3,15 +3,13 @@
 // OFFSET: LEGO1 0x100bec40
 MxVideoParamFlags::MxVideoParamFlags()
 {
-  // TODO: convert to EnableXXX function calls
-  unsigned char bVar1 = this->m_flags1;
-  this->m_flags1 = bVar1 & 0xfe;
-  this->m_flags1 = bVar1 & 0xfc;
-  this->m_flags1 = bVar1 & 0xf8;
-  this->m_flags1 = bVar1 & 0xf0;
-  this->m_flags1 = bVar1 & 0xe0;
-  this->m_flags2 = this->m_flags2 | 2;
-  this->m_flags1 = bVar1 & 0xc0;
-  this->m_flags1 = bVar1 & 0xc0 | 0x40;
-  this->m_flags1 = 0xc0;
+  this->SetFullScreen(0);
+  this->SetFlipSurfaces(0);
+  this->SetBackBuffers(0);
+  this->Set_f1bit3(0);
+  this->Set_f1bit4(0);
+  this->Set16Bit(0);
+  this->SetWideViewAngle(1);
+  this->Set_f1bit7(1);
+  this->Set_f2bit1(1);
 }

--- a/LEGO1/mxvideoparamflags.h
+++ b/LEGO1/mxvideoparamflags.h
@@ -3,85 +3,46 @@
 
 #include "legoinc.h"
 
+// Must be union with struct for match.
+typedef union {
+  struct {
+    BYTE bit0: 1;
+    BYTE bit1: 1;
+    BYTE bit2: 1;
+    BYTE bit3: 1;
+    BYTE bit4: 1;
+    BYTE bit5: 1;
+    BYTE bit6: 1;
+    BYTE bit7: 1;
+  };
+  // BYTE all; // ?
+} flag_bitfield;
+
 class MxVideoParamFlags
 {
 public:
-  enum LowFlags
-  {
-    FULL_SCREEN = 0x1,
-    FLIP_SURFACES = 0x2,
-    BACK_BUFFERS = 0x4,
-    ENABLE_16BIT = 0x20,
-    WIDE_VIEW_ANGLE = 0x40,
-    UNKNOWN3 = 0x80
-  };
-
-  enum HighFlags
-  {
-    UNKNOWN1 = 0x1,
-    UNKNOWN2 = 0x2
-  };
-
   __declspec(dllexport) MxVideoParamFlags();
 
-  inline void EnableFullScreen(BOOL e)
-  {
-    m_flags1 = (m_flags1 ^ (e << 0)) & FULL_SCREEN ^ m_flags1;
-  }
-
-  inline void EnableFlipSurfaces(BOOL e)
-  {
-    m_flags1 = (m_flags1 ^ (e << 1)) & FLIP_SURFACES ^ m_flags1;
-  }
-
-  inline void EnableBackBuffers(BOOL e)
-  {
-    m_flags1 = (m_flags1 ^ ((!e) << 2)) & BACK_BUFFERS ^ m_flags1;
-  }
-
-  inline void SetUnknown3(BOOL e)
-  {
-    m_flags1 = (m_flags1 ^ (e << 7)) & UNKNOWN3 ^ m_flags1;
-  }
-
-  inline void Set8Bit()
-  {
-    m_flags1 &= ~ENABLE_16BIT;
-  }
-
-  inline void Set16Bit()
-  {
-    m_flags1 |= ENABLE_16BIT;
-  }
-
-  inline void Enable16Bit(unsigned char e)
-  {
-    m_flags1 = ((e << 5) ^ m_flags1) & ENABLE_16BIT ^ m_flags1;
-  }
-
-  inline void EnableWideViewAngle(BOOL e)
-  {
-    m_flags1 = (m_flags1 ^ (e << 6)) & WIDE_VIEW_ANGLE ^ m_flags1;
-  }
-
-  inline void EnableUnknown1(BOOL e)
-  {
-    m_flags2 = (m_flags2 ^ ((!e) << 0)) & UNKNOWN1 ^ m_flags2;
-  }
-
-  inline void EnableUnknown2(BOOL e)
-  {
-    m_flags2 = (m_flags2 ^ (e << 1)) & UNKNOWN2 ^ m_flags2;
-  }
-
-  inline void EnableUnknown2()
-  {
-    m_flags2 |= UNKNOWN2;
-  }
+  inline void SetFullScreen(BOOL e)    { m_flags1.bit0 = e; }
+  inline void SetFlipSurfaces(BOOL e)  { m_flags1.bit1 = e; }
+  inline void SetBackBuffers(BOOL e)   { m_flags1.bit2 = e; }
+  inline void Set_f1bit3(BOOL e)       { m_flags1.bit3 = e; }
+  inline void Set_f1bit4(BOOL e)       { m_flags1.bit4 = e; }
+  inline void Set16Bit(BOOL e)         { m_flags1.bit5 = e; }
+  inline void SetWideViewAngle(BOOL e) { m_flags1.bit6 = e; }
+  inline void Set_f1bit7(BOOL e)       { m_flags1.bit7 = e; }
+  inline void Set_f2bit0(BOOL e)       { m_flags2.bit0 = e; }
+  inline void Set_f2bit1(BOOL e)       { m_flags2.bit1 = e; }
+  inline void Set_f2bit2(BOOL e)       { m_flags2.bit2 = e; }
+  inline void Set_f2bit3(BOOL e)       { m_flags2.bit3 = e; }
+  inline void Set_f2bit4(BOOL e)       { m_flags2.bit4 = e; }
+  inline void Set_f2bit5(BOOL e)       { m_flags2.bit5 = e; }
+  inline void Set_f2bit6(BOOL e)       { m_flags2.bit6 = e; }
+  inline void Set_f2bit7(BOOL e)       { m_flags2.bit7 = e; }
 
 private:
-  unsigned char m_flags1;
-  unsigned char m_flags2;
+  flag_bitfield m_flags1;
+  flag_bitfield m_flags2;
 
 };
 

--- a/LEGO1/mxvideoparamflags.h
+++ b/LEGO1/mxvideoparamflags.h
@@ -28,7 +28,7 @@ public:
   inline void SetBackBuffers(BOOL e)   { m_flags1.bit2 = e; }
   inline void Set_f1bit3(BOOL e)       { m_flags1.bit3 = e; }
   inline void Set_f1bit4(BOOL e)       { m_flags1.bit4 = e; }
-  inline void Set16Bit(BOOL e)         { m_flags1.bit5 = e; }
+  inline void Set16Bit(BYTE e)         { m_flags1.bit5 = e; }
   inline void SetWideViewAngle(BOOL e) { m_flags1.bit6 = e; }
   inline void Set_f1bit7(BOOL e)       { m_flags1.bit7 = e; }
   inline void Set_f2bit0(BOOL e)       { m_flags2.bit0 = e; }


### PR DESCRIPTION
Using a bitfield for MxVideoParamFlags results in the same xor/and logic that was partially inlined in the header file. This approach is a lot cleaner and there's a good chance this is what the devs would have landed on.

The code generation is really finicky -- other inlines in the header influence the code just by being there -- so I decided to stub out all of them. This got the match to 100%.

While I was in isle.cpp::SetupVideoFlags, I changed the signature so that the `m_using16bit` parameter is just `using16bit`. Two of the parameters from SetupVideoFlags are negated when we set the flags, which seems odd. Maybe a name change is in order on backBuffers?