### PR TITLE
lego: match GetClassName/IsClass

### DIFF
--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -68,18 +68,6 @@ long LegoOmni::Notify(MxParam &p)
   return 0;
 }
 
-// OFFSET: LEGO1 0x10058aa0
-const char *LegoOmni::GetClassName() const
-{
-  return "LegoOmni";
-}
-
-// OFFSET: LEGO1 0x10058ab0
-MxBool LegoOmni::IsClass(const char *name) const
-{
-  return strcmp("LegoOmni", name) == 0;
-}
-
 // OFFSET: LEGO1 0x10058bd0
 void LegoOmni::Init()
 {

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -30,8 +30,15 @@ public:
   virtual ~LegoOmni(); // vtable+00
 
   virtual long Notify(MxParam &p); // vtable+04
-  virtual const char *GetClassName() const; // vtable+0c
-  virtual MxBool IsClass(const char *name) const; // vtable+10;
+
+  // OFFSET: LEGO1 0x10058aa0
+  inline virtual const char *GetClassName() const { return "LegoOmni"; }; // vtable+0c
+
+  // OFFSET: LEGO1 0x10058ab0
+  inline virtual MxBool IsClass(const char *name) const {
+    return !strcmp(name, LegoOmni::GetClassName()) || MxOmni::IsClass(name);
+  }; // vtable+10;
+
   virtual void Init(); // vtable+14
   virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c

--- a/LEGO1/mxcore.cpp
+++ b/LEGO1/mxcore.cpp
@@ -1,7 +1,5 @@
 #include "mxcore.h"
 
-#include <string.h>
-
 // 0x1010141c
 unsigned int g_mxcoreCount = 0;
 
@@ -27,16 +25,4 @@ long MxCore::Notify(MxParam &p)
 long MxCore::Tickle()
 {
   return 0;
-}
-
-// OFFSET: LEGO1 0x100144c0
-const char *MxCore::GetClassName() const
-{
-  return "MxCore";
-}
-
-// OFFSET: LEGO1 0x100140d0
-MxBool MxCore::IsClass(const char *name) const
-{
-  return strcmp(name, "MxCore") == 0;
 }

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -1,6 +1,8 @@
 #ifndef MXCORE_H
 #define MXCORE_H
 
+#include <string.h>
+
 #include "mxbool.h"
 
 class MxParam;
@@ -12,8 +14,14 @@ public:
   __declspec(dllexport) virtual ~MxCore(); // vtable+00
   __declspec(dllexport) virtual long Notify(MxParam &p); // vtable+04
   virtual long Tickle(); // vtable+08
-  virtual const char *GetClassName() const; // vtable+0c
-  virtual MxBool IsClass(const char *name) const; // vtable+10
+
+  // OFFSET: LEGO1 0x100144c0
+  inline virtual const char *GetClassName() const { return "MxCore"; }; // vtable+0c
+
+  // OFFSET: LEGO1 0x100140d0
+  inline virtual MxBool IsClass(const char *name) const {
+    return !strcmp(name, MxCore::GetClassName());
+  }; // vtable+10
 
 private:
   unsigned int m_id;


### PR DESCRIPTION
A minor PR matching the currently implemented `GetClassName` / `IsClass` functions. They generally need to be declared inline. This pattern is probably used in all other classes as well.