### PR TITLE
lego1: Two more operators for MxString

### DIFF
--- a/LEGO1/mxstring.cpp
+++ b/LEGO1/mxstring.cpp
@@ -6,7 +6,7 @@
 MxString::MxString()
 {
   // Set string to one char in length and set that char to null terminator
-  this->m_data = (char *)malloc(1);
+  this->m_data = new char[1];
   this->m_data[0] = 0;
   this->m_length = 0;
 }
@@ -15,7 +15,7 @@ MxString::MxString()
 MxString::MxString(const MxString &str)
 {
   this->m_length = str.m_length;
-  this->m_data = (char *)malloc(this->m_length + 1);
+  this->m_data = new char[this->m_length + 1];
   strcpy(this->m_data, str.m_data);
 }
 
@@ -24,10 +24,10 @@ MxString::MxString(const char *str)
 {
   if (str) {
     this->m_length = strlen(str);
-    this->m_data = (char *)malloc(this->m_length + 1);
+    this->m_data = new char[this->m_length + 1];
     strcpy(this->m_data, str);
   } else {
-    this->m_data = (char *)malloc(1);
+    this->m_data = new char[1];
     this->m_data[0] = 0;
     this->m_length = 0;
   }
@@ -36,7 +36,7 @@ MxString::MxString(const char *str)
 // OFFSET: LEGO1 0x100ae420
 MxString::~MxString()
 {
-  free(this->m_data);
+  delete[] this->m_data;
 }
 
 // OFFSET: LEGO1 0x100ae490
@@ -52,30 +52,63 @@ void MxString::ToLowerCase()
 }
 
 // OFFSET: LEGO1 0x100ae4b0
-const MxString &MxString::operator=(MxString *param)
+MxString &MxString::operator=(MxString *param)
 {
   if (this->m_data != param->m_data)
   {
-    free(this->m_data);
+    delete[] this->m_data;
     this->m_length = param->m_length;
-    this->m_data = (char *)malloc(this->m_length + 1);
+    this->m_data = new char[this->m_length + 1];
     strcpy(this->m_data, param->m_data);
   }
 
   return *this;
 }
 
-// TODO: this *mostly* matches, again weird with the comparison
 // OFFSET: LEGO1 0x100ae510
 const MxString &MxString::operator=(const char *param)
 {
   if (this->m_data != param)
   {
-    free(this->m_data);
+    delete[] this->m_data;
     this->m_length = strlen(param);
-    this->m_data = (char *)malloc(this->m_length + 1);
+    this->m_data = new char[this->m_length + 1];
     strcpy(this->m_data, param);
   }
+
+  return *this;
+}
+
+// Return type is intentionally just MxString, not MxString&.
+// This forces MSVC to add $ReturnUdt$ to the stack for 100% match.
+// OFFSET: LEGO1 0x100ae580
+MxString MxString::operator+(const char *str)
+{
+  // MxString constructor allocates 1 byte for m_data, so free that first
+  MxString tmp;
+  delete[] tmp.m_data;
+
+  tmp.m_length = strlen(str) + this->m_length;
+  tmp.m_data = new char[tmp.m_length + 1];
+  
+  strcpy(tmp.m_data, this->m_data);
+  strcpy(tmp.m_data + this->m_length, str);
+
+  return MxString(tmp);
+}
+
+// OFFSET: LEGO1 0x100ae690
+MxString& MxString::operator+=(const char *str)
+{
+  int newlen = this->m_length + strlen(str);
+
+  char *tmp = new char[newlen + 1];
+  strcpy(tmp, this->m_data);
+  strcpy(tmp + this->m_length, str);
+  
+  delete[] this->m_data;
+  this->m_length = newlen;
+  this->m_data = tmp;
 
   return *this;
 }

--- a/LEGO1/mxstring.h
+++ b/LEGO1/mxstring.h
@@ -14,7 +14,9 @@ public:
   MxString(const char *);
   void ToUpperCase();
   void ToLowerCase();
-  const MxString &operator=(MxString *);
+  MxString&  operator=(MxString *);
+  MxString   operator+(const char *);
+  MxString& operator+=(const char *);
 
 private:
   char *m_data;


### PR DESCRIPTION
Followed the hint from @madebr in #31 that the next function in MxString was operator+. The one after that is operator+= and both are at 100%.

~~I thought maybe these new changes would magically fix the swapped regs in the `cmp` instruction from operator= at `0x100ae510`, but no luck.~~

Replaced malloc/free with new/delete, which had the side effect of fixing the swapped regs in operator=