### PR TITLE
lego1: match LegoOmni::GetInstance and deconstructor and add a few methods

### DIFF
--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -15,7 +15,7 @@ LegoOmni::~LegoOmni()
 // OFFSET: LEGO1 0x1005ad10
 LegoOmni *LegoOmni::GetInstance()
 {
-  return (LegoOmni *) m_instance;
+  return (LegoOmni*)MxOmni::GetInstance();
 }
 
 // OFFSET: LEGO1 0x10015700

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -85,6 +85,13 @@ LegoNavController *NavController()
   return LegoOmni::GetInstance()->GetNavController();
 }
 
+// OFFSET: LEGO1 0x10015900
+MxTransitionManager *TransitionManager()
+{
+  return LegoOmni::GetInstance()->GetTransitionManager();
+}
+
+
 // OFFSET: LEGO1 0x1005b5f0
 long LegoOmni::Notify(MxParam &p)
 {

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -15,13 +15,20 @@ LegoOmni::~LegoOmni()
 // OFFSET: LEGO1 0x1005ad10
 LegoOmni *LegoOmni::GetInstance()
 {
-  return (LegoOmni*)MxOmni::GetInstance();
+  return (LegoOmni *)MxOmni::GetInstance();
+}
+
+// OFFSET: LEGO1 0x1005ac90
+void LegoOmni::CreateInstance()
+{
+  MxOmni::DestroyInstance();
+  MxOmni::SetInstance(new LegoOmni());
 }
 
 // OFFSET: LEGO1 0x10015700
 LegoOmni *Lego()
 {
-  return (LegoOmni *) MxOmni::GetInstance();
+  return (LegoOmni *)MxOmni::GetInstance();
 }
 
 // OFFSET: LEGO1 0x10015710
@@ -29,7 +36,6 @@ LegoSoundManager *SoundManager()
 {
   return LegoOmni::GetInstance()->GetSoundManager();
 }
-
 
 // OFFSET: LEGO1 0x10015720
 LegoVideoManager *VideoManager()

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -84,7 +84,7 @@ private:
   char m_unk94[0x4];
   LegoBuildingManager* m_buildingManager; // 0x98
   LegoGameState *m_gameState; // 0x9c
-  char m_unka0[0x94];
+  MxDSAction m_action;
   MxBackgroundAudioManager *m_bkgAudioManager; // 0x134
   MxTransitionManager *m_transitionManager; // 0x138
   int m_unk13c;

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -93,26 +93,19 @@ private:
 
 __declspec(dllexport) MxBackgroundAudioManager * BackgroundAudioManager();
 __declspec(dllexport) MxDSObject * CreateStreamObject(MxDSFile *,short);
-__declspec(dllexport) MxEventManager * EventManager();
 __declspec(dllexport) LegoGameState * GameState();
 __declspec(dllexport) const char * GetNoCD_SourceName();
 __declspec(dllexport) LegoInputManager * InputManager();
 __declspec(dllexport) LegoOmni * Lego();
-__declspec(dllexport) MxSoundManager * MSoundManager();
 __declspec(dllexport) void MakeSourceName(char *, const char *);
-__declspec(dllexport) MxMusicManager * MusicManager();
 __declspec(dllexport) MxNotificationManager * NotificationManager();
 __declspec(dllexport) LegoEntity * PickEntity(long,long);
 __declspec(dllexport) LegoROI * PickROI(long,long);
 __declspec(dllexport) void SetOmniUserMessage(void (*)(const char *,int));
 __declspec(dllexport) LegoSoundManager * SoundManager();
 __declspec(dllexport) long Start(MxDSAction *);
-__declspec(dllexport) MxStreamer * Streamer();
-__declspec(dllexport) MxTickleManager * TickleManager();
 __declspec(dllexport) MxTransitionManager * TransitionManager();
-__declspec(dllexport) MxVariableTable * VariableTable();
 __declspec(dllexport) LegoVideoManager * VideoManager();
-
 __declspec(dllexport) long Start(MxDSAction *a);
 
 LegoBuildingManager* BuildingManager();

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -71,6 +71,7 @@ public:
   LegoPlantManager *GetLegoPlantManager() { return m_plantManager; }
   LegoGameState *GetGameState() { return m_gameState; }
   LegoNavController *GetNavController() { return m_navController; }
+  MxTransitionManager *GetTransitionManager() { return m_transitionManager; }
 
 private:
   int m_unk68;

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -83,8 +83,62 @@ long MxOmni::Notify(MxParam &p)
   return 0;
 }
 
+// OFFSET: LEGO1 0x100acea0
+MxObjectFactory *ObjectFactory()
+{
+  return MxOmni::GetInstance()->GetObjectFactory();
+}
+
+// OFFSET: LEGO1 0x100aceb0
+MxNotificationManager *NotificationManager()
+{
+  return MxOmni::GetInstance()->GetNotificationManager();
+}
+
+// OFFSET: LEGO1 0x100acec0
+MxTickleManager *TickleManager()
+{
+  return MxOmni::GetInstance()->GetTickleManager();
+}
+
 // OFFSET: LEGO1 0x100aced0
 MxTimer *Timer()
 {
   return MxOmni::GetInstance()->GetTimer();
+}
+
+// OFFSET: LEGO1 0x100acef0
+MxStreamer* Streamer()
+{
+  return MxOmni::GetInstance()->GetStreamer();
+} 
+
+// OFFSET: LEGO1 0x100acf00
+MxSoundManager* MSoundManager()
+{
+  return MxOmni::GetInstance()->GetSoundManager();
+}
+
+// OFFSET: LEGO1 0x100acf10
+MxVideoManager* MVideoManager()
+{
+  return MxOmni::GetInstance()->GetVideoManager();
+}
+
+// OFFSET: LEGO1 0x100acf20
+MxVariableTable* VariableTable()
+{
+  return MxOmni::GetInstance()->GetVariableTable();
+}
+
+// OFFSET: LEGO1 0x100acf30
+MxMusicManager* MusicManager()
+{
+  return MxOmni::GetInstance()->GetMusicManager();
+}
+
+// OFFSET: LEGO1 0x100acf40
+MxEventManager* EventManager()
+{
+  return MxOmni::GetInstance()->GetEventManager();
 }

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -1,7 +1,7 @@
 #include "mxomni.h"
 
 // 0x101015b0
-MxOmni *MxOmni::m_instance = NULL;
+MxOmni *MxOmni::g_instance = NULL;
 
 // OFFSET: LEGO1 0x100aef10
 MxOmni::MxOmni()
@@ -36,23 +36,23 @@ void MxOmni::Init()
 // OFFSET: LEGO1 0x100b0690
 void MxOmni::DestroyInstance()
 {
-  if (m_instance != NULL)
+  if (g_instance != NULL)
   {
-    delete m_instance;
-    m_instance = NULL;
+    delete g_instance;
+    g_instance = NULL;
   }
 }
 
 // OFFSET: LEGO1 0x100b0680
 MxOmni *MxOmni::GetInstance()
 {
-  return m_instance;
+  return g_instance;
 }
 
 // OFFSET: LEGO1 0x100af0b0
 void MxOmni::SetInstance(MxOmni *instance)
 {
-  m_instance = instance;
+  g_instance = instance;
 }
 
 // OFFSET: LEGO1 0x100af0c0

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -1,7 +1,7 @@
 #include "mxomni.h"
 
 // 0x101015b0
-MxOmni* MxOmni::m_instance = NULL;
+MxOmni *MxOmni::m_instance = NULL;
 
 // OFFSET: LEGO1 0x100aef10
 MxOmni::MxOmni()
@@ -33,10 +33,26 @@ void MxOmni::Init()
   m_unk64 = NULL;
 }
 
+// OFFSET: LEGO1 0x100b0690
+void MxOmni::DestroyInstance()
+{
+  if (m_instance != NULL)
+  {
+    delete m_instance;
+    m_instance = NULL;
+  }
+}
+
 // OFFSET: LEGO1 0x100b0680
 MxOmni *MxOmni::GetInstance()
 {
   return m_instance;
+}
+
+// OFFSET: LEGO1 0x100af0b0
+void MxOmni::SetInstance(MxOmni *instance)
+{
+  m_instance = instance;
 }
 
 // OFFSET: LEGO1 0x100af0c0

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -36,9 +36,16 @@ public:
   virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c
   static void SetInstance(MxOmni* instance);
-
+  MxObjectFactory* GetObjectFactory() const { return this->m_objectFactory; }
+  MxNotificationManager* GetNotificationManager() const { return this->m_notificationManager; }
+  MxTickleManager* GetTickleManager() const { return this->m_tickleManager; }
   MxTimer* GetTimer() const { return this->m_timer; }
-
+  MxStreamer* GetStreamer() const { return this->m_streamer; }
+  MxSoundManager* GetSoundManager() const { return this->m_soundManager; }
+  MxVideoManager* GetVideoManager() const { return this->m_videoManager; }
+  MxVariableTable* GetVariableTable() const { return this->m_variableTable; }
+  MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
+  MxEventManager* GetEventManager() const { return this->m_eventManager; }
 protected:
   static MxOmni* m_instance;
 
@@ -61,7 +68,12 @@ protected:
 
   unsigned char m_unk64; // 0x64
 };
-
+__declspec(dllexport) MxTickleManager * TickleManager();
 __declspec(dllexport) MxTimer * Timer();
+__declspec(dllexport) MxStreamer * Streamer();
+__declspec(dllexport) MxSoundManager * MSoundManager();
+__declspec(dllexport) MxVariableTable * VariableTable();
+__declspec(dllexport) MxMusicManager * MusicManager();
+__declspec(dllexport) MxEventManager * EventManager();
 
 #endif // MXOMNI_H

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -35,6 +35,7 @@ public:
   virtual void Init(); // vtable+14
   virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c
+  static void SetInstance(MxOmni* instance);
 
   MxTimer* GetTimer() const { return this->m_timer; }
 

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -47,7 +47,7 @@ public:
   MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
   MxEventManager* GetEventManager() const { return this->m_eventManager; }
 protected:
-  static MxOmni* m_instance;
+  static MxOmni* g_instance;
 
   MxString m_mediaPath; // 0x8
   HWND *m_windowHandle; // 0x18;


### PR DESCRIPTION
 - The m_unka0 field in LegoOmni is an MxDsAction, which allows the deconstructor to match
 - Implemented LegoOmni::GetInstance and Destroy instance
 - moves a few functions to their correct places