### PR TITLE
Faster reccmp.py on linux

### DIFF
--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -209,9 +209,12 @@ class SymInfo:
     for fn in self.lines:
       # Sometimes a PDB is compiled with a relative path while we always have
       # an absolute path. Therefore we must
-      if os.path.samefile(fn, filename):
-        filename = fn
-        break
+      try:
+        if os.path.samefile(fn, filename):
+          filename = fn
+          break
+      except FileNotFoundError as e:
+        continue
 
     if filename in self.lines and line in self.lines[fn]:
       addr = self.lines[fn][line]

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -76,15 +76,15 @@ class Bin:
 
     # Read ImageBase
     self.file.seek(0xB4)
-    self.imagebase = struct.unpack('i', self.file.read(4))[0]
+    self.imagebase, = struct.unpack('<i', self.file.read(4))
 
     # Read .text VirtualAddress
     self.file.seek(0x184)
-    self.textvirt = struct.unpack('i', self.file.read(4))[0]
+    self.textvirt, = struct.unpack('<i', self.file.read(4))
 
     # Read .text PointerToRawData
     self.file.seek(0x18C)
-    self.textraw = struct.unpack('i', self.file.read(4))[0]
+    self.textraw, = struct.unpack('<i', self.file.read(4))
     logger.debug('... Parsing finished')
 
   def __del__(self):


### PR DESCRIPTION
I noticed all paths in the output of `cvdump.exe` started with `.\`.
This pr proposes to do a naive string append + replace instead of executing winepath each time.

For my machine, this reduces the time of `reccmp.py` from ~80s to ~2s.

While looking for this bug, I added logging support which might be useful in the future.

Last, I sneaked in a little fix for those people developing on big-endian machines.