### PR TITLE
LEGO1: ConvertHSVToRGB is now effectively 100% matched

### DIFF
--- a/LEGO1/legoutil.cpp
+++ b/LEGO1/legoutil.cpp
@@ -9,10 +9,13 @@ void ConvertHSVToRGB(float h, float s, float v, float *r_out, float *b_out, floa
   double v9;
   double v12;
   double v13;
+
+  double s_dbl = s;
+
   if (s > 0.5f)
     calc = (1.0f - v) * s + v;
   else
-    calc = (v + 1.0) * s;
+    calc = (v + 1.0) * s_dbl;
   if (calc <= 0.0)
   {
     *g_out = 0.0f;
@@ -20,7 +23,7 @@ void ConvertHSVToRGB(float h, float s, float v, float *r_out, float *b_out, floa
     *r_out = 0.0f;
     return;
   }
-  p = s * 2.0 - calc;
+  p = s * 2.0f - calc;
   hue_index = h * 6.0;
   v9 = (h * 6.0 - (float)hue_index) * ((calc - p) / calc) * calc;
   v12 = p + v9;


### PR DESCRIPTION
`reccmp.py` currently gets confused by jump tables and only reports a ~90% match, but the actual code is matching now.