### PR TITLE
Define MxLong/MxULong

### DIFF
--- a/ISLE/define.cpp
+++ b/ISLE/define.cpp
@@ -37,4 +37,4 @@ int g_reqEnableRMDevice = 0;
 int g_startupDelay = 200;
 
 // 0x4101c0
-long g_lastFrameTime = 0;
+MxLong g_lastFrameTime = 0;

--- a/ISLE/define.h
+++ b/ISLE/define.h
@@ -1,6 +1,7 @@
 #ifndef DEFINE_H
 #define DEFINE_H
 
+#include <mxtypes.h>
 #include <windows.h>
 
 class IsleApp;
@@ -21,6 +22,6 @@ extern int g_targetHeight;
 extern int g_targetDepth;
 extern int g_reqEnableRMDevice;
 extern int g_startupDelay;
-extern long g_lastFrameTime;
+extern MxLong g_lastFrameTime;
 
 #endif // DEFINE_H

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -95,7 +95,7 @@ void IsleApp::Close()
     TransitionManager()->SetWaitIndicator(NULL);
     Lego()->vtable3c();
 
-    long lVar8;
+    MxLong lVar8;
     do {
       lVar8 = Streamer()->Close(NULL);
     } while (lVar8 == 0);
@@ -571,7 +571,7 @@ BOOL IsleApp::ReadReg(LPCSTR name, LPSTR outValue, DWORD outSize)
   DWORD valueType;
 
   BOOL out = FALSE;
-  unsigned long size = outSize;
+  MxULong size = outSize;
   if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Mindscape\\LEGO Island", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
     if (RegQueryValueExA(hKey, name, NULL, &valueType, (LPBYTE) outValue, &size) == ERROR_SUCCESS) {
       if (RegCloseKey(hKey) == ERROR_SUCCESS) {
@@ -695,7 +695,7 @@ inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
   if (!TickleManager()) return;
   if (!Timer()) return;
 
-  long currentTime = Timer()->GetRealTime();
+  MxLong currentTime = Timer()->GetRealTime();
   if (currentTime < g_lastFrameTime) {
     g_lastFrameTime = -this->m_frameDelta;
   }

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -571,7 +571,7 @@ BOOL IsleApp::ReadReg(LPCSTR name, LPSTR outValue, DWORD outSize)
   DWORD valueType;
 
   BOOL out = FALSE;
-  MxULong size = outSize;
+  DWORD size = outSize;
   if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Mindscape\\LEGO Island", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
     if (RegQueryValueExA(hKey, name, NULL, &valueType, (LPBYTE) outValue, &size) == ERROR_SUCCESS) {
       if (RegCloseKey(hKey) == ERROR_SUCCESS) {

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -56,7 +56,7 @@ public:
   // 40
   int m_islandTexture;
   int m_gameStarted;
-  long m_frameDelta;
+  MxLong m_frameDelta;
 
   // 4c
   MxVideoParam m_videoParam;

--- a/LEGO1/act2brick.cpp
+++ b/LEGO1/act2brick.cpp
@@ -13,7 +13,7 @@ Act2Brick::~Act2Brick()
 }
 
 // STUB OFFSET: LEGO1 0x1007a8c0 STUB
-long Act2Brick::Notify(MxParam &p)
+MxLong Act2Brick::Notify(MxParam &p)
 {
   // TODO
 
@@ -21,7 +21,7 @@ long Act2Brick::Notify(MxParam &p)
 }
 
 // OFFSET: LEGO1 0x1007a7f0 STUB
-long Act2Brick::Tickle()
+MxLong Act2Brick::Tickle()
 {
   // TODO
 

--- a/LEGO1/act2brick.h
+++ b/LEGO1/act2brick.h
@@ -11,8 +11,8 @@ public:
   Act2Brick();
   virtual ~Act2Brick() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
-  virtual long Tickle() override; // vtable+0x08
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Tickle() override; // vtable+0x08
 
   // OFFSET: LEGO1 0x1007a360
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/act2policestation.cpp
+++ b/LEGO1/act2policestation.cpp
@@ -1,7 +1,7 @@
 #include "act2policestation.h"
 
 // OFFSET: LEGO1 0x1004e0e0 STUB
-long Act2PoliceStation::Notify(MxParam &p)
+MxLong Act2PoliceStation::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/act2policestation.h
+++ b/LEGO1/act2policestation.h
@@ -8,7 +8,7 @@
 class Act2PoliceStation : public LegoEntity
 {
 public:
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
   // OFFSET: LEGO1 0x1000e200
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/beachhouseentity.cpp
+++ b/LEGO1/beachhouseentity.cpp
@@ -1,7 +1,7 @@
 #include "beachhouseentity.h"
 
 // OFFSET: LEGO1 0x100150a0 STUB
-long BeachHouseEntity::Notify(MxParam &p)
+MxLong BeachHouseEntity::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/beachhouseentity.h
+++ b/LEGO1/beachhouseentity.h
@@ -8,7 +8,7 @@
 class BeachHouseEntity : public BuildingEntity
 {
 public:
-  virtual long Notify(MxParam &p) override; // vtable+04
+  virtual MxLong Notify(MxParam &p) override; // vtable+04
 
   // OFFSET: LEGO1 0x1000ee80
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/elevatorbottom.cpp
+++ b/LEGO1/elevatorbottom.cpp
@@ -13,7 +13,7 @@ ElevatorBottom::~ElevatorBottom()
 }
 
 // OFFSET: LEGO1 0x10018150 STUB
-long ElevatorBottom::Notify(MxParam &p)
+MxLong ElevatorBottom::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/elevatorbottom.h
+++ b/LEGO1/elevatorbottom.h
@@ -10,7 +10,7 @@ public:
   ElevatorBottom();
   virtual ~ElevatorBottom() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
   // OFFSET: LEGO1 0x10017f20
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/gasstation.cpp
+++ b/LEGO1/gasstation.cpp
@@ -13,7 +13,7 @@ GasStation::~GasStation()
 }
 
 // OFFSET: LEGO1 0x10004a60 STUB
-long GasStation::Notify(MxParam &p)
+MxLong GasStation::Notify(MxParam &p)
 {
   // TODO
 
@@ -21,7 +21,7 @@ long GasStation::Notify(MxParam &p)
 }
 
 // OFFSET: LEGO1 0x10005c90 STUB
-long GasStation::Tickle()
+MxLong GasStation::Tickle()
 {
   // TODO
 

--- a/LEGO1/gasstation.h
+++ b/LEGO1/gasstation.h
@@ -12,8 +12,8 @@ public:
   GasStation();
   virtual ~GasStation() override; // vtable+0x0
   
-  virtual long Notify(MxParam &p) override; // vtable+0x4
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x10004780
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/historybook.cpp
+++ b/LEGO1/historybook.cpp
@@ -13,7 +13,7 @@ HistoryBook::~HistoryBook()
 }
 
 // OFFSET: LEGO1 0x10082680 STUB
-long HistoryBook::Notify(MxParam &p)
+MxLong HistoryBook::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/historybook.h
+++ b/LEGO1/historybook.h
@@ -11,7 +11,7 @@ public:
   HistoryBook();
   virtual ~HistoryBook() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
   // OFFSET: LEGO1 0x10082390
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/hospital.cpp
+++ b/LEGO1/hospital.cpp
@@ -13,7 +13,7 @@ Hospital::~Hospital()
 }
 
 // OFFSET: LEGO1 0x10074990 STUB
-long Hospital::Notify(MxParam &p)
+MxLong Hospital::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/hospital.h
+++ b/LEGO1/hospital.h
@@ -11,7 +11,7 @@ public:
   Hospital();
   virtual ~Hospital() override; // vtable+0x0
   
-  virtual long Notify(MxParam &p) override; // vtable+0x04
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x04
 
   // OFFSET: LEGO1 0x100746b0
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/infocenter.cpp
+++ b/LEGO1/infocenter.cpp
@@ -13,7 +13,7 @@ Infocenter::~Infocenter()
 }
 
 // OFFSET: LEGO1 0x1006ef10 STUB
-long Infocenter::Notify(MxParam &p)
+MxLong Infocenter::Notify(MxParam &p)
 {
   // TODO
 
@@ -21,7 +21,7 @@ long Infocenter::Notify(MxParam &p)
 }
 
 // OFFSET: LEGO1 0x10070af0 STUB
-long Infocenter::Tickle()
+MxLong Infocenter::Tickle()
 {
   // TODO
 

--- a/LEGO1/infocenter.h
+++ b/LEGO1/infocenter.h
@@ -11,8 +11,8 @@ public:
   Infocenter();
   virtual ~Infocenter() override;
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x1006eb40
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/infocenterdoor.cpp
+++ b/LEGO1/infocenterdoor.cpp
@@ -13,7 +13,7 @@ InfocenterDoor::~InfocenterDoor()
 }
 
 // OFFSET: LEGO1 0x100379e0 STUB
-long InfocenterDoor::Notify(MxParam &p)
+MxLong InfocenterDoor::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/infocenterdoor.h
+++ b/LEGO1/infocenterdoor.h
@@ -11,7 +11,7 @@ public:
   InfocenterDoor();
   virtual ~InfocenterDoor(); // vtable+0x0
   
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
   // OFFSET: LEGO1 0x100377b0
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/legoanimationmanager.cpp
+++ b/LEGO1/legoanimationmanager.cpp
@@ -15,7 +15,7 @@ LegoAnimationManager::~LegoAnimationManager()
 }
 
 // OFFSET: LEGO1 0x100619f0 STUB
-long LegoAnimationManager::Notify(MxParam &p)
+MxLong LegoAnimationManager::Notify(MxParam &p)
 {
   // TODO
 
@@ -23,7 +23,7 @@ long LegoAnimationManager::Notify(MxParam &p)
 }
 
 // OFFSET: LEGO1 0x10061cc0 STUB
-long LegoAnimationManager::Tickle()
+MxLong LegoAnimationManager::Tickle()
 {
   // TODO
 

--- a/LEGO1/legoanimationmanager.h
+++ b/LEGO1/legoanimationmanager.h
@@ -11,8 +11,8 @@ public:
   LegoAnimationManager();
   virtual ~LegoAnimationManager() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x1005ec80
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/legocarbuild.cpp
+++ b/LEGO1/legocarbuild.cpp
@@ -13,7 +13,7 @@ LegoCarBuild::~LegoCarBuild()
 }
 
 // OFFSET: LEGO1 0x10024050 STUB
-long LegoCarBuild::Notify(MxParam &p)
+MxLong LegoCarBuild::Notify(MxParam &p)
 {
   // TODO
 
@@ -21,7 +21,7 @@ long LegoCarBuild::Notify(MxParam &p)
 }
 
 // OFFSET: LEGO1 0x100238b0 STUB
-long LegoCarBuild::Tickle()
+MxLong LegoCarBuild::Tickle()
 {
   // TODO
 

--- a/LEGO1/legocarbuild.h
+++ b/LEGO1/legocarbuild.h
@@ -11,8 +11,8 @@ public:
   LegoCarBuild();
   virtual ~LegoCarBuild() override;
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x10022940
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/legocontrolmanager.cpp
+++ b/LEGO1/legocontrolmanager.cpp
@@ -13,7 +13,7 @@ LegoControlManager::~LegoControlManager()
 }
 
 // OFFSET: LEGO1 0x10029600 STUB
-long LegoControlManager::Tickle()
+MxLong LegoControlManager::Tickle()
 {
   // TODO
 

--- a/LEGO1/legocontrolmanager.h
+++ b/LEGO1/legocontrolmanager.h
@@ -10,7 +10,7 @@ public:
   LegoControlManager();
   virtual ~LegoControlManager() override; // vtable+0x0
 
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x10028cb0
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -7,7 +7,7 @@ LegoEntity::~LegoEntity()
 }
 
 // OFFSET: LEGO1 0x100114f0 STUB
-long LegoEntity::Notify(MxParam &p)
+MxLong LegoEntity::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -15,7 +15,7 @@ public:
 
   __declspec(dllexport) virtual ~LegoEntity() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
   // OFFSET: LEGO1 0x1000c2f0
   inline const char *ClassName() const override // vtable+0xc

--- a/LEGO1/legogamestate.cpp
+++ b/LEGO1/legogamestate.cpp
@@ -13,14 +13,14 @@ LegoGameState::~LegoGameState()
 }
 
 // OFFSET: LEGO1 0x10039c60
-long LegoGameState::Load(unsigned long)
+MxResult LegoGameState::Load(MxULong)
 {
   // TODO
   return 0;
 }
 
 // OFFSET: LEGO1 0x10039980
-long LegoGameState::Save(unsigned long p)
+MxResult LegoGameState::Save(MxULong p)
 {
   // TODO
   return 0;

--- a/LEGO1/legogamestate.h
+++ b/LEGO1/legogamestate.h
@@ -1,13 +1,15 @@
 #ifndef LEGOGAMESTATE_H
 #define LEGOGAMESTATE_H
 
+#include "mxtypes.h"
+
 class LegoGameState
 {
 public:
   __declspec(dllexport) LegoGameState();
   __declspec(dllexport) ~LegoGameState();
-  __declspec(dllexport) long Load(unsigned long);
-  __declspec(dllexport) long Save(unsigned long p);
+  __declspec(dllexport) MxResult Load(MxULong);
+  __declspec(dllexport) MxResult Save(MxULong p);
   __declspec(dllexport) void SerializePlayersInfo(short p);
   __declspec(dllexport) void SerializeScoreHistory(short p);
   __declspec(dllexport) void SetSavePath(char *p);

--- a/LEGO1/legoinputmanager.cpp
+++ b/LEGO1/legoinputmanager.cpp
@@ -17,7 +17,7 @@ LegoInputManager::~LegoInputManager()
 }
 
 // OFFSET: LEGO1 0x1005c740 STUB
-void LegoInputManager::QueueEvent(NotificationId id, unsigned char p2, long p3, long p4, unsigned char p5)
+void LegoInputManager::QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5)
 {
   // TODO
 }
@@ -35,7 +35,7 @@ void LegoInputManager::UnRegister(MxCore *)
 }
 
 // OFFSET: LEGO1 0x1005b8b0 STUB
-long LegoInputManager::Tickle()
+MxLong LegoInputManager::Tickle()
 {
   // TODO
 

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -22,11 +22,11 @@ public:
   LegoInputManager();
   virtual ~LegoInputManager() override;
 
-  __declspec(dllexport) void QueueEvent(NotificationId id, unsigned char p2, long p3, long p4, unsigned char p5);
+  __declspec(dllexport) void QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5);
   __declspec(dllexport) void Register(MxCore *);
   __declspec(dllexport) void UnRegister(MxCore *);
 
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Tickle() override; // vtable+0x8
 
   undefined m_pad40[0x15c];
   int m_joystickIndex;

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -25,7 +25,7 @@ void LegoOmni::CreateBackgroundAudio()
 }
 
 // OFFSET: LEGO1 0x1005af10 STUB
-void LegoOmni::RemoveWorld(const MxAtomId &p1, long p2)
+void LegoOmni::RemoveWorld(const MxAtomId &p1, MxLong p2)
 {
   // TODO
 }
@@ -50,7 +50,7 @@ void SetOmniUserMessage(void (*p_userMsg)(const char *,int))
 }
 
 // OFFSET: LEGO1 0x100acf50 STUB
-long Start(MxDSAction *)
+MxLong Start(MxDSAction *)
 {
   // TODO
   return 0;
@@ -149,21 +149,21 @@ const char *GetNoCD_SourceName()
 }
 
 // OFFSET: LEGO1 0x1005b5f0
-long LegoOmni::Notify(MxParam &p)
+MxLong LegoOmni::Notify(MxParam &p)
 {
   // FIXME: Stub
   return 0;
 }
 
 // OFFSET: LEGO1 0x1003dd70 STUB
-LegoROI *PickROI(long,long)
+LegoROI *PickROI(MxLong,MxLong)
 {
   // TODO
   return NULL;
 }
 
 // OFFSET: LEGO1 0x1003ddc0 STUB
-LegoEntity *PickEntity(long,long)
+LegoEntity *PickEntity(MxLong,MxLong)
 {
   // TODO
   return NULL;

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -28,7 +28,7 @@ class LegoOmni : public MxOmni
 {
 public:
   __declspec(dllexport) void CreateBackgroundAudio();
-  __declspec(dllexport) void RemoveWorld(const MxAtomId &p1, long p2);
+  __declspec(dllexport) void RemoveWorld(const MxAtomId &p1, MxLong p2);
   __declspec(dllexport) static int GetCurrPathInfo(LegoPathBoundary **,int &);
   __declspec(dllexport) static void CreateInstance();
   __declspec(dllexport) static LegoOmni *GetInstance();
@@ -36,7 +36,7 @@ public:
   LegoOmni();
   virtual ~LegoOmni(); // vtable+00
 
-  virtual long Notify(MxParam &p); // vtable+04
+  virtual MxLong Notify(MxParam &p); // vtable+04
 
   // OFFSET: LEGO1 0x10058aa0
   inline virtual const char *ClassName() const // vtable+0c
@@ -101,14 +101,14 @@ __declspec(dllexport) const char * GetNoCD_SourceName();
 __declspec(dllexport) LegoInputManager * InputManager();
 __declspec(dllexport) LegoOmni * Lego();
 __declspec(dllexport) void MakeSourceName(char *, const char *);
-__declspec(dllexport) LegoEntity * PickEntity(long,long);
-__declspec(dllexport) LegoROI * PickROI(long,long);
+__declspec(dllexport) LegoEntity * PickEntity(MxLong,MxLong);
+__declspec(dllexport) LegoROI * PickROI(MxLong,MxLong);
 __declspec(dllexport) void SetOmniUserMessage(void (*)(const char *,int));
 __declspec(dllexport) LegoSoundManager * SoundManager();
-__declspec(dllexport) long Start(MxDSAction *);
+__declspec(dllexport) MxLong Start(MxDSAction *);
 __declspec(dllexport) MxTransitionManager * TransitionManager();
 __declspec(dllexport) LegoVideoManager * VideoManager();
-__declspec(dllexport) long Start(MxDSAction *a);
+__declspec(dllexport) MxLong Start(MxDSAction *a);
 
 LegoBuildingManager* BuildingManager();
 Isle* GetIsle();

--- a/LEGO1/legopathcontroller.cpp
+++ b/LEGO1/legopathcontroller.cpp
@@ -13,7 +13,7 @@ LegoPathController::~LegoPathController()
 }
 
 // OFFSET: LEGO1 0x10045c10 STUB
-long LegoPathController::Tickle()
+MxLong LegoPathController::Tickle()
 {
   // TODO
   return 0;

--- a/LEGO1/legopathcontroller.h
+++ b/LEGO1/legopathcontroller.h
@@ -11,7 +11,7 @@ public:
   LegoPathController();
   virtual ~LegoPathController() override;
 
-  virtual long Tickle() override; // vtable+08
+  virtual MxLong Tickle() override; // vtable+08
 
   // OFFSET: LEGO1 0x10045110
   inline const char *ClassName() const override // vtable+0xc

--- a/LEGO1/legoplantmanager.cpp
+++ b/LEGO1/legoplantmanager.cpp
@@ -13,7 +13,7 @@ LegoPlantManager::~LegoPlantManager()
 }
 
 // OFFSET: LEGO1 0x10026e00 STUB
-long LegoPlantManager::Tickle()
+MxLong LegoPlantManager::Tickle()
 {
   // TODO
 

--- a/LEGO1/legoplantmanager.h
+++ b/LEGO1/legoplantmanager.h
@@ -11,7 +11,7 @@ public:
   LegoPlantManager();
   virtual ~LegoPlantManager() override; // vtable+0x0
 
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x10026290
   inline const char *ClassName() const override // vtable+0xc

--- a/LEGO1/legorace.cpp
+++ b/LEGO1/legorace.cpp
@@ -13,7 +13,7 @@ LegoRace::~LegoRace()
 }
 
 // OFFSET: LEGO1 0x10015e00 STUB
-long LegoRace::Notify(MxParam &p)
+MxLong LegoRace::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/legorace.h
+++ b/LEGO1/legorace.h
@@ -10,7 +10,7 @@ public:
   LegoRace();
   virtual ~LegoRace() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
   // OFFSET: LEGO1 0x10015ba0
   inline const char *ClassName() const override // vtable+0xc

--- a/LEGO1/legosoundmanager.cpp
+++ b/LEGO1/legosoundmanager.cpp
@@ -13,7 +13,7 @@ LegoSoundManager::~LegoSoundManager()
 }
 
 // OFFSET: LEGO1 0x1002a3a0 STUB
-long LegoSoundManager::Tickle()
+MxLong LegoSoundManager::Tickle()
 {
   // TODO
   return 0;

--- a/LEGO1/legosoundmanager.h
+++ b/LEGO1/legosoundmanager.h
@@ -10,7 +10,7 @@ class LegoSoundManager : public MxSoundManager
 public:
   LegoSoundManager();
   virtual ~LegoSoundManager() override;
-  virtual long Tickle() override; // vtable+08
+  virtual MxLong Tickle() override; // vtable+08
 
 private:
   void Init();

--- a/LEGO1/legoutil.cpp
+++ b/LEGO1/legoutil.cpp
@@ -1,11 +1,13 @@
 #include "legoutil.h"
 
+#include "mxtypes.h"
+
 // OFFSET: LEGO1 0x1003eae0
 void ConvertHSVToRGB(float h, float s, float v, float *r_out, float *b_out, float *g_out)
 {
   double calc;
   double p;
-  long hue_index;
+  MxLong hue_index;
   double v9;
   double v12;
   double v13;

--- a/LEGO1/mxbitmap.cpp
+++ b/LEGO1/mxbitmap.cpp
@@ -47,7 +47,7 @@ MxResult MxBitmap::LoadFile(HANDLE p_handle)
 }
 
 // OFFSET: LEGO1 0x100bcd10
-long MxBitmap::Read(const char *p_filename)
+MxLong MxBitmap::Read(const char *p_filename)
 {
   MxResult result = FAILURE;
   HANDLE handle = CreateFileA(

--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -17,7 +17,7 @@ public:
   virtual int vtable18(BITMAPINFOHEADER *p_bmiHeader);
   virtual int vtable1c(int p_width, int p_height, MxPalette *p_palette, int);
   virtual MxResult LoadFile(HANDLE p_handle);
-  __declspec(dllexport) virtual long Read(const char *p_filename); // vtable+24
+  __declspec(dllexport) virtual MxLong Read(const char *p_filename); // vtable+24
   virtual int vtable28(int);
   virtual void vtable2c(int, int, int, int, int, int, int);
   virtual void vtable30(int, int, int, int, int, int, int);

--- a/LEGO1/mxcore.cpp
+++ b/LEGO1/mxcore.cpp
@@ -16,13 +16,13 @@ MxCore::~MxCore()
 }
 
 // OFFSET: LEGO1 0x100ae1f0
-long MxCore::Notify(MxParam &p)
+MxLong MxCore::Notify(MxParam &p)
 {
   return 0;
 }
 
 // OFFSET: LEGO1 0x10001f70
-long MxCore::Tickle()
+MxLong MxCore::Tickle()
 {
   return 0;
 }

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -14,8 +14,8 @@ class MxCore
 public:
   __declspec(dllexport) MxCore();
   __declspec(dllexport) virtual ~MxCore(); // vtable+00
-  __declspec(dllexport) virtual long Notify(MxParam &p); // vtable+04
-  virtual long Tickle(); // vtable+08
+  __declspec(dllexport) virtual MxLong Notify(MxParam &p); // vtable+04
+  virtual MxLong Tickle(); // vtable+08
 
   // OFFSET: LEGO1 0x100144c0
   inline virtual const char *ClassName() const // vtable+0c

--- a/LEGO1/mxdiskstreamcontroller.cpp
+++ b/LEGO1/mxdiskstreamcontroller.cpp
@@ -13,7 +13,7 @@ MxDiskStreamController::~MxDiskStreamController()
 }
 
 // OFFSET: LEGO1 0x100c8640 STUB
-long MxDiskStreamController::Tickle()
+MxLong MxDiskStreamController::Tickle()
 {
   // TODO
 

--- a/LEGO1/mxdiskstreamcontroller.h
+++ b/LEGO1/mxdiskstreamcontroller.h
@@ -14,7 +14,7 @@ public:
   MxDiskStreamController();
   virtual ~MxDiskStreamController() override;
 
-  virtual long Tickle() override; // vtable+0x8
+  virtual MxLong Tickle() override; // vtable+0x8
 
   // OFFSET: LEGO1 0x100c7360
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/mxdsfile.cpp
+++ b/LEGO1/mxdsfile.cpp
@@ -8,7 +8,7 @@
 #define FOURCC(a, b, c, d) (((a) << 0) | ((b) << 8) | ((c) << 16) | ((d) << 24))
 
 // OFFSET: LEGO1 0x100cc4b0
-MxDSFile::MxDSFile(const char *filename, unsigned long skipReadingChunks)
+MxDSFile::MxDSFile(const char *filename, MxULong skipReadingChunks)
 {
   m_filename = filename;
   m_skipReadingChunks = skipReadingChunks;
@@ -21,11 +21,11 @@ MxDSFile::~MxDSFile()
 }
 
 // OFFSET: LEGO1 0x100cc590
-long MxDSFile::Open(unsigned long uStyle)
+MxLong MxDSFile::Open(MxULong uStyle)
 {
   // No idea what's stopping this one matching, but I'm pretty
   // confident it has the correct behavior.
-  long longResult = 1;
+  MxLong longResult = 1;
   memset(&m_io, 0, sizeof(MXIOINFO));
 
   if (m_io.Open(m_filename.GetData(), uStyle) != 0) {
@@ -50,7 +50,7 @@ long MxDSFile::Open(unsigned long uStyle)
 }
 
 // OFFSET: LEGO1 0x100cc780
-long MxDSFile::Read(unsigned char *pch, unsigned long cch)
+MxLong MxDSFile::Read(unsigned char *pch, MxULong cch)
 {
   if (m_io.Read((char*)pch, cch) != cch)
     return -1;
@@ -60,7 +60,7 @@ long MxDSFile::Read(unsigned char *pch, unsigned long cch)
 }
 
 // OFFSET: LEGO1 0x100cc620
-long MxDSFile::ReadChunks()
+MxLong MxDSFile::ReadChunks()
 {
   _MMCKINFO topChunk;
   _MMCKINFO childChunk;
@@ -82,7 +82,7 @@ long MxDSFile::ReadChunks()
     if (m_io.Descend(&childChunk, &topChunk, 0) != 0) {
       return -1;
     }
-    unsigned long* pLengthInDWords = &m_lengthInDWords;
+    MxULong* pLengthInDWords = &m_lengthInDWords;
     m_io.Read((char *)pLengthInDWords, 4);
     m_pBuffer = malloc(*pLengthInDWords * 4);
     m_io.Read((char*)m_pBuffer, *pLengthInDWords * 4);
@@ -97,25 +97,25 @@ long MxDSFile::ReadChunks()
 }
 
 // OFFSET: LEGO1 0x100cc7b0
-long MxDSFile::Seek(long lOffset, int iOrigin)
+MxLong MxDSFile::Seek(MxLong lOffset, int iOrigin)
 {
   return (m_position = m_io.Seek(lOffset, iOrigin)) == -1 ? -1 : 0;
 }
 
 // OFFSET: LEGO1 0x100cc7e0
-unsigned long MxDSFile::GetBufferSize()
+MxULong MxDSFile::GetBufferSize()
 {
   return m_header.bufferSize;
 }
 
 // OFFSET: LEGO1 0x100cc7f0
-unsigned long MxDSFile::GetStreamBuffersNum()
+MxULong MxDSFile::GetStreamBuffersNum()
 {
   return m_header.streamBuffersNum;
 }
 
 // OFFSET: LEGO1 0x100cc740
-long MxDSFile::Close()
+MxLong MxDSFile::Close()
 {
   m_io.Close(0);
   m_position = -1;

--- a/LEGO1/mxdsfile.h
+++ b/LEGO1/mxdsfile.h
@@ -9,7 +9,7 @@
 class MxDSFile : public MxDSSource
 {
 public:
-  __declspec(dllexport) MxDSFile(const char *filename, unsigned long skipReadingChunks);
+  __declspec(dllexport) MxDSFile(const char *filename, MxULong skipReadingChunks);
   __declspec(dllexport) virtual ~MxDSFile(); // vtable+0x0
 
   // OFFSET: LEGO1 0x100c0120
@@ -25,14 +25,14 @@ public:
     return !strcmp(name, MxDSFile::ClassName()) || MxDSSource::IsA(name);
   }
 
-  __declspec(dllexport) virtual long Open(unsigned long); // vtable+0x14
-  __declspec(dllexport) virtual long Close(); // vtable+0x18
-  __declspec(dllexport) virtual long Read(unsigned char *,unsigned long); // vtable+0x20
-  __declspec(dllexport) virtual long Seek(long,int); // vtable+0x24
-  __declspec(dllexport) virtual unsigned long GetBufferSize(); // vtable+0x28
-  __declspec(dllexport) virtual unsigned long GetStreamBuffersNum();  // vtable+0x2c
+  __declspec(dllexport) virtual MxLong Open(MxULong); // vtable+0x14
+  __declspec(dllexport) virtual MxLong Close(); // vtable+0x18
+  __declspec(dllexport) virtual MxLong Read(unsigned char *,MxULong); // vtable+0x20
+  __declspec(dllexport) virtual MxLong Seek(MxLong,int); // vtable+0x24
+  __declspec(dllexport) virtual MxULong GetBufferSize(); // vtable+0x28
+  __declspec(dllexport) virtual MxULong GetStreamBuffersNum();  // vtable+0x2c
 private:
-  long ReadChunks();
+  MxLong ReadChunks();
   struct ChunkHeader {
     ChunkHeader()
       : majorVersion(0)
@@ -43,7 +43,7 @@ private:
 
     unsigned short majorVersion;
     unsigned short minorVersion;
-    unsigned long bufferSize;
+    MxULong bufferSize;
     short streamBuffersNum;
     short reserved;
   };
@@ -54,7 +54,7 @@ private:
 
   // If false, read chunks immediately on open, otherwise
   // skip reading chunks until ReadChunks is explicitly called.
-  unsigned long m_skipReadingChunks;
+  MxULong m_skipReadingChunks;
 };
 
 #endif // MXDSFILE_H

--- a/LEGO1/mxdssource.cpp
+++ b/LEGO1/mxdssource.cpp
@@ -8,7 +8,7 @@ void MxDSSource::SomethingWhichCallsRead(void* pUnknownObject)
 }
 
 // OFFSET: LEGO1 0x100bfff0
-long MxDSSource::GetLengthInDWords()
+MxLong MxDSSource::GetLengthInDWords()
 {
   return m_lengthInDWords;
 }

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -26,19 +26,19 @@ public:
     return !strcmp(name, MxDSSource::ClassName()) || MxCore::IsA(name);
   }
 
-  virtual long Open(unsigned long) = 0;
-  virtual long Close() = 0;
+  virtual MxLong Open(MxULong) = 0;
+  virtual MxLong Close() = 0;
   virtual void SomethingWhichCallsRead(void* pUnknownObject);
-  virtual long Read(unsigned char *, unsigned long) = 0;
-  virtual long Seek(long, int) = 0;
-  virtual unsigned long GetBufferSize() = 0;
-  virtual unsigned long GetStreamBuffersNum() = 0;
-  virtual long GetLengthInDWords();
+  virtual MxLong Read(unsigned char *, MxULong) = 0;
+  virtual MxLong Seek(MxLong, int) = 0;
+  virtual MxULong GetBufferSize() = 0;
+  virtual MxULong GetStreamBuffersNum() = 0;
+  virtual MxLong GetLengthInDWords();
 
 protected:
-  unsigned long m_lengthInDWords;
+  MxULong m_lengthInDWords;
   void* m_pBuffer;
-  long m_position;
+  MxLong m_position;
 };
 
 #endif // MXDSSOURCE_H

--- a/LEGO1/mxioinfo.cpp
+++ b/LEGO1/mxioinfo.cpp
@@ -19,13 +19,13 @@ unsigned short MXIOINFO::Open(const char *filename, DWORD fdwOpen)
 }
 
 // OFFSET: LEGO1 0x100cc8e0
-void MXIOINFO::Close(long arg)
+void MXIOINFO::Close(MxLong arg)
 {
   
 }
 
 // OFFSET: LEGO1 0x100cc930
-unsigned long MXIOINFO::Read(HPSTR pch, LONG cch)
+MxULong MXIOINFO::Read(HPSTR pch, LONG cch)
 {
   return 0;
 }

--- a/LEGO1/mxioinfo.h
+++ b/LEGO1/mxioinfo.h
@@ -2,8 +2,9 @@
 #define MXIOINFO_H
 
 #include <windows.h>
+#include <mmsystem.h>
 
-#include "mmsystem.h"
+#include "mxtypes.h"
 
 class MXIOINFO
 {
@@ -12,9 +13,9 @@ public:
   __declspec(dllexport) ~MXIOINFO();
 
   unsigned short Open(const char *filename, DWORD fdwOpen);
-  void Close(long arg);
+  void Close(MxLong arg);
   LONG Seek(LONG lOffset, int iOrigin);
-  unsigned long Read(HPSTR pch, LONG cch);
+  MxULong Read(HPSTR pch, LONG cch);
   void SetBuffer(LPSTR pchBuffer, LONG cchBuffer, LONG unk);
   unsigned short Descend(LPMMCKINFO pmmcki, const MMCKINFO *pmmckiParent, UINT fuDescend);
 

--- a/LEGO1/mxmediapresenter.cpp
+++ b/LEGO1/mxmediapresenter.cpp
@@ -3,7 +3,7 @@
 DECOMP_SIZE_ASSERT(MxMediaPresenter, 0x50);
 
 // OFFSET: LEGO1 0x100b5d10 STUB
-long MxMediaPresenter::Tickle()
+MxLong MxMediaPresenter::Tickle()
 {
   // TODO
   return 0;

--- a/LEGO1/mxmediapresenter.h
+++ b/LEGO1/mxmediapresenter.h
@@ -14,7 +14,7 @@ public:
     Init();
   }
 
-  virtual long Tickle() override; // vtable+0x8, override MxCore
+  virtual MxLong Tickle() override; // vtable+0x8, override MxCore
 
   // OFFSET: LEGO1 0x1000c5c0
   inline virtual const char *ClassName() const override // vtable+0xc

--- a/LEGO1/mxnotificationmanager.cpp
+++ b/LEGO1/mxnotificationmanager.cpp
@@ -7,7 +7,7 @@ MxNotificationManager::~MxNotificationManager()
 }
 
 // OFFSET: LEGO1 0x100ac800 STUB
-long MxNotificationManager::Tickle()
+MxLong MxNotificationManager::Tickle()
 {
   // TODO
 

--- a/LEGO1/mxnotificationmanager.h
+++ b/LEGO1/mxnotificationmanager.h
@@ -9,7 +9,7 @@ class MxNotificationManager : public MxCore
 public:
   virtual ~MxNotificationManager(); // vtable+0x0
 
-  virtual long Tickle(); // vtable+0x8
+  virtual MxLong Tickle(); // vtable+0x8
 
   // 0x10: MxCriticalSection
 };

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -123,7 +123,7 @@ void MxOmni::Destroy()
 }
 
 // OFFSET: LEGO1 0x100b07f0
-long MxOmni::Notify(MxParam &p)
+MxLong MxOmni::Notify(MxParam &p)
 {
   // FIXME: Stub
   return 0;

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -32,7 +32,7 @@ public:
   MxOmni();
   virtual ~MxOmni() override;
 
-  virtual long Notify(MxParam &p); // vtable+04
+  virtual MxLong Notify(MxParam &p); // vtable+04
   virtual void Init(); // vtable+14
   virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -34,7 +34,7 @@ MxPresenter::~MxPresenter()
 }
 
 // OFFSET: LEGO1 0x100b5200 STUB
-long MxPresenter::Tickle()
+MxLong MxPresenter::Tickle()
 {
   // TODO
 
@@ -42,7 +42,7 @@ long MxPresenter::Tickle()
 }
 
 // OFFSET: LEGO1 0x100b4d80 STUB
-long MxPresenter::StartAction(MxStreamController *, MxDSAction *)
+MxLong MxPresenter::StartAction(MxStreamController *, MxDSAction *)
 {
   // TODO
 

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -31,7 +31,7 @@ public:
     return !strcmp(name, MxPresenter::ClassName()) || MxCore::IsA(name);
   }
 
-  __declspec(dllexport) virtual long Tickle() override; // vtable+0x8
+  __declspec(dllexport) virtual MxLong Tickle() override; // vtable+0x8
   virtual void VTable0x14(); // vtable+0x14
   virtual void VTable0x18(); // vtable+0x18
   virtual void VTable0x1c(); // vtable+0x1c
@@ -44,7 +44,7 @@ protected:
 public:
   virtual undefined4 VTable0x34(); // vtable+0x34
   virtual void InitVirtual(); // vtable+0x38
-  __declspec(dllexport) virtual long StartAction(MxStreamController *, MxDSAction *); // vtable+0x3c
+  __declspec(dllexport) virtual MxLong StartAction(MxStreamController *, MxDSAction *); // vtable+0x3c
   __declspec(dllexport) virtual void EndAction(); // vtable+0x40
   virtual void VTable0x44(undefined4 param); // vtable+0x44
   virtual unsigned char VTable0x48(unsigned char param); // vtable+0x48

--- a/LEGO1/mxscheduler.cpp
+++ b/LEGO1/mxscheduler.cpp
@@ -8,7 +8,7 @@ MxScheduler *MxScheduler::GetInstance()
 }
 
 // OFFSET: LEGO1 0x100bf500
-void MxScheduler::StartMultiTasking(unsigned long)
+void MxScheduler::StartMultiTasking(MxULong)
 {
   // Intentionally empty
 }

--- a/LEGO1/mxscheduler.h
+++ b/LEGO1/mxscheduler.h
@@ -1,11 +1,13 @@
 #ifndef MXSCHEDULER_H
 #define MXSCHEDULER_H
 
+#include "mxtypes.h"
+
 class MxScheduler
 {
 public:
   __declspec(dllexport) static MxScheduler *GetInstance();
-  __declspec(dllexport) void StartMultiTasking(unsigned long);
+  __declspec(dllexport) void StartMultiTasking(MxULong);
 };
 
 #endif // MXSCHEDULER_H

--- a/LEGO1/mxstreamer.cpp
+++ b/LEGO1/mxstreamer.cpp
@@ -14,14 +14,14 @@ MxStreamController *MxStreamer::Open(const char *name, unsigned short p)
 }
 
 // OFFSET: LEGO1 0x100b9570 STUB
-long MxStreamer::Close(const char *p)
+MxLong MxStreamer::Close(const char *p)
 {
   // TODO
   return 0;
 }
 
 // OFFSET: LEGO1 0x100b9b60 STUB
-long MxStreamer::Notify(MxParam &p)
+MxLong MxStreamer::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -12,9 +12,9 @@ public:
   virtual ~MxStreamer() override;
 
   __declspec(dllexport) MxStreamController *Open(const char *name, unsigned short p);
-  __declspec(dllexport) long Close(const char *p);
+  __declspec(dllexport) MxLong Close(const char *p);
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
   virtual MxResult VTable0x14(); // vtable+0x14
 };
 

--- a/LEGO1/mxticklemanager.h
+++ b/LEGO1/mxticklemanager.h
@@ -9,7 +9,7 @@ class MxTickleManager : public MxCore
 public:
   virtual ~MxTickleManager();
 
-  virtual long Tickle();
+  virtual MxLong Tickle();
   virtual const char *ClassName() const;
   virtual MxBool IsA(const char *name) const;
   virtual void vtable14();

--- a/LEGO1/mxtimer.cpp
+++ b/LEGO1/mxtimer.cpp
@@ -3,10 +3,10 @@
 #include <windows.h>
 
 // 0x10101414
-long MxTimer::s_LastTimeCalculated = 0;
+MxLong MxTimer::s_LastTimeCalculated = 0;
 
 // 0x10101418
-long MxTimer::s_LastTimeTimerStarted = 0;
+MxLong MxTimer::s_LastTimeTimerStarted = 0;
 
 // OFFSET: LEGO1 0x100ae060
 MxTimer::MxTimer()
@@ -27,15 +27,15 @@ void MxTimer::Start()
 // OFFSET: LEGO1 0x100ae180
 void MxTimer::Stop()
 {
-  long elapsed = this->GetRealTime();
-  long startTime = elapsed - MxTimer::s_LastTimeTimerStarted;
+  MxLong elapsed = this->GetRealTime();
+  MxLong startTime = elapsed - MxTimer::s_LastTimeTimerStarted;
   this->m_isRunning = FALSE;
   // this feels very stupid but it's what the assembly does
   this->m_startTime = this->m_startTime + startTime - 5;
 }
 
 // OFFSET: LEGO1 0x100ae140
-long MxTimer::GetRealTime()
+MxLong MxTimer::GetRealTime()
 {
   MxTimer::s_LastTimeCalculated = timeGetTime();
   return MxTimer::s_LastTimeCalculated - this->m_startTime;

--- a/LEGO1/mxtimer.h
+++ b/LEGO1/mxtimer.h
@@ -13,9 +13,9 @@ public:
   void Start();
   void Stop();
 
-  __declspec(dllexport) long GetRealTime();
+  __declspec(dllexport) MxLong GetRealTime();
 
-  inline long GetTime()
+  inline MxLong GetTime()
   {
     if (this->m_isRunning)
       return s_LastTimeCalculated;
@@ -24,10 +24,10 @@ public:
   }
 
 private:
-  long m_startTime;
+  MxLong m_startTime;
   MxBool m_isRunning;
-  static long s_LastTimeCalculated;
-  static long s_LastTimeTimerStarted;
+  static MxLong s_LastTimeCalculated;
+  static MxLong s_LastTimeTimerStarted;
 };
 
 #endif // MXTIMER_H

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -13,7 +13,7 @@ MxTransitionManager::~MxTransitionManager()
 }
 
 // OFFSET: LEGO1 0x1004bac0 STUB
-long MxTransitionManager::Tickle()
+MxLong MxTransitionManager::Tickle()
 {
   // TODO
 

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -14,7 +14,7 @@ public:
 
   __declspec(dllexport) void SetWaitIndicator(MxVideoPresenter *videoPresenter);
 
-  virtual long Tickle(); // vtable+0x8
+  virtual MxLong Tickle(); // vtable+0x8
 };
 
 #endif // MXTRANSITIONMANAGER_H

--- a/LEGO1/mxtypes.h
+++ b/LEGO1/mxtypes.h
@@ -8,11 +8,24 @@ typedef short MxS16;
 typedef unsigned int MxU32;
 typedef int MxS32;
 
-typedef unsigned long MxResult;
-const MxResult SUCCESS = 0;
-const MxResult FAILURE = 0xFFFFFFFFL;
+// On MSVC, a long is 32-bit, but on GCC/Clang, it's 64-bit. LEGO Island obviously
+// assumes the former in all cases, which could become an issue in the future.
+// The "longs" can't all be changed to "ints" (which are 32-bit on both) because
+// this will break DLL export compatibility. Therefore, we define MxLong/MxULong,
+// which is guaranteed to be 32-bit, and guaranteed to be a "long" on MSVC.
+#if defined(_MSC_VER)
+typedef long MxLong;
+typedef unsigned long MxULong;
+#else
+typedef int MxLong;
+typedef unsigned int MxULong;
+#endif
 
-typedef unsigned char MxBool;
+typedef MxLong MxResult;
+const MxResult SUCCESS = 0;
+const MxResult FAILURE = -1;
+
+typedef MxU8 MxBool;
 
 #ifndef TRUE
 #define TRUE 1

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -7,7 +7,7 @@ MxVideoManager::~MxVideoManager()
 }
 
 // OFFSET: LEGO1 0x100bea90 STUB
-long MxVideoManager::Tickle()
+MxLong MxVideoManager::Tickle()
 {
   // TODO
   
@@ -39,7 +39,7 @@ void MxVideoManager::InvalidateRect(MxRect32 &p_rect)
 }
 
 // OFFSET: LEGO1 0x100bebe0
-long MxVideoManager::RealizePalette(MxPalette *p_palette)
+MxLong MxVideoManager::RealizePalette(MxPalette *p_palette)
 {
   PALETTEENTRY paletteEntries[256];
 

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -11,10 +11,10 @@ class MxVideoManager : public MxUnknown100dc6b0
 public:
   virtual ~MxVideoManager();
 
-  virtual long Tickle(); // vtable+0x8
+  virtual MxLong Tickle(); // vtable+0x8
 
   __declspec(dllexport) void InvalidateRect(MxRect32 &);
-  __declspec(dllexport) virtual long RealizePalette(MxPalette *); // vtable+0x30
+  __declspec(dllexport) virtual MxLong RealizePalette(MxPalette *); // vtable+0x30
 
   MxVideoManager();
 

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -17,7 +17,7 @@ MxVideoParam::MxVideoParam()
 }
 
 // OFFSET: LEGO1 0x100beca0
-MxVideoParam::MxVideoParam(COMPAT_CONST MxRect32 &p_rect, MxPalette *p_pal, unsigned long p_backBuffers, COMPAT_CONST MxVideoParamFlags &p_flags)
+MxVideoParam::MxVideoParam(COMPAT_CONST MxRect32 &p_rect, MxPalette *p_pal, MxULong p_backBuffers, COMPAT_CONST MxVideoParamFlags &p_flags)
 {
   this->m_rect.m_left = p_rect.m_left;
   this->m_rect.m_top = p_rect.m_top;

--- a/LEGO1/mxvideoparam.h
+++ b/LEGO1/mxvideoparam.h
@@ -15,7 +15,7 @@ class MxVideoParam
 public:
   __declspec(dllexport) MxVideoParam();
   __declspec(dllexport) MxVideoParam(MxVideoParam &);
-  __declspec(dllexport) MxVideoParam(COMPAT_CONST MxRect32 &rect, MxPalette *pal, unsigned long p3, COMPAT_CONST MxVideoParamFlags &flags);
+  __declspec(dllexport) MxVideoParam(COMPAT_CONST MxRect32 &rect, MxPalette *pal, MxULong p3, COMPAT_CONST MxVideoParamFlags &flags);
   __declspec(dllexport) MxVideoParam &operator=(const MxVideoParam &);
   __declspec(dllexport) ~MxVideoParam();
 

--- a/LEGO1/police.cpp
+++ b/LEGO1/police.cpp
@@ -13,7 +13,7 @@ Police::~Police()
 }
 
 // OFFSET: LEGO1 0x1005e480 STUB
-long Police::Notify(MxParam &p)
+MxLong Police::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/police.h
+++ b/LEGO1/police.h
@@ -12,7 +12,7 @@ public:
   Police();
   virtual ~Police() override; // vtable+0x0
   
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
   
 };
 

--- a/LEGO1/registrationbook.cpp
+++ b/LEGO1/registrationbook.cpp
@@ -13,7 +13,7 @@ RegistrationBook::~RegistrationBook()
 }
 
 // OFFSET: LEGO1 0x100770e0 STUB
-long RegistrationBook::Notify(MxParam &p)
+MxLong RegistrationBook::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/registrationbook.h
+++ b/LEGO1/registrationbook.h
@@ -11,7 +11,7 @@ public:
   RegistrationBook();
   virtual ~RegistrationBook() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
 };
 

--- a/LEGO1/score.cpp
+++ b/LEGO1/score.cpp
@@ -13,7 +13,7 @@ Score::~Score()
 }
 
 // OFFSET: LEGO1 0x10001410 STUB
-long Score::Notify(MxParam &p)
+MxLong Score::Notify(MxParam &p)
 {
   // TODO
 

--- a/LEGO1/score.h
+++ b/LEGO1/score.h
@@ -11,7 +11,7 @@ public:
   Score();
   virtual ~Score() override; // vtable+0x0
 
-  virtual long Notify(MxParam &p) override; // vtable+0x4
+  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
 
 };
 


### PR DESCRIPTION
LEGO Island uses the `long` type a lot, which on MSVC is 32-bit, but on other compilers is 64-bit. Obviously LEGO Island will assume the former in all cases, which may cause problems later down the line. Unfortunately, we can't change this to something more reliably 32-bit (like `int` or `int32_t`) because this will break DLL export compatibility (the `long` type is considered distinct from/incompatible with the `int` type despite being the same size).

While our main focus is MSVC 4.2, this is probably the sort of thing that's better handled sooner rather than later. This introduces an `MxLong` and `MxULong` type which is guaranteed to be 32-bit on all compilers, and guaranteed to be a `long` on MSVC.

Some accuracy regressions appear to occur, but it's just the usual flipping of registers/operands that seem to change with every contribution (and will almost certainly switch back in a later one), so nothing really problematic.