### PR TITLE
lego: add MxDSType enum, add it to all ctors, refactor `MxDSObject`

### DIFF
--- a/LEGO1/mxatomid.h
+++ b/LEGO1/mxatomid.h
@@ -5,10 +5,10 @@
 
 enum LookupMode
 {
-    LookupMode_Exact = 0,
-    LookupMode_LowerCase = 1,
-    LookupMode_UpperCase = 2,
-    LookupMode_LowerCase2 = 3
+  LookupMode_Exact = 0,
+  LookupMode_LowerCase = 1,
+  LookupMode_UpperCase = 2,
+  LookupMode_LowerCase2 = 3
 };
 
 class MxAtomId

--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -4,9 +4,10 @@
 MxDSAction::MxDSAction()
 {
   // TODO
+  this->SetType(MxDSType_Action);
 }
 
-// OFFSET: LEGO1 0x100ada80
+// OFFSET: LEGO1 0x100ada80 STUB
 MxDSAction::~MxDSAction()
 {
   // TODO

--- a/LEGO1/mxdsanim.cpp
+++ b/LEGO1/mxdsanim.cpp
@@ -3,11 +3,10 @@
 // OFFSET: LEGO1 0x100c8ff0
 MxDSAnim::MxDSAnim()
 {
-  // TODO
+  this->SetType(MxDSType_Anim);
 }
 
 // OFFSET: LEGO1 0x100c91a0
 MxDSAnim::~MxDSAnim()
 {
-  // TODO
 }

--- a/LEGO1/mxdsevent.cpp
+++ b/LEGO1/mxdsevent.cpp
@@ -1,13 +1,12 @@
 #include "mxdsevent.h"
 
-// OFFSET: LEGO1 0x100c95f0 STUB
+// OFFSET: LEGO1 0x100c95f0
 MxDSEvent::MxDSEvent()
 {
-  // TODO
+  this->SetType(MxDSType_Event);
 }
 
-// OFFSET: LEGO1 0x100c97a0 STUB
+// OFFSET: LEGO1 0x100c97a0
 MxDSEvent::~MxDSEvent()
 {
-  // TODO
 }

--- a/LEGO1/mxdsmediaaction.cpp
+++ b/LEGO1/mxdsmediaaction.cpp
@@ -4,9 +4,10 @@
 MxDSMediaAction::MxDSMediaAction()
 {
   // TODO
+  this->SetType(MxDSType_MediaAction);
 }
 
-// OFFSET: LEGO1 0x100c8cf0
+// OFFSET: LEGO1 0x100c8cf0 STUB
 MxDSMediaAction::~MxDSMediaAction()
 {
   // TODO

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -3,11 +3,12 @@
 // OFFSET: LEGO1 0x100c9b90
 MxDSMultiAction::MxDSMultiAction()
 {
-
+  // TODO
+  this->SetType(MxDSType_MultiAction);
 }
 
-// OFFSET: LEGO1 0x100ca060
+// OFFSET: LEGO1 0x100ca060 STUB
 MxDSMultiAction::~MxDSMultiAction()
 {
-
+  // TODO
 }

--- a/LEGO1/mxdsobject.cpp
+++ b/LEGO1/mxdsobject.cpp
@@ -85,15 +85,15 @@ void MxDSObject::SetSourceName(const char *p_sourceName)
 }
 
 // OFFSET: LEGO1 0x100bf9c0
-int MxDSObject::unk14()
+undefined4 MxDSObject::unk14()
 {
   return 10;
 }
 
 // OFFSET: LEGO1 0x100bf9d0
-unsigned int MxDSObject::CalculateUnk08()
+MxU32 MxDSObject::CalculateUnk08()
 {
-  unsigned int unk08;
+  MxU32 unk08;
 
   if (this->m_sourceName)
     unk08 = strlen(this->m_sourceName) + 3;

--- a/LEGO1/mxdsobject.cpp
+++ b/LEGO1/mxdsobject.cpp
@@ -6,7 +6,7 @@
 // OFFSET: LEGO1 0x100bf6a0
 MxDSObject::MxDSObject()
 {
-  this->m_unk0c = 0;
+  this->SetType(MxDSType_Object);
   this->m_sourceName = NULL;
   this->m_unk14 = 0;
   this->m_objectName = NULL;

--- a/LEGO1/mxdsobject.cpp
+++ b/LEGO1/mxdsobject.cpp
@@ -113,16 +113,16 @@ unsigned int MxDSObject::CalculateUnk08()
 }
 
 // OFFSET: LEGO1 0x100bfa20
-void MxDSObject::Parse(char **p_source, MxU16 p_unk24)
+void MxDSObject::Parse(char **p_source, MxS16 p_unk24)
 {
   this->SetSourceName(*p_source);
   *p_source += strlen(this->m_sourceName) + 1;
-  this->m_unk14 = *(int*) *p_source;
+  this->m_unk14 = *(undefined4*) *p_source;
   *p_source += 4;
 
   this->SetObjectName(*p_source);
   *p_source += strlen(this->m_objectName) + 1;
-  this->m_unk1c = *(int*) *p_source;
+  this->m_unk1c = *(undefined4*) *p_source;
   *p_source += 4;
 
   this->m_unk24 = p_unk24;

--- a/LEGO1/mxdsobject.cpp
+++ b/LEGO1/mxdsobject.cpp
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+DECOMP_SIZE_ASSERT(MxDSObject, 0x2c);
+
 // OFFSET: LEGO1 0x100bf6a0
 MxDSObject::MxDSObject()
 {

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -10,15 +10,16 @@
 class MxDSObject : public MxCore
 {
 public:
-  __declspec(dllexport) void SetObjectName(const char *p_objectName);
-
   MxDSObject();
   virtual ~MxDSObject() override;
 
-  MxDSObject &operator=(MxDSObject &p_dsObject);
   void CopyFrom(MxDSObject &p_dsObject);
+  MxDSObject &operator=(MxDSObject &p_dsObject);
 
-    // OFFSET: LEGO1 0x100bf730
+  __declspec(dllexport) void SetObjectName(const char *p_objectName);
+  void SetSourceName(const char *p_sourceName);
+
+  // OFFSET: LEGO1 0x100bf730
   inline virtual const char *ClassName() const override { return "MxDSObject"; }; // vtable+0c
 
   // OFFSET: LEGO1 0x100bf740
@@ -27,8 +28,6 @@ public:
   virtual int unk14(); // vtable+14;
   virtual unsigned int CalculateUnk08(); // vtable+18;
   virtual void Parse(char **p_source, MxU16 p_unk24); // vtable+1c;
-
-  void SetSourceName(const char *p_sourceName);
 
   inline const MxAtomId& GetAtomId() { return this->m_atomId; }
   inline int GetUnknown1c() { return this->m_unk1c; }
@@ -40,6 +39,7 @@ public:
   // OFFSET: LEGO1 0x10005530
   inline void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; }
 
+protected:
   inline void SetType(MxDSType p_type) { this->m_type = p_type; }
 
 private:

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -3,6 +3,7 @@
 
 #include "mxcore.h"
 #include "mxatomid.h"
+#include "mxdstypes.h"
 
 // VTABLE 0x100dc868
 // SIZE 0x2c
@@ -39,9 +40,11 @@ public:
   // OFFSET: LEGO1 0x10005530
   inline void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; }
 
+  inline void SetType(MxDSType p_type) { this->m_type = p_type; }
+
 private:
   unsigned int m_unk08;
-  MxS16 m_unk0c;
+  MxS16 m_type;
   char* m_sourceName;
   int m_unk14;
   char *m_objectName;

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -1,6 +1,8 @@
 #ifndef MXDSOBJECT_H
 #define MXDSOBJECT_H
 
+#include "decomp.h"
+
 #include "mxcore.h"
 #include "mxatomid.h"
 #include "mxdstypes.h"
@@ -43,16 +45,15 @@ protected:
   inline void SetType(MxDSType p_type) { this->m_type = p_type; }
 
 private:
-  unsigned int m_unk08;
-  MxS16 m_type;
+  undefined4 m_unk08;
+  MxU16 m_type;
   char* m_sourceName;
-  int m_unk14;
+  undefined4 m_unk14;
   char *m_objectName;
-  int m_unk1c;
+  undefined4 m_unk1c;
   MxAtomId m_atomId;
   MxS16 m_unk24;
-  MxU16 m_unk26;
-  int m_unk28;
+  undefined4 m_unk28;
 };
 
 #endif // MXDSOBJECT_H

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -29,7 +29,7 @@ public:
 
   virtual int unk14(); // vtable+14;
   virtual unsigned int CalculateUnk08(); // vtable+18;
-  virtual void Parse(char **p_source, MxU16 p_unk24); // vtable+1c;
+  virtual void Parse(char **p_source, MxS16 p_unk24); // vtable+1c;
 
   inline const MxAtomId& GetAtomId() { return this->m_atomId; }
   inline int GetUnknown1c() { return this->m_unk1c; }

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -27,14 +27,14 @@ public:
   // OFFSET: LEGO1 0x100bf740
   inline virtual MxBool IsA(const char *name) const override { return !strcmp(name, MxDSObject::ClassName()) || MxCore::IsA(name); }; // vtable+10;
 
-  virtual int unk14(); // vtable+14;
-  virtual unsigned int CalculateUnk08(); // vtable+18;
+  virtual undefined4 unk14(); // vtable+14;
+  virtual MxU32 CalculateUnk08(); // vtable+18;
   virtual void Parse(char **p_source, MxS16 p_unk24); // vtable+1c;
 
   inline const MxAtomId& GetAtomId() { return this->m_atomId; }
-  inline int GetUnknown1c() { return this->m_unk1c; }
+  inline undefined4 GetUnknown1c() { return this->m_unk1c; }
 
-  inline void SetUnknown1c(int p_unk1c) { this->m_unk1c = p_unk1c; }
+  inline void SetUnknown1c(undefined4 p_unk1c) { this->m_unk1c = p_unk1c; }
   inline void SetUnknown24(MxS16 p_unk24) { this->m_unk24 = p_unk24; }
 
   // OFFSET: ISLE 0x401c40
@@ -45,7 +45,7 @@ protected:
   inline void SetType(MxDSType p_type) { this->m_type = p_type; }
 
 private:
-  undefined4 m_unk08;
+  MxU32 m_unk08;
   MxU16 m_type;
   char* m_sourceName;
   undefined4 m_unk14;

--- a/LEGO1/mxdsobjectaction.cpp
+++ b/LEGO1/mxdsobjectaction.cpp
@@ -3,11 +3,10 @@
 // OFFSET: LEGO1 0x100c8870
 MxDSObjectAction::MxDSObjectAction()
 {
-  // TODO
+  this->SetType(MxDSType_ObjectAction);
 }
 
 // OFFSET: LEGO1 0x100c8a20
 MxDSObjectAction::~MxDSObjectAction()
 {
-  // TODO
 }

--- a/LEGO1/mxdsparallelaction.cpp
+++ b/LEGO1/mxdsparallelaction.cpp
@@ -3,11 +3,10 @@
 // OFFSET: LEGO1 0x100cae80
 MxDSParallelAction::MxDSParallelAction()
 {
-
+  this->SetType(MxDSType_ParallelAction);
 }
 
 // OFFSET: LEGO1 0x100cb040
 MxDSParallelAction::~MxDSParallelAction()
 {
-
 }

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -3,11 +3,12 @@
 // OFFSET: LEGO1 0x100cb2b0
 MxDSSelectAction::MxDSSelectAction()
 {
-  
+  // TODO
+  this->SetType(MxDSType_SelectAction);
 }
 
-// OFFSET: LEGO1 0x100cb8d0
+// OFFSET: LEGO1 0x100cb8d0 STUB
 MxDSSelectAction::~MxDSSelectAction()
 {
-  
+  // TODO
 }

--- a/LEGO1/mxdsserialaction.cpp
+++ b/LEGO1/mxdsserialaction.cpp
@@ -3,11 +3,12 @@
 // OFFSET: LEGO1 0x100ca9d0
 MxDSSerialAction::MxDSSerialAction()
 {
-  
+  // TODO
+  this->SetType(MxDSType_SerialAction);
 }
 
-// OFFSET: LEGO1 0x100cac10
+// OFFSET: LEGO1 0x100cac10 STUB
 MxDSSerialAction::~MxDSSerialAction()
 {
-  
+  // TODO
 }

--- a/LEGO1/mxdssound.cpp
+++ b/LEGO1/mxdssound.cpp
@@ -4,10 +4,10 @@
 MxDSSound::MxDSSound()
 {
   // TODO
+  this->SetType(MxDSType_Sound);
 }
 
 // OFFSET: LEGO1 0x100c9470
 MxDSSound::~MxDSSound()
 {
-  // TODO
 }

--- a/LEGO1/mxdsstill.cpp
+++ b/LEGO1/mxdsstill.cpp
@@ -3,11 +3,10 @@
 // OFFSET: LEGO1 0x100c98c0
 MxDSStill::MxDSStill()
 {
-  // TODO
+  this->SetType(MxDSType_Still);
 }
 
 // OFFSET: LEGO1 0x100c9a70
 MxDSStill::~MxDSStill()
 {
-  // TODO
 }

--- a/LEGO1/mxdstypes.h
+++ b/LEGO1/mxdstypes.h
@@ -1,0 +1,20 @@
+#ifndef MXDSTYPES_H
+#define MXDSTYPES_H
+
+enum MxDSType
+{
+  MxDSType_Object = 0,
+  MxDSType_Action = 1,
+  MxDSType_MediaAction = 2,
+  MxDSType_Anim = 3,
+  MxDSType_Sound = 4,
+  MxDSType_MultiAction = 5,
+  MxDSType_SerialAction = 6,
+  MxDSType_ParallelAction = 7,
+  MxDSType_Event = 8,
+  MxDSType_SelectAction = 9,
+  MxDSType_Still = 10,
+  MxDSType_ObjectAction = 11,
+};
+
+#endif // MXDSTYPES_H


### PR DESCRIPTION
`m_unk0c` is a type ID in `MxDSObject`, and it's set in every `MxDS*` ctor that belongs to the `MxDSObject` family. It was renamed to `m_type`. In some classes, this is all the ctor does so they match completely now.

The regressions in some of the ctors are meaningless since the bulk of the code in them is still missing. Setting the type like this is correct though. 

The regressions (operand swaps) in two `MxDSObject` functions appeared after adding `DECOMP_SIZE_ASSERT`, so they should be disregarded.

I've marked the dtors as `STUB`'s that were completely empty (but shouldn't be) so they don't appear in the report anymore. The dtors that indeed don't "do" anything (other than the implicit stuff) had their `// TODO` and `STUB` removed if it was present and match 100% now.

Also refactored the members of `MxDSObject` and their types to reflect our current state of knowledge about them. `m_unk26` didn't exist, it's just implicit padding.