### PR TITLE
reccmp.py Disambiguate <OFFSET> + Better 100% match mechanics

### DIFF
--- a/tools/reccmp/template.html
+++ b/tools/reccmp/template.html
@@ -221,7 +221,9 @@
 
           addrCel.innerHTML = addrCel.dataset.value = element.address;
           nameCel.innerHTML = nameCel.dataset.value = element.name;
-          matchCel.innerHTML = (element.matching * 100).toFixed(2) + '%';
+
+          var effectiveNote = (element.matching == 1 && element.diff != '') ? '*' : '';
+          matchCel.innerHTML = (element.matching * 100).toFixed(2) + '%' + effectiveNote;
           matchCel.dataset.value = element.matching;
 
           row.classList.add('funcrow');


### PR DESCRIPTION
* Rather than using \<OFFSET\> as a replacement for all offsets in a function, label the unique offsets as \<OFFSET1\>, \<OFFSET2\>, etc. Doing this will avoid false-positive 100% matches resulting from the same function being called two times where a different on should have been called or vice versa. And the same for globals. I already encountered one case of this in the wild.

* When a 100% match initially fails, try to make the functions match by swapping register allocations. This makes it possible to get a 100% match where the generated machine code differs only in register allocation.

* Only apply the above when it is possible to reach a 100% match in that way. Otherwise show the developer the unadulterated diff to avoid causing problems. (This register swapping approach is only robust in the case where it results in a 100% match because it doesn't know which registers do what. It relies on the 100% match to confirm the that the way it replaced the registers is valid calling convention wise)

* In the result listing, show the functions which are "effective matches" in this way as "100%*" instead of "100%".