### PR TITLE
lego1: match MxVideoManager::RealizePalette

### DIFF
--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -1,5 +1,5 @@
-#ifndef MXUNKNOWN100DC768_H
-#define MXUNKNOWN100DC768_H
+#ifndef MXDISPLAYSURFACE_H
+#define MXDISPLAYSURFACE_H
 
 #include "mxcore.h"
 #include "mxpalette.h"
@@ -7,11 +7,11 @@
 #include "decomp.h"
 
 // VTABLE 0x100dc768
-class MxUnknown100dc768 : public MxCore
+class MxDisplaySurface : public MxCore
 {
 public:
-  MxUnknown100dc768();
-  virtual ~MxUnknown100dc768() override;
+  MxDisplaySurface();
+  virtual ~MxDisplaySurface() override;
 
   virtual undefined4 vtable14(undefined4, undefined4, undefined4, undefined4);
   virtual undefined4 vtable18(undefined4);
@@ -28,4 +28,4 @@ public:
   virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);
 };
 
-#endif // MXUNKNOWN100DC768_H
+#endif // MXDISPLAYSURFACE_H

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -1,8 +1,11 @@
 #ifndef MXDISPLAYSURFACE_H
 #define MXDISPLAYSURFACE_H
 
+#include <ddraw.h>
+
 #include "mxcore.h"
 #include "mxpalette.h"
+#include "mxvideoparam.h"
 
 #include "decomp.h"
 
@@ -13,16 +16,16 @@ public:
   MxDisplaySurface();
   virtual ~MxDisplaySurface() override;
 
-  virtual undefined4 vtable14(undefined4, undefined4, undefined4, undefined4);
-  virtual undefined4 vtable18(undefined4);
-  virtual MxResult Reset();
-  virtual void vtable20(MxPalette *p_palette);
+  virtual MxResult Init(MxVideoParam *p_videoParam, LPDIRECTDRAWSURFACE p_surface1, LPDIRECTDRAWSURFACE p_surface2, LPDIRECTDRAWCLIPPER p_clipper);
+  virtual MxResult Create(MxVideoParam *p_videoParam);
+  virtual void Clear();
+  virtual void SetPalette(MxPalette *p_palette);
   virtual void vtable24(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual MxBool vtable2c(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual void vtable38(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual undefined4 vtable3c(undefined4*);
   virtual undefined4 vtable40(undefined4);
   virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);

--- a/LEGO1/mxunknown100dc768.h
+++ b/LEGO1/mxunknown100dc768.h
@@ -1,0 +1,31 @@
+#ifndef MXUNKNOWN100DC768_H
+#define MXUNKNOWN100DC768_H
+
+#include "mxcore.h"
+#include "mxpalette.h"
+
+#include "decomp.h"
+
+// VTABLE 0x100dc768
+class MxUnknown100dc768 : public MxCore
+{
+public:
+  MxUnknown100dc768();
+  virtual ~MxUnknown100dc768() override;
+
+  virtual undefined4 vtable14(undefined4, undefined4, undefined4, undefined4);
+  virtual undefined4 vtable18(undefined4);
+  virtual MxResult Reset();
+  virtual void vtable20(MxPalette *p_palette);
+  virtual void vtable24(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual MxBool vtable2c(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
+  virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
+  virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual void vtable38(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual undefined4 vtable3c(undefined4*);
+  virtual undefined4 vtable40(undefined4);
+  virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);
+};
+
+#endif // MXUNKNOWN100DC768_H

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -25,7 +25,7 @@ int MxVideoManager::Init()
 {
   this->m_pDirectDraw = NULL;
   this->m_unk54 = NULL;
-  this->m_unk58 = NULL;
+  this->m_100dc768 = NULL;
   this->m_unk5c = 0;
   this->m_videoParam.SetPalette(NULL);
   this->m_unk60 = FALSE;
@@ -45,10 +45,10 @@ MxLong MxVideoManager::RealizePalette(MxPalette *p_palette)
 
   this->m_criticalSection.Enter();
 
-  if (p_palette && this->m_videoParam.GetPalette())
-  {
+  if (p_palette && this->m_videoParam.GetPalette()) {
     p_palette->GetEntries(paletteEntries);
-    // TODO
+    this->m_videoParam.GetPalette()->SetEntries(paletteEntries);
+    this->m_100dc768->vtable20(this->m_videoParam.GetPalette());
   }
 
   this->m_criticalSection.Leave();

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -48,7 +48,7 @@ MxLong MxVideoManager::RealizePalette(MxPalette *p_palette)
   if (p_palette && this->m_videoParam.GetPalette()) {
     p_palette->GetEntries(paletteEntries);
     this->m_videoParam.GetPalette()->SetEntries(paletteEntries);
-    this->m_displaySurface->vtable20(this->m_videoParam.GetPalette());
+    this->m_displaySurface->SetPalette(this->m_videoParam.GetPalette());
   }
 
   this->m_criticalSection.Leave();

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -25,7 +25,7 @@ int MxVideoManager::Init()
 {
   this->m_pDirectDraw = NULL;
   this->m_unk54 = NULL;
-  this->m_100dc768 = NULL;
+  this->m_displaySurface = NULL;
   this->m_unk5c = 0;
   this->m_videoParam.SetPalette(NULL);
   this->m_unk60 = FALSE;
@@ -48,7 +48,7 @@ MxLong MxVideoManager::RealizePalette(MxPalette *p_palette)
   if (p_palette && this->m_videoParam.GetPalette()) {
     p_palette->GetEntries(paletteEntries);
     this->m_videoParam.GetPalette()->SetEntries(paletteEntries);
-    this->m_100dc768->vtable20(this->m_videoParam.GetPalette());
+    this->m_displaySurface->vtable20(this->m_videoParam.GetPalette());
   }
 
   this->m_criticalSection.Leave();

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -2,6 +2,7 @@
 #define MXVIDEOMANAGER_H
 
 #include "mxunknown100dc6b0.h"
+#include "mxunknown100dc768.h"
 #include "mxvideoparam.h"
 
 // VTABLE 0x100dc810
@@ -26,7 +27,7 @@ private:
   MxVideoParam m_videoParam;
   LPDIRECTDRAW m_pDirectDraw;
   LPDIRECTDRAWSURFACE m_unk54;
-  void* m_unk58;
+  MxUnknown100dc768 *m_100dc768;
   int m_unk5c;
   MxBool m_unk60;
 };

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -2,7 +2,7 @@
 #define MXVIDEOMANAGER_H
 
 #include "mxunknown100dc6b0.h"
-#include "mxunknown100dc768.h"
+#include "mxdisplaysurface.h"
 #include "mxvideoparam.h"
 
 // VTABLE 0x100dc810
@@ -27,7 +27,7 @@ private:
   MxVideoParam m_videoParam;
   LPDIRECTDRAW m_pDirectDraw;
   LPDIRECTDRAWSURFACE m_unk54;
-  MxUnknown100dc768 *m_100dc768;
+  MxDisplaySurface *m_displaySurface;
   int m_unk5c;
   MxBool m_unk60;
 };


### PR DESCRIPTION
Completes/matches the implementation of `MxVideoManager::RealizePalette` and adds the `MxDisplaySurface` class and its virtual functions to do so.