### PR TITLE
[wip] lego1: MxAtomId and its tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(lego1 SHARED
   LEGO1/mxaudiopresenter.cpp
   LEGO1/mxautolocker.cpp
   LEGO1/mxbackgroundaudiomanager.cpp
+  LEGO1/mxbinarytree.cpp
   LEGO1/mxbitmap.cpp
   LEGO1/mxcompositemediapresenter.cpp
   LEGO1/mxcompositepresenter.cpp

--- a/LEGO1/mxatomid.cpp
+++ b/LEGO1/mxatomid.cpp
@@ -1,9 +1,18 @@
 #include "mxatomid.h"
+#include "mxomni.h"
 
 // OFFSET: LEGO1 0x100acf90
-MxAtomId::MxAtomId(const char *, LookupMode)
+MxAtomId::MxAtomId(const char *p_str, LookupMode p_mode)
 {
-  // TODO
+  if (!MxOmni::GetInstance())
+    return;
+
+  if (!AtomIdTree())
+    return;
+
+  TreeValue *value = try_to_open(p_str, p_mode);
+  m_internal = value->m_str.GetData();
+  value->RefCountInc();
 }
 
 // OFFSET: LEGO1 0x100acfd0
@@ -17,4 +26,47 @@ MxAtomId &MxAtomId::operator=(const MxAtomId &id)
 {
   // TODO
   return *this;
+}
+
+// OFFSET: LEGO1 0x100ad210
+TreeValue *MxAtomId::try_to_open(const char *p_str, LookupMode p_mode)
+{
+  TreeValue *value = new TreeValue(p_str);
+  TreeNode *node;
+
+  switch (p_mode) {
+    case LookupMode_LowerCase:
+    case LookupMode_LowerCase2:
+      value->m_str.ToLowerCase();
+      break;
+    case LookupMode_UpperCase:
+      value->m_str.ToUpperCase();
+      break;
+  }
+
+  MxBinaryTree *tree = AtomIdTree();
+  // get the closest node that matches the given value
+  node = tree->Search(value);
+  
+  // pointer reuse???
+  TreeNode *ptr_reuse = node;
+
+  // is the node an exact match?
+  if (tree->m_root == node || 
+      strcmp(value->m_str.GetData(), node->m_value->m_str.GetData()) > 0) {
+    ptr_reuse = tree->m_root;
+  }
+
+  ptr_reuse = ptr_reuse->m_child0;
+  if (ptr_reuse == AtomIdTree()->m_root) {
+    delete value;
+    value = ptr_reuse->m_value;
+  } else {
+
+  }
+
+  // LAB_100ad42b
+
+
+  return value;
 }

--- a/LEGO1/mxatomid.cpp
+++ b/LEGO1/mxatomid.cpp
@@ -37,16 +37,8 @@ void MxAtomId::Destroy()
   TreeValue *p = &value;
 
   // 100ad052
-  MxBinaryTree *tree = AtomIdTree();
-  TreeNode *root = tree->m_root;
-
   // should inline Search but NOT TreeValueCompare
-  TreeNode *node = tree->Search(p);
-  
-  TreeNode *ass = node;
-  if (node == root->m_parent || TreeValueCompare(p, node->m_value)) {
-    ass = root->m_parent;
-  }
+  TreeNode *node = AtomIdTree()->Find(p);
 
   node->m_value->RefCountDec();
 }
@@ -71,7 +63,6 @@ MxAtomId &MxAtomId::operator=(const MxAtomId &atomId)
 TreeValue *MxAtomId::try_to_open(const char *p_str, LookupMode p_mode)
 {
   TreeValue *value = new TreeValue(p_str);
-  TreeNode *node;
 
   switch (p_mode) {
     case LookupMode_LowerCase:
@@ -84,22 +75,13 @@ TreeValue *MxAtomId::try_to_open(const char *p_str, LookupMode p_mode)
   }
 
   // LAB_100ad2a1
-  MxBinaryTree *tree = AtomIdTree();
-  // get the closest node that matches the given value
-  // should NOT inline
-  node = tree->Search(value);
+  TreeNode *node = AtomIdTree()->Find(value);
   
-  TreeNode *t;
-
-  // is the node an exact match?
-  if (tree->m_root == node || TreeValueCompare(value, node->m_value)) {
-    t = tree->m_root;
-  } else {
-    t = node;
-  }
-
-  if (t->m_child0 != AtomIdTree()->m_root) {
-    delete value;
+  MxBinaryTree *tree = AtomIdTree();
+  if (node->m_child0 != tree->m_root) {
+    // unnecessary check?
+    if (value)
+      delete value;
     value = node->m_value;
   } else {
     // repeat?

--- a/LEGO1/mxatomid.h
+++ b/LEGO1/mxatomid.h
@@ -1,6 +1,8 @@
 #ifndef MXATOMID_H
 #define MXATOMID_H
 
+#include "mxbinarytree.h"
+#include "mxstring.h"
 #include "mxtypes.h"
 
 enum LookupMode
@@ -11,6 +13,7 @@ enum LookupMode
   LookupMode_LowerCase2 = 3
 };
 
+// SIZE 0x4
 class MxAtomId
 {
 public:
@@ -28,8 +31,11 @@ public:
     return this->m_internal == other.m_internal;
   }
 
+  // TODO: belongs here?
+  TreeValue *try_to_open(const char *, LookupMode);
+  
 private:
-  char *m_internal;
+  const char *m_internal;
 };
 
 #endif // MXATOMID_H

--- a/LEGO1/mxatomid.h
+++ b/LEGO1/mxatomid.h
@@ -33,6 +33,8 @@ public:
 
   // TODO: belongs here?
   TreeValue *try_to_open(const char *, LookupMode);
+  void Destroy();
+  void Clear();
   
 private:
   const char *m_internal;

--- a/LEGO1/mxbinarytree.cpp
+++ b/LEGO1/mxbinarytree.cpp
@@ -65,12 +65,12 @@ inline void MxBinaryTree::LeftRotate(TreeNode *x)
   }
 }
 
-inline TreeNode *minimum(TreeNode *p_node)
+inline TreeNode *MxBinaryTree::minimum(TreeNode *p_node)
 {
   // horrible. but it has to be this way to
   // force a non-branching JMP to repeat the loop.
   while (1) {
-    if (p_node->m_child1 == MxBinaryTree::g_Node_Nil)
+    if (p_node->m_child1 == g_Node_Nil)
       break;
     p_node = p_node->m_child1;
   }
@@ -80,7 +80,7 @@ inline TreeNode *minimum(TreeNode *p_node)
 
 
 // OFFSET: LEGO1 0x100ad480
-void Successor(TreeNode* &p_node)
+void MxBinaryTree::Successor(TreeNode* &p_node)
 {
   // I think this is checking whether this is the tree "root" node
   // i.e. MxBinaryTree->m_root
@@ -88,13 +88,13 @@ void Successor(TreeNode* &p_node)
   // If it is the "root" node, return the minimum value of the tree.
   // We have a reference to it at m_root->m_child1.
 
-  if (p_node->m_color == NODE_COLOR_RED
+  if (p_node->m_color == RBNodeColor_Red
       && p_node->m_parent->m_parent == p_node) {
     p_node = p_node->m_child1;
     return;
   }
 
-  if (p_node->m_child0 != MxBinaryTree::g_Node_Nil) {
+  if (p_node->m_child0 != g_Node_Nil) {
     p_node = minimum(p_node->m_child0);
     return;
   }
@@ -111,7 +111,7 @@ void Successor(TreeNode* &p_node)
 // OFFSET: LEGO1 0x100ad4d0
 void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_parent, TreeValue *&p_value)
 {
-  TreeNode *node = newTreeNode(p_parent, NODE_COLOR_RED);
+  TreeNode *node = newTreeNode(p_parent, RBNodeColor_Red);
   node->m_child0 = g_Node_Nil;
   node->m_child1 = g_Node_Nil;
   
@@ -125,7 +125,7 @@ void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_par
   // if param_2 is tree_nil (always true I think?)
   //
   if (m_root != p_parent
-      && p_leaf == MxBinaryTree::g_Node_Nil
+      && p_leaf == g_Node_Nil
       && TreeValueCompare(p_value, p_parent->m_value)) {
     p_parent->m_child1 = node;
     
@@ -152,7 +152,7 @@ void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_par
   while (m_root->m_parent != cur) {
     TreeNode *parent = cur->m_parent;
 
-    if (parent->m_color != NODE_COLOR_RED)
+    if (parent->m_color != RBNodeColor_Red)
       break;
 
     TreeNode *uncle = parent->m_parent->m_child0;
@@ -160,7 +160,7 @@ void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_par
       // wrong uncle
       uncle = parent->m_parent->m_child1;
 
-      if (uncle->m_color != NODE_COLOR_RED) {
+      if (uncle->m_color != RBNodeColor_Red) {
         
         // 100ad5d3
         if (parent->m_child1 == cur) {
@@ -169,36 +169,36 @@ void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_par
         }
 
         // LAB_100ad60f
-        cur->m_parent->m_color = NODE_COLOR_BLACK;
-        cur->m_parent->m_parent->m_color = NODE_COLOR_RED;
+        cur->m_parent->m_color = RBNodeColor_Black;
+        cur->m_parent->m_parent->m_color = RBNodeColor_Red;
         LeftRotate(cur->m_parent->m_parent);
         continue;
       }
     } else {
       // LAB_100ad67f
-      if (uncle->m_color != NODE_COLOR_RED) {
+      if (uncle->m_color != RBNodeColor_Red) {
         if (parent->m_child0 == cur) {
           cur = parent;
           LeftRotate(cur);
         }
 
         // LAB_100ad60f
-        cur->m_parent->m_color = NODE_COLOR_BLACK;
-        cur->m_parent->m_parent->m_color = NODE_COLOR_RED;
+        cur->m_parent->m_color = RBNodeColor_Black;
+        cur->m_parent->m_parent->m_color = RBNodeColor_Red;
         RightRotate(cur->m_parent->m_parent);
         continue;
       }
     }
 
     // LAB_100ad72c
-    parent->m_color = NODE_COLOR_BLACK;
-    uncle->m_color = NODE_COLOR_BLACK;
-    parent->m_parent->m_color = NODE_COLOR_RED;
+    parent->m_color = RBNodeColor_Black;
+    uncle->m_color = RBNodeColor_Black;
+    parent->m_parent->m_color = RBNodeColor_Red;
 
     cur = parent->m_parent;
   }
 
-  m_root->m_parent->m_color = NODE_COLOR_BLACK;
+  m_root->m_parent->m_color = RBNodeColor_Black;
   *p_output = node;
 }
 
@@ -241,10 +241,10 @@ MxBinaryTree::~MxBinaryTree()
 }
 
 // OFFSET: LEGO1 0x100af7a0
-void somethingWithNode(TreeNode*& p_node)
+void MxBinaryTree::Predecessor(TreeNode*& p_node)
 {
   // TODO
-  if (p_node->m_child1 != MxBinaryTree::g_Node_Nil) {
+  if (p_node->m_child1 != g_Node_Nil) {
     p_node = minimum(p_node->m_child1);
     return;
   }

--- a/LEGO1/mxbinarytree.cpp
+++ b/LEGO1/mxbinarytree.cpp
@@ -1,0 +1,240 @@
+#include "mxbinarytree.h"
+
+// 0x101013f0
+TreeNode *MxBinaryTree::g_Node_Nil = NULL;
+
+inline void MxBinaryTree::LeftRotate(TreeNode *x)
+{
+  TreeNode *y = x->m_child1;
+  x->m_child1 = y->m_child0;
+  
+  if (y->m_child0 != g_Node_Nil)
+    y->m_child0->m_parent = x;
+
+  y->m_parent = x->m_parent;
+
+  if (m_root->m_parent != x) {
+    if (x == x->m_parent->m_child0) {
+      x->m_parent->m_child0 = y;
+      y->m_child0 = x; //?
+      x->m_parent = y; //?
+    } else {
+      x->m_parent->m_child1 = y;
+      y->m_child1 = x; //?
+      x->m_parent = y; //?
+    }
+  } else {
+    // ?
+    y->m_child0 = x;
+    x->m_parent = y;
+  }
+}
+
+
+inline void MxBinaryTree::RightRotate(TreeNode *x)
+{
+  TreeNode *y = x->m_child0;
+  x->m_child0 = y->m_child1;
+  
+  if (y->m_child1 != g_Node_Nil)
+    y->m_child1->m_parent = x;
+
+  y->m_parent = x->m_parent;
+
+  if (m_root->m_parent != x) {
+    if (x == x->m_parent->m_child1) {
+      x->m_parent->m_child1 = y;
+      y->m_child1 = x; //?
+      x->m_parent = y; //?
+    } else {
+      x->m_parent->m_child0 = y;
+      y->m_child0 = x; //?
+      x->m_parent = y; //?
+    }
+  } else {
+    //?
+    y->m_child1 = x;
+    x->m_parent = y;
+  }
+}
+
+// OFFSET: LEGO1 0x100ad480
+void mini_walk(TreeNode* &p_node)
+{
+  if (p_node->m_color == NODE_COLOR_RED
+      && p_node->m_parent->m_parent == p_node) {
+    p_node = p_node->m_child1;
+    return;
+  }
+
+  TreeNode *t = p_node->m_child0;
+  if (t != MxBinaryTree::g_Node_Nil) {
+    
+    // wonky
+    while (1) {
+      if (t->m_child1 == MxBinaryTree::g_Node_Nil)
+        break;
+      t = t->m_child1;
+    }
+    
+    p_node = t;
+    return;
+  }
+
+  TreeNode *u = p_node->m_parent;
+  TreeNode *v = p_node;
+  while (u != v) {
+    p_node = u;
+    v = u;
+    u = u->m_parent;
+  }
+
+  p_node = u;
+}
+
+// OFFSET: LEGO1 0x100ad4d0
+void MxBinaryTree::FUN_100ad4d0(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_parent, TreeValue *&p_value)
+{
+  TreeNode *node = new TreeNode(p_parent, NODE_COLOR_RED);
+  node->m_child0 = g_Node_Nil;
+  node->m_child1 = g_Node_Nil;
+  
+  // TODO: ???
+  if (node->m_value) {
+    node->m_value = p_value;
+  }
+
+  this->m_p3++; // node count?
+
+  // if tree is NOT empty
+  // if param_2 is tree_nil (always true I think?)
+  //
+  if (this->m_root != p_parent
+      && p_leaf == MxBinaryTree::g_Node_Nil
+      && strcmp(p_value->m_str.GetData(),
+                p_parent->m_value->m_str.GetData()) <= 0) {
+    p_parent->m_child1 = node;
+    
+    if (m_root->m_child1 == p_parent)
+      m_root->m_child1 = node;
+  } else {
+    p_parent->m_child0 = node;
+
+    if (m_root != p_parent && m_root->m_child0 == p_parent) {
+      m_root->m_child0 = p_parent;
+    } else {
+      m_root->m_parent = node;
+      m_root->m_child1 = node;
+    }
+  }
+
+  // LAB_100ad593
+  // rebalance??
+  TreeNode *cur = node;
+  while (m_root->m_parent != cur) {
+    TreeNode *parent = cur->m_parent;
+
+    if (parent->m_color != NODE_COLOR_RED)
+      break;
+
+    TreeNode *grandparent = parent->m_parent;
+    TreeNode *uncle = grandparent->m_child0;
+
+    if (uncle == parent) {
+      // wrong uncle
+      uncle = grandparent->m_child1;
+
+      if (uncle->m_color != NODE_COLOR_RED) {
+        
+        // 100ad5d3
+        if (parent->m_child1 == cur) {
+          cur = parent;
+          LeftRotate(cur);
+          // rotate.
+          /*
+          parent->m_child1 = parent->m_child1->m_child0;
+          
+          // 100ad5e2
+          if (parent->m_child1 != g_Node_Nil)
+            parent->m_child1->m_parent = cur;
+
+          parent->m_child1->m_parent = grandparent;
+          if (m_root->m_parent == cur || grandparent->m_child0 == cur)
+            grandparent->m_child1 = parent;
+          else
+            grandparent->m_child0 = parent;
+
+          parent->m_child0 = cur;
+          grandparent->m_child0 = parent;
+          */
+        }
+
+        // LAB_100ad60f
+        cur->m_parent->m_color = NODE_COLOR_BLACK;
+        cur->m_parent->m_parent->m_color = NODE_COLOR_RED;
+        RightRotate(cur->m_parent->m_parent);
+        continue;
+      }
+    } else {
+      // LAB_100ad67f
+      if (uncle->m_color != NODE_COLOR_RED) {
+        if (parent->m_child0 == cur) {
+          cur = parent;
+          RightRotate(cur);
+        }
+
+        // LAB_100ad60f
+        cur->m_parent->m_color = NODE_COLOR_BLACK;
+        cur->m_parent->m_parent->m_color = NODE_COLOR_RED;
+        LeftRotate(cur->m_parent->m_parent);
+        continue;
+      }
+    }
+
+    // LAB_100ad72c
+    parent->m_color = NODE_COLOR_BLACK;
+    uncle->m_color = NODE_COLOR_BLACK;
+    parent->m_parent->m_color = NODE_COLOR_RED;
+
+    cur = parent->m_parent;
+  }
+
+  m_root->m_parent->m_color = NODE_COLOR_BLACK;
+  *p_output = node;
+}
+
+// OFFSET: LEGO1 0x100ad780
+TreeNode *MxBinaryTree::Search(TreeValue*& p_value)
+{
+  TreeNode *node_match = m_root;
+  TreeNode *t_node = node_match->m_parent;
+  
+  while (t_node != g_Node_Nil) {
+    int result = strcmp(t_node->m_value->m_str.GetData(), p_value->m_str.GetData());
+
+    if (result <= 0) {
+      // if strings equal or less than search string
+      // closest match?
+      // it either does match or is where we will insert the new node.
+      node_match = t_node;
+      t_node = t_node->m_child0;
+    } else {
+      t_node = t_node->m_child1;
+    }
+  }
+
+  return node_match;
+}
+
+// OFFSET: LEGO1 0x100ad7f0
+void TreeValue::RefCountInc()
+{
+  m_t0++;
+}
+
+// OFFSET: LEGO1 0x100ad800
+void TreeValue::RefCountDec()
+{
+  if (m_t0)
+    m_t0--;
+}

--- a/LEGO1/mxbinarytree.cpp
+++ b/LEGO1/mxbinarytree.cpp
@@ -3,11 +3,13 @@
 // 0x101013f0
 TreeNode *MxBinaryTree::g_Node_Nil = NULL;
 
+/*
 // OFFSET: LEGO1 0x100ad170
 TreeValue::~TreeValue()
 {
   // nothing.
 }
+*/
 
 inline void MxBinaryTree::RightRotate(TreeNode *x)
 {
@@ -76,8 +78,9 @@ inline TreeNode *minimum(TreeNode *p_node)
   return p_node;
 }
 
+
 // OFFSET: LEGO1 0x100ad480
-void mini_walk(TreeNode* &p_node)
+void Successor(TreeNode* &p_node)
 {
   // I think this is checking whether this is the tree "root" node
   // i.e. MxBinaryTree->m_root
@@ -91,7 +94,6 @@ void mini_walk(TreeNode* &p_node)
     return;
   }
 
-  // successor?
   if (p_node->m_child0 != MxBinaryTree::g_Node_Nil) {
     p_node = minimum(p_node->m_child0);
     return;
@@ -103,8 +105,8 @@ void mini_walk(TreeNode* &p_node)
     p_node = y;
     y = y->m_parent;
   }
-
 }
+
 
 // OFFSET: LEGO1 0x100ad4d0
 void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_parent, TreeValue *&p_value)
@@ -231,4 +233,25 @@ void TreeValue::RefCountDec()
 {
   if (m_t0)
     m_t0--;
+}
+
+// OFFSET: LEGO1 0x100af6d0 STUB
+MxBinaryTree::~MxBinaryTree()
+{
+}
+
+// OFFSET: LEGO1 0x100af7a0
+void somethingWithNode(TreeNode*& p_node)
+{
+  // TODO
+  if (p_node->m_child1 != MxBinaryTree::g_Node_Nil) {
+    p_node = minimum(p_node->m_child1);
+    return;
+  }
+
+  while (p_node->m_parent->m_child0 == p_node)
+      p_node = p_node->m_parent;
+
+  if (p_node->m_child1 == p_node->m_parent)
+    p_node = p_node->m_parent;
 }

--- a/LEGO1/mxbinarytree.cpp
+++ b/LEGO1/mxbinarytree.cpp
@@ -3,6 +3,12 @@
 // 0x101013f0
 TreeNode *MxBinaryTree::g_Node_Nil = NULL;
 
+// OFFSET: LEGO1 0x100ad170
+TreeValue::~TreeValue()
+{
+  // nothing.
+}
+
 inline void MxBinaryTree::LeftRotate(TreeNode *x)
 {
   TreeNode *y = x->m_child1;
@@ -14,22 +20,21 @@ inline void MxBinaryTree::LeftRotate(TreeNode *x)
   y->m_parent = x->m_parent;
 
   if (m_root->m_parent != x) {
-    if (x == x->m_parent->m_child0) {
-      x->m_parent->m_child0 = y;
-      y->m_child0 = x; //?
-      x->m_parent = y; //?
-    } else {
+    if (x != x->m_parent->m_child0) {
       x->m_parent->m_child1 = y;
-      y->m_child1 = x; //?
-      x->m_parent = y; //?
+      y->m_child0 = x;
+      x->m_parent = y;
+    } else {
+      x->m_parent->m_child0 = y;
+      y->m_child0 = x;
+      x->m_parent = y;
     }
   } else {
-    // ?
+    m_root->m_parent->m_child0 = y;
     y->m_child0 = x;
     x->m_parent = y;
   }
 }
-
 
 inline void MxBinaryTree::RightRotate(TreeNode *x)
 {
@@ -42,17 +47,17 @@ inline void MxBinaryTree::RightRotate(TreeNode *x)
   y->m_parent = x->m_parent;
 
   if (m_root->m_parent != x) {
-    if (x == x->m_parent->m_child1) {
-      x->m_parent->m_child1 = y;
-      y->m_child1 = x; //?
-      x->m_parent = y; //?
-    } else {
+    if (x != x->m_parent->m_child1) {
       x->m_parent->m_child0 = y;
-      y->m_child0 = x; //?
-      x->m_parent = y; //?
+      y->m_child1 = x;
+      x->m_parent = y;
+    } else {
+      x->m_parent->m_child1 = y;
+      y->m_child1 = x;
+      x->m_parent = y;
     }
   } else {
-    //?
+    m_root->m_parent->m_child1 = y;
     y->m_child1 = x;
     x->m_parent = y;
   }
@@ -93,26 +98,24 @@ void mini_walk(TreeNode* &p_node)
 }
 
 // OFFSET: LEGO1 0x100ad4d0
-void MxBinaryTree::FUN_100ad4d0(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_parent, TreeValue *&p_value)
+void MxBinaryTree::Insert(TreeNode **p_output, TreeNode *p_leaf, TreeNode *p_parent, TreeValue *&p_value)
 {
-  TreeNode *node = new TreeNode(p_parent, NODE_COLOR_RED);
+  TreeNode *node = newTreeNode(p_parent, NODE_COLOR_RED);
   node->m_child0 = g_Node_Nil;
   node->m_child1 = g_Node_Nil;
   
   // TODO: ???
-  if (node->m_value) {
+  if (&node->m_value)
     node->m_value = p_value;
-  }
 
-  this->m_p3++; // node count?
+  this->m_nodeCount++;
 
   // if tree is NOT empty
   // if param_2 is tree_nil (always true I think?)
   //
-  if (this->m_root != p_parent
+  if (m_root != p_parent
       && p_leaf == MxBinaryTree::g_Node_Nil
-      && strcmp(p_value->m_str.GetData(),
-                p_parent->m_value->m_str.GetData()) <= 0) {
+      && TreeValueCompare(p_value, p_parent->m_value)) {
     p_parent->m_child1 = node;
     
     if (m_root->m_child1 == p_parent)
@@ -120,8 +123,9 @@ void MxBinaryTree::FUN_100ad4d0(TreeNode **p_output, TreeNode *p_leaf, TreeNode 
   } else {
     p_parent->m_child0 = node;
 
-    if (m_root != p_parent && m_root->m_child0 == p_parent) {
-      m_root->m_child0 = p_parent;
+    if (m_root != p_parent) {
+      if (m_root->m_child0 == p_parent)
+        m_root->m_child0 = node;
     } else {
       m_root->m_parent = node;
       m_root->m_child1 = node;
@@ -129,7 +133,7 @@ void MxBinaryTree::FUN_100ad4d0(TreeNode **p_output, TreeNode *p_leaf, TreeNode 
   }
 
   // LAB_100ad593
-  // rebalance??
+  // rebalance the tree
   TreeNode *cur = node;
   while (m_root->m_parent != cur) {
     TreeNode *parent = cur->m_parent;
@@ -137,12 +141,10 @@ void MxBinaryTree::FUN_100ad4d0(TreeNode **p_output, TreeNode *p_leaf, TreeNode 
     if (parent->m_color != NODE_COLOR_RED)
       break;
 
-    TreeNode *grandparent = parent->m_parent;
-    TreeNode *uncle = grandparent->m_child0;
-
+    TreeNode *uncle = parent->m_parent->m_child0;
     if (uncle == parent) {
       // wrong uncle
-      uncle = grandparent->m_child1;
+      uncle = parent->m_parent->m_child1;
 
       if (uncle->m_color != NODE_COLOR_RED) {
         
@@ -150,23 +152,6 @@ void MxBinaryTree::FUN_100ad4d0(TreeNode **p_output, TreeNode *p_leaf, TreeNode 
         if (parent->m_child1 == cur) {
           cur = parent;
           LeftRotate(cur);
-          // rotate.
-          /*
-          parent->m_child1 = parent->m_child1->m_child0;
-          
-          // 100ad5e2
-          if (parent->m_child1 != g_Node_Nil)
-            parent->m_child1->m_parent = cur;
-
-          parent->m_child1->m_parent = grandparent;
-          if (m_root->m_parent == cur || grandparent->m_child0 == cur)
-            grandparent->m_child1 = parent;
-          else
-            grandparent->m_child0 = parent;
-
-          parent->m_child0 = cur;
-          grandparent->m_child0 = parent;
-          */
         }
 
         // LAB_100ad60f
@@ -210,10 +195,7 @@ TreeNode *MxBinaryTree::Search(TreeValue*& p_value)
   TreeNode *t_node = node_match->m_parent;
   
   while (t_node != g_Node_Nil) {
-    int result = strcmp(t_node->m_value->m_str.GetData(), p_value->m_str.GetData());
-
-    if (result <= 0) {
-      // if strings equal or less than search string
+    if (!TreeValueCompare(t_node->m_value, p_value)) {
       // closest match?
       // it either does match or is where we will insert the new node.
       node_match = t_node;

--- a/LEGO1/mxbinarytree.h
+++ b/LEGO1/mxbinarytree.h
@@ -47,6 +47,11 @@ inline TreeNode *newTreeNode(TreeNode *p_parent, int p_color)
 // OFFSET: LEGO1 0x100ad120
 inline int TreeValueCompare(TreeValue *&p_val0, TreeValue *&p_val1)
 {
+  // For strcmp, a result greater than 0 means that b > a.
+  // So: for this function, return TRUE if:
+  // * string values are non-equal
+  // * string values are in order: p_val0 < p_val1
+
   return strcmp(p_val0->m_str.GetData(), p_val1->m_str.GetData()) > 0;
 }
 

--- a/LEGO1/mxbinarytree.h
+++ b/LEGO1/mxbinarytree.h
@@ -3,9 +3,11 @@
 
 #include "mxstring.h"
 
-// TODO: enum instead?
-#define NODE_COLOR_RED   0
-#define NODE_COLOR_BLACK 1
+enum RBNodeColor
+{
+  RBNodeColor_Red = 0,
+  RBNodeColor_Black = 1,
+};
 
 // SIZE 0x14
 class TreeValue {
@@ -31,27 +33,16 @@ public:
   TreeNode *m_parent; // +4 // parent node
   TreeNode *m_child1; // +8 // string sorts before
   TreeValue *m_value; // +c
-  int m_color; // +10 // BLACK or RED.
+  RBNodeColor m_color; // +10 // BLACK or RED.
 };
 
 // TODO: helper to avoid using a non-default constructor
-inline TreeNode *newTreeNode(TreeNode *p_parent, int p_color)
+inline TreeNode *newTreeNode(TreeNode *p_parent, RBNodeColor p_color)
 {
   TreeNode *t = new TreeNode();
   t->m_parent = p_parent;
   t->m_color = p_color;
   return t;
-}
-
-// OFFSET: LEGO1 0x100ad120
-inline int TreeValueCompare(TreeValue *&p_val0, TreeValue *&p_val1)
-{
-  // For strcmp, a result greater than 0 means that b > a.
-  // So: for this function, return TRUE if:
-  // * string values are non-equal
-  // * string values are in order: p_val0 < p_val1
-
-  return strcmp(p_val0->m_str.GetData(), p_val1->m_str.GetData()) > 0;
 }
 
 // SIZE 0x10
@@ -63,18 +54,23 @@ public:
   MxBinaryTree()
   {
     if (!g_Node_Nil) {
-      g_Node_Nil = newTreeNode(NULL, NODE_COLOR_BLACK);
+      g_Node_Nil = newTreeNode(NULL, RBNodeColor_Black);
       g_Node_Nil->m_child0 = NULL;
       g_Node_Nil->m_child1 = NULL;
     }
 
-    m_root = newTreeNode(g_Node_Nil, NODE_COLOR_RED);
+    m_root = newTreeNode(g_Node_Nil, RBNodeColor_Red);
   }
   ~MxBinaryTree();
 
   void LeftRotate(TreeNode *);
   void RightRotate(TreeNode *);
   void Insert(TreeNode **, TreeNode *, TreeNode *, TreeValue *&);
+  void Successor(TreeNode* &p_node);
+  void Predecessor(TreeNode *&p_node);
+  int TreeValueCompare(TreeValue *&p_val0, TreeValue *&p_val1);
+  TreeNode *minimum(TreeNode *p_node);
+  TreeNode *maximum(TreeNode *p_node);
   TreeNode *Search(TreeValue *&);
   TreeNode *Find(TreeValue *&);
 
@@ -83,6 +79,17 @@ public:
   int m_p2; // +8
   int m_nodeCount; // +c
 };
+
+// OFFSET: LEGO1 0x100ad120
+inline int MxBinaryTree::TreeValueCompare(TreeValue *&p_val0, TreeValue *&p_val1)
+{
+  // For strcmp, a result greater than 0 means that b > a.
+  // So: for this function, return TRUE if:
+  // * string values are non-equal
+  // * string values are in order: p_val0 < p_val1
+
+  return strcmp(p_val0->m_str.GetData(), p_val1->m_str.GetData()) > 0;
+}
 
 inline TreeNode *MxBinaryTree::Find(TreeValue *&p_value)
 {

--- a/LEGO1/mxbinarytree.h
+++ b/LEGO1/mxbinarytree.h
@@ -15,7 +15,6 @@ public:
     m_str = p_str;
     m_t0 = 0;
   }
-  ~TreeValue();
 
   void RefCountInc();
   void RefCountDec();
@@ -71,16 +70,30 @@ public:
 
     m_root = newTreeNode(g_Node_Nil, NODE_COLOR_RED);
   }
+  ~MxBinaryTree();
 
   void LeftRotate(TreeNode *);
   void RightRotate(TreeNode *);
   void Insert(TreeNode **, TreeNode *, TreeNode *, TreeValue *&);
   TreeNode *Search(TreeValue *&);
+  TreeNode *Find(TreeValue *&);
 
   int m_p0; // +0
   TreeNode *m_root; // +4
   int m_p2; // +8
   int m_nodeCount; // +c
 };
+
+inline TreeNode *MxBinaryTree::Find(TreeValue *&p_value)
+{
+  TreeNode *node = Search(p_value);
+  
+  // we should only get the root back if the tree is empty.
+  if (m_root == node || TreeValueCompare(p_value, node->m_value)) {
+    node = m_root; // ??
+  }
+
+  return node->m_child0;
+}
 
 #endif //MXBINARYTREE_H

--- a/LEGO1/mxbinarytree.h
+++ b/LEGO1/mxbinarytree.h
@@ -1,0 +1,71 @@
+#ifndef MXBINARYTREE_H
+#define MXBINARYTREE_H
+
+#include "mxstring.h"
+
+// TODO: enum instead?
+#define NODE_COLOR_RED   0
+#define NODE_COLOR_BLACK 1
+
+// SIZE 0x14
+class TreeValue {
+public:
+  TreeValue(const char *p_str)
+  {
+    m_str = p_str;
+    m_t0 = 0;
+  }
+
+  void RefCountInc();
+  void RefCountDec();
+
+  MxString m_str;
+  MxU16 m_t0;
+  MxU16 m_t1;
+};
+
+// SIZE 0x14
+class TreeNode {
+public:
+  TreeNode(TreeNode *p_parent, int p_color)
+  {
+    m_parent = p_parent;
+    m_color = p_color;
+  }
+
+  TreeNode *m_child0; // +0 // string sorts after
+  TreeNode *m_parent; // +4 // parent node
+  TreeNode *m_child1; // +8 // string sorts before
+  TreeValue *m_value; // +c
+  int m_color; // +10 // BLACK or RED.
+};
+
+// SIZE 0x10
+class MxBinaryTree
+{
+public:
+  // Dummy node to represent null value.
+  static TreeNode *g_Node_Nil;
+  MxBinaryTree()
+  {
+    if (!g_Node_Nil) {
+      g_Node_Nil = new TreeNode(NULL, NODE_COLOR_BLACK);
+      g_Node_Nil->m_child0 = NULL;
+      g_Node_Nil->m_child1 = NULL;
+    }
+
+    m_root = new TreeNode(g_Node_Nil, NODE_COLOR_RED);
+  }
+
+  void LeftRotate(TreeNode *);
+  void RightRotate(TreeNode *);
+  void FUN_100ad4d0(TreeNode **, TreeNode *, TreeNode *, TreeValue *&);
+  TreeNode *Search(TreeValue *&);
+
+  int m_p0; // +0
+  TreeNode *m_root; // +4
+  int m_p2; // +8
+  int m_p3; // +c
+};
+
+#endif //MXBINARYTREE_H

--- a/LEGO1/mxbinarytree.h
+++ b/LEGO1/mxbinarytree.h
@@ -15,6 +15,7 @@ public:
     m_str = p_str;
     m_t0 = 0;
   }
+  ~TreeValue();
 
   void RefCountInc();
   void RefCountDec();
@@ -27,18 +28,27 @@ public:
 // SIZE 0x14
 class TreeNode {
 public:
-  TreeNode(TreeNode *p_parent, int p_color)
-  {
-    m_parent = p_parent;
-    m_color = p_color;
-  }
-
   TreeNode *m_child0; // +0 // string sorts after
   TreeNode *m_parent; // +4 // parent node
   TreeNode *m_child1; // +8 // string sorts before
   TreeValue *m_value; // +c
   int m_color; // +10 // BLACK or RED.
 };
+
+// TODO: helper to avoid using a non-default constructor
+inline TreeNode *newTreeNode(TreeNode *p_parent, int p_color)
+{
+  TreeNode *t = new TreeNode();
+  t->m_parent = p_parent;
+  t->m_color = p_color;
+  return t;
+}
+
+// OFFSET: LEGO1 0x100ad120
+inline int TreeValueCompare(TreeValue *&p_val0, TreeValue *&p_val1)
+{
+  return strcmp(p_val0->m_str.GetData(), p_val1->m_str.GetData()) > 0;
+}
 
 // SIZE 0x10
 class MxBinaryTree
@@ -49,23 +59,23 @@ public:
   MxBinaryTree()
   {
     if (!g_Node_Nil) {
-      g_Node_Nil = new TreeNode(NULL, NODE_COLOR_BLACK);
+      g_Node_Nil = newTreeNode(NULL, NODE_COLOR_BLACK);
       g_Node_Nil->m_child0 = NULL;
       g_Node_Nil->m_child1 = NULL;
     }
 
-    m_root = new TreeNode(g_Node_Nil, NODE_COLOR_RED);
+    m_root = newTreeNode(g_Node_Nil, NODE_COLOR_RED);
   }
 
   void LeftRotate(TreeNode *);
   void RightRotate(TreeNode *);
-  void FUN_100ad4d0(TreeNode **, TreeNode *, TreeNode *, TreeValue *&);
+  void Insert(TreeNode **, TreeNode *, TreeNode *, TreeValue *&);
   TreeNode *Search(TreeValue *&);
 
   int m_p0; // +0
   TreeNode *m_root; // +4
   int m_p2; // +8
-  int m_p3; // +c
+  int m_nodeCount; // +c
 };
 
 #endif //MXBINARYTREE_H

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -38,7 +38,7 @@ void MxOmni::Init()
   m_eventManager = NULL;
   m_timer = NULL;
   m_streamer = NULL;
-  m_unk44 = NULL;
+  m_atomIdTree = NULL;
   m_unk64 = NULL;
 }
 
@@ -104,6 +104,8 @@ void MxOmni::SetInstance(MxOmni *instance)
 // OFFSET: LEGO1 0x100af0c0
 MxResult MxOmni::Create(MxOmniCreateParam &p)
 {
+  m_atomIdTree = new MxBinaryTree();
+
   if (p.CreateFlags().CreateTimer())
   {
     MxTimer *timer = new MxTimer();
@@ -151,6 +153,12 @@ MxTickleManager *TickleManager()
 MxTimer *Timer()
 {
   return MxOmni::GetInstance()->GetTimer();
+}
+
+// OFFSET: LEGO1 0x100acee0
+MxBinaryTree *AtomIdTree()
+{
+  return MxOmni::GetInstance()->GetAtomIdTree();
 }
 
 // OFFSET: LEGO1 0x100acef0

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -14,6 +14,7 @@
 #include "mxtimer.h"
 #include "mxvariabletable.h"
 #include "mxvideomanager.h"
+#include "mxbinarytree.h"
 
 // VTABLE 0x100dc168
 // SIZE 0x68
@@ -47,6 +48,7 @@ public:
   MxVariableTable* GetVariableTable() const { return this->m_variableTable; }
   MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
   MxEventManager* GetEventManager() const { return this->m_eventManager; }
+  MxBinaryTree* GetAtomIdTree() const { return this->m_atomIdTree; }
 protected:
   static MxOmni* g_instance;
 
@@ -63,7 +65,7 @@ protected:
   MxTimer* m_timer; //0x3C
   MxStreamer* m_streamer; //0x40
 
-  int m_unk44; // 0x44
+  MxBinaryTree *m_atomIdTree; // 0x44
 
   MxCriticalSection m_criticalsection; // 0x48
 
@@ -78,5 +80,6 @@ __declspec(dllexport) MxMusicManager * MusicManager();
 __declspec(dllexport) MxEventManager * EventManager();
 __declspec(dllexport) MxNotificationManager * NotificationManager();
 MxVideoManager * MVideoManager();
+MxBinaryTree *AtomIdTree();
 
 #endif // MXOMNI_H


### PR DESCRIPTION
Been working on this for a little while; it's not finished but I could use some help. Match percentage is low in some places for reasons I'll explain.

The +0x44 member of `MxOmni` is a red-black binary tree that holds a string value and two `word`s. This is `TreeValue`. There is a connection between this and `MxAtomId`, which itself has only a single `char*` member. ~I'm not sure if there are any other BSTs used in the game, but~ I've named this one `MxBinaryTree` for now. There is a global `TreeNode` pointer at `0x101013f0` that is used to represent a null leaf node. This seems to be standard practice for RB tree implementations rather than just checking for NULL.

The members of the `TreeNode` class are defined in this order: right, parent, left. Yes... backwards. I confirmed that this is correct with a memory dump, unless the intent was to sort the tree in reverse-alphabetical order. The member names right now are `m_child0` (right) and `m_child1` (left) just so it makes sense in ghidra. This should definitely be changed before finalizing the PR.

There is an inlined init function `newTreeNode` that new's the POD object. If we did the obvious thing and used a constructor here, this would add the exception protection (i.e. `mov eax, fs:[0]`) to the start of the function `MxBinaryTree::Insert` at `0x100ad4d0`. But that function doesn't have those instructions. I'm not 100% confident that this is right, but the node's members are always set in the same order after malloc.

Where I'm having trouble matching/reversing this stuff is that there appear to be a lot of inlined function calls, but they are only sometimes inlined. For example: the function at `0x100ad120` compares two `TreeValue` strings (basically a big wrapper for `strcmp`) but it is *not* inlined when called at `0x100ad072`. The same is true for the "search" function at `0x100ad780`, which is called directly at `0x100ad2ae` but inlined in many other places.

I'm not sure how the "Successor" function at `0x100ad480` is meant to be called. It uses `[ECX]` as both input and output, but if I made this an instance method, then that would mean setting `TreeNode->m_child0` which doesn't make a lot of sense.

In all this work, I haven't uncovered what `MxAtomId` is _used for_ exactly.