### PR TITLE
Match MxDSAction::CopyFrom

### DIFF
--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -51,10 +51,9 @@ void MxDSAction::CopyFrom(MxDSAction &p_dsAction)
   this->m_duration = p_dsAction.m_duration;
   this->m_loopCount = p_dsAction.m_loopCount;
 
-  // TODO
-  // this->m_location.SetVector(p_dsAction.m_location.GetData());
-  // this->m_direction.SetVector(p_dsAction.m_direction.GetData());
-  // this->m_up.SetVector(p_dsAction.m_up.GetData());
+  this->m_location.CopyFrom(&p_dsAction.m_location);
+  this->m_direction.CopyFrom(&p_dsAction.m_direction);
+  this->m_up.CopyFrom(&p_dsAction.m_up);
 
   FUN_100ADE60(p_dsAction.m_unk80, p_dsAction.m_unk7c);
   this->m_unk84 = p_dsAction.m_unk84;

--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -51,9 +51,9 @@ void MxDSAction::CopyFrom(MxDSAction &p_dsAction)
   this->m_duration = p_dsAction.m_duration;
   this->m_loopCount = p_dsAction.m_loopCount;
 
-  this->m_location.CopyFrom(&p_dsAction.m_location);
-  this->m_direction.CopyFrom(&p_dsAction.m_direction);
-  this->m_up.CopyFrom(&p_dsAction.m_up);
+  this->m_location.CopyFrom(p_dsAction.m_location);
+  this->m_direction.CopyFrom(p_dsAction.m_direction);
+  this->m_up.CopyFrom(p_dsAction.m_up);
 
   FUN_100ADE60(p_dsAction.m_unk80, p_dsAction.m_unk7c);
   this->m_unk84 = p_dsAction.m_unk84;

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -149,11 +149,11 @@ public:
     };
   };
 
-  void CopyFrom(MxVector3Data *p_other) {
-    EqualsImpl(p_other->m_data);
+  void CopyFrom(MxVector3Data &p_other) {
+    EqualsImpl(p_other.m_data);
 
     float *dest = this->storage;
-    float *src = p_other->storage;
+    float *src = p_other.storage;
     for (size_t i = sizeof(storage) / sizeof(float); i > 0; --i)
       *dest++ = *src++; 
   }

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -152,8 +152,8 @@ public:
   void CopyFrom(MxVector3Data *p_other) {
     EqualsImpl(p_other->m_data);
 
-    float *src = this->storage;
-    float *dest = p_other->storage;
+    float *dest = this->storage;
+    float *src = p_other->storage;
     for (size_t i = sizeof(storage) / sizeof(float); i > 0; --i)
       *dest++ = *src++; 
   }

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -57,8 +57,8 @@ public:
   virtual void DivScalar(float *p_value);
 
   // vtable + 0x6C
-  virtual void SetVector(MxVector2 *other);
-  virtual void SetVector(float *other);
+  virtual void SetVector(MxVector2 *p_other);
+  virtual void SetVector(float *p_other);
 
   inline float& operator[](size_t idx) { return m_data[idx]; }
   inline const float operator[](size_t idx) const { return m_data[idx]; }
@@ -139,7 +139,24 @@ public:
     : MxVector3(&x)
     , x(p_x), y(p_y), z(p_z)
     {}
-  float x, y, z;
+
+  union {
+    float storage[3];
+    struct {
+      float x;
+      float y;
+      float z;
+    };
+  };
+
+  void CopyFrom(MxVector3Data *p_other) {
+    EqualsImpl(p_other->m_data);
+
+    float *src = this->storage;
+    float *dest = p_other->storage;
+    for (size_t i = sizeof(storage) / sizeof(float); i > 0; --i)
+      *dest++ = *src++; 
+  }
 };
 
 // VTABLE 0x100d41e8
@@ -148,7 +165,15 @@ class MxVector4Data : public MxVector4
 {
 public:
   inline MxVector4Data() : MxVector4(&x) {}
-  float x, y, z, w;
+  union {
+    float storage[4];
+    struct {
+      float x;
+      float y;
+      float z;
+      float w;
+    };
+  };
 };
 
 #endif // MXVECTOR_H

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -136,7 +136,7 @@ class MxVector3Data : public MxVector3
 public:
   inline MxVector3Data() : MxVector3(storage) {}
   inline MxVector3Data(float p_x, float p_y, float p_z)
-    : MxVector3(&x)
+    : MxVector3(storage)
     , x(p_x), y(p_y), z(p_z)
     {}
 

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -134,7 +134,7 @@ public:
 class MxVector3Data : public MxVector3
 {
 public:
-  inline MxVector3Data() : MxVector3(&x) {}
+  inline MxVector3Data() : MxVector3(storage) {}
   inline MxVector3Data(float p_x, float p_y, float p_z)
     : MxVector3(&x)
     , x(p_x), y(p_y), z(p_z)
@@ -164,7 +164,7 @@ public:
 class MxVector4Data : public MxVector4
 {
 public:
-  inline MxVector4Data() : MxVector4(&x) {}
+  inline MxVector4Data() : MxVector4(storage) {}
   union {
     float storage[4];
     struct {


### PR DESCRIPTION
Matches `CopyFrom` in `MxDSAction`. I've added an alternative accessor to the concrete storage of the vector since in this case the elements aren't addressed individually.