### PR TITLE
[workflow] Skip upload step for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
   upload:
     needs: [build, compare]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This is a minor thing, but builds on the master branch fail for all the forks. The reason is that only the main repo has the creds required to upload the progress report to legoisland.org. There's no reason to even attempt this for a fork, so just skip this step if we are on master branch but not isledecomp/isle.