### PR TITLE
Some functions in MxPresenter

### DIFF
--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -40,6 +40,12 @@ public:
   virtual MxLong GetSomeTimingField(); // vtable+3c;
   virtual MxLong GetCurrentTime(); // vtable+40;
 
+  inline char *GetUnkData() { return m_unkData; }
+  inline MxU16 GetUnkLength() const { return m_unkLength; }
+  inline void SetOmni(MxOmni *p_omni) { m_omni = p_omni; }
+  inline DWORD GetFlags() const { return m_flags; }
+  inline void SetFlags(DWORD p_flags) { m_flags = p_flags; }
+
   void AppendData(MxU16 p_unkLength, const char *p_unkData);
 
 private:

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -42,6 +42,55 @@ void MxOmni::Init()
   m_unk64 = NULL;
 }
 
+// OFFSET: LEGO1 0x100b0090 STUB
+void MxOmni::vtable0x20()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b00c0 STUB
+void MxOmni::DeleteObject()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b09a0 STUB
+void MxOmni::DoesEntityExist()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b00e0 STUB
+void MxOmni::vtable0x2c()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100aefb0 STUB
+int MxOmni::vtable0x30(char*, int, MxCore*)
+{
+  // TODO
+  return 0;
+}
+
+// OFFSET: LEGO1 0x100aefc0 STUB
+void MxOmni::NotifyCurrentEntity()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b09d0 STUB
+void MxOmni::StartTimer()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b0a00 STUB
+void MxOmni::vtable0x3c()
+{
+  // TODO
+}
+
 // OFFSET: LEGO1 0x100b0690
 void MxOmni::DestroyInstance()
 {

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -37,6 +37,14 @@ public:
   virtual void Init(); // vtable+14
   virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c
+  virtual void vtable0x20(); // vtable+20
+  virtual void DeleteObject(); // vtable+24
+  virtual void DoesEntityExist(); // vtable+28
+  virtual void vtable0x2c(); // vtable+2c
+  virtual int vtable0x30(char*, int, MxCore*); // vtable+30
+  virtual void NotifyCurrentEntity(); // vtable+34
+  virtual void StartTimer(); // vtable+38
+  virtual void vtable0x3c(); // vtable+3c
   static void SetInstance(MxOmni* instance);
   MxObjectFactory* GetObjectFactory() const { return this->m_objectFactory; }
   MxNotificationManager* GetNotificationManager() const { return this->m_notificationManager; }

--- a/LEGO1/mxparam.h
+++ b/LEGO1/mxparam.h
@@ -3,8 +3,7 @@
 
 #include "mxomnicreateparambase.h"
 #include "mxtypes.h"
-
-class MxCore;
+#include "mxcore.h"
 
 // VTABLE 0x100d56e0
 class MxParam : public MxOmniCreateParamBase

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -1,65 +1,17 @@
 #include "mxpresenter.h"
+#include "mxautolocker.h"
+#include "mxparam.h"
+#include <string.h>
 
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxPresenter, 0x40);
 
-// OFFSET: LEGO1 0x1000bee0 STUB
-void MxPresenter::DoneTickle()
-{
-  // TODO
-}
+// 0x10101eac
+char *g_pParseExtraTokens = ":;";
 
-// OFFSET: LEGO1 0x100b4d50
-void MxPresenter::Init()
-{
-  m_unk0x8 = 0;
-  m_action = NULL;
-  m_unk0x18 = 0;
-  m_unk0x3c = 0;
-  m_unk0xc = 0;
-  m_unk0x10 = 0;
-  m_unk0x14 = 0;
-}
-
-// OFFSET: LEGO1 0x100b4fc0 STUB
-void MxPresenter::ParseExtra()
-{
-  // TODO
-}
-
-// OFFSET: LEGO1 0x1000bf00
-MxPresenter::~MxPresenter()
-{
-}
-
-// OFFSET: LEGO1 0x100b5200 STUB
-MxLong MxPresenter::Tickle()
-{
-  // TODO
-
-  return 0;
-}
-
-// OFFSET: LEGO1 0x100b4d80 STUB
-MxLong MxPresenter::StartAction(MxStreamController *, MxDSAction *)
-{
-  // TODO
-
-  return 0;
-}
-
-// OFFSET: LEGO1 0x100b4e40 STUB
-void MxPresenter::EndAction()
-{
-  // TODO
-}
-
-// OFFSET: LEGO1 0x100b52d0 STUB
-void MxPresenter::Enable(unsigned char)
-{
-  // TODO
-}
+// 0x10101edc
+char *g_strWORLD = "WORLD";
 
 // OFFSET: LEGO1 0x1000be30
 void MxPresenter::VTable0x14()
@@ -102,6 +54,18 @@ void MxPresenter::VTable0x28()
   m_unk0x8 = 6;
 }
 
+// OFFSET: LEGO1 0x1000bee0
+void MxPresenter::DoneTickle()
+{
+  m_unk0xc |= (1 << m_unk0x8);
+  m_unk0x8 = 0;
+}
+
+// OFFSET: LEGO1 0x1000bf00
+MxPresenter::~MxPresenter()
+{
+}
+
 // OFFSET: LEGO1 0x1000bf70
 undefined4 MxPresenter::VTable0x34()
 {
@@ -113,6 +77,7 @@ void MxPresenter::InitVirtual()
 {
   Init();
 }
+
 // OFFSET: LEGO1 0x1000bf90
 void MxPresenter::VTable0x44(undefined4 param)
 {
@@ -136,4 +101,175 @@ undefined4 MxPresenter::VTable0x4c()
 undefined MxPresenter::VTable0x50(undefined4, undefined4)
 {
   return 0;
+}
+
+// OFFSET: LEGO1 0x100b4d50
+void MxPresenter::Init()
+{
+  m_unk0x8 = 0;
+  m_action = NULL;
+  m_unk0x18 = 0;
+  m_unk0x3c = 0;
+  m_unk0xc = 0;
+  m_unk0x10 = 0;
+  m_unk0x14 = 0;
+}
+
+// OFFSET: LEGO1 0x100b4d80 STUB
+MxLong MxPresenter::StartAction(MxStreamController *, MxDSAction *)
+{
+  // TODO
+
+  return 0;
+}
+
+// OFFSET: LEGO1 0x100b4e40 STUB
+void MxPresenter::EndAction()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b4fc0
+void MxPresenter::ParseExtra()
+{
+  MxAutoLocker lock(&m_criticalSection);
+
+  // TODO: this part isn't matching. wrong type for this variable?
+  MxU16 len = m_action->GetUnkLength();
+
+  if (len != 0) {
+    char t_actionData[512];
+    memcpy(t_actionData, m_action->GetUnkData(), len & MAXWORD);
+    t_actionData[len] = '\0';
+
+    char t_worldSection[512];
+    if (FUN_100b7050(t_worldSection, g_strWORLD, t_actionData)) {
+      char *token = strtok(t_worldSection, g_pParseExtraTokens);
+      char t_token[256];
+      strcpy(t_token, token);
+
+      token = strtok(NULL, g_pParseExtraTokens);
+      int val = token ? atoi(token) : 0;
+
+      int result = MxOmni::GetInstance()->vtable0x30(t_token, val, this);
+      
+      // TODO: magic number for flag
+      m_action->SetFlags(m_action->GetFlags() | 128);
+      
+      if (result)
+        FUN_100b5120(MxOmni::GetInstance());
+
+    }
+  }
+}
+
+// OFFSET: LEGO1 0x100b5120
+void MxPresenter::FUN_100b5120(MxOmni *p_omni)
+{
+  if (m_unk0x3c) {
+    MxAutoLocker lock(&m_criticalSection);
+
+    // TODO: remove cast once member type is understood
+    // TOOD: magic number used for notification type. replace with enum
+    NotificationManager()->Send((MxCore*)m_unk0x3c, &MxParam(5, this));
+
+    m_action->SetOmni(p_omni ? p_omni : MxOmni::GetInstance());
+    m_unk0x3c = 0;
+  }
+}
+
+// OFFSET: LEGO1 0x100b5200
+MxLong MxPresenter::Tickle()
+{
+  MxAutoLocker lock(&m_criticalSection);
+
+  switch (m_unk0x8) {
+    case 1:
+      VTable0x18();
+      if (m_unk0x8 != 2)
+        break;
+
+    case 2:
+      VTable0x1c();
+      if (m_unk0x8 != 3)
+        break;
+
+    case 3:
+      VTable0x20();
+      if (m_unk0x8 != 4)
+        break;
+
+    case 4:
+      VTable0x24();
+      if (m_unk0x8 != 5)
+        break;
+
+    case 5:
+      VTable0x28();
+      if (m_unk0x8 != 6)
+        break;
+
+    case 6:
+      DoneTickle();
+  }
+
+  return 0;
+}
+
+// OFFSET: LEGO1 0x100b52d0
+void MxPresenter::Enable(MxBool p_shouldEnable)
+{
+  // TODO: magic number for flag
+  if (m_action && p_shouldEnable != ActionIsEnabled()) {
+    DWORD flags = m_action->GetFlags();
+    if (p_shouldEnable) {
+      m_action->SetFlags(flags | 32);
+    } else {
+      m_action->SetFlags(flags & ~32);
+    }
+  }
+}
+
+// OFFSET: LEGO1 0x100b54c0
+MxBool MxPresenter::ActionIsEnabled()
+{
+  // TODO: magic number for flag
+  // TODO: making an assumption that bit 5 means "enabled"
+  return m_action && (m_action->GetFlags() & 32);
+}
+
+// OFFSET: LEGO1 0x100b7050
+MxBool FUN_100b7050(char *p_str0, char *p_str1, char *p_str2)
+{
+  MxBool didMatch = FALSE;
+
+  MxS16 len = strlen(p_str2);
+  char *temp = new char[len + 1];
+  strcpy(temp, p_str2);
+
+  char *token = strtok(temp, ", \t\r\n:");
+  while (token) {
+    len -= (strlen(token) + 1);
+
+    if (strcmpi(token, p_str1) == 0) {
+      if (p_str0 && len > 0) {
+        char *cur = &token[strlen(p_str1)];
+        cur++;
+        while (*cur != ',') {
+          if (*cur == ' ' || *cur == '\0' || *cur == '\t' || *cur == '\n' || *cur == '\r')
+            break;
+          *p_str0++ = *cur++;
+        }
+        *p_str0 = '\0';
+      }
+
+      didMatch = TRUE;
+      break;
+    }
+
+    token = strtok(NULL, ", \t\r\n:");
+  }
+
+  delete[] temp;
+  return didMatch;
 }

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -1,14 +1,16 @@
 #ifndef MXPRESENTER_H
 #define MXPRESENTER_H
 
+#include "mxtypes.h"
 #include "mxcore.h"
+#include "mxdsaction.h"
+#include "mxomni.h"
 
 #include "mxcriticalsection.h"
 
 #include "decomp.h"
 
 class MxStreamController;
-class MxDSAction;
 
 class MxPresenter : public MxCore
 {
@@ -50,21 +52,26 @@ public:
   virtual unsigned char VTable0x48(unsigned char param); // vtable+0x48
   virtual undefined4 VTable0x4c(); // vtable+0x4c
   virtual undefined VTable0x50(undefined4, undefined4); // vtable+0x50
-  __declspec(dllexport) virtual void Enable(unsigned char); // vtable+0x54
+  __declspec(dllexport) virtual void Enable(MxBool); // vtable+0x54
 protected:
   __declspec(dllexport) void Init();
 public:
+
+  void FUN_100b5120(MxOmni *p_omni);
+  MxBool ActionIsEnabled();
 
   undefined4 m_unk0x8;
   undefined4 m_unk0xc;
   undefined4 m_unk0x10;
   undefined4 m_unk0x14;
   undefined4 m_unk0x18;
-  MxDSAction* m_action; // 0
-  MxCriticalSection m_criticalSection;
+  MxDSAction* m_action; // 0x1c
+  MxCriticalSection m_criticalSection; // 0x20
   undefined4 m_unk0x3c;
 
   // VTABLE 0x100d4d38
 };
+
+MxBool FUN_100b7050(char *, char *, char *);
 
 #endif // MXPRESENTER_H


### PR DESCRIPTION
A few functions from MxPresenter.

### Notes:

* Reordered MxPresenter functions by their offset, hence the diff being what it is. I brought this up on the matrix chat. If we should go about this in a different way, let me know.

* FUN_100b5120 and FUN_100b7050 match but aren't named yet. This is an area where I'd like some insight if anyone has it. Particularly in the case of FUN_100b7050: it's pretty clear what it's doing, but some context on what kind of structure this is parsing (i.e. which file from the game, if it is a file) would help to name it. It looks like it's used in more places than just MxPresenter so I put it outside the class.

* I used global variables for some of the string literals here. I'm not 100% sure this is right but it matches the "pointer to a pointer" way this is structured in the original.

* Intentional switch/case fallthrough on MxPresenter::Tickle.

* MxParam now points at MxCore instead of the temporary reference

* Added some getter/setters for private members to MxDSAction

* Stubbed out more of the vtable in MxOmni because ParseExtra calls one. Named the functions that have a name in the shared ghidra project
