### PR TITLE
Add MxList, MxPresenterList, add to MxMediaManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(lego1 SHARED
   LEGO1/mxpalette.cpp
   LEGO1/mxparam.cpp
   LEGO1/mxpresenter.cpp
+  LEGO1/mxpresenterlist.cpp
   LEGO1/mxscheduler.cpp
   LEGO1/mxsemaphore.cpp
   LEGO1/mxsmkpresenter.cpp

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -1,0 +1,80 @@
+#ifndef MXLIST_H
+#define MXLIST_H
+
+#include "mxtypes.h"
+#include "mxcore.h"
+
+template <class T>
+class MxListEntry
+{
+public:
+  MxListEntry<T>() {}
+  MxListEntry<T>(T *p_obj) {
+    m_obj = p_obj;
+    m_prev = NULL;
+    m_next = NULL;
+  }
+
+  T *m_obj;
+  MxListEntry *m_prev;
+  MxListEntry *m_next;
+};
+
+// VTABLE 0x100d6350
+// SIZE 0x10
+template <class T>
+class MxListParent : public MxCore
+{
+public:
+  MxListParent() {
+    m_count = 0;
+    m_customDestructor = Destroy;
+  }
+
+  // OFFSET: LEGO1 0x1001cd30
+  static void Destroy(T *) {};
+
+  // OFFSET: LEGO1 0x1001cd20
+  virtual MxS8 Compare(T *, T *) = 0;
+
+protected:
+  MxU32 m_count;                   // +0x8
+  void (*m_customDestructor)(T *); // +0xc
+};
+
+// VTABLE 0x100d6368
+// SIZE 0x18
+template <class T>
+class MxList : protected MxListParent<T>
+{
+public:
+  MxList() {
+    m_last = NULL;
+    m_first = NULL;
+  }
+
+  virtual ~MxList();
+protected:
+  MxListEntry<T> *m_first; // +0x10
+  MxListEntry<T> *m_last;  // +0x14
+};
+
+template <class T>
+// OFFSET: LEGO1 0x1001cfe0
+MxList<T>::~MxList()
+{
+  MxListEntry<T> *t = m_first;
+
+  while (t) {
+    MxListEntry<T> *next = t->m_next;
+    m_customDestructor(t->m_obj);
+    delete t;
+    t = next;
+  }
+
+  m_count = 0;
+  m_last = NULL;
+  m_first = NULL;
+}
+
+#endif // MXLIST_H

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -30,6 +30,8 @@ public:
     m_count = 0;
     m_customDestructor = Destroy;
   }
+  // OFFSET: LEGO1 0x1001cdd0
+  virtual ~MxListParent() {}
 
   // OFFSET: LEGO1 0x1001cd30
   static void Destroy(T *) {};
@@ -60,12 +62,13 @@ protected:
 };
 
 template <class T>
-// OFFSET: LEGO1 0x1001cfe0
+// OFFSET: LEGO1 0x1001ce20
 MxList<T>::~MxList()
 {
-  MxListEntry<T> *t = m_first;
+  for (MxListEntry<T> *t = m_first;;) {
+    if (!t)
+      break;
 
-  while (t) {
     MxListEntry<T> *next = t->m_next;
     m_customDestructor(t->m_obj);
     delete t;

--- a/LEGO1/mxmediamanager.cpp
+++ b/LEGO1/mxmediamanager.cpp
@@ -1,4 +1,5 @@
 #include "mxmediamanager.h"
+#include "mxautolocker.h"
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxMediaManager, 0x2c);
@@ -12,22 +13,45 @@ MxMediaManager::MxMediaManager()
 // OFFSET: LEGO1 0x100b8560
 MxMediaManager::~MxMediaManager()
 {
-  Teardown();
+  Destroy();
 }
 
 // OFFSET: LEGO1 0x100b85d0
 MxResult MxMediaManager::Init()
 {
-  this->m_unk08 = NULL;
+  this->m_presenters = NULL;
   this->m_thread = NULL;
   return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b8710
-void MxMediaManager::Teardown()
+void MxMediaManager::Destroy()
 {
-  if(this->m_unk08) {
-    delete this->m_unk08;
-  }
+  MxAutoLocker lock(&this->m_criticalSection);
+
+  if (this->m_presenters)
+    delete this->m_presenters;
+    
   Init();
+}
+
+// OFFSET: LEGO1 0x100b8790 STUB
+MxResult MxMediaManager::Tickle()
+{
+  return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x100b85e0
+MxResult MxMediaManager::InitPresenters()
+{
+  MxAutoLocker lock(&this->m_criticalSection);
+
+  this->m_presenters = new MxPresenterList;
+
+  if (!this->m_presenters) {
+    this->Destroy();
+    return FAILURE;
+  }
+
+  return SUCCESS;
 }

--- a/LEGO1/mxmediamanager.h
+++ b/LEGO1/mxmediamanager.h
@@ -4,19 +4,27 @@
 #include "mxcore.h"
 #include "mxcriticalsection.h"
 #include "mxthread.h"
+#include "mxpresenterlist.h"
 #include "mxtypes.h"
 
 // VTABLE 0x100dc6b0
+// SIZE 0x2c
 class MxMediaManager : public MxCore
 {
 public:
   MxMediaManager();
   virtual ~MxMediaManager() override;
 
+  virtual MxResult Tickle(); // vtable+08
+  virtual MxResult InitPresenters(); // vtable+14
+  virtual void Destroy(); // vtable+18
+  // vtable+1c
+  // vtable+20
+  // vtable+24
+
   MxResult Init();
-  void Teardown();
 private:
-  void* m_unk08;
+  MxPresenterList *m_presenters;
   MxThread* m_thread; // 0xc
 
 protected:

--- a/LEGO1/mxpresenterlist.cpp
+++ b/LEGO1/mxpresenterlist.cpp
@@ -1,0 +1,14 @@
+#include "mxpresenterlist.h"
+#include "mxpresenter.h"
+
+DECOMP_SIZE_ASSERT(MxPresenterList, 0x18);
+
+// OFFSET: LEGO1 0x1001cd00
+MxS8 MxPresenterList::Compare(MxPresenter *p_var0, MxPresenter *p_var1)
+{
+  if (p_var1 == p_var0)
+    return 0;
+  if (p_var1 <= p_var0)
+    return 1;
+  return -1;
+}

--- a/LEGO1/mxpresenterlist.h
+++ b/LEGO1/mxpresenterlist.h
@@ -1,0 +1,27 @@
+#ifndef MXPRESENTERLIST_H
+#define MXPRESENTERLIST_H
+
+#include "mxlist.h"
+
+class MxPresenter;
+
+// Unclear what the purpose of this class is
+// VTABLE 0x100d62f0
+// SIZE 0x18
+class MxPresenterListParent : public MxList<MxPresenter>
+{
+public:
+  MxPresenterListParent() {
+    m_customDestructor = Destroy;
+  }
+};
+
+// VTABLE 0x100d6308
+// SIZE 0x18
+class MxPresenterList : public MxPresenterListParent
+{
+public:
+  virtual MxS8 Compare(MxPresenter *, MxPresenter *); // +0x14
+};
+
+#endif // MXPRESENTERLIST_H


### PR DESCRIPTION
The pattern used for `MxList` (and subsequently `MxPresenterList`) is fairly similar to the one used for `MxHashTable`/`MxVariableTable` so I could re-use a fair amount of @disinvite 's code. `MxList` isn't complete yet, it looks like it will also have a `MxListCursor` similarly to `MxHashTableCursor`.

`MxMediaManager` contains the `MxPresenterList` and a function to initialize it, both are implemented and matching.