### PR TITLE
Implement/match MxPresenter::StartAction

### DIFF
--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -52,6 +52,7 @@ public:
   inline void SetFlags(MxU32 m_flags) { this->m_flags = m_flags; }
   inline char *GetExtraData() { return m_extraData; }
   inline MxU16 GetExtraLength() const { return m_extraLength; }
+  inline const MxVector3Data &GetLocation() const { return m_location; }
   inline void SetOmni(MxOmni *p_omni) { m_omni = p_omni; }
 
 private:

--- a/LEGO1/mxpoint32.h
+++ b/LEGO1/mxpoint32.h
@@ -7,10 +7,10 @@ class MxPoint32
 {
 public:
   MxPoint32() { }
-  MxPoint32(MxS32 x, MxS32 y)
+  MxPoint32(MxS32 p_x, MxS32 p_y)
   {
-    this->m_x = x;
-    this->m_y = y;
+    this->m_x = p_x;
+    this->m_y = p_y;
   }
 
   MxS32 m_x;

--- a/LEGO1/mxpoint32.h
+++ b/LEGO1/mxpoint32.h
@@ -1,0 +1,20 @@
+#ifndef MXPOINT32_H
+#define MXPOINT32_H
+
+#include "mxtypes.h"
+
+class MxPoint32
+{
+public:
+  MxPoint32() { }
+  MxPoint32(MxS32 x, MxS32 y)
+  {
+    this->m_x = x;
+    this->m_y = y;
+  }
+
+  MxS32 m_x;
+  MxS32 m_y;
+};
+
+#endif // MXPOINT32_H

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -19,11 +19,10 @@ void MxPresenter::Init()
 {
   m_currentTickleState = TickleState_Idle;
   m_action = NULL;
-  m_unk0x18 = 0;
+  m_location = MxPoint32(0, 0);
+  m_locationZ = 0;
   m_unkPresenter = NULL;
   m_previousTickleStates = 0;
-  m_unk0x10 = 0;
-  m_unk0x14 = 0;
 }
 
 // OFFSET: LEGO1 0x100b4fc0
@@ -116,15 +115,25 @@ MxLong MxPresenter::Tickle()
       break;
   }
 
-  return 0;
+  return SUCCESS;
 }
 
-// OFFSET: LEGO1 0x100b4d80 STUB
-MxLong MxPresenter::StartAction(MxStreamController *, MxDSAction *)
+// OFFSET: LEGO1 0x100b4d80
+MxLong MxPresenter::StartAction(MxStreamController *, MxDSAction *p_action)
 {
-  // TODO
+  MxAutoLocker lock(&this->m_criticalSection);
 
-  return 0;
+  this->m_action = p_action;
+
+  const MxVector3Data& location = this->m_action->GetLocation();
+  MxS32 previousTickleState = this->m_currentTickleState;
+
+  this->m_location = MxPoint32(location[0], location[1]);
+  this->m_locationZ = location[2];
+  this->m_previousTickleStates |= 1 << (unsigned char)previousTickleState;
+  this->m_currentTickleState = TickleState_Ready;
+
+  return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b4e40 STUB

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -2,6 +2,7 @@
 #define MXPRESENTER_H
 
 #include "mxcore.h"
+#include "mxpoint32.h"
 #include "mxdsaction.h"
 #include "mxcriticalsection.h"
 #include "mxomni.h"
@@ -74,9 +75,8 @@ protected:
 private:
   MxS32 m_currentTickleState; // 0x8
   MxU32 m_previousTickleStates;
-  undefined4 m_unk0x10;
-  undefined4 m_unk0x14;
-  undefined4 m_unk0x18;
+  MxPoint32 m_location;
+  MxS32 m_locationZ;
   MxDSAction* m_action; // 0
   MxCriticalSection m_criticalSection;
   MxPresenter *m_unkPresenter; // 0x3c


### PR DESCRIPTION
There is a very minor diff, which might be related to how the location floats are accessed, but otherwise the function matches. The remaining unknown members of `MxPresenter` were coordinates (consisting of `MxPoint32`, introduced with this PR; and a single `Mx32`)

`MxPresenter::Init` also matches now.