### PR TITLE
Implement/match MxMediaManager::Tickle

### DIFF
--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -84,7 +84,7 @@ public:
   void Detach();
   MxBool Next(T*& p_obj);
   void Reset() { m_match = NULL; }
-  
+
 private:
   MxList<T> *m_list;
   MxListEntry<T> *m_match;

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -83,7 +83,8 @@ public:
   MxBool Find(T *p_obj);
   void Detach();
   MxBool Next(T*& p_obj);
-
+  void Reset() { m_match = NULL; }
+  
 private:
   MxList<T> *m_list;
   MxListEntry<T> *m_match;

--- a/LEGO1/mxmediamanager.cpp
+++ b/LEGO1/mxmediamanager.cpp
@@ -27,9 +27,21 @@ MxResult MxMediaManager::Init()
   return SUCCESS;
 }
 
-// OFFSET: LEGO1 0x100b8790 STUB
+// OFFSET: LEGO1 0x100b8790
 MxResult MxMediaManager::Tickle()
 {
+  MxAutoLocker lock(&this->m_criticalSection);
+  MxPresenter *presenter;
+  MxPresenterListCursor cursor(this->m_presenters);
+
+  while (cursor.Next(presenter))
+    presenter->Tickle();
+
+  cursor.Reset();
+
+  while (cursor.Next(presenter))
+    presenter->VTable0x4c();
+
   return SUCCESS;
 }
 


### PR DESCRIPTION
`MxMediaManager::Tickle` iterates over all its internally held presenters, "tickles" them and eventually calls `VTable0x4c` on all of them.