### PR TITLE
LegoOmni::CreateStreamObject and related

### DIFF
--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -159,15 +159,15 @@ MxDSObject *CreateStreamObject(MxDSFile *p_file, MxS16 p_ofs)
     return NULL;
   }
 
-  if (p_file->Read(&tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'S', 't')) {
-    if (p_file->Read(&tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'O', 'b')) {
+  if (p_file->Read((MxU8*)&tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'S', 't')) {
+    if (p_file->Read((MxU8*)&tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'O', 'b')) {
 
       buf = new char[tmp_chunk.cksize];
       if (!buf) {
         return NULL;
       }
 
-      if (p_file->Read(buf, tmp_chunk.cksize) != 0) {
+      if (p_file->Read((MxU8*)buf, tmp_chunk.cksize) != 0) {
         return NULL;
       }
 

--- a/LEGO1/mxdsfile.cpp
+++ b/LEGO1/mxdsfile.cpp
@@ -47,13 +47,13 @@ MxLong MxDSFile::Open(MxULong uStyle)
 }
 
 // OFFSET: LEGO1 0x100cc780
-MxLong MxDSFile::Read(unsigned char *pch, MxULong cch)
+MxResult MxDSFile::Read(void *p_buf, MxULong p_nbytes)
 {
-  if (m_io.Read((char*)pch, cch) != cch)
-    return -1;
+  if (m_io.Read(p_buf, p_nbytes) != p_nbytes)
+    return FAILURE;
 
-  m_position += cch;
-  return 0;
+  m_position += p_nbytes;
+  return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100cc620
@@ -72,7 +72,7 @@ MxLong MxDSFile::ReadChunks()
     return -1;
   }
 
-  m_io.Read((char*)&m_header, 0xc);
+  m_io.Read(&m_header, 0xc);
   if ((m_header.majorVersion == SI_MAJOR_VERSION) && (m_header.minorVersion == SI_MINOR_VERSION))
   {
     childChunk.ckid = FOURCC('M', 'x', 'O', 'f');
@@ -80,9 +80,9 @@ MxLong MxDSFile::ReadChunks()
       return -1;
     }
     MxULong* pLengthInDWords = &m_lengthInDWords;
-    m_io.Read((char *)pLengthInDWords, 4);
+    m_io.Read(pLengthInDWords, 4);
     m_pBuffer = malloc(*pLengthInDWords * 4);
-    m_io.Read((char*)m_pBuffer, *pLengthInDWords * 4);
+    m_io.Read(m_pBuffer, *pLengthInDWords * 4);
     return 0;
   }
   else

--- a/LEGO1/mxdsfile.cpp
+++ b/LEGO1/mxdsfile.cpp
@@ -47,7 +47,7 @@ MxLong MxDSFile::Open(MxULong uStyle)
 }
 
 // OFFSET: LEGO1 0x100cc780
-MxResult MxDSFile::Read(void *p_buf, MxULong p_nbytes)
+MxResult MxDSFile::Read(unsigned char *p_buf, MxULong p_nbytes)
 {
   if (m_io.Read(p_buf, p_nbytes) != p_nbytes)
     return FAILURE;

--- a/LEGO1/mxdsfile.h
+++ b/LEGO1/mxdsfile.h
@@ -4,6 +4,7 @@
 #include "mxdssource.h"
 #include "mxioinfo.h"
 #include "mxstring.h"
+#include "mxtypes.h"
 
 // VTABLE 0x100dc890
 class MxDSFile : public MxDSSource
@@ -27,7 +28,7 @@ public:
 
   __declspec(dllexport) virtual MxLong Open(MxULong); // vtable+0x14
   __declspec(dllexport) virtual MxLong Close(); // vtable+0x18
-  __declspec(dllexport) virtual MxLong Read(unsigned char *,MxULong); // vtable+0x20
+  __declspec(dllexport) virtual MxResult Read(void *,MxULong); // vtable+0x20
   __declspec(dllexport) virtual MxLong Seek(MxLong,int); // vtable+0x24
   __declspec(dllexport) virtual MxULong GetBufferSize(); // vtable+0x28
   __declspec(dllexport) virtual MxULong GetStreamBuffersNum();  // vtable+0x2c

--- a/LEGO1/mxdsfile.h
+++ b/LEGO1/mxdsfile.h
@@ -28,7 +28,7 @@ public:
 
   __declspec(dllexport) virtual MxLong Open(MxULong); // vtable+0x14
   __declspec(dllexport) virtual MxLong Close(); // vtable+0x18
-  __declspec(dllexport) virtual MxResult Read(void *,MxULong); // vtable+0x20
+  __declspec(dllexport) virtual MxResult Read(unsigned char *,MxULong); // vtable+0x20
   __declspec(dllexport) virtual MxLong Seek(MxLong,int); // vtable+0x24
   __declspec(dllexport) virtual MxULong GetBufferSize(); // vtable+0x28
   __declspec(dllexport) virtual MxULong GetStreamBuffersNum();  // vtable+0x2c

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -1,5 +1,7 @@
 #include "mxdsmultiaction.h"
 
+DECOMP_SIZE_ASSERT(MxDSMultiAction, 0x9c)
+
 // OFFSET: LEGO1 0x100c9b90
 MxDSMultiAction::MxDSMultiAction()
 {

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -2,6 +2,7 @@
 #define MXDSMULTIACTION_H
 
 #include "mxdsaction.h"
+#include "decomp.h"
 
 // VTABLE 0x100dcef0
 // SIZE 0x9c
@@ -23,6 +24,9 @@ public:
   {
     return !strcmp(name, MxDSMultiAction::ClassName()) || MxDSAction::IsA(name);
   }
+
+  undefined4 m_unk0x94;
+  undefined4 m_unk0x98;
 };
 
 #endif // MXDSMULTIACTION_H

--- a/LEGO1/mxdsobject.cpp
+++ b/LEGO1/mxdsobject.cpp
@@ -3,6 +3,19 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "mxdstypes.h"
+#include "mxdsaction.h"
+#include "mxdsmediaaction.h"
+#include "mxdsanim.h"
+#include "mxdssound.h"
+#include "mxdsmultiaction.h"
+#include "mxdsserialaction.h"
+#include "mxdsparallelaction.h"
+#include "mxdsevent.h"
+#include "mxdsselectaction.h"
+#include "mxdsstill.h"
+#include "mxdsobjectaction.h"
+
 DECOMP_SIZE_ASSERT(MxDSObject, 0x2c);
 
 // OFFSET: LEGO1 0x100bf6a0
@@ -126,4 +139,61 @@ void MxDSObject::Deserialize(char **p_source, MxS16 p_unk24)
   *p_source += sizeof(MxU32);
 
   this->m_unk24 = p_unk24;
+}
+
+
+// OFFSET: LEGO1 0x100bfb30
+MxDSObject *DeserializeDSObjectDispatch(char **p_source, MxS16 p_flags)
+{
+  MxU16 type = *(MxU16*) *p_source;
+  *p_source += 2;
+
+  MxDSObject *obj = NULL;
+
+  switch (type) {
+    default:
+      return NULL;
+    case MxDSType_Object:
+      obj = new MxDSObject();
+      break;
+    case MxDSType_Action:
+      obj = new MxDSAction();
+      break;
+    case MxDSType_MediaAction:
+      obj = new MxDSMediaAction();
+      break;
+    case MxDSType_Anim:
+      obj = new MxDSAnim();
+      break;
+    case MxDSType_Sound:
+      obj = new MxDSSound();
+      break;
+    case MxDSType_MultiAction:
+      obj = new MxDSMultiAction();
+      break;
+    case MxDSType_SerialAction:
+      obj = new MxDSSerialAction();
+      break;
+    case MxDSType_ParallelAction:
+      obj = new MxDSParallelAction();
+      break;
+    case MxDSType_Event:
+      obj = new MxDSEvent();
+      break;
+    case MxDSType_SelectAction:
+      obj = new MxDSSelectAction();
+      break;
+    case MxDSType_Still:
+      obj = new MxDSStill();
+      break;
+    case MxDSType_ObjectAction:
+      obj = new MxDSObjectAction();
+      break;
+  }
+
+  if (obj) {
+    obj->Deserialize(p_source, p_flags);
+  }
+
+  return obj;
 }

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -56,4 +56,6 @@ private:
   undefined4 m_unk28;
 };
 
+MxDSObject *DeserializeDSObjectDispatch(char **, MxS16);
+
 #endif // MXDSOBJECT_H

--- a/LEGO1/mxdsparallelaction.cpp
+++ b/LEGO1/mxdsparallelaction.cpp
@@ -1,5 +1,7 @@
 #include "mxdsparallelaction.h"
 
+DECOMP_SIZE_ASSERT(MxDSParallelAction, 0x9c)
+
 // OFFSET: LEGO1 0x100cae80
 MxDSParallelAction::MxDSParallelAction()
 {

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -1,5 +1,7 @@
 #include "mxdsselectaction.h"
 
+DECOMP_SIZE_ASSERT(MxDSSelectAction, 0xb0)
+
 // OFFSET: LEGO1 0x100cb2b0
 MxDSSelectAction::MxDSSelectAction()
 {

--- a/LEGO1/mxdsselectaction.h
+++ b/LEGO1/mxdsselectaction.h
@@ -2,6 +2,7 @@
 #define MXDSSELECTACTION_H
 
 #include "mxdsparallelaction.h"
+#include "decomp.h"
 
 // VTABLE 0x100dcfc8
 // SIZE 0xb0
@@ -23,6 +24,12 @@ public:
   {
     return !strcmp(name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(name);
   }
+
+  undefined4 m_unk0x9c;
+  undefined4 m_unk0xa0;
+  undefined4 m_unk0xa4;
+  undefined4 m_unk0xa8;
+  undefined4 m_unk0xac;
 
 };
 

--- a/LEGO1/mxdsserialaction.cpp
+++ b/LEGO1/mxdsserialaction.cpp
@@ -1,5 +1,7 @@
 #include "mxdsserialaction.h"
 
+DECOMP_SIZE_ASSERT(MxDSSerialAction, 0xa8)
+
 // OFFSET: LEGO1 0x100ca9d0
 MxDSSerialAction::MxDSSerialAction()
 {

--- a/LEGO1/mxdsserialaction.h
+++ b/LEGO1/mxdsserialaction.h
@@ -2,6 +2,7 @@
 #define MXDSSERIALACTION_H
 
 #include "mxdsmultiaction.h"
+#include "decomp.h"
 
 // VTABLE 0x100dcf38
 // SIZE 0xa8
@@ -23,6 +24,10 @@ public:
   {
     return !strcmp(name, MxDSSerialAction::ClassName()) || MxDSMultiAction::IsA(name);
   }
+
+  undefined4 m_unk0x9c;
+  undefined4 m_unk0xa0;
+  undefined4 m_unk0xa4;
 };
 
 #endif // MXDSSERIALACTION_H

--- a/LEGO1/mxdssource.cpp
+++ b/LEGO1/mxdssource.cpp
@@ -12,3 +12,9 @@ MxLong MxDSSource::GetLengthInDWords()
 {
   return m_lengthInDWords;
 }
+
+// OFFSET: LEGO1 0x100c0000
+void *MxDSSource::GetBuffer()
+{
+  return m_pBuffer;
+}

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -29,11 +29,12 @@ public:
   virtual MxLong Open(MxULong) = 0;
   virtual MxLong Close() = 0;
   virtual void SomethingWhichCallsRead(void* pUnknownObject);
-  virtual MxLong Read(unsigned char *, MxULong) = 0;
+  virtual MxResult Read(void *, MxULong) = 0;
   virtual MxLong Seek(MxLong, int) = 0;
   virtual MxULong GetBufferSize() = 0;
   virtual MxULong GetStreamBuffersNum() = 0;
   virtual MxLong GetLengthInDWords();
+  virtual void* GetBuffer(); // 0x34
 
 protected:
   MxULong m_lengthInDWords;

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -29,7 +29,7 @@ public:
   virtual MxLong Open(MxULong) = 0;
   virtual MxLong Close() = 0;
   virtual void SomethingWhichCallsRead(void* pUnknownObject);
-  virtual MxResult Read(void *, MxULong) = 0;
+  virtual MxResult Read(unsigned char *, MxULong) = 0;
   virtual MxLong Seek(MxLong, int) = 0;
   virtual MxULong GetBufferSize() = 0;
   virtual MxULong GetStreamBuffersNum() = 0;


### PR DESCRIPTION
- 100% match on LegoOmni::CreateStreamObject. 
- Near match on MxDSObject::DeserializeDSObjectDispatch. Instruction order and the jump table are throwing this one off.
- Aesthetic change to MxDSFile::Read to improve clarity. Changed the params to match our style guide.
- Removed some unneeded casts to (char*) when calling MXIOINFO::Read
- Added size asserts and dummy members to children of MxDSAction. This was needed for DeserializeDSObjectDispatch.
- Added MxDSSource::GetBuffer. The buffer type is currently (void*), so there's a slightly ugly cast when it gets called in CreateStreamObject.