### PR TITLE
Improve match for MxMatrix::EqualsDataProduct

### DIFF
--- a/LEGO1/mxmatrix.cpp
+++ b/LEGO1/mxmatrix.cpp
@@ -111,21 +111,20 @@ void MxMatrix::EqualsMxProduct(const MxMatrix *p_a, const MxMatrix *p_b)
   EqualsDataProduct(p_a->m_data, p_b->m_data);
 }
 
-// Just a placeholder matrix multiply implementation. I think the decomp will
-// look roughly like this but it's not close to matching and won't be until
-// an exact match is found given it's all loop and float crunching.
-// OFFSET: LEGO1 0x100024d0 STUB
+// OFFSET: LEGO1 0x100024d0
 void MxMatrix::EqualsDataProduct(const float *p_a, const float *p_b)
 {
+  float *cur = m_data;
   for (int row = 0; row < 4; ++row)
   {
     for (int col = 0; col < 4; ++col)
     {
-      m_data[row * 4 + col] = 0.0f;
+      *cur = 0.0f;
       for (int k = 0; k < 4; ++k)
       {
-        m_data[row * 4 + col] += p_a[row * 4 + k] * p_b[k * 4 + col];
+        *cur += p_a[row * 4 + k] * p_b[k * 4 + col];
       }
+      cur++;
     }
   }
 }


### PR DESCRIPTION
Quick one in MxMatrix. The for loop variables need to be optimized away for this to match. To do that, I used a pointer to update m_data and then just incremented it directly rather than relying on the `row * 4 + col` calculation each time.

It seems to work, except for the usual business of the wrong registers getting used. Also, I'm not sure why the compiler thinks that the the first param is `esp + 0x18` instead of `+ 0x10`. You can see how this gets called in the neighbor function EqualsMxProduct, and there are only two dword-sized params.