### PR TITLE
Implement/match remaining MxDSMultiAction functions

### DIFF
--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -73,6 +73,8 @@ private:
   undefined4 m_unk84;
   undefined4 m_unk88;
   MxOmni *m_omni; // 0x8c
+
+protected:
   MxLong m_someTimingField; // 0x90
 };
 

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -39,7 +39,6 @@ MxDSMultiAction &MxDSMultiAction::operator=(MxDSMultiAction &p_dsMultiAction)
   return *this;
 }
 
-
 // OFFSET: LEGO1 0x100ca290
 void MxDSMultiAction::SetSomeTimingField(MxLong p_someTimingField)
 {

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -44,3 +44,29 @@ MxU32 MxDSMultiAction::GetSizeOnDisk()
 
   return totalSizeOnDisk;
 }
+
+// OFFSET: LEGO1 0x100ca7b0
+void MxDSMultiAction::Deserialize(char **p_source, MxS16 p_unk24)
+{
+  MxDSAction::Deserialize(p_source, p_unk24);
+
+  MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
+  *p_source += 12;
+
+  MxU32 count = *(MxU32*) *p_source;
+  *p_source += sizeof(count);
+
+  if (count) {
+    while (count--) {
+      MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
+      *p_source += 8;
+
+      MxDSAction *action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk24);
+      *p_source += extraFlag;
+
+      this->m_actions->Append(action);
+    }
+  }
+
+  *p_source += extraFlag;
+}

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -17,6 +17,78 @@ MxDSMultiAction::~MxDSMultiAction()
     delete this->m_actions;
 }
 
+// OFFSET: LEGO1 0x100ca0d0
+void MxDSMultiAction::CopyFrom(MxDSMultiAction &p_dsMultiAction)
+{
+  this->m_actions->DeleteAll();
+
+  MxDSActionListCursor cursor(p_dsMultiAction.m_actions);
+  MxDSAction *action;
+  while (cursor.Next(action))
+    this->m_actions->Append(action->Clone());
+}
+
+// OFFSET: LEGO1 0x100ca260
+MxDSMultiAction &MxDSMultiAction::operator=(MxDSMultiAction &p_dsMultiAction)
+{
+  if (this == &p_dsMultiAction)
+    return *this;
+
+  MxDSAction::operator=(p_dsMultiAction);
+  this->CopyFrom(p_dsMultiAction);
+  return *this;
+}
+
+
+// OFFSET: LEGO1 0x100ca290
+void MxDSMultiAction::SetSomeTimingField(MxLong p_someTimingField)
+{
+  this->m_someTimingField = p_someTimingField;
+
+  MxDSActionListCursor cursor(this->m_actions);
+  MxDSAction *action;
+  while (cursor.Next(action))
+    action->SetSomeTimingField(p_someTimingField);
+}
+
+// OFFSET: LEGO1 0x100ca370
+void MxDSMultiAction::MergeFrom(MxDSAction &p_dsMultiAction)
+{
+  MxDSAction::MergeFrom(p_dsMultiAction);
+
+  MxDSActionListCursor cursor(this->m_actions);
+  MxDSAction *action;
+  while (cursor.Next(action))
+    action->MergeFrom(p_dsMultiAction);
+}
+
+// OFFSET: LEGO1 0x100ca450
+MxBool MxDSMultiAction::HasId(MxU32 p_objectId)
+{
+  if (this->GetObjectId() == p_objectId)
+    return TRUE;
+
+  MxDSActionListCursor cursor(this->m_actions);
+  MxDSAction *action;
+  while (cursor.Next(action)) {
+    if (action->HasId(p_objectId))
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+// OFFSET: LEGO1 0x100ca550
+MxDSAction *MxDSMultiAction::Clone()
+{
+  MxDSMultiAction *clone = new MxDSMultiAction();
+
+  if (clone)
+    *clone = *this;
+
+  return clone;
+}
+
 // OFFSET: LEGO1 0x100ca5e0
 undefined4 MxDSMultiAction::unk14()
 {
@@ -69,4 +141,15 @@ void MxDSMultiAction::Deserialize(char **p_source, MxS16 p_unk24)
   }
 
   *p_source += extraFlag;
+}
+
+// OFFSET: LEGO1 0x100ca8c0
+void MxDSMultiAction::SetAtomId(MxAtomId p_atomId)
+{
+  MxDSAction::SetAtomId(p_atomId);
+
+  MxDSActionListCursor cursor(this->m_actions);
+  MxDSAction *action;
+  while (cursor.Next(action))
+    action->SetAtomId(p_atomId);
 }

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -12,6 +12,9 @@ public:
   MxDSMultiAction();
   virtual ~MxDSMultiAction() override;
 
+  void CopyFrom(MxDSMultiAction &p_dsMultiAction);
+  MxDSMultiAction &operator=(MxDSMultiAction &p_dsMultiAction);
+
   // OFFSET: LEGO1 0x100c9f50
   inline virtual const char *ClassName() const override // vtable+0x0c
   {
@@ -28,6 +31,11 @@ public:
   virtual undefined4 unk14(); // vtable+14;
   virtual MxU32 GetSizeOnDisk(); // vtable+18;
   virtual void Deserialize(char **p_source, MxS16 p_unk24); // vtable+1c;
+  virtual void SetAtomId(MxAtomId p_atomId); // vtable+20;
+  virtual MxDSAction *Clone(); // vtable+2c;
+  virtual void MergeFrom(MxDSAction &p_dsAction); // vtable+30;
+  virtual MxBool HasId(MxU32 p_objectId); // vtable+34;
+  virtual void SetSomeTimingField(MxLong p_someTimingField); // vtable+38;
 
 private:
   MxU32 m_sizeOnDisk;

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -27,6 +27,7 @@ public:
 
   virtual undefined4 unk14(); // vtable+14;
   virtual MxU32 GetSizeOnDisk(); // vtable+18;
+  virtual void Deserialize(char **p_source, MxS16 p_unk24); // vtable+1c;
 
 private:
   MxU32 m_sizeOnDisk;

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -59,6 +59,7 @@ public:
   virtual ~MxList();
 
   void Append(T*);
+  void DeleteAll();
   MxU32 GetCount() { return m_count; }
   void SetDestroy(void (*p_customDestructor)(T *)) { this->m_customDestructor = p_customDestructor; }
 
@@ -115,6 +116,12 @@ public:
 template <class T>
 // OFFSET: LEGO1 0x1001ce20
 MxList<T>::~MxList()
+{
+  DeleteAll();
+}
+
+template <class T>
+inline void MxList<T>::DeleteAll()
 {
   for (MxListEntry<T> *t = m_first;;) {
     if (!t)


### PR DESCRIPTION
Implements all the remaining functions of `MxDSMultiAction`. They are all 100% matches.

Note: currently the match for `Deserialize` is only about ~74%, however this is entirely due to compiler randomness. To prove this, I've moved the location of the implementation *before* `GetSizeOnDisk` and that will then yield a 100% match:

![image](https://github.com/isledecomp/isle/assets/1135351/2ae7bcc0-0458-470f-a632-14506c3f8cf4)

However, I will leave the location as-is to preserve the order as observed in the original.