### PR TITLE
Fix LegoOmni vtable

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -91,9 +91,9 @@ void IsleApp::Close()
     VideoManager()->Get3DManager()->GetLego3DView()->GetViewManager()->RemoveAll(NULL);
 
     Lego()->RemoveWorld(ds.GetAtomId(), ds.GetObjectId());
-    Lego()->vtable24(ds);
+    Lego()->DeleteObject(ds);
     TransitionManager()->SetWaitIndicator(NULL);
-    Lego()->vtable3c();
+    Lego()->vtable0x3c();
 
     MxLong lVar8;
     do {
@@ -101,7 +101,7 @@ void IsleApp::Close()
     } while (lVar8 == 0);
 
     while (Lego()) {
-      if (Lego()->vtable28(ds) != FALSE) {
+      if (Lego()->DoesEntityExist(ds)) {
         break;
       }
 
@@ -232,7 +232,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         g_reqEnableRMDevice = 0;
         VideoManager()->EnableRMDevice();
         g_rmDisabled = 0;
-        Lego()->vtable3c();
+        Lego()->vtable0x3c();
       }
 
       if (g_closed) {
@@ -379,7 +379,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         else if (!valid) {
           g_rmDisabled = 1;
-          Lego()->vtable38();
+          Lego()->StartTimer();
           VideoManager()->DisableRMDevice();
         }
       }

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -253,48 +253,49 @@ void LegoOmni::Destroy()
   // FIXME: Stub
 }
 
-void LegoOmni::vtable20()
+void LegoOmni::vtable0x20()
 {
   // FIXME: Stub
 }
 
-void LegoOmni::vtable24(MxDSAction &ds)
+void LegoOmni::DeleteObject(MxDSAction &ds)
 {
   // FIXME: Stub
 }
 
-MxBool LegoOmni::vtable28(MxDSAction &ds)
+MxBool LegoOmni::DoesEntityExist(MxDSAction &ds)
 {
   // FIXME: Stub
   return TRUE;
 }
 
-void LegoOmni::vtable2c()
+void LegoOmni::vtable0x2c()
 {
   // FIXME: Stub
 }
 
-void LegoOmni::vtable30()
+int LegoOmni::vtable0x30(char*, int, MxCore*)
+{
+  // FIXME: Stub
+  return 0;
+}
+
+void LegoOmni::NotifyCurrentEntity()
 {
   // FIXME: Stub
 }
 
-void LegoOmni::vtable34()
+void LegoOmni::StartTimer()
 {
   // FIXME: Stub
 }
 
-void LegoOmni::vtable38()
+void LegoOmni::vtable0x3c()
 {
   // FIXME: Stub
 }
 
-void LegoOmni::vtable3c()
-{
-  // FIXME: Stub
-}
-
-unsigned char LegoOmni::vtable40()
+MxBool LegoOmni::vtable40()
 {
   // FIXME: Stub
   return 0;

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -36,33 +36,33 @@ public:
   LegoOmni();
   virtual ~LegoOmni(); // vtable+00
 
-  virtual MxLong Notify(MxParam &p); // vtable+04
+  virtual MxLong Notify(MxParam &p) override; // vtable+04
 
   // OFFSET: LEGO1 0x10058aa0
-  inline virtual const char *ClassName() const // vtable+0c
+  inline virtual const char *ClassName() const override // vtable+0c
   {
     // 0x100f671c
     return "LegoOmni";
   }
 
   // OFFSET: LEGO1 0x10058ab0
-  inline virtual MxBool IsA(const char *name) const // vtable+10
+  inline virtual MxBool IsA(const char *name) const override // vtable+10
   {
     return !strcmp(name, LegoOmni::ClassName()) || MxOmni::IsA(name);
   }
 
-  virtual void Init(); // vtable+14
-  virtual MxResult Create(COMPAT_CONST MxOmniCreateParam &p); // vtable+18
-  virtual void Destroy(); // vtable+1c
-  virtual void vtable20();
-  virtual void vtable24(MxDSAction &ds);
-  virtual MxBool vtable28(MxDSAction &ds);
-  virtual void vtable2c();
-  virtual void vtable30();
-  virtual void vtable34();
-  virtual void vtable38();
-  virtual void vtable3c();
-  virtual unsigned char vtable40();
+  virtual void Init() override; // vtable+14
+  virtual MxResult Create(COMPAT_CONST MxOmniCreateParam &p) override; // vtable+18
+  virtual void Destroy() override; // vtable+1c
+  virtual void vtable0x20() override;
+  virtual void DeleteObject(MxDSAction &ds) override;
+  virtual MxBool DoesEntityExist(MxDSAction &ds) override;
+  virtual void vtable0x2c() override;
+  virtual int vtable0x30(char*, int, MxCore*) override;
+  virtual void NotifyCurrentEntity() override;
+  virtual void StartTimer() override;
+  virtual void vtable0x3c() override;
+  virtual MxBool vtable40();
 
   LegoVideoManager *GetVideoManager() { return (LegoVideoManager *) m_videoManager; }
   LegoSoundManager *GetSoundManager() { return (LegoSoundManager *)m_soundManager;}

--- a/LEGO1/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/mxbackgroundaudiomanager.cpp
@@ -1,5 +1,7 @@
 #include "mxbackgroundaudiomanager.h"
 
+#include "mxomni.h"
+
 DECOMP_SIZE_ASSERT(MxBackgroundAudioManager, 0x150)
 
 // OFFSET: LEGO1 0x1007ea90

--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -3,6 +3,8 @@
 #include <float.h>
 #include <limits.h>
 
+#include "mxomni.h"
+
 DECOMP_SIZE_ASSERT(MxDSAction, 0x94)
 
 // GLOBAL OFFSET: LEGO1 0x10101410
@@ -214,6 +216,9 @@ MxLong MxDSAction::GetSomeTimingField()
 {
   return this->m_someTimingField;
 }
+
+// Win32 defines GetCurrentTime to GetTickCount
+#undef GetCurrentTime
 
 // OFFSET: LEGO1 0x100adcd0
 MxLong MxDSAction::GetCurrentTime()

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -2,8 +2,10 @@
 #define MXDSACTION_H
 
 #include "mxdsobject.h"
+#include "mxtypes.h"
 #include "mxvector.h"
-#include "mxomni.h"
+
+class MxOmni;
 
 // VTABLE 0x100dc098
 // SIZE 0x94
@@ -40,7 +42,7 @@ public:
   virtual MxU32 GetSizeOnDisk(); // vtable+18;
   virtual void Deserialize(char **p_source, MxS16 p_unk24); // vtable+1c;
   virtual MxLong GetDuration(); // vtable+24;
-  virtual void SetDuration(LONG p_duration); // vtable+28;
+  virtual void SetDuration(MxLong p_duration); // vtable+28;
   virtual MxDSAction *Clone(); // vtable+2c;
   virtual void MergeFrom(MxDSAction &p_dsAction); // vtable+30;
   virtual MxBool HasId(MxU32 p_objectId); // vtable+34;

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -49,15 +49,16 @@ void MxOmni::vtable0x20()
 }
 
 // OFFSET: LEGO1 0x100b00c0 STUB
-void MxOmni::DeleteObject()
+void MxOmni::DeleteObject(MxDSAction &ds)
 {
   // TODO
 }
 
 // OFFSET: LEGO1 0x100b09a0 STUB
-void MxOmni::DoesEntityExist()
+MxBool MxOmni::DoesEntityExist(MxDSAction &ds)
 {
   // TODO
+  return FALSE;
 }
 
 // OFFSET: LEGO1 0x100b00e0 STUB

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -2,6 +2,7 @@
 #define MXOMNI_H
 
 #include "mxcriticalsection.h"
+#include "mxdsaction.h"
 #include "mxeventmanager.h"
 #include "mxmusicmanager.h"
 #include "mxnotificationmanager.h"
@@ -33,13 +34,13 @@ public:
   MxOmni();
   virtual ~MxOmni() override;
 
-  virtual MxLong Notify(MxParam &p); // vtable+04
+  virtual MxLong Notify(MxParam &p) override; // vtable+04
   virtual void Init(); // vtable+14
-  virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
+  virtual MxResult Create(COMPAT_CONST MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c
   virtual void vtable0x20(); // vtable+20
-  virtual void DeleteObject(); // vtable+24
-  virtual void DoesEntityExist(); // vtable+28
+  virtual void DeleteObject(MxDSAction &ds); // vtable+24
+  virtual MxBool DoesEntityExist(MxDSAction &ds); // vtable+28
   virtual void vtable0x2c(); // vtable+2c
   virtual int vtable0x30(char*, int, MxCore*); // vtable+30
   virtual void NotifyCurrentEntity(); // vtable+34


### PR DESCRIPTION
LegoOmni and MxOmni share some vtable functions, but some changes in MxOmni caused shifts in LegoOmni's table.

We should probably have a script that ensures correct vtables and their addresses. I'm not sure how to pull that info from the PDB yet but it's got to be in there.