### PR TITLE
LegoEntity parsing extra Action strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(lego1 SHARED
   LEGO1/buildingentity.cpp
   LEGO1/bumpbouy.cpp
   LEGO1/carrace.cpp
+  LEGO1/define.cpp
   LEGO1/dllmain.cpp
   LEGO1/dunebuggy.cpp
   LEGO1/elevatorbottom.cpp

--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -1,0 +1,10 @@
+#include "define.h"
+
+// 0x10101eac
+const char *g_parseExtraTokens = ":;";
+
+// 0x10101edc
+const char *g_strWORLD = "WORLD";
+
+// 0x10102040
+const char *g_strACTION = "ACTION";

--- a/LEGO1/define.h
+++ b/LEGO1/define.h
@@ -1,0 +1,8 @@
+#ifndef DEFINE_H
+#define DEFINE_H
+
+extern const char *g_parseExtraTokens;
+extern const char *g_strWORLD;
+extern const char *g_strACTION;
+
+#endif // DEFINE_H

--- a/LEGO1/extra.h
+++ b/LEGO1/extra.h
@@ -1,0 +1,21 @@
+#ifndef EXTRA_H
+#define EXTRA_H
+
+// Items related to the Extra string of key-value pairs found in MxOb
+
+enum ExtraActionType
+{
+  ExtraActionType_opendisk = 1,
+  ExtraActionType_openram  = 2,
+  ExtraActionType_close    = 3,
+  ExtraActionType_start    = 4,
+  ExtraActionType_stop     = 5,
+  ExtraActionType_run      = 6,
+  ExtraActionType_exit     = 7,
+  ExtraActionType_enable   = 8,
+  ExtraActionType_disable  = 9,
+  ExtraActionType_notify   = 10,
+  ExtraActionType_unknown  = 11,
+};
+
+#endif // EXTRA_H

--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -2,11 +2,9 @@
 
 #include "legoomni.h"
 #include "legoutil.h"
+#include "define.h"
 
 DECOMP_SIZE_ASSERT(LegoEntity, 0x68)
-
-// 0x10102040
-char *g_strACTION = "ACTION";
 
 // OFFSET: LEGO1 0x1000c290
 LegoEntity::~LegoEntity()

--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -1,6 +1,12 @@
 #include "legoentity.h"
 
+#include "legoomni.h"
+#include "legoutil.h"
+
 DECOMP_SIZE_ASSERT(LegoEntity, 0x68)
+
+// 0x10102040
+char *g_strACTION = "ACTION";
 
 // OFFSET: LEGO1 0x1000c290
 LegoEntity::~LegoEntity()
@@ -16,8 +22,37 @@ MxLong LegoEntity::Notify(MxParam &p)
   return 0;
 }
 
+// OFFSET: LEGO1 0x100107e0 STUB
+void LegoEntity::vtable18()
+{
+
+}
+
 // OFFSET: LEGO1 0x10010810 STUB
 void LegoEntity::Destroy()
 {
   // TODO
+}
+
+// OFFSET: LEGO1 0x10010e10
+void LegoEntity::ParseAction(char *p_extra)
+{
+  char copy[1024];
+  char actionValue[1024];
+  strcpy(copy, p_extra);
+
+  if (KeyValueStringParse(actionValue, g_strACTION, copy)) {
+    m_actionType = MatchActionString(strtok(actionValue, g_parseExtraTokens));
+
+    if (m_actionType != ExtraActionType_exit) {
+      char *token = strtok(NULL, g_parseExtraTokens);
+
+      m_actionArgString = new char[strlen(token) + 1];
+      strcpy(m_actionArgString, token);
+
+      if (m_actionType != ExtraActionType_run) {
+        m_actionArgNumber = atoi(strtok(NULL, g_parseExtraTokens));
+      }
+    }
+  }
 }

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -33,7 +33,7 @@ public:
   }
 
   virtual void vtable18(); // vtable+0x18
-  virtual void Destroy() override; // vtable+0x1c
+  virtual void Destroy(); // vtable+0x1c
   virtual void ParseAction(char *); // vtable+0x20
 
 protected:

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -2,6 +2,7 @@
 #define LEGOENTITY_H
 
 #include "mxentity.h"
+#include "extra.h"
 
 // VTABLE 0x100d4858
 // SIZE 0x68 (probably)
@@ -31,7 +32,16 @@ public:
     return !strcmp(name, LegoEntity::ClassName()) || MxEntity::IsA(name);
   }
 
+  virtual void vtable18(); // vtable+0x18
   virtual void Destroy() override; // vtable+0x1c
+  virtual void ParseAction(char *); // vtable+0x20
+
+protected:
+  // For tokens from the extra string that look like this:
+  // "Action:openram;\lego\scripts\Race\CarRaceR;0"
+  ExtraActionType m_actionType; // 0x5c
+  char *m_actionArgString; // 0x60
+  MxS32 m_actionArgNumber; // 0x64
 
 };
 

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -58,7 +58,7 @@ void MakeSourceName(char *p_output, const char *p_input)
 }
 
 // OFFSET: LEGO1 0x100b7050
-MxBool KeyValueStringParse(char *p_outputValue, char *p_key, char *p_source)
+MxBool KeyValueStringParse(char *p_outputValue, const char *p_key, const char *p_source)
 {
   MxBool didMatch = FALSE;
 

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -113,6 +113,6 @@ __declspec(dllexport) MxLong Start(MxDSAction *a);
 LegoBuildingManager* BuildingManager();
 Isle* GetIsle();
 LegoPlantManager* PlantManager();
-MxBool KeyValueStringParse(char *, char *, char *);
+MxBool KeyValueStringParse(char *, const char *, const char *);
 
 #endif // LEGOOMNI_H

--- a/LEGO1/legoutil.cpp
+++ b/LEGO1/legoutil.cpp
@@ -2,6 +2,36 @@
 
 #include "mxtypes.h"
 
+#include <string.h>
+
+// OFFSET: LEGO1 0x1003e300
+ExtraActionType MatchActionString(const char *p_str) {
+  ExtraActionType result = ExtraActionType_unknown;
+
+  if (!strcmpi("openram", p_str))
+    result = ExtraActionType_openram;
+  else if (!strcmpi("opendisk", p_str))
+    result = ExtraActionType_opendisk;
+  else if (!strcmpi("close", p_str))
+    result = ExtraActionType_close;
+  else if (!strcmpi("start", p_str))
+    result = ExtraActionType_start;
+  else if (!strcmpi("stop", p_str))
+    result = ExtraActionType_stop;
+  else if (!strcmpi("run", p_str))
+    result = ExtraActionType_run;
+  else if (!strcmpi("exit", p_str))
+    result = ExtraActionType_exit;
+  else if (!strcmpi("enable", p_str))
+    result = ExtraActionType_enable;
+  else if (!strcmpi("disable", p_str))
+    result = ExtraActionType_disable;
+  else if (!strcmpi("notify", p_str))
+    result = ExtraActionType_notify;
+
+  return result;
+}
+
 // OFFSET: LEGO1 0x1003eae0
 void ConvertHSVToRGB(float h, float s, float v, float *r_out, float *b_out, float *g_out)
 {

--- a/LEGO1/legoutil.h
+++ b/LEGO1/legoutil.h
@@ -1,6 +1,8 @@
 #ifndef LEGOUTIL_H
 #define LEGOUTIL_H
 
+#include "extra.h"
+
 template <class T>
 inline T Abs(T p_t)
 {
@@ -19,6 +21,7 @@ inline T Max(T p_t1, T p_t2)
   return p_t1 > p_t2 ? p_t1 : p_t2;
 }
 
+ExtraActionType MatchActionString(const char *);
 void ConvertHSVToRGB(float r, float g, float b, float* out_r, float* out_g, float* out_b);
 
 #endif // LEGOUTIL_H

--- a/LEGO1/mxentity.cpp
+++ b/LEGO1/mxentity.cpp
@@ -1,6 +1,8 @@
 #include "mxentity.h"
 
-// DECOMP_SIZE_ASSERT(MxEntity, 0x68)
+// Size subject to change. It's not clear yet which members belong to
+// MxEntity and which belong only the subclasses.
+DECOMP_SIZE_ASSERT(MxEntity, 0x5c)
 
 // OFFSET: LEGO1 0x1001d190
 MxEntity::MxEntity()

--- a/LEGO1/mxentity.cpp
+++ b/LEGO1/mxentity.cpp
@@ -1,6 +1,6 @@
 #include "mxentity.h"
 
-DECOMP_SIZE_ASSERT(MxEntity, 0x68)
+// DECOMP_SIZE_ASSERT(MxEntity, 0x68)
 
 // OFFSET: LEGO1 0x1001d190
 MxEntity::MxEntity()

--- a/LEGO1/mxentity.h
+++ b/LEGO1/mxentity.h
@@ -31,7 +31,7 @@ public:
 private:
   MxS32 m_mxEntityId; // 0x8
   MxAtomId m_atom; // 0xc
-  undefined m_unk10[0x58];
+  undefined m_unk10[76];
 };
 
 #endif // MXENTITY_H

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -7,14 +7,9 @@
 #include <string.h>
 
 #include "decomp.h"
+#include "define.h"
 
 DECOMP_SIZE_ASSERT(MxPresenter, 0x40);
-
-// 0x10101eac
-char *g_parseExtraTokens = ":;";
-
-// 0x10101edc
-char *g_strWORLD = "WORLD";
 
 // OFFSET: LEGO1 0x100b4d50
 void MxPresenter::Init()

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -85,5 +85,6 @@ private:
 };
 
 char *PresenterNameDispatch(const MxDSAction &);
+extern char *g_parseExtraTokens;
 
 #endif // MXPRESENTER_H

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -85,6 +85,5 @@ private:
 };
 
 char *PresenterNameDispatch(const MxDSAction &);
-extern char *g_parseExtraTokens;
 
 #endif // MXPRESENTER_H


### PR DESCRIPTION
Two new functions and a few changes all related to parsing the Extra string from an MxOb chunk. Specifically: parsing the "Action" section. For example:

```"Action:openram;\lego\scripts\Race\CarRaceR;0"``` (from CARRACE.SI)

Action is the key we are interested in; the rest is the value, with ';' as the delimiter. The first section is the action type, and a new function MatchActionString converts this to an int (enum) that I put in the new file extra.h.

There's no obvious name for the second and third tokens and they don't appear (or are ignored) for some action types. I named these m_actionArgString and m_actionArgNumber for now. The new function LegoEntity::ParseAction sets these variables.

I commented out the size assert on MxEntity (or we could just remove it). It felt more correct to have these new member values defined in LegoEntity instead of MxEntity, because they are set in the PasrseAction function that is part of LegoEntity's vtable only. There isn't an obvious break between which members should go in MxEntity or LegoEntity and we probably can't say for certain until all the MxEntity functions are decomped so we know what things it uses.

Lastly, I put another string literal as a global variable (where I last did so in #123 for MxPresenter). The asm doesn't match unless we push a pointer to the string's address (versus the address where the characters start). I also borrowed the ParseExtra tokens from MxPresenter. Is there a good practice to follow for how and where to define strings like these so we don't have to move them later? Is it not actually required to make these global vars?

**Updates after review**
- Modified size assert is restored to MxEntity
- Moved global string variables (including the ones from #123) to their own define.cpp file
- Minor change to KeyValueStringParse to use const char* args where it makes sense