### PR TITLE
LegoEntity::Reset

### DIFF
--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -9,7 +9,7 @@ DECOMP_SIZE_ASSERT(LegoEntity, 0x68)
 // OFFSET: LEGO1 0x1000c290
 LegoEntity::~LegoEntity()
 {
-  Destroy();
+  Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100114f0 STUB
@@ -20,6 +20,26 @@ MxLong LegoEntity::Notify(MxParam &p)
   return 0;
 }
 
+// OFFSET: LEGO1 0x100105f0
+void LegoEntity::Reset()
+{
+  float value = 0.0f;
+  m_vec1.EqualsScalar(&value);
+
+  value = 0.0f;
+  m_vec2.EqualsScalar(&value);
+
+  m_unk50 = 0;
+  m_unk54 = 0;
+  m_unk58 = 0;
+  m_actionArgString = NULL;
+  m_unk10 = 0;
+  m_unk11 = 0;
+  m_actionType = ExtraActionType_unknown;
+  m_actionArgNumber = -1;
+  m_unk59 = 4;
+}
+
 // OFFSET: LEGO1 0x100107e0 STUB
 void LegoEntity::vtable18()
 {
@@ -27,9 +47,14 @@ void LegoEntity::vtable18()
 }
 
 // OFFSET: LEGO1 0x10010810 STUB
-void LegoEntity::Destroy()
+void LegoEntity::Destroy(MxBool)
 {
-  // TODO
+  if (m_unk54) {
+    // TODO
+  }
+
+  delete[] m_actionArgString;
+  Reset();
 }
 
 // OFFSET: LEGO1 0x10010e10

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -2,7 +2,9 @@
 #define LEGOENTITY_H
 
 #include "mxentity.h"
+#include "mxvector.h"
 #include "extra.h"
+#include "decomp.h"
 
 // VTABLE 0x100d4858
 // SIZE 0x68 (probably)
@@ -33,10 +35,21 @@ public:
   }
 
   virtual void vtable18(); // vtable+0x18
-  virtual void Destroy(); // vtable+0x1c
+  virtual void Destroy(MxBool); // vtable+0x1c
   virtual void ParseAction(char *); // vtable+0x20
 
 protected:
+  void Reset();
+
+  undefined m_unk10;
+  undefined m_unk11;
+  MxVector3Data m_vec1; // 0x14
+  MxVector3Data m_vec2; // 0x28
+  MxVector3Data m_vec3; // 0x3c
+  undefined4 m_unk50;
+  undefined4 m_unk54;
+  undefined m_unk58;
+  undefined m_unk59;
   // For tokens from the extra string that look like this:
   // "Action:openram;\lego\scripts\Race\CarRaceR;0"
   ExtraActionType m_actionType; // 0x5c

--- a/LEGO1/mxentity.cpp
+++ b/LEGO1/mxentity.cpp
@@ -1,8 +1,6 @@
 #include "mxentity.h"
 
-// Size subject to change. It's not clear yet which members belong to
-// MxEntity and which belong only the subclasses.
-DECOMP_SIZE_ASSERT(MxEntity, 0x5c)
+DECOMP_SIZE_ASSERT(MxEntity, 0x10)
 
 // OFFSET: LEGO1 0x1001d190
 MxEntity::MxEntity()

--- a/LEGO1/mxentity.h
+++ b/LEGO1/mxentity.h
@@ -7,7 +7,7 @@
 #include "mxtypes.h"
 
 // VTABLE 0x100d5390
-// SIZE 0x68 or less
+// SIZE 0x10
 class MxEntity : public MxCore
 {
 public:
@@ -31,7 +31,6 @@ public:
 private:
   MxS32 m_mxEntityId; // 0x8
   MxAtomId m_atom; // 0xc
-  undefined m_unk10[76];
 };
 
 #endif // MXENTITY_H


### PR DESCRIPTION
Added a Reset method to LegoEntity. It zeroes out member values or restores to defaults.

In each place this is called, we are inside of a LegoEntity method or have just created an object where the LegoEntity vtable is set. In #141, we debated how many of the members in the 0x68 sized LegoEntity footprint belong to superclass MxEntity. With this Reset method setting members from 0x10 and up, I feel pretty confident that MxEntity owns just the two members referenced in SetEntityId(). I moved everything over to LegoEntity and updated the size asserts.

The Destroy() method has a parameter (probably a bool based on the callers) but Ghidra (and I) can't see where it's used. Adding this brings the destructor to 100%.

The debugger shows m_unk54 set to an object with vtable 0x100dbe38. The shared Ghidra has this as "VideoStuff::ClassA_D::VTABLE_D" right now.