### PR TITLE
MxTransitionManager::Dissolve

### DIFF
--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -33,6 +33,7 @@ public:
   virtual void ReleaseDC(HDC p_hdc);
   virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);
 
+  inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return this->m_ddSurface1; }
   inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }
 
 private:

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -90,7 +90,7 @@ void MxTransitionManager::Transition_Dissolve()
   }
 
   if (res == DD_OK) {
-    FUN_1004c4d0(&ddsd);
+    FUN_1004c4d0(ddsd);
 
     for (int i = 0; i < 640; i++) {
       // Select 16 columns on each tick
@@ -115,7 +115,7 @@ void MxTransitionManager::Transition_Dissolve()
       }
     }
 
-    FUN_1004c580(&ddsd);
+    FUN_1004c580(ddsd);
     m_ddSurface->Unlock(ddsd.lpSurface);
 
     if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
@@ -134,13 +134,13 @@ void MxTransitionManager::SetWaitIndicator(MxVideoPresenter *videoPresenter)
 }
 
 // OFFSET: LEGO1 0x1004c4d0 STUB
-void MxTransitionManager::FUN_1004c4d0(DDSURFACEDESC *ddsc)
+void MxTransitionManager::FUN_1004c4d0(DDSURFACEDESC &ddsc)
 {
   // TODO
 }
 
 // OFFSET: LEGO1 0x1004c580 STUB
-void MxTransitionManager::FUN_1004c580(DDSURFACEDESC *ddsc)
+void MxTransitionManager::FUN_1004c580(DDSURFACEDESC &ddsc)
 {
   // TODO
 }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -5,7 +5,7 @@
 DECOMP_SIZE_ASSERT(MxTransitionManager, 0x900);
 
 // 0x100f4378
-RECT g_rect_100f4378 = {0, 0, 640, 480};
+RECT g_fullScreenRect = {0, 0, 640, 480};
 
 // OFFSET: LEGO1 0x1004b8d0
 MxTransitionManager::MxTransitionManager()
@@ -120,7 +120,7 @@ void MxTransitionManager::Transition_Dissolve()
 
     if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
       LPDIRECTDRAWSURFACE surf = VideoManager()->GetDisplaySurface()->GetDirectDrawSurface1();
-      surf->BltFast(NULL, NULL, m_ddSurface, &g_rect_100f4378, 0x10);
+      surf->BltFast(NULL, NULL, m_ddSurface, &g_fullScreenRect, 0x10);
     }
 
     m_animationTimer++;

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -4,6 +4,9 @@
 
 DECOMP_SIZE_ASSERT(MxTransitionManager, 0x900);
 
+// 0x100f4378
+RECT g_rect_100f4378 = {0, 0, 640, 480};
+
 // OFFSET: LEGO1 0x1004b8d0
 MxTransitionManager::MxTransitionManager()
 {
@@ -38,8 +41,102 @@ MxResult MxTransitionManager::Tickle()
   return 0;
 }
 
+// OFFSET: LEGO1 0x1004bc30 STUB
+void MxTransitionManager::EndTransition(MxBool)
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004bd10
+void MxTransitionManager::Transition_Dissolve()
+{
+  // If the animation is finished
+  if (m_animationTimer == 40) {
+    m_animationTimer = 0;
+    EndTransition(TRUE);
+    return;
+  }
+
+  // If we are starting the animation
+  if (m_animationTimer == 0) {
+    // Populate
+    for (int i = 0; i < 640; i++) {
+      m_pad36[i] = i;
+    }
+
+    // Randomize (sorta)
+    for (i = 0; i < 640; i++) {
+      int swap_ofs = rand() % 640;
+      undefined2 t = m_pad36[i];
+      m_pad36[i] = m_pad36[swap_ofs];
+      m_pad36[swap_ofs] = t;
+    }
+
+    for (i = 0; i < 480; i++) {
+      m_pad536[i] = rand() % 640;
+    }
+  }
+
+  // Else run one tick of the animation
+  DDSURFACEDESC ddsd;
+  memset(&ddsd, 0, sizeof(ddsd));
+  ddsd.dwSize = sizeof(ddsd);
+
+  HRESULT res = m_ddSurface->Lock(NULL, &ddsd, 1, NULL);
+  if (res == DDERR_SURFACELOST) {
+    m_ddSurface->Restore();
+    res = m_ddSurface->Lock(NULL, &ddsd, 1, NULL);
+  }
+
+  if (res == DD_OK) {
+    FUN_1004c4d0(&ddsd);
+
+    for (int i = 0; i < 640; i++) {
+      if (m_animationTimer * 16 > m_pad36[i])
+        continue;
+
+      if (m_animationTimer * 16 + 15 < m_pad36[i])
+        continue;
+
+      for (int j = 0; j < 480; j++) {
+        int jt = (m_pad536[j] + i) % 640;
+
+        if (ddsd.ddpfPixelFormat.dwRGBBitCount == 8) {
+          MxU8 *pix = (MxU8*)ddsd.lpSurface;
+          pix[j * ddsd.lPitch + jt] = 0;
+        } else {
+          MxU16 *pix = (MxU16*)ddsd.lpSurface;
+          pix[j * ddsd.lPitch + jt] = 0;
+        }
+      }
+    }
+
+    FUN_1004c580(&ddsd);
+    m_ddSurface->Unlock(ddsd.lpSurface);
+
+    if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
+      LPDIRECTDRAWSURFACE surf = VideoManager()->GetDisplaySurface()->GetDirectDrawSurface1();
+      surf->BltFast(NULL, NULL, m_ddSurface, &g_rect_100f4378, 0x10);
+    }
+
+    m_animationTimer++;
+  }
+}
+
 // OFFSET: LEGO1 0x1004c470 STUB
 void MxTransitionManager::SetWaitIndicator(MxVideoPresenter *videoPresenter)
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004c4d0 STUB
+void MxTransitionManager::FUN_1004c4d0(DDSURFACEDESC *ddsc)
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004c580 STUB
+void MxTransitionManager::FUN_1004c580(DDSURFACEDESC *ddsc)
 {
   // TODO
 }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -60,13 +60,13 @@ void MxTransitionManager::Transition_Dissolve()
   // If we are starting the animation
   if (m_animationTimer == 0) {
     // Generate the list of columns in order...
-    for (int i = 0; i < 640; i++) {
+    for (MxS32 i = 0; i < 640; i++) {
       m_columnOrder[i] = i;
     }
 
     // ...then shuffle the list (to ensure that we hit each column once)
     for (i = 0; i < 640; i++) {
-      int swap = rand() % 640;
+      MxS32 swap = rand() % 640;
       MxU16 t = m_columnOrder[i];
       m_columnOrder[i] = m_columnOrder[swap];
       m_columnOrder[swap] = t;
@@ -92,7 +92,7 @@ void MxTransitionManager::Transition_Dissolve()
   if (res == DD_OK) {
     FUN_1004c4d0(ddsd);
 
-    for (int i = 0; i < 640; i++) {
+    for (MxS32 i = 0; i < 640; i++) {
       // Select 16 columns on each tick
       if (m_animationTimer * 16 > m_columnOrder[i])
         continue;
@@ -100,11 +100,11 @@ void MxTransitionManager::Transition_Dissolve()
       if (m_animationTimer * 16 + 15 < m_columnOrder[i])
         continue;
 
-      for (int j = 0; j < 480; j++) {
+      for (MxS32 j = 0; j < 480; j++) {
         // Shift the chosen column a different amount at each scanline.
         // We use the same shift for that scanline each time.
         // By the end, every pixel gets hit.
-        int ofs = (m_randomShift[j] + i) % 640;
+        MxS32 ofs = (m_randomShift[j] + i) % 640;
 
         // Set the chosen pixel to black
         if (ddsd.ddpfPixelFormat.dwRGBBitCount == 8) {

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -107,8 +107,8 @@ private:
   TransitionType m_transitionType;
   LPDIRECTDRAWSURFACE m_ddSurface;
   MxU16 m_animationTimer;
-  undefined2 m_pad36[640]; // 0x36
-  undefined2 m_pad536[480]; // 0x536
+  MxU16 m_columnOrder[640]; // 0x36
+  MxU16 m_randomShift[480]; // 0x536
   MxULong m_systemTime;
   MxS32 m_animationSpeed;
 };

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -89,6 +89,11 @@ public:
   MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, MxBool p_unk, MxBool p_playMusicInAnim);
 
 private:
+  void EndTransition(MxBool);
+  void Transition_Dissolve();
+  void FUN_1004c4d0(DDSURFACEDESC*);
+  void FUN_1004c580(DDSURFACEDESC*);
+
   MxTransitionManagerUnknownSubclass1 *m_unk08;
   undefined4 m_unk0c;
   undefined4 m_unk10;
@@ -102,7 +107,8 @@ private:
   TransitionType m_transitionType;
   LPDIRECTDRAWSURFACE m_ddSurface;
   MxU16 m_animationTimer;
-  undefined m_pad36[0x8c2];
+  undefined2 m_pad36[640]; // 0x36
+  undefined2 m_pad536[480]; // 0x536
   MxULong m_systemTime;
   MxS32 m_animationSpeed;
 };

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -91,8 +91,8 @@ public:
 private:
   void EndTransition(MxBool);
   void Transition_Dissolve();
-  void FUN_1004c4d0(DDSURFACEDESC*);
-  void FUN_1004c580(DDSURFACEDESC*);
+  void FUN_1004c4d0(DDSURFACEDESC &);
+  void FUN_1004c580(DDSURFACEDESC &);
 
   MxTransitionManagerUnknownSubclass1 *m_unk08;
   undefined4 m_unk0c;


### PR DESCRIPTION
Dissolve transition, as selected by the Tickle() method. The code comments give my reasoning for naming the two array members from the class. I tried to figure out `FUN_1004c4d0` and `FUN_1004c580` (called by each of the transition functions) to at least give a name, but they both depend on pieces we don't have yet. `FUN_1004c4d0` is doing a memcpy on something. Maybe part of page flipping?

The pixel plot for the "two bytes per pixel" case doesn't match exactly. There is either some subtlety in the casting that I'm missing, or it's our old pal compiler weirdness.

Do we have a preference for using the `ddraw.h` macros for calling virtual methods? e.g. `IDirectDrawSurface_BltFast` versus `surf->BltFast()`.