### PR TITLE
Implement MxTransitionManager::EndTransition and GetCurrentWorld

### DIFF
--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -312,3 +312,9 @@ MxBool LegoOmni::vtable40()
   // FIXME: Stub
   return 0;
 }
+
+// OFFSET: LEGO1 0x100157a0
+LegoWorld *GetCurrentWorld()
+{
+  return LegoOmni::GetInstance()->GetCurrentWorld();
+}

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -75,12 +75,16 @@ public:
   LegoGameState *GetGameState() { return m_gameState; }
   LegoNavController *GetNavController() { return m_navController; }
   MxTransitionManager *GetTransitionManager() { return m_transitionManager; }
+  LegoWorld *GetCurrentWorld() { return m_currentWorld; }
 
 private:
   int m_unk68;
   int m_unk6c;
   LegoInputManager *m_inputMgr; // 0x70
-  char m_unk74[0x10];
+  undefined4 m_unk74;
+  undefined4 m_unk78;
+  LegoWorld *m_currentWorld;
+  undefined4 m_unk80;
   LegoNavController *m_navController; // 0x84
   Isle* m_isle; // 0x88
   char m_unk8c[0x4];
@@ -115,5 +119,6 @@ LegoBuildingManager* BuildingManager();
 Isle* GetIsle();
 LegoPlantManager* PlantManager();
 MxBool KeyValueStringParse(char *, const char *, const char *);
+LegoWorld *GetCurrentWorld();
 
 #endif // LEGOOMNI_H

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -55,8 +55,7 @@ void MxTransitionManager::EndTransition(MxBool p_notifyWorld)
       LegoWorld *world = GetCurrentWorld();
 
       if (world) {
-        MxParam p(0x18, this);
-        world->Notify(p);
+        world->Notify(MxParam(0x18, this));
       }
     }
   }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -41,10 +41,25 @@ MxResult MxTransitionManager::Tickle()
   return 0;
 }
 
-// OFFSET: LEGO1 0x1004bc30 STUB
-void MxTransitionManager::EndTransition(MxBool)
+// OFFSET: LEGO1 0x1004bc30
+void MxTransitionManager::EndTransition(MxBool p_notifyWorld)
 {
-  // TODO
+  if (m_transitionType != NOT_TRANSITIONING) {
+    m_transitionType = NOT_TRANSITIONING;
+
+    m_unk20.bit0 = FALSE;
+
+    TickleManager()->UnregisterClient(this);
+
+    if (p_notifyWorld) {
+      LegoWorld *world = GetCurrentWorld();
+
+      if (world) {
+        MxParam p(0x18, this);
+        world->Notify(p);
+      }
+    }
+  }
 }
 
 // OFFSET: LEGO1 0x1004bd10

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -89,7 +89,7 @@ public:
   MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, MxBool p_unk, MxBool p_playMusicInAnim);
 
 private:
-  void EndTransition(MxBool);
+  void EndTransition(MxBool p_notifyWorld);
   void Transition_Dissolve();
   void FUN_1004c4d0(DDSURFACEDESC &);
   void FUN_1004c580(DDSURFACEDESC &);
@@ -109,8 +109,8 @@ private:
   MxU16 m_animationTimer;
   MxU16 m_columnOrder[640]; // 0x36
   MxU16 m_randomShift[480]; // 0x536
-  MxULong m_systemTime;
-  MxS32 m_animationSpeed;
+  MxULong m_systemTime; // 0x8f8
+  MxS32 m_animationSpeed; // 0x8fc
 };
 
 #endif // MXTRANSITIONMANAGER_H


### PR DESCRIPTION
EndTransition is *almost* 100%. It's off by a single instruction (`mov dword ptr [ebp - 4] , esi`), which alters some surrounding jmps:

![Screenshot_20231003_213548](https://github.com/isledecomp/isle/assets/34096995/62ea7b44-5cc6-435e-ae24-e0f591098d16)

If anyone has any suggestions to improve this, I'd be happy to hear them, though it could also be random compiler entropy and is arguably close enough to be merged at this state (the missing instruction is literally pointless since it immediately gets replaced in the next instruction anyway)
