### PR TITLE
MxSoundManager: dtor, destroy, update types

### DIFF
--- a/LEGO1/mxmediamanager.h
+++ b/LEGO1/mxmediamanager.h
@@ -7,8 +7,6 @@
 #include "mxpresenterlist.h"
 #include "mxtypes.h"
 
-#include <dsound.h>
-
 // VTABLE 0x100dc6b0
 // SIZE 0x2c
 class MxMediaManager : public MxCore

--- a/LEGO1/mxmediamanager.h
+++ b/LEGO1/mxmediamanager.h
@@ -7,6 +7,8 @@
 #include "mxpresenterlist.h"
 #include "mxtypes.h"
 
+#include <dsound.h>
+
 // VTABLE 0x100dc6b0
 // SIZE 0x2c
 class MxMediaManager : public MxCore

--- a/LEGO1/mxsoundmanager.cpp
+++ b/LEGO1/mxsoundmanager.cpp
@@ -1,21 +1,48 @@
 #include "mxsoundmanager.h"
 
+#include "mxomni.h"
+
+DECOMP_SIZE_ASSERT(MxSoundManager, 0x3c);
+
 // OFFSET: LEGO1 0x100ae740
 MxSoundManager::MxSoundManager()
 {
   Init();
 }
 
-// OFFSET: LEGO1 0x100ae7d0 STUB
+// OFFSET: LEGO1 0x100ae7d0
 MxSoundManager::~MxSoundManager()
 {
-  // TODO
+  Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100ae830
 void MxSoundManager::Init()
 {
   m_unk30 = 0;
-  m_unk34 = 0;
+  m_dsBuffer = NULL;
 }
 
+// OFFSET: LEGO1 0x100ae840
+void MxSoundManager::Destroy(MxBool p_param)
+{
+  if(this->m_thread) {
+    this->m_thread->Terminate();
+    delete this->m_thread;
+  } else {
+    TickleManager()->UnregisterClient(this);
+  }
+
+  this->m_criticalSection.Enter();
+
+  if(this->m_dsBuffer) {
+    this->m_dsBuffer->Release();
+  }
+
+  Init();
+  this->m_criticalSection.Leave();
+
+  if(!p_param) {
+    MxAudioManager::Destroy();
+  }
+}

--- a/LEGO1/mxsoundmanager.cpp
+++ b/LEGO1/mxsoundmanager.cpp
@@ -26,23 +26,24 @@ void MxSoundManager::Init()
 // OFFSET: LEGO1 0x100ae840
 void MxSoundManager::Destroy(MxBool p_param)
 {
-  if(this->m_thread) {
+  if (this->m_thread) {
     this->m_thread->Terminate();
     delete this->m_thread;
-  } else {
+  }
+  else {
     TickleManager()->UnregisterClient(this);
   }
 
   this->m_criticalSection.Enter();
 
-  if(this->m_dsBuffer) {
+  if (this->m_dsBuffer) {
     this->m_dsBuffer->Release();
   }
 
   Init();
   this->m_criticalSection.Leave();
 
-  if(!p_param) {
+  if (!p_param) {
     MxAudioManager::Destroy();
   }
 }

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -4,9 +4,10 @@
 #include "decomp.h"
 #include "mxaudiomanager.h"
 
+#include <dsound.h>
+
 // VTABLE 0x100dc128
 // SIZE 0x3c
-// Base vtables are: MxCore -> 0x100dc6b0 -> MxAudioManager -> MxSoundManager
 class MxSoundManager : public MxAudioManager
 {
 public:
@@ -16,8 +17,9 @@ public:
 private:
   void Init();
   void Destroy(MxBool);
+
   undefined4 m_unk30;
-  LPDIRECTSOUNDBUFFER m_dsBuffer;  // 0x34
+  LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x34
   undefined m_unk35[4];
 };
 

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -1,6 +1,7 @@
 #ifndef MXSOUNDMANAGER_H
 #define MXSOUNDMANAGER_H
 
+#include "decomp.h"
 #include "mxaudiomanager.h"
 
 // VTABLE 0x100dc128
@@ -14,8 +15,10 @@ public:
 
 private:
   void Init();
-  int m_unk30;
-  int m_unk34;
+  void Destroy(MxBool);
+  undefined4 m_unk30;
+  LPDIRECTSOUNDBUFFER m_dsBuffer;  // 0x34
+  undefined m_unk35[4];
 };
 
 #endif // MXSOUNDMANAGER_H

--- a/LEGO1/mxthread.h
+++ b/LEGO1/mxthread.h
@@ -24,6 +24,8 @@ public:
 
 protected:
   MxThread();
+
+public:
   virtual ~MxThread();
 
 private:


### PR DESCRIPTION
Also make MxThread's destructor public.

ckdev also found the type of m_unk34, which is very helpful. I placed the import for DirectSound at the header of mxmediamanager so the other classes have it