### PR TITLE
Implement MxTransitionManager SetWaitIndicator and SetupCopyRect

### DIFF
--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -174,7 +174,7 @@ void MxDisplaySurface::SetPalette(MxPalette *p_palette)
 }
 
 // OFFSET: LEGO1 0x100bc200 STUB
-void MxDisplaySurface::vtable24(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
+void MxDisplaySurface::vtable24(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
 {
 
 }
@@ -186,7 +186,7 @@ MxBool MxDisplaySurface::vtable28(undefined4, undefined4, undefined4, undefined4
 }
 
 // OFFSET: LEGO1 0x100bc630 STUB
-MxBool MxDisplaySurface::vtable2c(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
+MxBool MxDisplaySurface::vtable2c(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
 {
   return 0;
 }

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -174,7 +174,7 @@ void MxDisplaySurface::SetPalette(MxPalette *p_palette)
 }
 
 // OFFSET: LEGO1 0x100bc200 STUB
-void MxDisplaySurface::vtable24(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
+void MxDisplaySurface::vtable24(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
 {
 
 }
@@ -186,7 +186,7 @@ MxBool MxDisplaySurface::vtable28(undefined4, undefined4, undefined4, undefined4
 }
 
 // OFFSET: LEGO1 0x100bc630 STUB
-MxBool MxDisplaySurface::vtable2c(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
+MxBool MxDisplaySurface::vtable2c(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
 {
   return 0;
 }

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -23,9 +23,9 @@ public:
   virtual MxResult Create(MxVideoParam &p_videoParam);
   virtual void Clear();
   virtual void SetPalette(MxPalette *p_palette);
-  virtual void vtable24(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual void vtable24(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual MxBool vtable2c(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
+  virtual MxBool vtable2c(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -23,9 +23,9 @@ public:
   virtual MxResult Create(MxVideoParam &p_videoParam);
   virtual void Clear();
   virtual void SetPalette(MxPalette *p_palette);
-  virtual void vtable24(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual void vtable24(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual MxBool vtable2c(DDSURFACEDESC&, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
+  virtual MxBool vtable2c(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -16,6 +16,7 @@ public:
   {
     Flag_Looping = 0x01,
     Flag_Bit3 = 0x04,
+    Flag_Bit5 = 0x10,
     Flag_Enabled = 0x20,
     Flag_Parsed = 0x80,
     Flag_Bit9 = 0x200,

--- a/LEGO1/mxmediapresenter.cpp
+++ b/LEGO1/mxmediapresenter.cpp
@@ -17,3 +17,9 @@ void MxMediaPresenter::Init()
   this->m_unk48 = NULL;
   this->m_unk4c = NULL;
 }
+
+// OFFSET: LEGO1 0x100b5f10 STUB
+void MxMediaPresenter::VTable0x58()
+{
+  // TODO
+}

--- a/LEGO1/mxmediapresenter.h
+++ b/LEGO1/mxmediapresenter.h
@@ -29,6 +29,8 @@ public:
     return !strcmp(name, MxMediaPresenter::ClassName()) || MxPresenter::IsA(name);
   }
 
+  virtual void VTable0x58(); // vtable+0x58
+
   undefined4 m_unk40;
   undefined4 m_unk44;
   undefined4 m_unk48;

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -68,6 +68,8 @@ public:
 
   MxBool IsEnabled();
 
+  inline MxS32 GetCurrentTickleState() { return this->m_currentTickleState; }
+  inline MxPoint32 GetLocation() { return this->m_location; }
   inline MxS32 GetDisplayZ() { return this->m_displayZ; }
   inline MxDSAction *GetAction() { return this->m_action; }
 

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -252,9 +252,7 @@ void MxTransitionManager::SetWaitIndicator(MxVideoPresenter *p_waitIndicator)
     if (m_waitIndicator->GetCurrentTickleState() < MxPresenter::TickleState_Streaming) {
       m_waitIndicator->Tickle();
     }
-  }
-  else
-  {
+  } else {
     // Disable copy rect
     m_copyFlags.bit0 = FALSE;
   }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -336,7 +336,7 @@ void MxTransitionManager::SetupCopyRect(DDSURFACEDESC &ddsc)
   }
 
   // Setup display surface
-  if ((m_waitIndicator->GetAction()->GetFlags() & 0x10) != 0)
+  if ((m_waitIndicator->GetAction()->GetFlags() & MxDSAction::Flag_Bit5) != 0)
   {
     MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
     MxBool unkbool = FALSE;

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -231,10 +231,32 @@ void MxTransitionManager::Transition_Wipe()
   }
 }
 
-// OFFSET: LEGO1 0x1004c470 STUB
-void MxTransitionManager::SetWaitIndicator(MxVideoPresenter *videoPresenter)
+// OFFSET: LEGO1 0x1004c470
+void MxTransitionManager::SetWaitIndicator(MxVideoPresenter *p_waitIndicator)
 {
-  // TODO
+  // End current wait indicator
+  if (m_waitIndicator != NULL) {
+    m_waitIndicator->GetAction()->SetFlags(m_waitIndicator->GetAction()->GetFlags() & ~MxDSAction::Flag_Parsed);
+    m_waitIndicator->EndAction();
+    m_waitIndicator = NULL;
+  }
+
+  // Check if we were given a new wait indicator
+  if (p_waitIndicator != NULL) {
+    // Setup the new wait indicator
+    m_waitIndicator = p_waitIndicator;
+
+    LegoVideoManager *videoManager = VideoManager();
+    videoManager->RemovePresenter(*m_waitIndicator);
+
+    if (m_waitIndicator->GetCurrentTickleState() < MxPresenter::TickleState_Streaming) {
+      m_waitIndicator->Tickle();
+    }
+    return;
+  }
+
+  // Disable copy rect
+  m_copyFlags.bit0 = FALSE;
 }
 
 // OFFSET: LEGO1 0x1004c4d0
@@ -272,5 +294,58 @@ void MxTransitionManager::SubmitCopyRect(DDSURFACEDESC &ddsc)
 // OFFSET: LEGO1 0x1004c580 STUB
 void MxTransitionManager::SetupCopyRect(DDSURFACEDESC &ddsc)
 {
-  // TODO
+  // Check if the copy rect is setup
+  if (m_copyFlags.bit0 == FALSE || m_waitIndicator == NULL) {
+    return;
+  }
+
+  // Tickle wait indicator
+  m_waitIndicator->Tickle();
+
+  // Check if wait indicator has started
+  if (m_waitIndicator->GetCurrentTickleState() >= MxPresenter::TickleState_Streaming) {
+    MxS32 left = m_waitIndicator->GetLocation().m_x;
+    MxS32 top = m_waitIndicator->GetLocation().m_y;
+
+    DWORD bytesPerPixel = ddsc.ddpfPixelFormat.dwRGBBitCount / 8;
+    DWORD copyPitch = bytesPerPixel * (m_copyRect.right - m_copyRect.left + 1);
+
+    m_copyRect.left = left;
+    m_copyRect.top = top;
+
+    MxS32 height = m_waitIndicator->GetHeight();
+    MxS32 width = m_waitIndicator->GetWidth();
+
+    m_copyRect.right = left + width - 1;
+    m_copyRect.bottom = top + height - 1;
+
+    const char *src;
+    char *copyBuffer;
+
+    src = (const char*)ddsc.lpSurface + m_copyRect.top * ddsc.lPitch + bytesPerPixel * m_copyRect.left;
+    copyBuffer = (char*)malloc(bytesPerPixel * (m_copyRect.right - m_copyRect.left + 1) * (m_copyRect.bottom - m_copyRect.top + 1));
+
+    this->m_copyBuffer = copyBuffer;
+    if (!copyBuffer)
+      return;
+
+    for (LONG i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++)
+    {
+      memcpy(copyBuffer, src, copyPitch);
+      copyBuffer += copyPitch;
+      src += ddsc.lPitch;
+    }
+  }
+
+  if ((m_waitIndicator->GetAction()->GetFlags() & 0x10) != 0)
+  {
+    MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
+    MxBool unkbool = FALSE;
+    displaySurface->vtable2c(ddsc, m_waitIndicator->m_unk50, 0, 0, m_waitIndicator->GetLocation().m_x, m_waitIndicator->GetLocation().m_y, m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight(), unkbool);
+  }
+  else
+  {
+    MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
+    displaySurface->vtable24(ddsc, m_waitIndicator->m_unk50, 0, 0, m_waitIndicator->GetLocation().m_x, m_waitIndicator->GetLocation().m_y, m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight());
+  }
 }

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -46,8 +46,8 @@ private:
   void EndTransition(MxBool p_notifyWorld);
   void Transition_Dissolve();
   void Transition_Wipe();
-  void SubmitCopyRect(DDSURFACEDESC &);
-  void SetupCopyRect(DDSURFACEDESC &);
+  void SubmitCopyRect(LPDDSURFACEDESC ddsc);
+  void SetupCopyRect(LPDDSURFACEDESC ddsc);
 
   MxVideoPresenter *m_waitIndicator;
   RECT m_copyRect;

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -12,7 +12,7 @@ public:
   MxTransitionManager();
   virtual ~MxTransitionManager() override; // vtable+0x0
 
-  __declspec(dllexport) void SetWaitIndicator(MxVideoPresenter *videoPresenter);
+  __declspec(dllexport) void SetWaitIndicator(MxVideoPresenter *p_waitIndicator);
 
   virtual MxResult Tickle(); // vtable+0x8
 

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -2,8 +2,88 @@
 
 DECOMP_SIZE_ASSERT(MxVideoPresenter, 0x64);
 
+// OFFSET: LEGO1 0x1000c700 STUB
+void MxVideoPresenter::VTable0x5c()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c710 STUB
+void MxVideoPresenter::VTable0x60()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c720 STUB
+void MxVideoPresenter::VTable0x68()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c730 STUB
+void MxVideoPresenter::VTable0x70()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c740
+MxVideoPresenter::~MxVideoPresenter()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c7a0 STUB
+void MxVideoPresenter::InitVirtual()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c7b0 STUB
+void MxVideoPresenter::VTable0x78()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c7c0 STUB
+void MxVideoPresenter::VTable0x7c()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1000c7e0 STUB
+MxS32 MxVideoPresenter::GetWidth()
+{
+  // TODO
+  return 0;
+}
+
+// OFFSET: LEGO1 0x1000c800 STUB
+MxS32 MxVideoPresenter::GetHeight()
+{
+  // TODO
+  return 0;
+}
+
 // OFFSET: LEGO1 0x100b2760 STUB
 void MxVideoPresenter::Init()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b28b0 STUB
+void MxVideoPresenter::VTable0x64()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b2a70 STUB
+void MxVideoPresenter::VTable0x6c()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b3300 STUB
+void MxVideoPresenter::VTable0x74()
 {
   // TODO
 }

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -29,7 +29,7 @@ void MxVideoPresenter::VTable0x70()
 // OFFSET: LEGO1 0x1000c740
 MxVideoPresenter::~MxVideoPresenter()
 {
-  // TODO
+  Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x1000c7a0 STUB
@@ -66,6 +66,12 @@ MxS32 MxVideoPresenter::GetHeight()
 
 // OFFSET: LEGO1 0x100b2760 STUB
 void MxVideoPresenter::Init()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100b27b0 STUB
+void MxVideoPresenter::Destroy(MxBool)
 {
   // TODO
 }

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -13,6 +13,8 @@ public:
     Init();
   }
 
+  virtual ~MxVideoPresenter() override; // vtable+0x0
+
   // OFFSET: LEGO1 0x1000c820
   inline virtual const char *ClassName() const override // vtable+0x0c
   {
@@ -27,6 +29,20 @@ public:
   }
 
   void Init();
+
+  virtual void InitVirtual() override; // vtable+0x38
+
+  virtual void VTable0x5c(); // vtable+0x5c
+  virtual void VTable0x60(); // vtable+0x60
+  virtual void VTable0x64(); // vtable+0x64
+  virtual void VTable0x68(); // vtable+0x68
+  virtual void VTable0x6c(); // vtable+0x6c
+  virtual void VTable0x70(); // vtable+0x70
+  virtual void VTable0x74(); // vtable+0x74
+  virtual void VTable0x78(); // vtable+0x78
+  virtual void VTable0x7c(); // vtable+0x7c
+  virtual MxS32 GetWidth();  // vtable+0x80
+  virtual MxS32 GetHeight(); // vtable+0x84
 
   undefined4 m_unk50;
   undefined4 m_unk54;

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -29,6 +29,7 @@ public:
   }
 
   void Init();
+  void Destroy(MxBool);
 
   virtual void InitVirtual() override; // vtable+0x38
 


### PR DESCRIPTION
This PR implements and matches `MxTransition::SetWaitIndicator`
This PR implements `MxTransition::SetupCopyRect`
`SetupCopyRect` does not currently match.

This PR touches into various other classes out of necessity.