### PR TITLE
(Proposal) Add injection hooking to test decompiled functions in-game

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(isle CXX)
 
 option(ISLE_BUILD_APP "Build ISLE.EXE application" ON)
+option(ISLE_BUILD_PATCH "Build patching into ISLE.EXE and LEGO1.DLL (requires ISLE_BUILD_APP)" OFF)
 option(ISLE_USE_SMARTHEAP "Build with SmartHeap" ${MSVC})
 option(ISLE_USE_DX5 "Build with internal DirectX 5 SDK" ON)
 
@@ -219,6 +220,22 @@ target_link_libraries(lego1 PRIVATE ddraw dsound dxguid dinput winmm)
 set_property(TARGET lego1 PROPERTY OUTPUT_NAME LEGO1)
 set_property(TARGET lego1 PROPERTY SUFFIX ".DLL")
 
+# Forward ISLE_BUILD_PATCH
+if (ISLE_BUILD_PATCH)
+  target_sources(lego1 PRIVATE LEGO1/decomp.cpp)
+
+  target_compile_definitions(lego1 PRIVATE ISLE_BUILD_PATCH)
+
+  # Copy LEGO1.DLL to LEGO1_PATCH.DLL after LEGO1.DLL is built
+  # This is a crappy hack, but when building the patcher, we want
+  # ISLE.EXE to import the original LEGO1.DLL, then load LEGO1_PATCH.DLL
+  # (our DLL) manually
+  add_custom_command(
+    TARGET lego1 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:lego1> $<TARGET_FILE_DIR:lego1>/LEGO1_PATCH.DLL
+  )
+endif()
+
 if (ISLE_BUILD_APP)
   add_executable(isle WIN32
     ISLE/res/isle.rc
@@ -245,6 +262,11 @@ if (ISLE_BUILD_APP)
   # Make sure filenames are ALL CAPS
   set_property(TARGET isle PROPERTY OUTPUT_NAME ISLE)
   set_property(TARGET isle PROPERTY SUFFIX ".EXE")
+
+  # Forward ISLE_BUILD_PATCH
+  if (ISLE_BUILD_PATCH)
+    target_compile_definitions(isle PRIVATE ISLE_BUILD_PATCH)
+  endif()
 endif()
 
 if (MSVC)

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -155,6 +155,21 @@ BOOL StartDirectSound(void);
 // OFFSET: ISLE 0x401610
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
+#ifdef ISLE_BUILD_PATCH
+  // Load LEGO1_PATCH.DLL
+  {
+    HMODULE hModule = LoadLibraryA("LEGO1_PATCH.DLL");
+    if (hModule) {
+      typedef void (*PatchFunc)(void*);
+      PatchFunc patchFunc = (PatchFunc)GetProcAddress(hModule, "Patch");
+      if (patchFunc) {
+        void *root = (char*)VideoManager - 0x10015720;
+        patchFunc(root);
+      }
+    }
+  }
+#endif
+
   // Look for another instance, if we find one, bring it to the foreground instead
   if (!FindExistingInstance()) {
     return 0;

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -156,14 +156,20 @@ BOOL StartDirectSound(void);
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
 #ifdef ISLE_BUILD_PATCH
-  // Load LEGO1_PATCH.DLL
   {
-    HMODULE hModule = LoadLibraryA("LEGO1_PATCH.DLL");
-    if (hModule) {
+    // Find the imported LEGO1.DLL module
+    HMODULE hLego1Module = GetModuleHandleA("LEGO1.DLL");
+    if (!hLego1Module) {
+      return 1;
+    }
+
+    // Load LEGO1_PATCH.DLL
+    HMODULE hPatchModule = LoadLibraryA("LEGO1_PATCH.DLL");
+    if (hPatchModule) {
       typedef void (*PatchFunc)(void*);
-      PatchFunc patchFunc = (PatchFunc)GetProcAddress(hModule, "Patch");
+      PatchFunc patchFunc = (PatchFunc)GetProcAddress(hPatchModule, "Patch");
       if (patchFunc) {
-        void *root = (char*)VideoManager - 0x10015720;
+        void *root = (char*)hLego1Module - 0x10000000;
         patchFunc(root);
       }
     }

--- a/LEGO1/decomp.cpp
+++ b/LEGO1/decomp.cpp
@@ -2,8 +2,106 @@
 
 #include "Windows.h"
 
-// Export "Patch" function (non-mangled name)
+#include <stdio.h>
+
+#ifdef ISLE_BUILD_PATCH
+
+// Managed list class for patches
+static class DecompPatchList
+{
+private:
+  struct DecompPatchNode
+  {
+    DecompPatchNode *next;
+    void *origFunc, *newFunc;
+  } *m_head;
+
+public:
+  DecompPatchList()
+  {
+    // I'm having CRT initialization order issues
+    // with MSVC 4.20, so I'm going to leave m_head
+    // uninitialized. It's static so it should be
+    // zeroed anyways.
+    // m_head = NULL;
+  }
+
+  ~DecompPatchList()
+  {
+    // Delete all nodes
+    for (DecompPatchNode *node = m_head; node != NULL;)
+    {
+      DecompPatchNode *next = node->next;
+      delete node;
+      node = next;
+    }
+  }
+
+  void Add(void *origFunc, void *newFunc)
+  {
+    // Create new node
+    DecompPatchNode *node = new DecompPatchNode;
+    node->origFunc = origFunc;
+    node->newFunc = newFunc;
+    node->next = m_head;
+
+    // Add to head of list
+    m_head = node;
+  }
+
+  void Patch(void *root)
+  {
+    // Go through all nodes
+    for (DecompPatchNode *node = m_head; node != NULL; node = node->next)
+    {
+      // Inject JMP instruction
+      BYTE *location = (BYTE*)((DWORD)root + (DWORD)node->origFunc);
+      BYTE *newFunction = (BYTE*)node->newFunc;
+
+      /*
+      DWORD dwOldProtection;
+      VirtualProtect(location, 5, PAGE_EXECUTE_READWRITE, &dwOldProtection);
+      location[0] = 0xE9; //jmp
+      *((DWORD*)(location + 1)) = (DWORD)(((DWORD)newFunction - (DWORD)location) - 5);
+      VirtualProtect(location, 5, dwOldProtection, &dwOldProtection);
+      */
+
+      BYTE code[5];
+      code[0] = 0xE9; //jmp
+      *((DWORD*)(code + 1)) = (DWORD)(((DWORD)newFunction - (DWORD)location) - 5);
+
+      char buffer[256];
+      sprintf(buffer, "location %p, newFunction %p, origFunc %p, root %p", location, newFunction, node->origFunc, root);
+      MessageBoxA(NULL, buffer, "DecompPatchList", MB_ICONERROR);
+
+      static HANDLE hProcess = GetCurrentProcess();
+      DWORD written = 0;
+      if (WriteProcessMemory(hProcess, location, code, sizeof(code), &written) == FALSE || written != sizeof(code))
+      {
+        // Print error reason
+        sprintf(buffer, "WriteProcessMemory failed: %d", GetLastError());
+        MessageBoxA(NULL, buffer, "DecompPatchList", MB_ICONERROR);
+
+        MessageBoxA(NULL, "Patch failed", "DecompPatchList", MB_ICONERROR);
+      }
+    }
+  }
+} decompPatchList;
+
+// Function called to add a patch to the list of patches
+void DecompPatchAdd(void *origFunc, void *newFunc)
+{
+  // Add to list
+  decompPatchList.Add(origFunc, newFunc);
+}
+
+// Exported "Patch" function
+// This goes through all our added patches and applies them
+// Root is the root address of LEGO1.DLL
 extern "C" __declspec(dllexport) void Patch(void *root)
 {
-  MessageBoxA(NULL, "HELLO", "HELLO", 0);
+  // Apply all patches
+  decompPatchList.Patch(root);
 }
+
+#endif

--- a/LEGO1/decomp.cpp
+++ b/LEGO1/decomp.cpp
@@ -58,32 +58,11 @@ public:
       BYTE *location = (BYTE*)((DWORD)root + (DWORD)node->origFunc);
       BYTE *newFunction = (BYTE*)node->newFunc;
 
-      /*
       DWORD dwOldProtection;
       VirtualProtect(location, 5, PAGE_EXECUTE_READWRITE, &dwOldProtection);
       location[0] = 0xE9; //jmp
       *((DWORD*)(location + 1)) = (DWORD)(((DWORD)newFunction - (DWORD)location) - 5);
       VirtualProtect(location, 5, dwOldProtection, &dwOldProtection);
-      */
-
-      BYTE code[5];
-      code[0] = 0xE9; //jmp
-      *((DWORD*)(code + 1)) = (DWORD)(((DWORD)newFunction - (DWORD)location) - 5);
-
-      char buffer[256];
-      sprintf(buffer, "location %p, newFunction %p, origFunc %p, root %p", location, newFunction, node->origFunc, root);
-      MessageBoxA(NULL, buffer, "DecompPatchList", MB_ICONERROR);
-
-      static HANDLE hProcess = GetCurrentProcess();
-      DWORD written = 0;
-      if (WriteProcessMemory(hProcess, location, code, sizeof(code), &written) == FALSE || written != sizeof(code))
-      {
-        // Print error reason
-        sprintf(buffer, "WriteProcessMemory failed: %d", GetLastError());
-        MessageBoxA(NULL, buffer, "DecompPatchList", MB_ICONERROR);
-
-        MessageBoxA(NULL, "Patch failed", "DecompPatchList", MB_ICONERROR);
-      }
     }
   }
 } decompPatchList;

--- a/LEGO1/decomp.cpp
+++ b/LEGO1/decomp.cpp
@@ -20,7 +20,7 @@ public:
   DecompPatchList()
   {
     // I'm having CRT initialization order issues
-    // with MSVC 4.20, so I'm going to leave m_head
+    // with MSVC 4.2, so I'm going to leave m_head
     // uninitialized. It's static so it should be
     // zeroed anyways.
     // m_head = NULL;

--- a/LEGO1/decomp.cpp
+++ b/LEGO1/decomp.cpp
@@ -1,0 +1,9 @@
+#include "decomp.h"
+
+#include "Windows.h"
+
+// Export "Patch" function (non-mangled name)
+extern "C" __declspec(dllexport) void Patch(void *root)
+{
+  MessageBoxA(NULL, "HELLO", "HELLO", 0);
+}

--- a/LEGO1/decomp.h
+++ b/LEGO1/decomp.h
@@ -12,4 +12,21 @@ typedef unsigned char undefined;
 typedef unsigned short undefined2;
 typedef unsigned int undefined4;
 
+#ifdef ISLE_BUILD_PATCH
+
+class PatchHook
+{
+public:
+  PatchHook(void *p_ourFunc, void *p_origFunc);
+};
+
+#define PATCH_HOOK(ourFunc, origFunc) \
+  static PatchHook _patchHook_##__COUNTER__ ((void *)ourFunc, (void *)origFunc)
+
+#else
+
+#define PATCH_HOOK(ourFunc, origFunc)
+
+#endif
+
 #endif // DECOMP_H

--- a/LEGO1/decomp.h
+++ b/LEGO1/decomp.h
@@ -14,25 +14,31 @@ typedef unsigned int undefined4;
 
 #ifdef ISLE_BUILD_PATCH
 
+// Function called to add a patch to the list of patches
 void DecompPatchAdd(void *origFunc, void *newFunc);
 
-#define DECOMP_METHOD_HOOK(origFunc, cls, method, retv, args) \
-namespace _DecompPatchHook_##__COUNTER__ \
-{ \
-  class DecompPatchHook \
+// Class decomp hook macros
+#define DECOMP_HOOK_DECL_CLS() \
+  static void _ExportHooks()
+
+#define DECOMP_HOOK_START_CLS(cls) \
+  void cls::_ExportHooks() {
+#define DECOMP_HOOK_END_CLS(cls) \
+  } static struct _ExportHooks_##cls { _ExportHooks_##cls () { cls::_ExportHooks(); } } _exportHooks_##cls
+
+#define DECOMP_HOOK_EXPORT_CLS(origFunc, cls, retv, method, args) \
   { \
-  public: \
-    DecompPatchHook() \
-    { \
-      retv(cls :: *method) args = cls::method; \
-      DecompPatchAdd((void*)origFunc, (void*)&_patchHook); \
-    } \
-  } _patchHook; \
-}
+    retv(cls :: * _ourFunc ) args = cls::method; \
+    DecompPatchAdd((void*)origFunc, (void*)*((DWORD*)& _ourFunc )); \
+  }
 
 #else
 
 #define DECOMP_METHOD_HOOK()
+
+#define DECOMP_HOOK_DECL_EXPORT()
+#define DECOMP_HOOK_DEFN_EXPORT()
+#define DECOMP_HOOK_EXPORT()
 
 #endif
 

--- a/LEGO1/decomp.h
+++ b/LEGO1/decomp.h
@@ -34,11 +34,10 @@ void DecompPatchAdd(void *origFunc, void *newFunc);
 
 #else
 
-#define DECOMP_METHOD_HOOK()
-
-#define DECOMP_HOOK_DECL_EXPORT()
-#define DECOMP_HOOK_DEFN_EXPORT()
-#define DECOMP_HOOK_EXPORT()
+#define DECOMP_HOOK_DECL_CLS()
+#define DECOMP_HOOK_START_CLS()
+#define DECOMP_HOOK_END_CLS()
+#define DECOMP_HOOK_EXPORT_CLS()
 
 #endif
 

--- a/LEGO1/decomp.h
+++ b/LEGO1/decomp.h
@@ -14,18 +14,25 @@ typedef unsigned int undefined4;
 
 #ifdef ISLE_BUILD_PATCH
 
-class PatchHook
-{
-public:
-  PatchHook(void *p_ourFunc, void *p_origFunc);
-};
+void DecompPatchAdd(void *origFunc, void *newFunc);
 
-#define PATCH_HOOK(ourFunc, origFunc) \
-  static PatchHook _patchHook_##__COUNTER__ ((void *)ourFunc, (void *)origFunc)
+#define DECOMP_METHOD_HOOK(origFunc, cls, method, retv, args) \
+namespace _DecompPatchHook_##__COUNTER__ \
+{ \
+  class DecompPatchHook \
+  { \
+  public: \
+    DecompPatchHook() \
+    { \
+      retv(cls :: *method) args = cls::method; \
+      DecompPatchAdd((void*)origFunc, (void*)&_patchHook); \
+    } \
+  } _patchHook; \
+}
 
 #else
 
-#define PATCH_HOOK(ourFunc, origFunc)
+#define DECOMP_METHOD_HOOK()
 
 #endif
 

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -4,6 +4,10 @@
 
 DECOMP_SIZE_ASSERT(MxTransitionManager, 0x900);
 
+DECOMP_HOOK_START_CLS(MxTransitionManager);
+DECOMP_HOOK_EXPORT_CLS(0x1004bb70, MxTransitionManager, void, SubmitCopyRect, (DDSURFACEDESC&));
+DECOMP_HOOK_END_CLS(MxTransitionManager);
+
 // 0x100f4378
 RECT g_fullScreenRect = {0, 0, 640, 480};
 
@@ -153,7 +157,6 @@ MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, MxS32 p_speed,
                                               MxBool p_doCopy, MxBool p_playMusicInAnim)
 {
-  Beep(750, 300);
   if (this->m_transitionType == NOT_TRANSITIONING) {
     if (!p_playMusicInAnim) {
       MxBackgroundAudioManager *backgroundAudioManager = BackgroundAudioManager();
@@ -192,8 +195,6 @@ MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, Mx
   }
   return FAILURE;
 }
-
-DECOMP_METHOD_HOOK(0x1004bb70, MxTransitionManager, StartTransition, MxResult, (MxTransitionManager::TransitionType, MxS32, MxBool, MxBool));
 
 // OFFSET: LEGO1 0x1004c170
 void MxTransitionManager::Transition_Wipe()
@@ -253,7 +254,7 @@ void MxTransitionManager::SubmitCopyRect(DDSURFACEDESC &ddsc)
 
   DWORD bytesPerPixel = ddsc.ddpfPixelFormat.dwRGBBitCount / 8;
 
-  const char *src = (const char *)m_copyBuffer;
+  const char *src = (const char*)m_copyBuffer;
 
   LONG copyPitch;
   copyPitch = ((m_copyRect.right - m_copyRect.left) + 1) * bytesPerPixel;

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -153,6 +153,7 @@ MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, MxS32 p_speed,
                                               MxBool p_doCopy, MxBool p_playMusicInAnim)
 {
+  Beep(750, 300);
   if (this->m_transitionType == NOT_TRANSITIONING) {
     if (!p_playMusicInAnim) {
       MxBackgroundAudioManager *backgroundAudioManager = BackgroundAudioManager();
@@ -192,10 +193,7 @@ MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, Mx
   return FAILURE;
 }
 
-void Test()
-{
-  MxResult (MxTransitionManager:: * pfTarget)(MxTransitionManager::TransitionType, MxS32, MxBool, MxBool) = MxTransitionManager::StartTransition;
-}
+DECOMP_METHOD_HOOK(0x1004bb70, MxTransitionManager, StartTransition, MxResult, (MxTransitionManager::TransitionType, MxS32, MxBool, MxBool));
 
 // OFFSET: LEGO1 0x1004c170
 void MxTransitionManager::Transition_Wipe()

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -5,7 +5,7 @@
 DECOMP_SIZE_ASSERT(MxTransitionManager, 0x900);
 
 DECOMP_HOOK_START_CLS(MxTransitionManager);
-DECOMP_HOOK_EXPORT_CLS(0x1004bb70, MxTransitionManager, void, SubmitCopyRect, (DDSURFACEDESC&));
+DECOMP_HOOK_EXPORT_CLS(0x1004bb70, MxTransitionManager, void, SubmitCopyRect, (LPDDSURFACEDESC));
 DECOMP_HOOK_END_CLS(MxTransitionManager);
 
 // 0x100f4378
@@ -275,7 +275,7 @@ void MxTransitionManager::SubmitCopyRect(LPDDSURFACEDESC ddsc)
 
   DWORD bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-  const char *src = (const char*)m_copyBuffer;
+  const char *src = (const char *)m_copyBuffer;
 
   LONG copyPitch;
   copyPitch = ((m_copyRect.right - m_copyRect.left) + 1) * bytesPerPixel;

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -192,6 +192,11 @@ MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, Mx
   return FAILURE;
 }
 
+void Test()
+{
+  MxResult (MxTransitionManager:: * pfTarget)(MxTransitionManager::TransitionType, MxS32, MxBool, MxBool) = MxTransitionManager::StartTransition;
+}
+
 // OFFSET: LEGO1 0x1004c170
 void MxTransitionManager::Transition_Wipe()
 {

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -9,6 +9,8 @@
 class MxTransitionManager : public MxCore
 {
 public:
+  DECOMP_HOOK_DECL_CLS();
+
   MxTransitionManager();
   virtual ~MxTransitionManager() override; // vtable+0x0
 


### PR DESCRIPTION
This proposal adds a new compile option and a few macros that allows the decompilation to be built as to patch decompiled functions into the original LEGO1.DLL.

It's just a draft right now, there's a few things that still need to be worked out:
- SmartHeap is static linked into the patch DLL, which breaks memory allocation. There is probably a simple solution to this.
- Global variables do not have hooks yet. MSVC 4.2 makes this pretty hard so I'm not sure where to go with this.

I'm hoping some other people can provide insight on how to move this forward, as it'll help to be able to test non-matching functions in-game.