### PR TITLE
MxTransitionManager::Tickle() & FUN_1004bcf0

### DIFF
--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -232,7 +232,7 @@ undefined4 MxDisplaySurface::vtable44(undefined4, undefined4*, undefined4, undef
 }
 
 // OFFSET: LEGO1 0x100ba640 STUB
-void MxDisplaySurface::FUN_100ba640(MxDisplaySurface *p_displaySurface)
+void MxDisplaySurface::FUN_100ba640()
 {
   // TODO
 }

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -230,3 +230,9 @@ undefined4 MxDisplaySurface::vtable44(undefined4, undefined4*, undefined4, undef
 {
   return 0;
 }
+
+// OFFSET: LEGO1 0x100ba640 STUB
+void MxDisplaySurface::FUN_100ba640(MxDisplaySurface *p_displaySurface)
+{
+  // TODO
+}

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -19,6 +19,8 @@ public:
 
   void Reset();
 
+  static void FUN_100ba640(MxDisplaySurface *p_displaySurface);
+
   virtual MxResult Init(MxVideoParam &p_videoParam, LPDIRECTDRAWSURFACE p_ddSurface1, LPDIRECTDRAWSURFACE p_ddSurface2, LPDIRECTDRAWCLIPPER p_ddClipper);
   virtual MxResult Create(MxVideoParam &p_videoParam);
   virtual void Clear();

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -19,7 +19,7 @@ public:
 
   void Reset();
 
-  static void FUN_100ba640(MxDisplaySurface *p_displaySurface);
+  void FUN_100ba640();
 
   virtual MxResult Init(MxVideoParam &p_videoParam, LPDIRECTDRAWSURFACE p_ddSurface1, LPDIRECTDRAWSURFACE p_ddSurface2, LPDIRECTDRAWCLIPPER p_ddClipper);
   virtual MxResult Create(MxVideoParam &p_videoParam);

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -19,34 +19,31 @@ MxTransitionManager::~MxTransitionManager()
 // OFFSET: LEGO1 0x1004bac0
 MxResult MxTransitionManager::Tickle()
 {
-  MxS32 speed = this->m_animationSpeed;
-  MxULong storedTime = this->m_systemTime;
-  MxULong realTime = timeGetTime();
-
-  if (speed + storedTime <= realTime) {
-    storedTime = timeGetTime();
-    this->m_systemTime = storedTime;
-
-    switch (this->m_transitionType) {
-      case NO_ANIMATION:
-        FUN_1004bcf0();
-        return SUCCESS;
-      case DISSOLVE:
-        FUN_1004bd10();
-        return SUCCESS;
-      case PIXELATION:
-        FUN_1004bed0();
-        return SUCCESS;
-      case SCREEN_WIPE:
-        FUN_1004c170();
-        return SUCCESS;
-      case WINDOWS:
-        FUN_1004c270();
-        return SUCCESS;
-      case BROKEN:
-        FUN_1004c3e0();
-    }
+  if (this->m_animationSpeed + this->m_systemTime > timeGetTime()) {
     return SUCCESS;
+  }
+
+  this->m_systemTime = timeGetTime();
+
+  switch (this->m_transitionType) {
+    case NO_ANIMATION:
+      FUN_1004bcf0();
+      break;
+    case DISSOLVE:
+      FUN_1004bd10();
+      break;
+    case PIXELATION:
+      FUN_1004bed0();
+      break;
+    case SCREEN_WIPE:
+      FUN_1004c170();
+      break;
+    case WINDOWS:
+      FUN_1004c270();
+      break;
+    case BROKEN:
+      FUN_1004c3e0();
+      break;
   }
   return SUCCESS;
 }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -108,7 +108,7 @@ void MxTransitionManager::EndTransition(MxBool p_unk)
 void MxTransitionManager::FUN_1004bcf0()
 {
   LegoVideoManager *videoManager = VideoManager();
-  MxDisplaySurface::FUN_100ba640(videoManager->GetDisplaySurface());
+  videoManager->GetDisplaySurface()->FUN_100ba640();
   EndTransition(TRUE);
 }
 

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -16,12 +16,39 @@ MxTransitionManager::~MxTransitionManager()
   // TODO
 }
 
-// OFFSET: LEGO1 0x1004bac0 STUB
+// OFFSET: LEGO1 0x1004bac0
 MxResult MxTransitionManager::Tickle()
 {
-  // TODO
+  MxS32 speed = this->m_animationSpeed;
+  MxULong storedTime = this->m_systemTime;
+  MxULong realTime = timeGetTime();
 
-  return 0;
+  if (speed + storedTime <= realTime) {
+    storedTime = timeGetTime();
+    this->m_systemTime = storedTime;
+
+    switch (this->m_transitionType) {
+      case NO_ANIMATION:
+        FUN_1004bcf0();
+        return SUCCESS;
+      case DISSOLVE:
+        FUN_1004bd10();
+        return SUCCESS;
+      case PIXELATION:
+        FUN_1004bed0();
+        return SUCCESS;
+      case SCREEN_WIPE:
+        FUN_1004c170();
+        return SUCCESS;
+      case WINDOWS:
+        FUN_1004c270();
+        return SUCCESS;
+      case BROKEN:
+        FUN_1004c3e0();
+    }
+    return SUCCESS;
+  }
+  return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1004c470 STUB
@@ -53,7 +80,7 @@ MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, Mx
 
       // TODO: This part of the function is mangled and I can't make out what it's doing right now
 
-      MxU32 time = timeGetTime();
+      MxULong time = timeGetTime();
       this->m_systemTime = time;
 
       this->m_animationSpeed = p_speed;
@@ -72,4 +99,40 @@ MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, Mx
       return SUCCESS;
   }
   return FAILURE;
+}
+
+// OFFSET: LEGO1 0x1004bcf0 STUB
+void MxTransitionManager::FUN_1004bcf0()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004bd10 STUB
+void MxTransitionManager::FUN_1004bd10()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004bed0 STUB
+void MxTransitionManager::FUN_1004bed0()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004c170 STUB
+void MxTransitionManager::FUN_1004c170()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004c270 STUB
+void MxTransitionManager::FUN_1004c270()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x1004c3e0 STUB
+void MxTransitionManager::FUN_1004c3e0()
+{
+  // TODO
 }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -47,19 +47,19 @@ MxResult MxTransitionManager::Tickle()
       FUN_1004bcf0();
       break;
     case DISSOLVE:
-      FUN_1004bd10();
+      Transition_Dissolve();
       break;
     case PIXELATION:
-      FUN_1004bed0();
+      Transition_Pixelation();
       break;
     case SCREEN_WIPE:
-      FUN_1004c170();
+      Transition_Wipe();
       break;
     case WINDOWS:
-      FUN_1004c270();
+      Transition_Windows();
       break;
     case BROKEN:
-      FUN_1004c3e0();
+      Transition_Broken();
       break;
   }
   return SUCCESS;
@@ -225,20 +225,20 @@ void MxTransitionManager::FUN_1004bcf0()
 }
 
 // OFFSET: LEGO1 0x1004bed0 STUB
-void MxTransitionManager::FUN_1004bed0()
+void MxTransitionManager::Transition_Pixelation()
 {
   // TODO
 }
 
 
 // OFFSET: LEGO1 0x1004c270 STUB
-void MxTransitionManager::FUN_1004c270()
+void MxTransitionManager::Transition_Windows()
 {
   // TODO
 }
 
 // OFFSET: LEGO1 0x1004c3e0 STUB
-void MxTransitionManager::FUN_1004c3e0()
+void MxTransitionManager::Transition_Broken()
 {
   // TODO
 }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -98,10 +98,18 @@ MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, Mx
   return FAILURE;
 }
 
-// OFFSET: LEGO1 0x1004bcf0 STUB
-void MxTransitionManager::FUN_1004bcf0()
+// OFFSET: LEGO1 0x1004bc30 STUB
+void MxTransitionManager::EndTransition(MxBool p_unk)
 {
   // TODO
+}
+
+// OFFSET: LEGO1 0x1004bcf0
+void MxTransitionManager::FUN_1004bcf0()
+{
+  LegoVideoManager *videoManager = VideoManager();
+  MxDisplaySurface::FUN_100ba640(videoManager->GetDisplaySurface());
+  EndTransition(TRUE);
 }
 
 // OFFSET: LEGO1 0x1004bd10 STUB

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -42,20 +42,17 @@ public:
 
   MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, MxBool p_doCopy, MxBool p_playMusicInAnim);
 
-  void MxTransitionManager::EndTransition(MxBool p_unk);
-
-  void FUN_1004bcf0();
-  void FUN_1004bd10();
-  void FUN_1004bed0();
-  void FUN_1004c170();
-  void FUN_1004c270();
-  void FUN_1004c3e0();
-
 
 private:
   void EndTransition(MxBool p_notifyWorld);
   void Transition_Dissolve();
+  void Transition_Pixelation();
   void Transition_Wipe();
+  void Transition_Windows();
+  void Transition_Broken();
+
+  void FUN_1004bcf0();
+
   void SubmitCopyRect(LPDDSURFACEDESC ddsc);
   void SetupCopyRect(LPDDSURFACEDESC ddsc);
 

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -42,6 +42,14 @@ public:
 
   MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, undefined p_unk, MxBool p_playMusicInAnim);
 
+  void FUN_1004bcf0();
+  void FUN_1004bd10();
+  void FUN_1004bed0();
+  void FUN_1004c170();
+  void FUN_1004c270();
+  void FUN_1004c3e0();
+
+
 private:
   undefined m_pad00[0x20];
   undefined m_pad20[0x04];

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -42,6 +42,8 @@ public:
 
   MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, undefined p_unk, MxBool p_playMusicInAnim);
 
+  void MxTransitionManager::EndTransition(MxBool p_unk);
+
   void FUN_1004bcf0();
   void FUN_1004bd10();
   void FUN_1004bed0();


### PR DESCRIPTION
Implements MxTransitionManager::Tickle() and MxTransitionManager::FUN_1004bcf0().

FUN_1004bcf0 is 100% matching. Tickle() was matching before merge.

This PR also additionally stubs all of the unimplemented transition methods.