### PR TITLE
[gave up] BuildingEntity

### DIFF
--- a/LEGO1/buildingentity.cpp
+++ b/LEGO1/buildingentity.cpp
@@ -5,6 +5,11 @@
 // OFFSET: LEGO1 0x10014e20
 BuildingEntity::BuildingEntity()
 {
+  // this->m_vec1.m_data = this->m_vec1.storage;
+  // this->m_vec2.m_data = this->m_vec2.storage;
+  // this->m_vec3.m_data = this->m_vec3.storage;
+  this->m_mxEntityId = -1;
+  Reset();
   NotificationManager()->Register(this);
 }
 

--- a/LEGO1/buildingentity.cpp
+++ b/LEGO1/buildingentity.cpp
@@ -1,13 +1,15 @@
 #include "buildingentity.h"
 
-// OFFSET: LEGO1 0x10014e20 STUB
+#include "mxomni.h"
+
+// OFFSET: LEGO1 0x10014e20
 BuildingEntity::BuildingEntity()
 {
-  // TODO
+  NotificationManager()->Register(this);
 }
 
-// OFFSET: LEGO1 0x10015030 STUB
+// OFFSET: LEGO1 0x10015030
 BuildingEntity::~BuildingEntity()
 {
-  // TODO
+  NotificationManager()->Unregister(this);
 }

--- a/LEGO1/mxentity.h
+++ b/LEGO1/mxentity.h
@@ -28,8 +28,10 @@ public:
   }
 
   virtual MxResult SetEntityId(MxS32 p_id, const MxAtomId &p_atom); // vtable+0x14
-private:
+public:
   MxS32 m_mxEntityId; // 0x8
+
+protected:
   MxAtomId m_atom; // 0xc
 };
 


### PR DESCRIPTION
Dtor matches. 

It looks like adding what seems to be doing stuff with the vector data makes it match less. Here is what I got, up to 52% for the ctor. 52% is what I could do. m_mxEntityId also has to be made public for this

edit: frick it, closing issue.