### PR TITLE
Supporting items for SetupCopyRect()

### DIFF
--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -25,6 +25,8 @@ struct MxBITMAPINFO {
 #define LOWCOLOR 0 // 256 color
 #define HIGHCOLOR 1 // High Color (16-bit)
 
+// SIZE 0x20
+// VTABLE 0x100dc7b0
 class MxBitmap : public MxCore
 {
 public:
@@ -43,6 +45,8 @@ public:
   virtual void ImportPalette(MxPalette* p_palette); // vtable+38
   virtual MxResult SetBitDepth(MxBool); // vtable+3c
   virtual MxResult StretchBits(HDC p_hdc, int p_xSrc, int p_ySrc, int p_xDest, int p_yDest, int p_destWidth, int p_destHeight); // vtable+40
+
+  inline BITMAPINFOHEADER *GetBmiHeader() const { return m_bmiHeader; }
 
 private:
   MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -174,7 +174,7 @@ void MxDisplaySurface::SetPalette(MxPalette *p_palette)
 }
 
 // OFFSET: LEGO1 0x100bc200 STUB
-void MxDisplaySurface::vtable24(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
+void MxDisplaySurface::vtable24(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
 {
 
 }
@@ -186,7 +186,7 @@ MxBool MxDisplaySurface::vtable28(undefined4, undefined4, undefined4, undefined4
 }
 
 // OFFSET: LEGO1 0x100bc630 STUB
-MxBool MxDisplaySurface::vtable2c(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
+MxBool MxDisplaySurface::vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
 {
   return 0;
 }

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -3,6 +3,7 @@
 
 #include <ddraw.h>
 
+#include "mxbitmap.h"
 #include "mxcore.h"
 #include "mxpalette.h"
 #include "mxvideoparam.h"
@@ -25,9 +26,9 @@ public:
   virtual MxResult Create(MxVideoParam &p_videoParam);
   virtual void Clear();
   virtual void SetPalette(MxPalette *p_palette);
-  virtual void vtable24(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+  virtual void vtable24(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual MxBool vtable2c(LPDDSURFACEDESC, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
+  virtual MxBool vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
   virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
   virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -70,8 +70,8 @@ public:
 
   inline MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
   inline MxPoint32 GetLocation() const { return this->m_location; }
-  inline MxS32 GetDisplayX() const { return this->m_location.m_x; }
-  inline MxS32 GetDisplayY() const { return this->m_location.m_y; }
+  inline MxS32 GetLocationX() const { return this->m_location.m_x; }
+  inline MxS32 GetLocationY() const { return this->m_location.m_y; }
   inline MxS32 GetDisplayZ() const { return this->m_displayZ; }
   inline MxDSAction *GetAction() const { return this->m_action; }
 

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -68,17 +68,19 @@ public:
 
   MxBool IsEnabled();
 
-  inline MxS32 GetCurrentTickleState() { return this->m_currentTickleState; }
-  inline MxPoint32 GetLocation() { return this->m_location; }
-  inline MxS32 GetDisplayZ() { return this->m_displayZ; }
-  inline MxDSAction *GetAction() { return this->m_action; }
+  inline MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
+  inline MxPoint32 GetLocation() const { return this->m_location; }
+  inline MxS32 GetDisplayX() const { return this->m_location.m_x; }
+  inline MxS32 GetDisplayY() const { return this->m_location.m_y; }
+  inline MxS32 GetDisplayZ() const { return this->m_displayZ; }
+  inline MxDSAction *GetAction() const { return this->m_action; }
 
 protected:
   __declspec(dllexport) void Init();
   void SendTo_unkPresenter(MxOmni *);
 
 private:
-  MxS32 m_currentTickleState; // 0x8
+  TickleState m_currentTickleState; // 0x8
   MxU32 m_previousTickleStates;
   MxPoint32 m_location;
   MxS32 m_displayZ;

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -15,3 +15,14 @@ void MxSmkPresenter::Init()
 {
   // TODO
 }
+
+// OFFSET: LEGO1 0x100b3960
+void MxSmkPresenter::VTable0x60()
+{
+  if (m_bitmap) {
+    delete m_bitmap;
+  }
+
+  m_bitmap = new MxBitmap();
+  m_bitmap->SetSize(m_smkWidth, m_smkHeight, NULL, NULL);
+}

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -12,7 +12,12 @@ class MxSmkPresenter : public MxVideoPresenter
 public:
   MxSmkPresenter();
 
-  undefined4 m_unk64[430];
+  virtual void VTable0x60() override;
+
+  undefined4 m_unk64;
+  MxS32 m_smkWidth; // 0x68
+  MxS32 m_smkHeight; // 0x6c
+  undefined4 m_unk70[427];
   undefined4 m_unk71c;
 private:
   void Init();

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -23,7 +23,7 @@ MxTransitionManager::MxTransitionManager()
 // OFFSET: LEGO1 0x1004ba00
 MxTransitionManager::~MxTransitionManager()
 {
-  free(m_copyBuffer);
+  delete[] m_copyBuffer;
 
   if (m_waitIndicator != NULL) {
     delete m_waitIndicator->GetAction();
@@ -337,7 +337,7 @@ void MxTransitionManager::SubmitCopyRect(LPDDSURFACEDESC ddsc)
   }
 
   // Free the copy buffer
-  free(m_copyBuffer);
+  delete[] m_copyBuffer;
   m_copyBuffer = NULL;
 }
 
@@ -358,8 +358,8 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
     DWORD copyPitch = (ddsc->ddpfPixelFormat.dwRGBBitCount / 8) * (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
     DWORD bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-    m_copyRect.left = m_waitIndicator->GetDisplayX();
-    m_copyRect.top = m_waitIndicator->GetDisplayY();
+    m_copyRect.left = m_waitIndicator->GetLocationX();
+    m_copyRect.top = m_waitIndicator->GetLocationY();
 
     MxS32 height = m_waitIndicator->GetHeight();
     MxS32 width = m_waitIndicator->GetWidth();
@@ -370,7 +370,7 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
     // Allocate the copy buffer
     const char *src = (const char*)ddsc->lpSurface + m_copyRect.top * ddsc->lPitch + bytesPerPixel * m_copyRect.left;
 
-    m_copyBuffer = malloc(bytesPerPixel * width * height);
+    m_copyBuffer = new char[bytesPerPixel * width * height];
     if (!m_copyBuffer)
       return;
 
@@ -390,11 +390,11 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
   {
     MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
     MxBool unkbool = FALSE;
-    displaySurface->vtable2c(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetDisplayX(), m_waitIndicator->GetDisplayY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight(), unkbool);
+    displaySurface->vtable2c(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetLocationX(), m_waitIndicator->GetLocationY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight(), unkbool);
   }
   else
   {
     MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
-    displaySurface->vtable24(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetDisplayX(), m_waitIndicator->GetDisplayY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight());
+    displaySurface->vtable24(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetLocationX(), m_waitIndicator->GetLocationY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight());
   }
 }

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -318,17 +318,17 @@ void MxTransitionManager::SubmitCopyRect(LPDDSURFACEDESC ddsc)
   }
 
   // Copy the copy rect onto the surface
-  char *dst;
+  MxU8 *dst;
 
-  DWORD bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
+  MxU32 bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-  const char *src = (const char *)m_copyBuffer;
+  const MxU8 *src = (const MxU8 *)m_copyBuffer;
 
-  LONG copyPitch;
+  MxS32 copyPitch;
   copyPitch = ((m_copyRect.right - m_copyRect.left) + 1) * bytesPerPixel;
 
-  LONG y;
-  dst = (char *)ddsc->lpSurface + (ddsc->lPitch * m_copyRect.top) + (bytesPerPixel * m_copyRect.left);
+  MxS32 y;
+  dst = (MxU8 *)ddsc->lpSurface + (ddsc->lPitch * m_copyRect.top) + (bytesPerPixel * m_copyRect.left);
 
   for (y = 0; y < m_copyRect.bottom - m_copyRect.top + 1; ++y) {
     memcpy(dst, src, copyPitch);
@@ -355,8 +355,8 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
   // Check if wait indicator has started
   if (m_waitIndicator->GetCurrentTickleState() >= MxPresenter::TickleState_Streaming) {
     // Setup the copy rect
-    DWORD copyPitch = (ddsc->ddpfPixelFormat.dwRGBBitCount / 8) * (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
-    DWORD bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
+    MxU32 copyPitch = (ddsc->ddpfPixelFormat.dwRGBBitCount / 8) * (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
+    MxU32 bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
     m_copyRect.left = m_waitIndicator->GetLocationX();
     m_copyRect.top = m_waitIndicator->GetLocationY();
@@ -368,14 +368,14 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
     m_copyRect.bottom = m_copyRect.top + height - 1;
 
     // Allocate the copy buffer
-    const char *src = (const char*)ddsc->lpSurface + m_copyRect.top * ddsc->lPitch + bytesPerPixel * m_copyRect.left;
+    const MxU8 *src = (const MxU8*)ddsc->lpSurface + m_copyRect.top * ddsc->lPitch + bytesPerPixel * m_copyRect.left;
 
-    m_copyBuffer = new char[bytesPerPixel * width * height];
+    m_copyBuffer = new MxU8[bytesPerPixel * width * height];
     if (!m_copyBuffer)
       return;
 
     // Copy into the copy buffer
-    char *dst = (char*)m_copyBuffer;
+    MxU8 *dst = m_copyBuffer;
 
     for (MxS32 i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++)
     {

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -358,8 +358,8 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
     DWORD copyPitch = (ddsc->ddpfPixelFormat.dwRGBBitCount / 8) * (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
     DWORD bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-    m_copyRect.left = m_waitIndicator->GetLocation().m_x;
-    m_copyRect.top = m_waitIndicator->GetLocation().m_y;
+    m_copyRect.left = m_waitIndicator->GetDisplayX();
+    m_copyRect.top = m_waitIndicator->GetDisplayY();
 
     MxS32 height = m_waitIndicator->GetHeight();
     MxS32 width = m_waitIndicator->GetWidth();
@@ -390,11 +390,11 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
   {
     MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
     MxBool unkbool = FALSE;
-    displaySurface->vtable2c(ddsc, m_waitIndicator->m_unk50, 0, 0, m_waitIndicator->GetLocation().m_x, m_waitIndicator->GetLocation().m_y, m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight(), unkbool);
+    displaySurface->vtable2c(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetDisplayX(), m_waitIndicator->GetDisplayY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight(), unkbool);
   }
   else
   {
     MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
-    displaySurface->vtable24(ddsc, m_waitIndicator->m_unk50, 0, 0, m_waitIndicator->GetLocation().m_x, m_waitIndicator->GetLocation().m_y, m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight());
+    displaySurface->vtable24(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetDisplayX(), m_waitIndicator->GetDisplayY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight());
   }
 }

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -57,7 +57,7 @@ private:
 
   MxVideoPresenter *m_waitIndicator;
   RECT m_copyRect;
-  void *m_copyBuffer;
+  MxU8 *m_copyBuffer;
 
   flag_bitfield m_copyFlags;
   undefined4 m_unk24;

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -57,7 +57,7 @@ MxS32 MxVideoPresenter::GetWidth()
                  : m_bitmap->GetBmiHeader()->biWidth;
 }
 
-// OFFSET: LEGO1 0x1000c800 STUB
+// OFFSET: LEGO1 0x1000c800
 MxS32 MxVideoPresenter::GetHeight()
 {
   return m_unk54 ? m_unk54->height

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -8,10 +8,10 @@ void MxVideoPresenter::VTable0x5c()
   // TODO
 }
 
-// OFFSET: LEGO1 0x1000c710 STUB
+// OFFSET: LEGO1 0x1000c710
 void MxVideoPresenter::VTable0x60()
 {
-  // TODO
+  // Empty
 }
 
 // OFFSET: LEGO1 0x1000c720 STUB
@@ -44,24 +44,24 @@ void MxVideoPresenter::VTable0x78()
   // TODO
 }
 
-// OFFSET: LEGO1 0x1000c7c0 STUB
-void MxVideoPresenter::VTable0x7c()
+// OFFSET: LEGO1 0x1000c7c0
+MxBool MxVideoPresenter::VTable0x7c()
 {
-  // TODO
+  return (m_bitmap != NULL) || (m_unk54 != NULL);
 }
 
-// OFFSET: LEGO1 0x1000c7e0 STUB
+// OFFSET: LEGO1 0x1000c7e0
 MxS32 MxVideoPresenter::GetWidth()
 {
-  // TODO
-  return 0;
+  return m_unk54 ? m_unk54->width
+                 : m_bitmap->GetBmiHeader()->biWidth;
 }
 
 // OFFSET: LEGO1 0x1000c800 STUB
 MxS32 MxVideoPresenter::GetHeight()
 {
-  // TODO
-  return 0;
+  return m_unk54 ? m_unk54->height
+                 : m_bitmap->GetBmiHeader()->biHeight;
 }
 
 // OFFSET: LEGO1 0x100b2760 STUB

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -2,9 +2,11 @@
 #define MXVIDEOPRESENTER_H
 
 #include "mxmediapresenter.h"
+#include "mxbitmap.h"
 
 #include "decomp.h"
 
+// VTABLE 0x100d4be8
 class MxVideoPresenter : public MxMediaPresenter
 {
 public:
@@ -41,12 +43,20 @@ public:
   virtual void VTable0x70(); // vtable+0x70
   virtual void VTable0x74(); // vtable+0x74
   virtual void VTable0x78(); // vtable+0x78
-  virtual void VTable0x7c(); // vtable+0x7c
+  virtual MxBool VTable0x7c(); // vtable+0x7c
   virtual MxS32 GetWidth();  // vtable+0x80
   virtual MxS32 GetHeight(); // vtable+0x84
 
-  undefined4 m_unk50;
-  undefined4 m_unk54;
+  // TODO: Not sure what this is. Seems to have size of 12 bytes
+  // based on 0x100b9e9a. Values are copied from the bitmap header.
+  typedef struct {
+    undefined unk0[8];
+    MxU16 width;
+    MxU16 height;
+  } unknown_meta_struct;
+
+  MxBitmap *m_bitmap;
+  unknown_meta_struct *m_unk54;
   undefined4 m_unk58;
   undefined2 m_unk5c;
   unsigned char m_flags; // 0x5e


### PR DESCRIPTION
I was looking at SetupCopyRect() in MxTransitionManager (#165) to see if I could improve the match percentage. No such luck but I have some minor improvements to offer for the related code.

GetWidth() and GetHeight() from MxVideoPresenter point at a reference to MxBitmap. Confirmed with debugger. The 0x60 vtable method from subclass MxSmkPresenter sets this up, so I implemented that to give an example. The 0x60 method from MxVideoPresenter is a no-op. The width and height methods should be correct, but the compiler keeps picking the wrong order for the if/else. I went with the most concise syntax in hope that it will resolve itself later.

The one direct improvement to SetupCopyRect has to do with the m_location member of m_waitIndicator. Grabbing both the x and y coordinates of the MxPoint32 struct pulls in a pointer to the object. I added getter methods to grab the values directly and this eliminates the reference to better match the code. (I thought maybe this meant that MxPresenter does not use MxPoint32 at all, but if you break it out into two MxS32 members, StartAction() no longer matches.)

Plus: A few other very minor improvements while I had the files open.