### PR TITLE
Silence all C4786 warnings

### DIFF
--- a/LEGO1/compat.h
+++ b/LEGO1/compat.h
@@ -18,6 +18,9 @@
 // Impossible to avoid this if using STL map or set.
 // This removes most (but not all) occurrences of the warning.
 #pragma warning( disable : 4786 )
+// To really remove *all* of the warnings, we have to employ the following,
+// obscure workaround from https://www.earthli.com/news/view_article.php?id=376
+static class msVC6_4786WorkAround { public: msVC6_4786WorkAround() {} } msVC6_4786WorkAround;
 
 #define MSVC420_VERSION 1020
 


### PR DESCRIPTION
I've found a rather obscure workaround that eliminates all of the `C4786` warning spam. The fact that the `#pragma` doesn't work has been a bug that survived all the way into VC6:

https://web.archive.org/web/20140128153313/http://support.microsoft.com/kb/167355

The workaround has been figured out by someone about 20 years ago, credit is in the comments.