### PR TITLE
Implement remaining MxDSSelectAction functions

### DIFF
--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -37,10 +37,8 @@ public:
   virtual MxBool HasId(MxU32 p_objectId) override; // vtable+34;
   virtual void SetSomeTimingField(MxLong p_someTimingField) override; // vtable+38;
 
-private:
-  MxU32 m_sizeOnDisk;
-
 protected:
+  MxU32 m_sizeOnDisk;
   MxDSActionList *m_actions;
 };
 

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -83,19 +83,17 @@ void MxDSSelectAction::Deserialize(char **p_source, MxS16 p_unk24)
 
   this->m_unk0x9c = *p_source;
 
-  const char *result;
-  char buffer[6];
   if (!strnicmp(this->m_unk0x9c.GetData(), "RANDOM_", strlen("RANDOM_"))) {
+    char buffer[10];
     MxS16 value = atoi(&this->m_unk0x9c.GetData()[strlen("RANDOM_")]);
 
     srand(Timer()->GetTime());
     MxS32 random = rand() % value;
-    result = itoa((MxS16) random, buffer, 10);
+    string = itoa((MxS16) random, buffer, 10);
   }
   else
-    result = VariableTable()->GetVariable(*p_source);
+    string = VariableTable()->GetVariable(*p_source);
 
-  string = result;
   *p_source += strlen(*p_source) + 1;
 
   MxU32 count = *(MxU32*) *p_source;

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -1,4 +1,7 @@
 #include "mxdsselectaction.h"
+#include "mxvariabletable.h"
+#include "mxtimer.h"
+#include "mxomni.h"
 
 DECOMP_SIZE_ASSERT(MxDSSelectAction, 0xb0)
 
@@ -48,4 +51,83 @@ MxDSAction *MxDSSelectAction::Clone()
     *clone = *this;
 
   return clone;
+}
+
+// OFFSET: LEGO1 0x100cbe10
+MxU32 MxDSSelectAction::GetSizeOnDisk()
+{
+  MxU32 totalSizeOnDisk = MxDSParallelAction::GetSizeOnDisk();
+
+  totalSizeOnDisk += strlen(this->m_unk0x9c.GetData()) + 1;
+
+  MxStringListCursor cursor(this->m_unk0xac);
+  MxString string;
+  while (cursor.Next(string))
+    totalSizeOnDisk += strlen(string.GetData()) + 1;
+
+  // Note: unlike the other classes, MxDSSelectAction does not have its own
+  // sizeOnDisk member. Instead, it overrides the one from MxDSMultiAction.
+  this->m_sizeOnDisk = totalSizeOnDisk;
+
+  return totalSizeOnDisk;
+}
+
+// OFFSET: LEGO1 0x100cbf60
+void MxDSSelectAction::Deserialize(char **p_source, MxS16 p_unk24)
+{
+  MxString string;
+  MxDSAction::Deserialize(p_source, p_unk24);
+
+  MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
+  *p_source += 12;
+
+  this->m_unk0x9c = *p_source;
+
+  const char *result;
+  char buffer[6];
+  if (!strnicmp(this->m_unk0x9c.GetData(), "RANDOM_", strlen("RANDOM_"))) {
+    MxS16 value = atoi(&this->m_unk0x9c.GetData()[strlen("RANDOM_")]);
+
+    srand(Timer()->GetTime());
+    MxS32 random = rand() % value;
+    result = itoa((MxS16) random, buffer, 10);
+  }
+  else
+    result = VariableTable()->GetVariable(*p_source);
+
+  string = result;
+  *p_source += strlen(*p_source) + 1;
+
+  MxU32 count = *(MxU32*) *p_source;
+  *p_source += sizeof(MxU32);
+
+  if (count) {
+    MxS32 index = -1;
+    this->m_unk0xac->DeleteAll();
+
+    MxU32 i;
+    for (i = 0; i < count; i++) {
+      if (!strcmp(string.GetData(), *p_source))
+        index = i;
+
+      this->m_unk0xac->OtherAppend(*p_source);
+      *p_source += strlen(*p_source) + 1;
+    }
+
+    for (i = 0; i < count; i++) {
+      MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
+      *p_source += 8;
+
+      MxDSAction *action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk24);
+
+      if (index == i)
+        this->m_actions->Append(action);
+      else
+        delete action;
+
+      *p_source += extraFlag;
+    }
+  }
+
+  *p_source += extraFlag;
 }

--- a/LEGO1/mxdsselectaction.h
+++ b/LEGO1/mxdsselectaction.h
@@ -29,9 +29,8 @@ public:
     return !strcmp(name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(name);
   }
 
-  //virtual MxU32 GetSizeOnDisk() override; // vtable+18;
-  //virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
-  //virtual MxLong GetDuration() override; // vtable+24;
+  virtual MxU32 GetSizeOnDisk() override; // vtable+18;
+  virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
   virtual MxDSAction *Clone() override; // vtable+2c;
 
 private:


### PR DESCRIPTION
Matches:

* `GetSizeOnDisk`: 100%
* `Deserialize`: ~97% (remaining % is compiler randomness)

`Deserialize` is a fairly involved function, but gives a hint on what the "select" part of the class name is referring to - it only picks out a single action from the data stream based on an identifier and adds it to the list.

I believe this marks the completion in terms of both functional implementation and accuracy of all the subclasses of `MxDSObject` (unless I missed something), except for this one `TODO`: https://github.com/isledecomp/isle/blob/master/LEGO1/mxdsaction.cpp#L165