### PR TITLE
MxStream provider and controller vtables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(lego1 SHARED
   LEGO1/mxpresenter.cpp
   LEGO1/mxpresenterlist.cpp
   LEGO1/mxramstreamcontroller.cpp
+  LEGO1/mxramstreamprovider.cpp
   LEGO1/mxscheduler.cpp
   LEGO1/mxsemaphore.cpp
   LEGO1/mxsmkpresenter.cpp
@@ -162,6 +163,7 @@ add_library(lego1 SHARED
   LEGO1/mxstillpresenter.cpp
   LEGO1/mxstreamcontroller.cpp
   LEGO1/mxstreamer.cpp
+  LEGO1/mxstreamprovider.cpp
   LEGO1/mxstring.cpp
   LEGO1/mxstringlist.cpp
   LEGO1/mxthread.cpp

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -734,7 +734,7 @@ inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
         return;
       }
 
-      ds.SetAtomId(stream->atom);
+      ds.SetAtomId(stream->GetAtom());
       ds.SetUnknown24(-1);
       ds.SetObjectId(0);
       VideoManager()->EnableFullScreenMovie(TRUE, TRUE);
@@ -743,7 +743,7 @@ inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
         return;
       }
     } else {
-      ds.SetAtomId(stream->atom);
+      ds.SetAtomId(stream->GetAtom());
       ds.SetUnknown24(-1);
       ds.SetObjectId(0);
       if (Start(&ds) != SUCCESS) {

--- a/LEGO1/mxramstreamcontroller.cpp
+++ b/LEGO1/mxramstreamcontroller.cpp
@@ -1,3 +1,25 @@
 #include "mxramstreamcontroller.h"
+#include "mxramstreamprovider.h"
 
 DECOMP_SIZE_ASSERT(MxRAMStreamController, 0x98);
+
+// OFFSET: LEGO1 0x100c6110 STUB
+MxResult MxRAMStreamController::Open(const char *p_filename)
+{
+  // TODO STUB
+  return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100c6210 STUB
+MxResult MxRAMStreamController::vtable0x20(MxDSAction* action)
+{
+  // TODO STUB
+  return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100c6320 STUB
+MxResult MxRAMStreamController::vtable0x24(undefined4 p_unknown)
+{
+  // TODO STUB
+  return FAILURE;
+}

--- a/LEGO1/mxramstreamcontroller.cpp
+++ b/LEGO1/mxramstreamcontroller.cpp
@@ -11,7 +11,7 @@ MxResult MxRAMStreamController::Open(const char *p_filename)
 }
 
 // OFFSET: LEGO1 0x100c6210 STUB
-MxResult MxRAMStreamController::vtable0x20(MxDSAction* action)
+MxResult MxRAMStreamController::vtable0x20(MxDSAction* p_action)
 {
   // TODO STUB
   return FAILURE;

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -11,6 +11,23 @@ class MxRAMStreamController : public MxStreamController
 public:
   inline MxRAMStreamController() {}
 
+  // OFFSET: LEGO1 0x100b9430
+  inline virtual const char *ClassName() const override // vtable+0xc
+  {
+    // 0x10102130
+    return "MxRAMStreamController";
+  }
+
+  // OFFSET: LEGO1 0x100b9440
+  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
+  {
+    return !strcmp(name, MxStreamController::ClassName()) || MxCore::IsA(name);
+  }
+
+  virtual MxResult Open(const char *p_filename) override;
+  virtual MxResult vtable0x20(MxDSAction* action) override;
+  virtual MxResult vtable0x24(undefined4 p_unknown) override;
+
 private:
   MxDSBuffer m_buffer;
 

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -21,7 +21,7 @@ public:
   // OFFSET: LEGO1 0x100b9440
   inline virtual MxBool IsA(const char *name) const override // vtable+0x10
   {
-    return !strcmp(name, MxStreamController::ClassName()) || MxCore::IsA(name);
+    return !strcmp(name, MxRAMStreamController::ClassName()) || !strcmp(name, MxStreamController::ClassName()) || MxCore::IsA(name);
   }
 
   virtual MxResult Open(const char *p_filename) override;

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -25,7 +25,7 @@ public:
   }
 
   virtual MxResult Open(const char *p_filename) override;
-  virtual MxResult vtable0x20(MxDSAction* action) override;
+  virtual MxResult vtable0x20(MxDSAction* p_action) override;
   virtual MxResult vtable0x24(undefined4 p_unknown) override;
 
 private:

--- a/LEGO1/mxramstreamprovider.cpp
+++ b/LEGO1/mxramstreamprovider.cpp
@@ -1,0 +1,59 @@
+#include "mxramstreamprovider.h"
+#include "decomp.h"
+
+DECOMP_SIZE_ASSERT(MxRAMStreamProvider, 0x24);
+
+// OFFSET: LEGO1 0x100d0730
+MxRAMStreamProvider::MxRAMStreamProvider()
+{
+  m_bufferSize = 0;
+  m_fileSize = 0;
+  m_pBufferOfFileSize = NULL;
+  m_lengthInDWords = 0;
+  m_bufferForDWords = NULL;
+}
+
+// OFFSET: LEGO1 0x100d0a50
+MxRAMStreamProvider::~MxRAMStreamProvider()
+{
+  m_bufferSize = 0;
+  m_fileSize = 0;
+
+  free(m_pBufferOfFileSize);
+  m_pBufferOfFileSize = NULL;
+
+  m_lengthInDWords = 0;
+
+  free(m_bufferForDWords);
+  m_bufferForDWords = NULL;
+}
+
+// OFFSET: LEGO1 0x100d0ae0 STUB
+MxResult MxRAMStreamProvider::SetResourceToGet(void* p_resource)
+{
+  return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100d0930
+MxU32 MxRAMStreamProvider::GetFileSize()
+{
+  return m_fileSize;
+}
+
+// OFFSET: LEGO1 0x100d0940
+MxU32 MxRAMStreamProvider::vtable0x1C()
+{
+  return 1;
+}
+
+// OFFSET: LEGO1 0x100d0950
+MxU32 MxRAMStreamProvider::GetLengthInDWords()
+{
+  return m_lengthInDWords;
+}
+
+// OFFSET: LEGO1 0x100d0960
+void* MxRAMStreamProvider::GetBufferForDWords()
+{
+  return m_bufferForDWords;
+}

--- a/LEGO1/mxramstreamprovider.h
+++ b/LEGO1/mxramstreamprovider.h
@@ -8,12 +8,14 @@ class MxRAMStreamProvider : public MxStreamProvider
 {
 public:
   MxRAMStreamProvider();
-  ~MxRAMStreamProvider() override;
+  virtual ~MxRAMStreamProvider() override;
+  
   virtual MxResult SetResourceToGet(void* p_resource) override; //vtable+0x14
   virtual MxU32 GetFileSize() override; //vtable+0x18
   virtual MxU32 vtable0x1C() override; //vtable+0x1c
   virtual MxU32 GetLengthInDWords() override; //vtable+0x24
   virtual void* GetBufferForDWords() override; //vtable+0x28
+
 protected:
   MxU32 m_bufferSize;
   MxU32 m_fileSize;

--- a/LEGO1/mxramstreamprovider.h
+++ b/LEGO1/mxramstreamprovider.h
@@ -11,7 +11,7 @@ public:
   ~MxRAMStreamProvider() override;
   virtual MxResult SetResourceToGet(void* p_resource) override; //vtable+0x14
   virtual MxU32 GetFileSize() override; //vtable+0x18
-  virtual MxU32 vtable0x1C(); //vtable+0x1c
+  virtual MxU32 vtable0x1C() override; //vtable+0x1c
   virtual MxU32 GetLengthInDWords() override; //vtable+0x24
   virtual void* GetBufferForDWords() override; //vtable+0x28
 protected:

--- a/LEGO1/mxramstreamprovider.h
+++ b/LEGO1/mxramstreamprovider.h
@@ -6,7 +6,20 @@
 // VTABLE 0x100dd0d0
 class MxRAMStreamProvider : public MxStreamProvider
 {
-
+public:
+  MxRAMStreamProvider();
+  ~MxRAMStreamProvider() override;
+  virtual MxResult SetResourceToGet(void* p_resource) override; //vtable+0x14
+  virtual MxU32 GetFileSize() override; //vtable+0x18
+  virtual MxU32 vtable0x1C(); //vtable+0x1c
+  virtual MxU32 GetLengthInDWords() override; //vtable+0x24
+  virtual void* GetBufferForDWords() override; //vtable+0x28
+protected:
+  MxU32 m_bufferSize;
+  MxU32 m_fileSize;
+  void* m_pBufferOfFileSize;
+  MxU32 m_lengthInDWords;
+  void* m_bufferForDWords;
 };
 
 #endif // MXRAMSTREAMPROVIDER_H

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -51,3 +51,28 @@ MxResult MxStreamController::vtable0x20(MxDSAction* action)
   // TODO STUB
   return FAILURE;
 }
+
+// OFFSET: LEGO1 0x100c1740 STUB
+MxResult MxStreamController::vtable0x24(undefined4 p_unknown)
+{
+  // TODO STUB
+  return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100b9420
+MxResult MxStreamController::vtable0x28()
+{
+  return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x100c1c10 STUB
+MxResult MxStreamController::vtable0x2c(undefined4 p_unknown1, undefined4 p_unknow2)
+{
+  return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100c1ce0 STUB
+MxResult MxStreamController::vtable0x30(undefined4 p_unknown)
+{
+  return FAILURE;
+}

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -46,7 +46,7 @@ MxResult MxStreamController::vtable0x1C(undefined4 p_unknown, undefined4 p_unkno
 }
 
 // OFFSET: LEGO1 0x100c1690 STUB
-MxResult MxStreamController::vtable0x20(MxDSAction* action)
+MxResult MxStreamController::vtable0x20(MxDSAction* p_action)
 {
   // TODO STUB
   return FAILURE;

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -7,7 +7,6 @@
 #include "mxcore.h"
 #include "mxdsobject.h"
 #include "mxdsaction.h"
-#include "mxstreamprovider.h"
 
 // VTABLE 0x100dc968
 // SIZE 0x64
@@ -34,7 +33,7 @@ public:
   virtual MxResult Open(const char *p_filename); // vtable+0x14
   virtual MxResult vtable0x18(undefined4 p_unknown, undefined4 p_unknown2); //vtable+0x18
   virtual MxResult vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2); //vtable+0x1c
-  virtual MxResult vtable0x20(MxDSAction* action); //vtable+0x20
+  virtual MxResult vtable0x20(MxDSAction* p_action); //vtable+0x20
   virtual MxResult vtable0x24(undefined4 p_unknown); //vtable+0x24
   virtual MxResult vtable0x28(); //vtable+0x28
   virtual MxResult vtable0x2c(undefined4 p_unknown1, undefined4 p_unknow2); //vtable+0x2c
@@ -42,12 +41,12 @@ public:
 
   MxBool FUN_100c20d0(MxDSObject &p_obj);
 
-  inline MxAtomId GetAtom() const { return atom; };
+  inline MxAtomId &GetAtom() { return atom; };
 protected:
   MxCriticalSection m_criticalSection;
   MxAtomId atom;
-  MxStreamProvider* m_provider;
-  int m_unk2c;
+  undefined4 m_unk28; // MxStreamProvider*
+  undefined4 m_unk2c;
   undefined m_unk30[0x34];
 };
 

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -7,6 +7,7 @@
 #include "mxcore.h"
 #include "mxdsobject.h"
 #include "mxdsaction.h"
+#include "mxstreamprovider.h"
 
 // VTABLE 0x100dc968
 // SIZE 0x64
@@ -34,12 +35,18 @@ public:
   virtual MxResult vtable0x18(undefined4 p_unknown, undefined4 p_unknown2); //vtable+0x18
   virtual MxResult vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2); //vtable+0x1c
   virtual MxResult vtable0x20(MxDSAction* action); //vtable+0x20
+  virtual MxResult vtable0x24(undefined4 p_unknown); //vtable+0x24
+  virtual MxResult vtable0x28(); //vtable+0x28
+  virtual MxResult vtable0x2c(undefined4 p_unknown1, undefined4 p_unknow2); //vtable+0x2c
+  virtual MxResult vtable0x30(undefined4 p_unknown); //vtable+0x30
 
   MxBool FUN_100c20d0(MxDSObject &p_obj);
 
+  inline MxAtomId GetAtom() const { return atom; };
+protected:
   MxCriticalSection m_criticalSection;
   MxAtomId atom;
-  int m_unk28;
+  MxStreamProvider* m_provider;
   int m_unk2c;
   undefined m_unk30[0x34];
 };

--- a/LEGO1/mxstreamer.cpp
+++ b/LEGO1/mxstreamer.cpp
@@ -80,7 +80,7 @@ MxLong MxStreamer::Close(const char *p)
   for (list<MxStreamController *>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
     MxStreamController *c = *it;
 
-    if (!p || !strcmp(p, c->atom.GetInternal())) {
+    if (!p || !strcmp(p, c->GetAtom().GetInternal())) {
       m_openStreams.erase(it);
 
       if (!c->FUN_100c20d0(ds)) {
@@ -109,7 +109,7 @@ MxStreamController *MxStreamer::GetOpenStream(const char *p_name)
 {
   for (list<MxStreamController *>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
     MxStreamController *c = *it;
-    MxAtomId &atom = c->atom;
+    MxAtomId &atom = c->GetAtom();
     if (p_name) {
       if (!strcmp(atom.GetInternal(), p_name)) {
        return *it;

--- a/LEGO1/mxstreamprovider.cpp
+++ b/LEGO1/mxstreamprovider.cpp
@@ -1,0 +1,17 @@
+#include "decomp.h"
+#include "mxstreamprovider.h"
+
+DECOMP_SIZE_ASSERT(MxStreamProvider, 0x10);
+
+// OFFSET: LEGO1 0x100d07c0
+MxResult MxStreamProvider::SetResourceToGet(void* p_resource)
+{
+  m_pLookup = p_resource;
+  return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x100d07d0
+void MxStreamProvider::vtable0x20(undefined4 p_unknown1)
+{
+
+}

--- a/LEGO1/mxstreamprovider.h
+++ b/LEGO1/mxstreamprovider.h
@@ -6,13 +6,11 @@
 #include "mxdsfile.h"
 
 // VTABLE 0x100dd100
+// SIZE 0x10
 class MxStreamProvider : public MxCore
 {
 public:
-  inline MxStreamProvider() {
-    this->m_pLookup = NULL;
-    this->m_pFile = NULL;
-  }
+  inline MxStreamProvider() : m_pLookup(NULL), m_pFile(NULL) {}
 
   // OFFSET: LEGO1 0x100d07e0
   inline virtual const char *ClassName() const override // vtable+0x0c

--- a/LEGO1/mxstreamprovider.h
+++ b/LEGO1/mxstreamprovider.h
@@ -1,6 +1,7 @@
 #ifndef MXSTREAMPROVIDER_H
 #define MXSTREAMPROVIDER_H
 
+#include "decomp.h"
 #include "mxcore.h"
 #include "mxdsfile.h"
 
@@ -24,6 +25,13 @@ public:
   {
     return !strcmp(name, MxStreamProvider::ClassName()) || MxCore::IsA(name);
   }
+
+  virtual MxResult SetResourceToGet(void* p_resource); //vtable+0x14
+  virtual MxU32 GetFileSize() = 0; //vtable+0x18
+  virtual MxU32 vtable0x1C() = 0; //vtable+0x1c
+  virtual void vtable0x20(undefined4 p_unknown1); //vtable+0x20
+  virtual MxU32 GetLengthInDWords() = 0; //vtable+0x24
+  virtual void* GetBufferForDWords() = 0; //vtable+0x28
 
 protected:
   void *m_pLookup;


### PR DESCRIPTION
Everything matches except MxRAMStreamProvider::MxRAMStreamProvider because the vtable gets written after `m_bufferSize = 0;` for some reason.