### PR TITLE
Fix MxDSMediaAction structure/matches

### DIFF
--- a/LEGO1/mxdsmediaaction.cpp
+++ b/LEGO1/mxdsmediaaction.cpp
@@ -8,8 +8,8 @@ DECOMP_SIZE_ASSERT(MxDSMediaAction, 0xb8)
 MxDSMediaAction::MxDSMediaAction()
 {
   this->m_mediaSrcPath = NULL;
-  this->m_unk9c = 0;
-  this->m_unka0 = 0;
+  this->m_unk9c.m_unk00 = 0;
+  this->m_unk9c.m_unk04 = 0;
   this->m_framesPerSecond = 0;
   this->m_mediaFormat = 0;
   this->m_paletteManagement = 1;
@@ -29,10 +29,7 @@ void MxDSMediaAction::CopyFrom(MxDSMediaAction &p_dsMediaAction)
 {
   CopyMediaSrcPath(p_dsMediaAction.m_mediaSrcPath);
 
-  // TODO
   this->m_unk9c = p_dsMediaAction.m_unk9c;
-  this->m_unka0 = p_dsMediaAction.m_unka0;
-
   this->m_framesPerSecond = p_dsMediaAction.m_framesPerSecond;
   this->m_mediaFormat = p_dsMediaAction.m_mediaFormat;
   this->m_paletteManagement = p_dsMediaAction.m_paletteManagement;
@@ -71,8 +68,8 @@ void MxDSMediaAction::Deserialize(char **p_source, MxS16 p_unk24)
   MxDSAction::Deserialize(p_source, p_unk24);
 
   GetString(p_source, this->m_mediaSrcPath, this, &MxDSMediaAction::CopyMediaSrcPath);
-  GetScalar(p_source, this->m_unk9c);
-  GetScalar(p_source, this->m_unka0);
+  GetScalar(p_source, this->m_unk9c.m_unk00);
+  GetScalar(p_source, this->m_unk9c.m_unk04);
   GetScalar(p_source, this->m_framesPerSecond);
   GetScalar(p_source, this->m_mediaFormat);
   GetScalar(p_source, this->m_paletteManagement);

--- a/LEGO1/mxdsmediaaction.h
+++ b/LEGO1/mxdsmediaaction.h
@@ -3,6 +3,7 @@
 
 #include "decomp.h"
 #include "mxdsaction.h"
+#include "mxpoint32.h"
 
 // VTABLE 0x100dcd40
 // SIZE 0xb8
@@ -38,8 +39,10 @@ public:
 private:
   MxU32 m_sizeOnDisk;
   char *m_mediaSrcPath;
-  undefined4 m_unk9c;
-  undefined4 m_unka0;
+  struct {
+    undefined4 m_unk00;
+    undefined4 m_unk04;
+  } m_unk9c;
   MxS32 m_framesPerSecond;
   MxS32 m_mediaFormat;
   MxS32 m_paletteManagement;


### PR DESCRIPTION
This completes the remaining, open inaccuracies in the class. Two members are part of a structure (which remains unknown for now; could be `MxPoint32` or similar).