### PR TITLE
Implemented  MxVector4::SetMatrixProductWrapper

### DIFF
--- a/LEGO1/mxvector.cpp
+++ b/LEGO1/mxvector.cpp
@@ -410,9 +410,10 @@ void MxVector4::EqualsScalar(float *p_value)
   m_data[3] = *p_value;
 }
 
-// OFFSET: LEGO1 0x10002ae0 STUB
-void MxVector4::unk1(MxVector4 *p_a, float *p_b)
+// OFFSET: LEGO1 0x10002ae0
+void MxVector4::SetMatrixProductWrapper(MxVector4 *p_a, float *p_b)
 {
+  SetMatrixProduct(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x10002a40

--- a/LEGO1/mxvector.cpp
+++ b/LEGO1/mxvector.cpp
@@ -411,13 +411,13 @@ void MxVector4::EqualsScalar(float *p_value)
 }
 
 // OFFSET: LEGO1 0x10002ae0
-void MxVector4::SetMatrixProductWrapper(MxVector4 *p_a, float *p_b)
+void MxVector4::SetMatrixProduct(MxVector4 *p_a, float *p_b)
 {
-  SetMatrixProduct(p_a->m_data, p_b);
+  SetMatrixProductImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x10002a40
-void MxVector4::SetMatrixProduct(float *p_vec, float *p_mat)
+void MxVector4::SetMatrixProductImpl(float *p_vec, float *p_mat)
 {
   m_data[0] =
       p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] +

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -125,8 +125,8 @@ public:
   void EqualsScalar(float *p_value);
 
   // vtable + 0x84
-  virtual void SetMatrixProductWrapper(MxVector4 *p_a, float *p_b);
-  virtual void SetMatrixProduct(float *p_vec, float *p_mat);
+  virtual void SetMatrixProduct(MxVector4 *p_a, float *p_b);
+  virtual void SetMatrixProductImpl(float *p_vec, float *p_mat);
   virtual MxResult NormalizeQuaternion();
   virtual void UnknownQuaternionOp(MxVector4 *p_a, MxVector4 *p_b);
 };

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -125,7 +125,7 @@ public:
   void EqualsScalar(float *p_value);
 
   // vtable + 0x84
-  virtual void unk1(MxVector4 *p_a, float *p_b);
+  virtual void SetMatrixProductWrapper(MxVector4 *p_a, float *p_b);
   virtual void SetMatrixProduct(float *p_vec, float *p_mat);
   virtual MxResult NormalizeQuaternion();
   virtual void UnknownQuaternionOp(MxVector4 *p_a, MxVector4 *p_b);


### PR DESCRIPTION
Implemented SetMatrixProductWrapper with 100% match. Notably this function is a wrapper for SetMatrixProduct with different parameters. The name is not the same with the function overloading paradigm since it makes the function no longer have 100% binary match.