### PR TITLE
rename all uncertain labels to unk

### DIFF
--- a/LEGO1/infocenterstate.h
+++ b/LEGO1/infocenterstate.h
@@ -31,7 +31,7 @@ public:
 private:
   // Members should be renamed with their offsets before use
   /*
-    struct SomeStruct
+    struct UnkStruct
     {
       undefined4 unk1;
       undefined2 unk2;
@@ -53,7 +53,7 @@ private:
     undefined2 unk10;
     undefined2 unk11;
     undefined2 padding3;
-    SomeStruct unk12[6];
+    UnkStruct unk12[6];
     undefined4 unk13;
   */
 

--- a/LEGO1/legogamestate.cpp
+++ b/LEGO1/legogamestate.cpp
@@ -143,9 +143,9 @@ MxResult LegoGameState::Save(MxULong p_slot)
     if (fileStream.Open(savePath.GetData(), LegoStream::WriteBit) != FAILURE) {
       MxU32 maybeVersion = 0x1000C;
       fileStream.Write(&maybeVersion, 4);
-      fileStream.Write(&m_secondThingWritten, 2);
-      fileStream.Write(&m_someEnumState, 2);
-      fileStream.Write(&m_someModeSwitch, 1);
+      fileStream.Write(&m_unk24, 2);
+      fileStream.Write(&m_unk10, 2);
+      fileStream.Write(&m_unkC, 1);
 
       for (MxS32 i = 0; i < sizeof(g_colorSaveData) / sizeof(g_colorSaveData[0]); ++i) {
         if (LegoStream::WriteVariable(&fileStream, variableTable, g_colorSaveData[i].m_targetName) == FAILURE)

--- a/LEGO1/legogamestate.h
+++ b/LEGO1/legogamestate.h
@@ -42,14 +42,14 @@ private:
   char *m_savePath; // 0x0
   MxS16 m_stateCount;
   LegoState **m_stateArray;
-  MxU8 m_someModeSwitch;
-  MxU32 m_someEnumState;
+  MxU8 m_unkC;
+  MxU32 m_unk10;
   undefined4 m_unk0x14;
   LegoBackgroundColor *m_backgroundColor; // 0x18
   LegoBackgroundColor *m_tempBackgroundColor; // 0x1c
   LegoFullScreenMovie *m_fullScreenMovie; // 0x20
-  MxU16 m_secondThingWritten;
-  undefined m_unk24[1032];
+  MxU16 m_unk24; // 0x24
+  undefined m_unk28[1032];
 };
 
 #endif // LEGOGAMESTATE_H

--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -29,7 +29,7 @@ MxDSAction::MxDSAction()
   this->m_unk84 = 0;
   this->m_unk88 = 0;
   this->m_omni = NULL;
-  this->m_someTimingField = INT_MIN;
+  this->m_unkTimingField = INT_MIN;
 }
 
 // OFFSET: LEGO1 0x100ada80
@@ -55,7 +55,7 @@ void MxDSAction::CopyFrom(MxDSAction &p_dsAction)
   this->m_unk84 = p_dsAction.m_unk84;
   this->m_unk88 = p_dsAction.m_unk88;
   this->m_omni = p_dsAction.m_omni;
-  this->m_someTimingField = p_dsAction.m_someTimingField;
+  this->m_unkTimingField = p_dsAction.m_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100adc10
@@ -185,15 +185,15 @@ MxBool MxDSAction::HasId(MxU32 p_objectId)
 }
 
 // OFFSET: LEGO1 0x100ada40
-void MxDSAction::SetSomeTimingField(MxLong p_someTimingField)
+void MxDSAction::SetUnkTimingField(MxLong p_unkTimingField)
 {
-  this->m_someTimingField = p_someTimingField;
+  this->m_unkTimingField = p_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100ada50
-MxLong MxDSAction::GetSomeTimingField()
+MxLong MxDSAction::GetUnkTimingField()
 {
-  return this->m_someTimingField;
+  return this->m_unkTimingField;
 }
 
 // Win32 defines GetCurrentTime to GetTickCount
@@ -202,7 +202,7 @@ MxLong MxDSAction::GetSomeTimingField()
 // OFFSET: LEGO1 0x100adcd0
 MxLong MxDSAction::GetCurrentTime()
 {
-  return Timer()->GetTime() - this->m_someTimingField;
+  return Timer()->GetTime() - this->m_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100ade60

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -48,8 +48,8 @@ public:
   virtual MxDSAction *Clone(); // vtable+2c;
   virtual void MergeFrom(MxDSAction &p_dsAction); // vtable+30;
   virtual MxBool HasId(MxU32 p_objectId); // vtable+34;
-  virtual void SetSomeTimingField(MxLong p_someTimingField); // vtable+38;
-  virtual MxLong GetSomeTimingField(); // vtable+3c;
+  virtual void SetUnkTimingField(MxLong p_unkTimingField); // vtable+38;
+  virtual MxLong GetUnkTimingField(); // vtable+3c;
   virtual MxLong GetCurrentTime(); // vtable+40;
 
   void AppendData(MxU16 p_extraLength, const char *p_extraData);
@@ -87,7 +87,7 @@ private:
   MxOmni *m_omni; // 0x8c
 
 protected:
-  MxLong m_someTimingField; // 0x90
+  MxLong m_unkTimingField; // 0x90
 };
 
 #endif // MXDSACTION_H

--- a/LEGO1/mxdschunk.cpp
+++ b/LEGO1/mxdschunk.cpp
@@ -4,16 +4,16 @@
 MxDSChunk::MxDSChunk()
 {
   this->m_length = 0;
-  this->m_pStuff = NULL;
+  this->m_unk18 = NULL;
   this->m_buffer = -1;
-  this->m_long1FromHeader = 0;
-  this->m_long2FromHeader = 0;
+  this->m_unk10 = 0;
+  this->m_unk14 = 0;
 }
 
 // OFFSET: LEGO1 0x100be170
 MxDSChunk::~MxDSChunk()
 {
   if ((this->m_length & 1) != 0) {
-    delete this->m_pStuff;
+    delete this->m_unk18;
   }
 }

--- a/LEGO1/mxdschunk.h
+++ b/LEGO1/mxdschunk.h
@@ -26,10 +26,10 @@ public:
 private:
   MxS16 m_length; // 0x8
   MxLong m_buffer; // 0xc
-  MxLong m_long1FromHeader; // 0x10
-  MxLong m_long2FromHeader; // 0x14
-  void* m_pStuff; // 0x18
-  void* m_pSomething; // 0x1c
+  MxLong m_unk10; // 0x10
+  MxLong m_unk14; // 0x14
+  void* m_unk18; // 0x18
+  void* m_unk1c; // 0x1c
 };
 
 #endif // MXDSCHUNK_H

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -40,14 +40,14 @@ MxDSMultiAction &MxDSMultiAction::operator=(MxDSMultiAction &p_dsMultiAction)
 }
 
 // OFFSET: LEGO1 0x100ca290
-void MxDSMultiAction::SetSomeTimingField(MxLong p_someTimingField)
+void MxDSMultiAction::SetUnkTimingField(MxLong p_unkTimingField)
 {
-  this->m_someTimingField = p_someTimingField;
+  this->m_unkTimingField = p_unkTimingField;
 
   MxDSActionListCursor cursor(this->m_actions);
   MxDSAction *action;
   while (cursor.Next(action))
-    action->SetSomeTimingField(p_someTimingField);
+    action->SetUnkTimingField(p_unkTimingField);
 }
 
 // OFFSET: LEGO1 0x100ca370

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -35,7 +35,7 @@ public:
   virtual MxDSAction *Clone() override; // vtable+2c;
   virtual void MergeFrom(MxDSAction &p_dsAction) override; // vtable+30;
   virtual MxBool HasId(MxU32 p_objectId) override; // vtable+34;
-  virtual void SetSomeTimingField(MxLong p_someTimingField) override; // vtable+38;
+  virtual void SetUnkTimingField(MxLong p_unkTimingField) override; // vtable+38;
 
 protected:
   MxU32 m_sizeOnDisk;

--- a/LEGO1/mxdssource.cpp
+++ b/LEGO1/mxdssource.cpp
@@ -1,9 +1,9 @@
 #include "mxdssource.h"
 
 // OFFSET: LEGO1 0x100bffd0
-void MxDSSource::SomethingWhichCallsRead(void* pUnknownObject)
+void MxDSSource::FUN_100bffd0(void* p_unk)
 {
-  // TODO: Calls read, reading into a buffer somewhere in pUnknownObject.
+  // TODO: Calls read, reading into a buffer somewhere in p_unk.
   Read(NULL, 0);
 }
 

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -28,7 +28,7 @@ public:
 
   virtual MxLong Open(MxULong) = 0;
   virtual MxLong Close() = 0;
-  virtual void SomethingWhichCallsRead(void* pUnknownObject);
+  virtual void FUN_100bffd0(void* p_unk);
   virtual MxResult Read(unsigned char *, MxULong) = 0;
   virtual MxLong Seek(MxLong, int) = 0;
   virtual MxULong GetBufferSize() = 0;

--- a/LEGO1/mxmatrix.cpp
+++ b/LEGO1/mxmatrix.cpp
@@ -175,7 +175,7 @@ void MxMatrix::ToQuaternion(MxVector4 *p_outQuat)
 // No idea what this function is doing and it will be hard to tell until
 // we have a confirmed usage site.
 // OFFSET: LEGO1 0x10002710 STUB
-MxResult MxMatrix::DoSomethingWithLength(const MxVector3 *p_vec)
+MxResult MxMatrix::FUN_10002710(const MxVector3 *p_vec)
 {
   return FAILURE;
 }

--- a/LEGO1/mxmatrix.h
+++ b/LEGO1/mxmatrix.h
@@ -36,7 +36,7 @@ public:
 
   // vtable + 0x40
   virtual void ToQuaternion(MxVector4 *p_resultQuat);
-  virtual MxResult DoSomethingWithLength(const MxVector3 *p_vec);
+  virtual MxResult FUN_10002710(const MxVector3 *p_vec);
 
 private:
   float *m_data;


### PR DESCRIPTION
This PR renames all uncertain member/variable/method names to `unk` equivalents. The reason for this is that labeling something that is unknown does not change the fact that, ultimately, it is still unknown and just serves to further complicate the code style of the project. These names still end up providing little useful information to the developer. This naming style also creates further issues as the existence of these labels in the code makes it impossible to get an accurate number of unlabeled members/variables/methods if we were to, for instance, `grep` or otherwise search for all instances of `unk` or `unknown` in the repository.