### PR TITLE
Implement MxVideoManager::Destroy / destructor

### DIFF
--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -55,7 +55,7 @@ MxResult MxVideoManager::Init()
 // OFFSET: LEGO1 0x100be340
 void MxVideoManager::Destroy(MxBool p_fromDestructor)
 {
-  if (m_thread != NULL) {
+  if (m_thread) {
     m_thread->Terminate();
     delete m_thread;
   }

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -1,6 +1,8 @@
 #include "mxvideomanager.h"
 #include "mxautolocker.h"
 #include "mxpresenter.h"
+#include "mxticklemanager.h"
+#include "legoomni.h"
 
 // OFFSET: LEGO1 0x100be1f0
 MxVideoManager::MxVideoManager()
@@ -8,10 +10,10 @@ MxVideoManager::MxVideoManager()
   Init();
 }
 
-// OFFSET: LEGO1 0x100be2a0 STUB
+// OFFSET: LEGO1 0x100be2a0
 MxVideoManager::~MxVideoManager()
 {
-  // TODO
+  Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100bea90
@@ -48,6 +50,41 @@ MxResult MxVideoManager::Init()
   this->m_videoParam.SetPalette(NULL);
   this->m_unk60 = FALSE;
   return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x100be340
+void MxVideoManager::Destroy(MxBool p_fromDestructor)
+{
+  if (m_thread != NULL) {
+    m_thread->Terminate();
+    delete m_thread;
+  }
+  else
+    TickleManager()->UnregisterClient(this);
+
+  m_criticalSection.Enter();
+
+  if (m_displaySurface)
+    delete m_displaySurface;
+
+  if (m_region)
+    delete m_region;
+
+  if (m_videoParam.GetPalette())
+    delete m_videoParam.GetPalette();
+
+  if (m_unk60) {
+    if (m_pDirectDraw)
+      m_pDirectDraw->Release();
+    if (m_pDDSurface)
+      m_pDDSurface->Release();
+  }
+
+  Init();
+  m_criticalSection.Leave();
+
+  if (!p_fromDestructor)
+    MxMediaManager::Destroy();
 }
 
 // OFFSET: LEGO1 0x100be440
@@ -87,6 +124,12 @@ void MxVideoManager::SortPresenterList()
 void MxVideoManager::UpdateRegion()
 {
   // TODO
+}
+
+// OFFSET: LEGO1 0x100bea50
+void MxVideoManager::Destroy()
+{
+  Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100bea60 STUB

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -14,6 +14,7 @@ public:
   virtual ~MxVideoManager();
 
   virtual MxResult Tickle() override; // vtable+0x8
+  virtual void Destroy() override; // vtable+0x18
   virtual void vtable0x28(); // vtable+0x28 (TODO ARGUMENTS)
   virtual MxResult vtable0x2c(MxVideoParam& p_videoParam, undefined4 p_unknown1, MxU8 p_unknown2); // vtable+0x2c
 
@@ -23,6 +24,7 @@ public:
   MxVideoManager();
 
   MxResult Init();
+  void Destroy(MxBool p_fromDestructor);
   void SortPresenterList();
   void UpdateRegion();
 

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -11,7 +11,7 @@
 class MxVideoManager : public MxMediaManager
 {
 public:
-  virtual ~MxVideoManager();
+  virtual ~MxVideoManager() override;
 
   virtual MxResult Tickle() override; // vtable+0x8
   virtual void Destroy() override; // vtable+0x18

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -65,11 +65,11 @@ MxVideoParam &MxVideoParam::operator=(const MxVideoParam &p_videoParam)
 void MxVideoParam::SetDeviceName(char *id)
 {
   if (this->m_deviceId != 0)
-    free(this->m_deviceId);
+    delete[] this->m_deviceId;
 
   if (id != 0)
   {
-    this->m_deviceId = (char *)malloc(strlen(id) + 1);
+    this->m_deviceId = new char[strlen(id) + 1];
 
     if (this->m_deviceId != 0) {
       strcpy(this->m_deviceId, id);
@@ -84,5 +84,5 @@ void MxVideoParam::SetDeviceName(char *id)
 MxVideoParam::~MxVideoParam()
 {
   if (this->m_deviceId != 0)
-    free(this->m_deviceId);
+    delete[] this->m_deviceId;
 }


### PR DESCRIPTION
Implements `MxVideoManager::Destroy` and related functions (destructor, virtual `Destroy`). 100% matches.

Also replaced some `malloc/free` with `new/delete[]` in `MxVideoParam`