### PR TITLE
Implement MxVideoManager::vtable0x28 and Create

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(lego1 SHARED
   LEGO1/mxpresenterlist.cpp
   LEGO1/mxramstreamcontroller.cpp
   LEGO1/mxramstreamprovider.cpp
+  LEGO1/mxregion.cpp
   LEGO1/mxscheduler.cpp
   LEGO1/mxsemaphore.cpp
   LEGO1/mxsmkpresenter.cpp

--- a/LEGO1/mxmusicmanager.cpp
+++ b/LEGO1/mxmusicmanager.cpp
@@ -120,44 +120,32 @@ void MxMusicManager::SetVolume(MxS32 p_volume)
 }
 
 // OFFSET: LEGO1 0x100c0840
-MxResult MxMusicManager::StartMIDIThread(MxU32 p_frequencyMS, MxBool p_noRegister)
+MxResult MxMusicManager::StartMIDIThread(MxU32 p_frequencyMS, MxBool p_createThread)
 {
   MxResult status = FAILURE;
   MxBool locked = FALSE;
 
-  MxResult result = MxAudioManager::InitPresenters();
-  if (result == SUCCESS)
-  {
-    if (p_noRegister)
-    {
+  if (MxAudioManager::InitPresenters() == SUCCESS) {
+    if (p_createThread) {
       m_criticalSection.Enter();
       locked = TRUE;
       m_thread = new MxTickleThread(this, p_frequencyMS);
 
-      if (m_thread)
-      {
-        if (m_thread->Start(0, 0) == SUCCESS)
-        {
-          status = SUCCESS;
-        }
-      }
+      if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
+        goto done;
     }
     else
-    {
       TickleManager()->RegisterClient(this, p_frequencyMS);
-      status = SUCCESS;
-    }
+    
+    status = SUCCESS;
   }
 
+done:
   if (status != SUCCESS)
-  {
     Destroy();
-  }
 
   if (locked)
-  {
     m_criticalSection.Leave();
-  }
 
   return status;
 }

--- a/LEGO1/mxmusicmanager.h
+++ b/LEGO1/mxmusicmanager.h
@@ -14,7 +14,7 @@ public:
 
   virtual void Destroy() override; // vtable+18
   virtual void SetVolume(MxS32 p_volume) override; // vtable+2c
-  virtual MxResult StartMIDIThread(MxU32 p_frequencyMS, MxU8 p_noRegister); // vtable+30
+  virtual MxResult StartMIDIThread(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+30
 
   inline MxBool GetMIDIInitialized() { return m_MIDIInitialized; }
 

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -254,8 +254,7 @@ MxResult MxOmni::Create(MxOmniCreateParam &p)
     MxVideoManager *videoManager = new MxVideoManager();
     this->m_videoManager = videoManager;
 
-    if (videoManager != NULL && videoManager->vtable0x2c(p.GetVideoParam(), 100, 0) != SUCCESS)
-    {
+    if (videoManager && videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
       delete m_videoManager;
       m_videoManager = NULL;
     }

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -1,0 +1,39 @@
+#include "mxregion.h"
+
+DECOMP_SIZE_ASSERT(MxRegion, 0x1c);
+
+// OFFSET: LEGO1 0x100c31c0 STUB
+MxRegion::MxRegion()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100c3690 STUB
+MxRegion::~MxRegion()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100c3700 STUB
+void MxRegion::Reset()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100c3750 STUB
+void MxRegion::vtable18()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100c3e20 STUB
+void MxRegion::vtable1c()
+{
+  // TODO
+}
+
+// OFFSET: LEGO1 0x100c3660 STUB
+void MxRegion::vtable20()
+{
+  // TODO
+}

--- a/LEGO1/mxregion.h
+++ b/LEGO1/mxregion.h
@@ -2,6 +2,7 @@
 #define MXREGION_H
 
 #include "mxcore.h"
+#include "decomp.h"
 
 // VTABLE 0x100dcae8
 // SIZE 0x1c
@@ -21,6 +22,7 @@ private:
   // MxList<MxRect32> *m_rects;
   // 4 coordinates (could be MxRect32)
   // MxS32 left, top, right, bottom;
+  undefined pad[0x14];
 };
 
 #endif // MXREGION_H

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -55,7 +55,7 @@ MxResult MxVideoManager::Init()
 // OFFSET: LEGO1 0x100be340
 void MxVideoManager::Destroy(MxBool p_fromDestructor)
 {
-  if (m_thread != NULL) {
+  if (m_thread) {
     m_thread->Terminate();
     delete m_thread;
   }

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -229,7 +229,7 @@ done:
 }
 
 // OFFSET: LEGO1 0x100be820
-MxResult MxVideoManager::vtable0x2c(
+MxResult MxVideoManager::Create(
     MxVideoParam &p_videoParam,
     MxU32 p_frequencyMS,
     MxBool p_createThread)

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -1,6 +1,8 @@
 #include "mxvideomanager.h"
 #include "mxautolocker.h"
 #include "mxpresenter.h"
+#include "mxticklemanager.h"
+#include "legoomni.h"
 
 // OFFSET: LEGO1 0x100be1f0
 MxVideoManager::MxVideoManager()
@@ -8,10 +10,10 @@ MxVideoManager::MxVideoManager()
   Init();
 }
 
-// OFFSET: LEGO1 0x100be2a0 STUB
+// OFFSET: LEGO1 0x100be2a0
 MxVideoManager::~MxVideoManager()
 {
-  // TODO
+  Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100bea90
@@ -48,6 +50,41 @@ MxResult MxVideoManager::Init()
   this->m_videoParam.SetPalette(NULL);
   this->m_unk60 = FALSE;
   return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x100be340
+void MxVideoManager::Destroy(MxBool p_fromDestructor)
+{
+  if (m_thread != NULL) {
+    m_thread->Terminate();
+    delete m_thread;
+  }
+  else
+    TickleManager()->UnregisterClient(this);
+
+  m_criticalSection.Enter();
+
+  if (m_displaySurface)
+    delete m_displaySurface;
+
+  if (m_region)
+    delete m_region;
+
+  if (m_videoParam.GetPalette())
+    delete m_videoParam.GetPalette();
+
+  if (m_unk60) {
+    if (m_pDirectDraw)
+      m_pDirectDraw->Release();
+    if (m_pDDSurface)
+      m_pDDSurface->Release();
+  }
+
+  Init();
+  m_criticalSection.Leave();
+
+  if (!p_fromDestructor)
+    MxMediaManager::Destroy();
 }
 
 // OFFSET: LEGO1 0x100be440
@@ -87,6 +124,12 @@ void MxVideoManager::SortPresenterList()
 void MxVideoManager::UpdateRegion()
 {
   // TODO
+}
+
+// OFFSET: LEGO1 0x100bea50
+void MxVideoManager::Destroy()
+{
+  Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100bea60 STUB

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -14,6 +14,7 @@ public:
   virtual ~MxVideoManager();
 
   virtual MxResult Tickle() override; // vtable+0x8
+  virtual void Destroy() override; // vtable+0x18
   virtual void vtable0x28(); // vtable+0x28 (TODO ARGUMENTS)
   virtual MxResult vtable0x2c(MxVideoParam& p_videoParam, undefined4 p_unknown1, MxU8 p_unknown2); // vtable+0x2c
 
@@ -23,6 +24,7 @@ public:
   MxVideoManager();
 
   MxResult Init();
+  void Destroy(MxBool p_fromDestructor);
   void SortPresenterList();
   void UpdateRegion();
 

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -15,7 +15,16 @@ public:
 
   virtual MxResult Tickle() override; // vtable+0x8
   virtual void Destroy() override; // vtable+0x18
-  virtual void vtable0x28(); // vtable+0x28 (TODO ARGUMENTS)
+  virtual MxResult vtable0x28(
+    MxVideoParam& p_videoParam,
+    LPDIRECTDRAW p_pDirectDraw,
+    LPDIRECTDRAWSURFACE p_pDDSurface,
+    LPDIRECTDRAWSURFACE p_ddSurface1,
+    LPDIRECTDRAWSURFACE p_ddSurface2,
+    LPDIRECTDRAWCLIPPER p_ddClipper,
+    MxU32 p_frequencyMS,
+    MxBool p_createThread
+  ); // vtable+0x28
   virtual MxResult vtable0x2c(MxVideoParam& p_videoParam, undefined4 p_unknown1, MxU8 p_unknown2); // vtable+0x2c
 
   __declspec(dllexport) void InvalidateRect(MxRect32 &);

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -25,7 +25,7 @@ public:
     MxU32 p_frequencyMS,
     MxBool p_createThread
   ); // vtable+0x28
-  virtual MxResult vtable0x2c(MxVideoParam& p_videoParam, undefined4 p_unknown1, MxU8 p_unknown2); // vtable+0x2c
+  virtual MxResult vtable0x2c(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x2c
 
   __declspec(dllexport) void InvalidateRect(MxRect32 &);
   __declspec(dllexport) virtual MxLong RealizePalette(MxPalette *); // vtable+0x30

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -11,7 +11,7 @@
 class MxVideoManager : public MxMediaManager
 {
 public:
-  virtual ~MxVideoManager();
+  virtual ~MxVideoManager() override;
 
   virtual MxResult Tickle() override; // vtable+0x8
   virtual void Destroy() override; // vtable+0x18

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -25,7 +25,7 @@ public:
     MxU32 p_frequencyMS,
     MxBool p_createThread
   ); // vtable+0x28
-  virtual MxResult vtable0x2c(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x2c
+  virtual MxResult Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x2c
 
   __declspec(dllexport) void InvalidateRect(MxRect32 &);
   __declspec(dllexport) virtual MxLong RealizePalette(MxPalette *); // vtable+0x30

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -65,11 +65,11 @@ MxVideoParam &MxVideoParam::operator=(const MxVideoParam &p_videoParam)
 void MxVideoParam::SetDeviceName(char *id)
 {
   if (this->m_deviceId != 0)
-    free(this->m_deviceId);
+    delete[] this->m_deviceId;
 
   if (id != 0)
   {
-    this->m_deviceId = (char *)malloc(strlen(id) + 1);
+    this->m_deviceId = new char[strlen(id) + 1];
 
     if (this->m_deviceId != 0) {
       strcpy(this->m_deviceId, id);
@@ -84,5 +84,5 @@ void MxVideoParam::SetDeviceName(char *id)
 MxVideoParam::~MxVideoParam()
 {
   if (this->m_deviceId != 0)
-    free(this->m_deviceId);
+    delete[] this->m_deviceId;
 }


### PR DESCRIPTION
Depends on https://github.com/isledecomp/isle/pull/207

Implements `MxVideoManager::vtable0x28` and `0x2c`, 100% matches.

They are both very similar. `0x28` uses `MxDisplaySurface::Init` and `0x2c` uses `MxDisplaySurface::Create` instead. `m_unk60` indicates which one of the methods has been used to initialize the class. I can't really think of good names right now so I'll leave them as-is. 

Note: the usage of the `goto` pattern is intentional, just like in `MxDisplaySurface`. I've also added this pattern to `MxMusicManager::StartMIDIThread` in order to achieve a 100% match. There's no other way to get the 100% match I believe (also the usage of this pattern is confirmed by the 1996 source).