### PR TITLE
MxOmni::Create 100% match, make Create calls consistent

### DIFF
--- a/LEGO1/mxeventmanager.cpp
+++ b/LEGO1/mxeventmanager.cpp
@@ -49,17 +49,16 @@ MxResult MxEventManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
       locked = TRUE;
       this->m_thread = new MxTickleThread(this, p_frequencyMS);
 
-      if (this->m_thread) {
-        if (this->m_thread->Start(0, 0) == SUCCESS)
-          status = SUCCESS;
-      }
+      if (!this->m_thread || this->m_thread->Start(0, 0) != SUCCESS)
+        goto done;
     }
-    else {
+    else
       TickleManager()->RegisterClient(this, p_frequencyMS);
-      status = SUCCESS;
-    }
+
+    status = SUCCESS;
   }
 
+done:
   if (status != SUCCESS)
     Destroy();
 

--- a/LEGO1/mxeventmanager.cpp
+++ b/LEGO1/mxeventmanager.cpp
@@ -37,14 +37,14 @@ void MxEventManager::Destroy(MxBool p_fromDestructor)
 }
 
 // OFFSET: LEGO1 0x100c04a0
-MxResult MxEventManager::CreateEventThread(MxU32 p_frequencyMS, MxBool p_noRegister)
+MxResult MxEventManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
   MxResult status = FAILURE;
   MxBool locked = FALSE;
 
   MxResult result = MxMediaManager::InitPresenters();
   if (result == SUCCESS) {
-    if (p_noRegister) {
+    if (p_createThread) {
       this->m_criticalSection.Enter();
       locked = TRUE;
       this->m_thread = new MxTickleThread(this, p_frequencyMS);

--- a/LEGO1/mxeventmanager.h
+++ b/LEGO1/mxeventmanager.h
@@ -13,7 +13,7 @@ public:
   virtual ~MxEventManager() override;
 
   virtual void Destroy() override; // vtable+18
-  virtual MxResult CreateEventThread(MxU32 p_frequencyMS, MxBool p_noRegister); // vtable+28
+  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+28
 
 private:
   void Init();

--- a/LEGO1/mxmusicmanager.cpp
+++ b/LEGO1/mxmusicmanager.cpp
@@ -120,7 +120,7 @@ void MxMusicManager::SetVolume(MxS32 p_volume)
 }
 
 // OFFSET: LEGO1 0x100c0840
-MxResult MxMusicManager::StartMIDIThread(MxU32 p_frequencyMS, MxBool p_createThread)
+MxResult MxMusicManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
   MxResult status = FAILURE;
   MxBool locked = FALSE;

--- a/LEGO1/mxmusicmanager.h
+++ b/LEGO1/mxmusicmanager.h
@@ -14,7 +14,7 @@ public:
 
   virtual void Destroy() override; // vtable+18
   virtual void SetVolume(MxS32 p_volume) override; // vtable+2c
-  virtual MxResult StartMIDIThread(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+30
+  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+30
 
   inline MxBool GetMIDIInitialized() { return m_MIDIInitialized; }
 

--- a/LEGO1/mxnotificationmanager.cpp
+++ b/LEGO1/mxnotificationmanager.cpp
@@ -72,7 +72,7 @@ MxResult MxNotificationManager::Tickle()
 }
 
 // OFFSET: LEGO1 0x100ac600
-MxResult MxNotificationManager::Create(MxS32 p_unk1, MxS32 p_unk2)
+MxResult MxNotificationManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
   MxResult result = SUCCESS;
   m_queue = new MxNotificationPtrList();

--- a/LEGO1/mxnotificationmanager.h
+++ b/LEGO1/mxnotificationmanager.h
@@ -45,7 +45,7 @@ public:
 
   virtual MxResult Tickle(); // vtable+0x8
   // TODO: Where does this method come from?
-  virtual MxResult Create(MxS32 p_unk1, MxS32 p_unk2); // vtable+0x14
+  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x14
   void Register(MxCore *p_listener);
   void Unregister(MxCore *p_listener);
   MxResult Send(MxCore *p_listener, MxNotificationParam *p_param);

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -221,13 +221,13 @@ MxResult MxOmni::Create(MxOmniCreateParam &p)
       if (m_notificationManager->Create(100, 0) != SUCCESS)
         goto done;
     }
+    else
+      goto done;
   }
 
   if (p.CreateFlags().CreateStreamer()) {
-    if (m_streamer = new MxStreamer()) {
-      if (m_streamer->Create() != SUCCESS)
-        goto done;
-    }
+    if (!(m_streamer = new MxStreamer()) || m_streamer->Create() != SUCCESS) 
+      goto done;
   }
 
   if (p.CreateFlags().CreateVideoManager()) {

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -189,118 +189,87 @@ void MxOmni::SetInstance(MxOmni *instance)
 MxResult MxOmni::Create(MxOmniCreateParam &p)
 {
   MxResult result = FAILURE;
-  m_atomIdCounterSet = new MxAtomIdCounterSet();
-  if (m_atomIdCounterSet == NULL)
-  {
-    goto failure;
-  }
+
+  if (!(m_atomIdCounterSet = new MxAtomIdCounterSet()))
+    goto done;
+
   m_mediaPath = p.GetMediaPath();
   m_windowHandle = p.GetWindowHandle();
-  if (p.CreateFlags().CreateObjectFactory())
-  {
-    MxObjectFactory *objectFactory = new MxObjectFactory();
-    this->m_objectFactory = objectFactory;
 
-    if (objectFactory == NULL)
-      goto failure;
+  if (p.CreateFlags().CreateObjectFactory()) {
+    if (!(m_objectFactory = new MxObjectFactory()))
+      goto done;
   }
 
-  if (p.CreateFlags().CreateVariableTable())
-  {
-    MxVariableTable *variableTable = new MxVariableTable();
-    this->m_variableTable = variableTable;
-
-    if (variableTable == NULL)
-      goto failure;
+  if (p.CreateFlags().CreateVariableTable()) {
+    if (!(m_variableTable = new MxVariableTable()))
+      goto done;
   }
 
-  if (p.CreateFlags().CreateTimer())
-  {
-    MxTimer *timer = new MxTimer();
-    this->m_timer = timer;
-
-    if (timer == NULL)
-      return FAILURE;
+  if (p.CreateFlags().CreateTimer()) {
+    if (!(m_timer = new MxTimer()))
+      goto done;
   }
 
-  if (p.CreateFlags().CreateTickleManager())
-  {
-    this->m_tickleManager = new MxTickleManager();
-
-    if (m_tickleManager == NULL)
-      goto failure;
+  if (p.CreateFlags().CreateTickleManager()) {
+    if (!(m_tickleManager = new MxTickleManager()))
+      goto done;
   }
 
-  if (p.CreateFlags().CreateNotificationManager())
-  {
-    MxNotificationManager *notificationManager = new MxNotificationManager();
-    this->m_notificationManager = notificationManager;
-
-    if (notificationManager == NULL || notificationManager->Create(100, 0) != SUCCESS)
-      goto failure;
-  }
-
-  if (p.CreateFlags().CreateStreamer())
-  {
-    MxStreamer *streamer = new MxStreamer();
-    this->m_streamer = streamer;
-
-    if (streamer == NULL || streamer->Init() != SUCCESS)
-      goto failure;
-  }
-
-  if (p.CreateFlags().CreateVideoManager())
-  {
-    MxVideoManager *videoManager = new MxVideoManager();
-    this->m_videoManager = videoManager;
-
-    if (videoManager && videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
-      delete m_videoManager;
-      m_videoManager = NULL;
+  if (p.CreateFlags().CreateNotificationManager()) {
+    if (m_notificationManager = new MxNotificationManager()) {
+      if (m_notificationManager->Create(100, 0) != SUCCESS)
+        goto done;
     }
   }
 
-  if (p.CreateFlags().CreateSoundManager())
-  {
-    MxSoundManager *soundManager = new MxSoundManager();
-    this->m_soundManager = soundManager;
-
-    //TODO
-    if (soundManager != NULL && soundManager->StartDirectSound(10, 0) != SUCCESS)
-    {
-      delete m_soundManager;
-      m_soundManager = NULL;
+  if (p.CreateFlags().CreateStreamer()) {
+    if (m_streamer = new MxStreamer()) {
+      if (m_streamer->Create() != SUCCESS)
+        goto done;
     }
   }
 
-  if (p.CreateFlags().CreateMusicManager())
-  {
-    MxMusicManager *musicManager = new MxMusicManager();
-    this->m_musicManager = musicManager;
-    if (musicManager != NULL && musicManager->StartMIDIThread(50, 0) != SUCCESS)
-    {
-      delete m_musicManager;
-      m_musicManager = NULL;
+  if (p.CreateFlags().CreateVideoManager()) {
+    if (m_videoManager = new MxVideoManager()) {
+      if (m_videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
+        delete m_videoManager;
+        m_videoManager = NULL;
+      }
     }
   }
 
-  if (p.CreateFlags().CreateEventManager())
-  {
-    MxEventManager *eventManager = new MxEventManager();
-    this->m_eventManager = eventManager;
-    if (m_eventManager != NULL && m_eventManager->CreateEventThread(50, 0) != SUCCESS)
-    {
-      delete m_eventManager;
-      m_eventManager = NULL;
+  if (p.CreateFlags().CreateSoundManager()) {
+    if (m_soundManager = new MxSoundManager()) {
+      if (m_soundManager->Create(10, 0) != SUCCESS) {
+        delete m_soundManager;
+        m_soundManager = NULL;
+      }
+    }
+  }
+
+  if (p.CreateFlags().CreateMusicManager()) {
+    if (m_musicManager = new MxMusicManager()) {
+      if (m_musicManager->Create(50, 0) != SUCCESS) {
+        delete m_musicManager;
+        m_musicManager = NULL;
+      }
+    }
+  }
+
+  if (p.CreateFlags().CreateEventManager()) {
+    if (m_eventManager = new MxEventManager()) {
+      if (m_eventManager->Create(50, 0) != SUCCESS) {
+        delete m_eventManager;
+        m_eventManager = NULL;
+      }
     }
   }
 
   result = SUCCESS;
-  failure:
+done:
   if (result != SUCCESS)
-  {
     Destroy();
-  }
 
   return result;
 }

--- a/LEGO1/mxomnicreateparam.h
+++ b/LEGO1/mxomnicreateparam.h
@@ -14,7 +14,7 @@ public:
   __declspec(dllexport) MxOmniCreateParam(const char *mediaPath, struct HWND__ *windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags);
 
   const MxOmniCreateFlags& CreateFlags() const { return this->m_createFlags; }
-  const const MxString& GetMediaPath() const { return m_mediaPath; }
+  const MxString& GetMediaPath() const { return m_mediaPath; }
   const HWND GetWindowHandle() const { return m_windowHandle; }
   MxVideoParam& GetVideoParam() { return m_videoParam; }
 

--- a/LEGO1/mxomnicreateparam.h
+++ b/LEGO1/mxomnicreateparam.h
@@ -14,7 +14,7 @@ public:
   __declspec(dllexport) MxOmniCreateParam(const char *mediaPath, struct HWND__ *windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags);
 
   const MxOmniCreateFlags& CreateFlags() const { return this->m_createFlags; }
-  const MxString GetMediaPath() const { return m_mediaPath; }
+  const const MxString& GetMediaPath() const { return m_mediaPath; }
   const HWND GetWindowHandle() const { return m_windowHandle; }
   MxVideoParam& GetVideoParam() { return m_videoParam; }
 

--- a/LEGO1/mxsoundmanager.cpp
+++ b/LEGO1/mxsoundmanager.cpp
@@ -49,9 +49,9 @@ void MxSoundManager::Destroy(MxBool p_fromDestructor)
 }
 
 // OFFSET: LEGO1 0x100ae8b0 STUB
-MxResult MxSoundManager::StartDirectSound(undefined4 p_unknown1, MxBool p_unknown2)
+MxResult MxSoundManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  // TODO STUB
+  // TODO
   return FAILURE;
 }
 

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -14,7 +14,7 @@ public:
   MxSoundManager();
   virtual ~MxSoundManager() override; // vtable+0x0
 
-  virtual MxResult StartDirectSound(undefined4 p_unknown1, MxBool p_unknown2); //vtable+0x30
+  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); //vtable+0x30
   virtual void vtable0x34(); // vtable+0x34
   virtual void vtable0x38(); // vtable+0x38
 

--- a/LEGO1/mxstreamer.cpp
+++ b/LEGO1/mxstreamer.cpp
@@ -16,7 +16,7 @@ MxStreamer::MxStreamer()
 }
 
 // OFFSET: LEGO1 0x100b9190
-MxResult MxStreamer::Init()
+MxResult MxStreamer::Create()
 {
   undefined *b = new undefined[m_subclass1.GetSize() * 0x5800];
   m_subclass1.SetBuffer(b);

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -90,7 +90,7 @@ public:
     return !strcmp(p_name, MxStreamer::ClassName()) || MxCore::IsA(p_name);
   }
 
-  virtual MxResult Init(); // vtable+0x14
+  virtual MxResult Create(); // vtable+0x14
 
   MxStreamController *GetOpenStream(const char *p_name);
 

--- a/LEGO1/mxstring.cpp
+++ b/LEGO1/mxstring.cpp
@@ -56,7 +56,7 @@ void MxString::ToLowerCase()
 }
 
 // OFFSET: LEGO1 0x100ae4b0
-MxString &MxString::operator=(MxString &param)
+MxString &MxString::operator=(const MxString &param)
 {
   if (this->m_data != param.m_data)
   {

--- a/LEGO1/mxstring.h
+++ b/LEGO1/mxstring.h
@@ -15,7 +15,7 @@ public:
   MxString(const char *);
   void ToUpperCase();
   void ToLowerCase();
-  MxString&  operator=(MxString &);
+  MxString&  operator=(const MxString &);
   MxString   operator+(const char *);
   MxString& operator+=(const char *);
 

--- a/LEGO1/mxticklemanager.h
+++ b/LEGO1/mxticklemanager.h
@@ -53,14 +53,13 @@ private:
   MxU16 m_flags; // 0xc
 };
 
-class MxTickleClientPtrList : public list<MxTickleClient *>
-{};
+typedef list<MxTickleClient*> MxTickleClientPtrList;
 
 // VTABLE 0x100d86d8
 class MxTickleManager : public MxCore
 {
 public:
-  inline MxTickleManager() : MxCore(), m_clients() {}
+  inline MxTickleManager() {}
   virtual ~MxTickleManager(); // vtable+0x0 (scalar deleting destructor)
 
   virtual MxResult Tickle(); // vtable+0x8


### PR DESCRIPTION
Mostly refactoring (renaming the "create" functions to `Create` with proper argument names) and several fixes, getting the match of `MxOmni::Create` to 100%.