### PR TITLE
Add LegoVehicleBuildState

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(lego1 SHARED
   LEGO1/legotexturepresenter.cpp
   LEGO1/legoutil.cpp
   LEGO1/legounksavedatawriter.cpp
+  LEGO1/legovehiclebuildstate.cpp
   LEGO1/legovideomanager.cpp
   LEGO1/legoworld.cpp
   LEGO1/legoworldpresenter.cpp

--- a/LEGO1/legovehiclebuildstate.cpp
+++ b/LEGO1/legovehiclebuildstate.cpp
@@ -9,17 +9,17 @@ DECOMP_SIZE_ASSERT(LegoVehicleBuildState::UnkStruct, 0xc);
 LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
 {
   this->m_className = p_classType;
-  this->m_unk2 = 0;
-  this->m_unk3 = 0;
-  this->m_unk4 = 0;
+  this->m_unk4c = 0;
+  this->m_unk4d = 0;
+  this->m_unk4e = 0;
   this->m_placedPartCount = 0;
 }
 
 // OFFSET: LEGO1 10017c00
 LegoVehicleBuildState::UnkStruct::UnkStruct()
 {
-  m_unk1 = 0;
-  m_unk0 = 0;
-  m_unk2 = 0;
-  m_unk3 = 0;
+  m_unk04 = 0;
+  m_unk00 = 0;
+  m_unk06 = 0;
+  m_unk08 = 0;
 }

--- a/LEGO1/legovehiclebuildstate.cpp
+++ b/LEGO1/legovehiclebuildstate.cpp
@@ -1,0 +1,25 @@
+#include "legovehiclebuildstate.h"
+
+#include "decomp.h"
+
+DECOMP_SIZE_ASSERT(LegoVehicleBuildState, 0x50); // 1000acd7
+DECOMP_SIZE_ASSERT(LegoVehicleBuildState::UnkStruct, 0xc);
+
+// OFFSET: LEGO1 0x10025f30
+LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
+{
+  this->m_className = p_classType;
+  this->m_unk2 = 0;
+  this->m_unk3 = 0;
+  this->m_unk4 = 0;
+  this->m_placedPartCount = 0;
+}
+
+// OFFSET: LEGO1 10017c00
+LegoVehicleBuildState::UnkStruct::UnkStruct()
+{
+  m_unk1 = 0;
+  m_unk0 = 0;
+  m_unk2 = 0;
+  m_unk3 = 0;
+}

--- a/LEGO1/legovehiclebuildstate.h
+++ b/LEGO1/legovehiclebuildstate.h
@@ -1,0 +1,61 @@
+#ifndef LEGOVEHICLEBUILDSTATE_H
+#define LEGOVEHICLEBUILDSTATE_H
+
+#include "legostate.h"
+#include "mxstring.h"
+#include "decomp.h"
+
+#include "decomp.h"
+
+// VTABLE 0x100d66e0
+// SIZE 0x50 (from 1000acd7)
+class LegoVehicleBuildState : public LegoState
+{
+public:
+  LegoVehicleBuildState(char* p_classType);
+
+  // OFFSET: LEGO1 0x10025ff0
+  inline virtual const char *ClassName() const override // vtable+0x0c
+  {
+    return this->m_className.GetData();
+  }
+
+  // OFFSET: LEGO1 0x10026000
+  inline virtual MxBool IsA(const char *p_name) const override // vtable+0x10
+  {
+    return !strcmp(p_name, this->m_className.GetData()) || LegoState::IsA(p_name);
+  }
+
+public:
+  struct UnkStruct
+  {
+    undefined4 m_unk0;
+    undefined2 m_unk1;
+    undefined2 m_unk2;
+    undefined2 m_unk3;
+    undefined2 _padding;
+
+    UnkStruct();
+  };
+private:
+  UnkStruct m_unk0[4]; // 0x08
+
+  // This can be one of the following:
+  // * LegoRaceCarBuildState
+  // * LegoCopterBuildState
+  // * LegoDuneCarBuildState
+  // * LegoJetskiBuildState
+  MxString m_className; // 0x38
+
+  // Known States:
+  // * 1 == enter(ing) build screen
+  // * 3 == cutscene/dialogue
+  // * 6 == exit(ing) build screen
+  MxU32 m_animationState; // 0x48
+  undefined m_unk2; // 0x4c
+  undefined m_unk3; // 0x4d
+  undefined m_unk4; // 0x4e
+  MxU8 m_placedPartCount; // 0x4f
+};
+
+#endif // LEGOVEHICLEBUILDSTATE_H

--- a/LEGO1/legovehiclebuildstate.h
+++ b/LEGO1/legovehiclebuildstate.h
@@ -29,16 +29,15 @@ public:
 public:
   struct UnkStruct
   {
-    undefined4 m_unk0;
-    undefined2 m_unk1;
-    undefined2 m_unk2;
-    undefined2 m_unk3;
-    undefined2 _padding;
+    undefined4 m_unk00;
+    undefined2 m_unk04;
+    undefined2 m_unk06;
+    undefined2 m_unk08;
 
     UnkStruct();
   };
 private:
-  UnkStruct m_unk0[4]; // 0x08
+  UnkStruct m_unk08[4]; // 0x08
 
   // This can be one of the following:
   // * LegoRaceCarBuildState
@@ -52,9 +51,9 @@ private:
   // * 3 == cutscene/dialogue
   // * 6 == exit(ing) build screen
   MxU32 m_animationState; // 0x48
-  undefined m_unk2; // 0x4c
-  undefined m_unk3; // 0x4d
-  undefined m_unk4; // 0x4e
+  undefined m_unk4c; // 0x4c
+  undefined m_unk4d; // 0x4d
+  undefined m_unk4e; // 0x4e
   MxU8 m_placedPartCount; // 0x4f
 };
 


### PR DESCRIPTION
This is a bit of an odd class which reflects it's class name through a member field set on construction (rather then through proper inheritance). I've named this class `LegoVehicleBuildState` as it doesn't have a single static string associated with it in the binary. Instead it's created for all of the following "class" strings in the `LegoObjectFactory::Create` method:

* `LegoRaceCarBuildState`
* `LegoCopterBuildState`
* `LegoDuneCarBuildState`
* `LegoJetskiBuildState`



New functions/method match rates:
```
LegoVehicleBuildState::LegoVehicleBuildState (0x10025f30) is 100.00% similar to the original
LegoVehicleBuildState::UnkStruct::UnkStruct (0x10017c00) is 100.00% similar to the original
LegoVehicleBuildState::ClassName (0x10025ff0) is 100.00% similar to the original
LegoVehicleBuildState::IsA (0x10026000) is 100.00% similar to the original
```