### PR TITLE
implement GasStationState::GasStationState()

### DIFF
--- a/LEGO1/gasstationstate.cpp
+++ b/LEGO1/gasstationstate.cpp
@@ -1,7 +1,14 @@
 #include "gasstationstate.h"
 
-// OFFSET: LEGO1 0x10005eb0 STUB
+// OFFSET: LEGO1 0x10005eb0
 GasStationState::GasStationState()
 {
-  // TODO
+  m_unk0x18 = 0;
+  m_unk0x1a = 0;
+  m_unk0x1c = 0;
+  m_unk0x1e = 0;
+  m_unk0x20 = 0;
+  m_unk0x08 = -1;
+  m_unk0x0c = -1;
+  m_unk0x10 = -1;
 }

--- a/LEGO1/gasstationstate.cpp
+++ b/LEGO1/gasstationstate.cpp
@@ -1,5 +1,7 @@
 #include "gasstationstate.h"
 
+DECOMP_SIZE_ASSERT(GasStationState, 0x24);
+
 // OFFSET: LEGO1 0x10005eb0
 GasStationState::GasStationState()
 {
@@ -8,7 +10,9 @@ GasStationState::GasStationState()
   m_unk0x1c = 0;
   m_unk0x1e = 0;
   m_unk0x20 = 0;
-  m_unk0x08 = -1;
-  m_unk0x0c = -1;
-  m_unk0x10 = -1;
+
+  undefined4 *unk = m_unk0x08;
+  unk[0] = -1;
+  unk[1] = -1;
+  unk[2] = -1;
 }

--- a/LEGO1/gasstationstate.h
+++ b/LEGO1/gasstationstate.h
@@ -23,6 +23,16 @@ public:
     return !strcmp(name, GasStationState::ClassName()) || LegoState::IsA(name);
   }
 
+private:
+  undefined4 m_unk0x08;
+  undefined4 m_unk0x0c;
+  undefined4 m_unk0x10;
+  undefined4 m_unk0x14;
+  undefined2 m_unk0x18;
+  undefined2 m_unk0x1a;
+  undefined2 m_unk0x1c;
+  undefined2 m_unk0x1e;
+  undefined m_unk0x20;
 };
 
 #endif // GASSTATIONSTATE_H

--- a/LEGO1/gasstationstate.h
+++ b/LEGO1/gasstationstate.h
@@ -24,15 +24,13 @@ public:
   }
 
 private:
-  undefined4 m_unk0x08;
-  undefined4 m_unk0x0c;
-  undefined4 m_unk0x10;
+  undefined4 m_unk0x08[3];
   undefined4 m_unk0x14;
   undefined2 m_unk0x18;
   undefined2 m_unk0x1a;
   undefined2 m_unk0x1c;
   undefined2 m_unk0x1e;
-  undefined m_unk0x20;
+  undefined2 m_unk0x20;
 };
 
 #endif // GASSTATIONSTATE_H

--- a/LEGO1/legostate.cpp
+++ b/LEGO1/legostate.cpp
@@ -1,5 +1,7 @@
 #include "legostate.h"
 
+DECOMP_SIZE_ASSERT(LegoState, 0x08);
+
 // OFFSET: LEGO1 0x10005f40
 LegoState::~LegoState()
 {

--- a/LEGO1/legostate.h
+++ b/LEGO1/legostate.h
@@ -1,6 +1,8 @@
 #ifndef LEGOSTATE_H
 #define LEGOSTATE_H
 
+#include "decomp.h"
+
 #include "mxcore.h"
 
 // VTABLE 0x100d46c0


### PR DESCRIPTION
Implements GasStationState::GasStationState(). This is not matching due to register swapping, and I wasn't able to remedy it successfully.

This PR also adds a size assert for LegoState as we were able to confirm it is a small class at only `0x08`. All classes that derive from it are expected to create their own members.