### PR TITLE
fix LegoState::VTable0x1C fake-match & implement LegoFileStream::FUN_10006030

### DIFF
--- a/LEGO1/legostate.cpp
+++ b/LEGO1/legostate.cpp
@@ -25,3 +25,16 @@ MxResult LegoState::VTable0x1C(LegoFileStream *p_legoFileStream)
   }
   return SUCCESS;
 }
+
+// OFFSET: LEGO1 0x10006030
+LegoFileStream *LegoFileStream::FUN_10006030(MxString p_str)
+{
+  const char *data = p_str.GetData();
+  MxU32 fullLength = strlen(data);
+
+  MxU16 limitedLength = fullLength;
+  Write(&limitedLength, sizeof(limitedLength));
+  Write(data, (MxS16) fullLength);
+
+  return this;
+}

--- a/LEGO1/legostate.cpp
+++ b/LEGO1/legostate.cpp
@@ -18,16 +18,10 @@ MxBool LegoState::VTable0x18() {
 }
 
 // OFFSET: LEGO1 0x10005fb0
-MxResult LegoState::VTable0x1C(LegoState *p_legoState)
+MxResult LegoState::VTable0x1C(LegoFileStream *p_legoFileStream)
 {
-  if (p_legoState->VTable0x14()) {
-    p_legoState->FUN_10006030(this->ClassName());
+  if (p_legoFileStream->IsWriteMode()) {
+    p_legoFileStream->FUN_10006030(this->ClassName());
   }
   return SUCCESS;
-}
-
-// OFFSET: LEGO1 0x10006030 STUB
-void LegoState::FUN_10006030(MxString p_str)
-{
-  // TODO
 }

--- a/LEGO1/legostate.h
+++ b/LEGO1/legostate.h
@@ -5,6 +5,7 @@
 
 #include "mxcore.h"
 #include "mxstring.h"
+#include "legostream.h"
 
 // VTABLE 0x100d46c0
 class LegoState : public MxCore
@@ -27,9 +28,7 @@ public:
 
   virtual MxBool VTable0x14(); // vtable+0x14
   virtual MxBool VTable0x18(); // vtable+0x18
-  virtual MxResult VTable0x1C(LegoState *p_legoState); // vtable+0x1C
-
-  void FUN_10006030(MxString p_str);
+  virtual MxResult VTable0x1C(LegoFileStream *p_legoFileStream); // vtable+0x1C
 };
 
 #endif // LEGOSTATE_H

--- a/LEGO1/legostream.cpp
+++ b/LEGO1/legostream.cpp
@@ -116,6 +116,18 @@ MxResult LegoFileStream::Open(const char* p_filename, OpenFlags p_mode)
   return (m_hFile = fopen(p_filename, modeString)) ? SUCCESS : FAILURE;
 }
 
+// OFFSET: LEGO1 0x10006030
+LegoFileStream *LegoFileStream::FUN_10006030(MxString p_str)
+{
+  MxS16 strLength = strlen(p_str.GetData());
+  const char *strData = p_str.GetData();
+
+  Write(&strLength, sizeof(strLength));
+  Write(strData, strLength);
+
+  return this;
+}
+
 // OFFSET: LEGO1 0x10099080
 LegoMemoryStream::LegoMemoryStream(char* p_buffer)
   : LegoStream()

--- a/LEGO1/legostream.cpp
+++ b/LEGO1/legostream.cpp
@@ -116,18 +116,6 @@ MxResult LegoFileStream::Open(const char* p_filename, OpenFlags p_mode)
   return (m_hFile = fopen(p_filename, modeString)) ? SUCCESS : FAILURE;
 }
 
-// OFFSET: LEGO1 0x10006030
-LegoFileStream *LegoFileStream::FUN_10006030(MxString p_str)
-{
-  MxS16 strLength = strlen(p_str.GetData());
-  const char *strData = p_str.GetData();
-
-  Write(&strLength, sizeof(strLength));
-  Write(strData, strLength);
-
-  return this;
-}
-
 // OFFSET: LEGO1 0x10099080
 LegoMemoryStream::LegoMemoryStream(char* p_buffer)
   : LegoStream()

--- a/LEGO1/legostream.h
+++ b/LEGO1/legostream.h
@@ -4,6 +4,7 @@
 #include "compat.h"
 #include "decomp.h"
 #include "mxtypes.h"
+#include "mxstring.h"
 
 #include <iosfwd>
 
@@ -54,6 +55,8 @@ public:
   MxResult Seek(MxU32 p_offset) override;
 
   MxResult Open(const char* p_filename, OpenFlags p_mode);
+
+  LegoFileStream *FUN_10006030(MxString p_str);
 
 private:
   FILE *m_hFile;


### PR DESCRIPTION
This PR corrects LegoState::VTable0x1C to take a `LegoFileStream *` parameter instead of the initially assumed `LegoState *` parameter that happened to coincidentally work out while still retaining its' match. I've confirmed this is the correct class through dynamic analysis. It also implements LegoFileStream::FUN_10006030 (moved from `LegoState`) which is currently a 75% match. This function is tricky and I wasn't able to improve it further from around an hour's worth of testing.