### PR TITLE
label ScoreState::VTable0x18 and associated member

### DIFF
--- a/LEGO1/scorestate.cpp
+++ b/LEGO1/scorestate.cpp
@@ -8,8 +8,8 @@ MxBool ScoreState::VTable0x14() {
 }
 
 // OFFSET: LEGO1 0x1000de30
-MxBool ScoreState::VTable0x18()
+MxBool ScoreState::SetScoreCubeTutorialFlag()
 {
-  m_unk0x08 = TRUE;
+  m_playCubeTutorial = TRUE;
   return TRUE;
 }

--- a/LEGO1/scorestate.h
+++ b/LEGO1/scorestate.h
@@ -22,10 +22,10 @@ public:
   };
 
   virtual MxBool VTable0x14() override; // vtable+0x14
-  virtual MxBool VTable0x18() override; // vtable+0x18
+  virtual MxBool SetScoreCubeTutorialFlag() override; // vtable+0x18
 
 private:
-    MxBool m_unk0x08;
+    MxBool m_playCubeTutorial;
 };
 
 #endif // SCORESTATE_H


### PR DESCRIPTION
This PR gives the name `SetScoreCubeTutorialFlag` to `VTable0x18` in ScoreState and labels its associated member. This bool `m_playCubeTutorial` is responsible for determining whether or not the explanation audio for the first time a player visits the Score Cube room plays.