### PR TITLE
Rename virtual function to fix override

### DIFF
--- a/LEGO1/legostate.cpp
+++ b/LEGO1/legostate.cpp
@@ -13,7 +13,7 @@ MxBool LegoState::VTable0x14() {
 }
 
 // OFFSET: LEGO1 0x10005fa0
-MxBool LegoState::VTable0x18() {
+MxBool LegoState::SetFlag() {
   return FALSE;
 }
 

--- a/LEGO1/legostate.h
+++ b/LEGO1/legostate.h
@@ -27,7 +27,7 @@ public:
   }
 
   virtual MxBool VTable0x14(); // vtable+0x14
-  virtual MxBool VTable0x18(); // vtable+0x18
+  virtual MxBool SetFlag(); // vtable+0x18
   virtual MxResult VTable0x1C(LegoFileStream *p_legoFileStream); // vtable+0x1C
 };
 

--- a/LEGO1/scorestate.cpp
+++ b/LEGO1/scorestate.cpp
@@ -8,7 +8,7 @@ MxBool ScoreState::VTable0x14() {
 }
 
 // OFFSET: LEGO1 0x1000de30
-MxBool ScoreState::SetScoreCubeTutorialFlag()
+MxBool ScoreState::SetFlag()
 {
   m_playCubeTutorial = TRUE;
   return TRUE;

--- a/LEGO1/scorestate.h
+++ b/LEGO1/scorestate.h
@@ -22,7 +22,7 @@ public:
   };
 
   virtual MxBool VTable0x14() override; // vtable+0x14
-  virtual MxBool SetScoreCubeTutorialFlag() override; // vtable+0x18
+  virtual MxBool SetFlag() override; // vtable+0x18
 
 private:
     MxBool m_playCubeTutorial;


### PR DESCRIPTION
Noticed after meging that the override isn't working. I've given the function a more generic name since it's based in `LegoState`. Maybe its purpose is something like "Activate", but we'd have to figure that out first.