### PR TITLE
Implement MxOmni::DoesEntityExist and related

### DIFF
--- a/LEGO1/mxnotificationmanager.h
+++ b/LEGO1/mxnotificationmanager.h
@@ -50,6 +50,8 @@ public:
   void Unregister(MxCore *p_listener);
   MxResult Send(MxCore *p_listener, MxNotificationParam *p_param);
 
+  inline MxNotificationPtrList *GetQueue() { return m_queue; }
+
 private:
   void FlushPending(MxCore *p_listener);
 };

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -68,15 +68,20 @@ MxResult MxOmni::Start(MxDSAction* p_dsAction)
 }
 
 // OFFSET: LEGO1 0x100b00c0 STUB
-void MxOmni::DeleteObject(MxDSAction &ds)
+void MxOmni::DeleteObject(MxDSAction &p_dsAction)
 {
   // TODO
 }
 
-// OFFSET: LEGO1 0x100b09a0 STUB
-MxBool MxOmni::DoesEntityExist(MxDSAction &ds)
+// OFFSET: LEGO1 0x100b09a0
+MxBool MxOmni::DoesEntityExist(MxDSAction &p_dsAction)
 {
-  // TODO
+  if (m_streamer->FUN_100b9b30(p_dsAction)) {
+    MxNotificationPtrList *queue = m_notificationManager->GetQueue();
+
+    if (!queue || queue->size() == 0)
+      return TRUE;
+  }
   return FALSE;
 }
 

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -61,7 +61,7 @@ MxResult MxOmni::Start(MxDSAction* p_dsAction)
   MxResult result = FAILURE;
   if(p_dsAction->GetAtomId().GetInternal() != NULL && p_dsAction->GetObjectId() != -1 && m_streamer != NULL)
   {
-    result = m_streamer->Unknown100b99b0(p_dsAction);
+    result = m_streamer->FUN_100b99b0(p_dsAction);
   }
 
   return result;

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -41,8 +41,8 @@ public:
   virtual MxResult Create(COMPAT_CONST MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c
   virtual MxResult Start(MxDSAction* p_dsAction); // vtable+20
-  virtual void DeleteObject(MxDSAction &ds); // vtable+24
-  virtual MxBool DoesEntityExist(MxDSAction &ds); // vtable+28
+  virtual void DeleteObject(MxDSAction &p_dsAction); // vtable+24
+  virtual MxBool DoesEntityExist(MxDSAction &p_dsAction); // vtable+28
   virtual void vtable0x2c(); // vtable+2c
   virtual int vtable0x30(char*, int, MxCore*); // vtable+30
   virtual void NotifyCurrentEntity(MxParam *p_param); // vtable+34

--- a/LEGO1/mxstreamer.cpp
+++ b/LEGO1/mxstreamer.cpp
@@ -147,6 +147,15 @@ MxResult MxStreamer::Unknown100b99b0(MxDSAction* p_action)
   return FAILURE;
 }
 
+// OFFSET: LEGO1 0x100b9b30
+MxBool MxStreamer::FUN_100b9b30(MxDSObject &p_dsObject)
+{
+  MxStreamController *controller = GetOpenStream(p_dsObject.GetAtomId().GetInternal());
+  if (controller)
+    return controller->FUN_100c20d0(p_dsObject);
+  return TRUE;
+}
+
 // OFFSET: LEGO1 0x100b9b60
 MxLong MxStreamer::Notify(MxParam &p)
 {

--- a/LEGO1/mxstreamer.cpp
+++ b/LEGO1/mxstreamer.cpp
@@ -132,7 +132,7 @@ MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController *stream)
 }
 
 // OFFSET: LEGO1 0x100b99b0
-MxResult MxStreamer::Unknown100b99b0(MxDSAction* p_action)
+MxResult MxStreamer::FUN_100b99b0(MxDSAction* p_action)
 {
   MxStreamController* controller;
   if (p_action != NULL && p_action->GetAtomId().GetInternal() != NULL && p_action->GetObjectId() != -1)

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -96,7 +96,7 @@ public:
   MxBool FUN_100b9b30(MxDSObject &p_dsObject);
   MxStreamController *GetOpenStream(const char *p_name);
   MxResult AddStreamControllerToOpenList(MxStreamController *p_stream);
-  MxResult Unknown100b99b0(MxDSAction* p_action);
+  MxResult FUN_100b99b0(MxDSAction* p_action);
 
 private:
   list<MxStreamController *> m_openStreams; // 0x8

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -7,6 +7,7 @@
 #include "mxcore.h"
 #include "mxnotificationparam.h"
 #include "mxstreamcontroller.h"
+#include "mxdsobject.h"
 #include "mxtypes.h"
 
 // NOTE: This feels like some kind of templated class, maybe something from the
@@ -92,11 +93,10 @@ public:
 
   virtual MxResult Create(); // vtable+0x14
 
+  MxBool FUN_100b9b30(MxDSObject &p_dsObject);
   MxStreamController *GetOpenStream(const char *p_name);
-
   MxResult AddStreamControllerToOpenList(MxStreamController *p_stream);
-
-  MxResult MxStreamer::Unknown100b99b0(MxDSAction* p_action);
+  MxResult Unknown100b99b0(MxDSAction* p_action);
 
 private:
   list<MxStreamController *> m_openStreams; // 0x8


### PR DESCRIPTION
Implements `MxOmni::DoesEntityExist` and `MxStreamer::FUN_100b9b30`, 100% matches.