### PR TITLE
Copy constructor for MxVideoPresenter::AlphaMask

### DIFF
--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -67,7 +67,7 @@ MxS32 MxVideoPresenter::GetHeight()
 }
 
 // OFFSET: LEGO1 0x100b24f0
-MxVideoPresenter::AlphaMask::AlphaMask(MxBitmap &p_bitmap)
+MxVideoPresenter::AlphaMask::AlphaMask(const MxBitmap &p_bitmap)
 {
   m_width  = p_bitmap.GetBmiWidth();
   // DECOMP: ECX becomes word-sized if these are not two separate actions.
@@ -146,6 +146,18 @@ seek_to_last_row:
     t_ptr = bitmap_src_ptr;
   }
 }
+
+// OFFSET: LEGO1 0x100b2670
+MxVideoPresenter::AlphaMask::AlphaMask(const MxVideoPresenter::AlphaMask &p_alpha)
+{
+  m_width  = p_alpha.m_width;
+  m_height = p_alpha.m_height;
+
+  MxS32 size = ((m_width * m_height) / 8) + 1;
+  m_bitmask = new MxU8[size];
+  memcpy(m_bitmask, p_alpha.m_bitmask, size);
+}
+
 
 // OFFSET: LEGO1 0x100b26d0
 MxVideoPresenter::AlphaMask::~AlphaMask()

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -55,7 +55,8 @@ public:
     MxU16 m_width;
     MxU16 m_height;
 
-    AlphaMask(MxBitmap &);
+    AlphaMask(const MxBitmap &);
+    AlphaMask(const AlphaMask &);
     virtual ~AlphaMask();
   };
 


### PR DESCRIPTION
Turns out that what I thought was the `MxStillPresenter` version of the `AlphaMask` (#226) constructor is actually the copy constructor that belongs in `MxVideoPresenter`.

100% match. I also made both constructors have a `const` parameter because why not.

This gets called for `MxStillPresenter` at `0x100ba49f` so I had it in my head that it belonged to that class.

Whoops! ~You forgot to put the CD in your computer.~