### PR TITLE
(Proposal) Introduce clang-format to enforce consistent code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+BasedOnStyle: Microsoft
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: BlockIndent
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BracedInitializerIndentWidth: 4
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterStruct: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+IncludeBlocks: Regroup
+IndentAccessModifiers: false
+IndentWidth: 4
+PointerAlignment: Left
+SpaceAfterCStyleCast: true
+TabWidth: 4
+UseTab: ForContinuationAndIndentation

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,13 @@
 root = true
-[*.{cpp,h,py,txt,editorconfig}]
 
+[*.{py,txt,editorconfig}]
 indent_style = space
 indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,h}]
+indent_style = tab
+tab_width = 4
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,20 @@
+name: Format
+
+on: [push, pull_request]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run clang-format
+      run: |
+        pipx run "clang-format>=17,<18" \
+          --Werror \
+          --dry-run \
+          --style=file \
+          ISLE/*.cpp ISLE/*.h \
+          LEGO1/*.cpp LEGO1/*.h \
+          LEGO1/realtime/*.cpp LEGO1/realtime/*.h

--- a/ISLE/define.cpp
+++ b/ISLE/define.cpp
@@ -1,7 +1,7 @@
 #include "define.h"
 
 // 0x410030
-IsleApp *g_isle = 0;
+IsleApp* g_isle = 0;
 
 // 0x410034
 unsigned char g_mousedown = 0;

--- a/ISLE/define.h
+++ b/ISLE/define.h
@@ -6,7 +6,7 @@
 
 class IsleApp;
 
-extern IsleApp *g_isle;
+extern IsleApp* g_isle;
 extern int g_closed;
 // 0x4101c4
 #define WNDCLASS_NAME "Lego Island MainNoM App"

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1,8 +1,6 @@
 #include "isleapp.h"
+
 #include "define.h"
-
-#include <dsound.h>
-
 #include "legoanimationmanager.h"
 #include "legobuildingmanager.h"
 #include "legogamestate.h"
@@ -22,142 +20,153 @@
 #include "mxticklemanager.h"
 #include "mxtimer.h"
 #include "mxtransitionmanager.h"
-
 #include "res/resource.h"
+
+#include <dsound.h>
 
 // OFFSET: ISLE 0x401000
 IsleApp::IsleApp()
 {
-  m_hdPath = NULL;
-  m_cdPath = NULL;
-  m_deviceId = NULL;
-  m_savePath = NULL;
-  m_fullScreen = 1;
-  m_flipSurfaces = 0;
-  m_backBuffersInVram = 1;
-  m_using8bit = 0;
-  m_using16bit = 1;
-  m_unk24 = 0;
-  m_drawCursor = 0;
-  m_use3dSound = 1;
-  m_useMusic = 1;
-  m_useJoystick = 0;
-  m_joystickIndex = 0;
-  m_wideViewAngle = 1;
-  m_islandQuality = 1;
-  m_islandTexture = 1;
-  m_gameStarted = 0;
-  m_frameDelta = 10;
-  m_windowActive = 1;
+	m_hdPath = NULL;
+	m_cdPath = NULL;
+	m_deviceId = NULL;
+	m_savePath = NULL;
+	m_fullScreen = 1;
+	m_flipSurfaces = 0;
+	m_backBuffersInVram = 1;
+	m_using8bit = 0;
+	m_using16bit = 1;
+	m_unk24 = 0;
+	m_drawCursor = 0;
+	m_use3dSound = 1;
+	m_useMusic = 1;
+	m_useJoystick = 0;
+	m_joystickIndex = 0;
+	m_wideViewAngle = 1;
+	m_islandQuality = 1;
+	m_islandTexture = 1;
+	m_gameStarted = 0;
+	m_frameDelta = 10;
+	m_windowActive = 1;
 
-  m_videoParam = MxVideoParam(MxRect32(0, 0, 639, 479), NULL, 1, MxVideoParamFlags());
-  m_videoParam.flags().Set16Bit(MxDirectDraw::GetPrimaryBitDepth() == 16);
+	m_videoParam = MxVideoParam(MxRect32(0, 0, 639, 479), NULL, 1, MxVideoParamFlags());
+	m_videoParam.flags().Set16Bit(MxDirectDraw::GetPrimaryBitDepth() == 16);
 
-  m_windowHandle = NULL;
-  m_cursorArrow = NULL;
-  m_cursorBusy = NULL;
-  m_cursorNo = NULL;
-  m_cursorCurrent = NULL;
+	m_windowHandle = NULL;
+	m_cursorArrow = NULL;
+	m_cursorBusy = NULL;
+	m_cursorNo = NULL;
+	m_cursorCurrent = NULL;
 
-  LegoOmni::CreateInstance();
+	LegoOmni::CreateInstance();
 }
 
 // OFFSET: ISLE 0x4011a0
 IsleApp::~IsleApp()
 {
-  if (LegoOmni::GetInstance()) {
-    Close();
-    MxOmni::DestroyInstance();
-  }
+	if (LegoOmni::GetInstance()) {
+		Close();
+		MxOmni::DestroyInstance();
+	}
 
-  if (m_hdPath) {
-    delete [] m_hdPath;
-  }
+	if (m_hdPath) {
+		delete[] m_hdPath;
+	}
 
-  if (m_cdPath) {
-    delete [] m_cdPath;
-  }
+	if (m_cdPath) {
+		delete[] m_cdPath;
+	}
 
-  if (m_deviceId) {
-    delete [] m_deviceId;
-  }
+	if (m_deviceId) {
+		delete[] m_deviceId;
+	}
 
-  if (m_savePath) {
-    delete [] m_savePath;
-  }
+	if (m_savePath) {
+		delete[] m_savePath;
+	}
 }
 
 // OFFSET: ISLE 0x401260
 void IsleApp::Close()
 {
-  MxDSAction ds;
-  ds.SetUnknown24(-2);
+	MxDSAction ds;
+	ds.SetUnknown24(-2);
 
-  if (Lego()) {
-    GameState()->Save(0);
-    if (InputManager()) {
-      InputManager()->QueueEvent(KEYDOWN, 0, 0, 0, 0x20);
-    }
+	if (Lego()) {
+		GameState()->Save(0);
+		if (InputManager()) {
+			InputManager()->QueueEvent(KEYDOWN, 0, 0, 0, 0x20);
+		}
 
-    VideoManager()->Get3DManager()->GetLego3DView()->GetViewManager()->RemoveAll(NULL);
+		VideoManager()->Get3DManager()->GetLego3DView()->GetViewManager()->RemoveAll(NULL);
 
-    Lego()->RemoveWorld(ds.GetAtomId(), ds.GetObjectId());
-    Lego()->DeleteObject(ds);
-    TransitionManager()->SetWaitIndicator(NULL);
-    Lego()->StopTimer();
+		Lego()->RemoveWorld(ds.GetAtomId(), ds.GetObjectId());
+		Lego()->DeleteObject(ds);
+		TransitionManager()->SetWaitIndicator(NULL);
+		Lego()->StopTimer();
 
-    MxLong lVar8;
-    do {
-      lVar8 = Streamer()->Close(NULL);
-    } while (lVar8 == 0);
+		MxLong lVar8;
+		do {
+			lVar8 = Streamer()->Close(NULL);
+		} while (lVar8 == 0);
 
-    while (Lego()) {
-      if (Lego()->DoesEntityExist(ds)) {
-        break;
-      }
+		while (Lego()) {
+			if (Lego()->DoesEntityExist(ds)) {
+				break;
+			}
 
-      Timer()->GetRealTime();
-      TickleManager()->Tickle();
-    }
-  }
+			Timer()->GetRealTime();
+			TickleManager()->Tickle();
+		}
+	}
 }
 
 // OFFSET: ISLE 0x4013b0
 BOOL IsleApp::SetupLegoOmni()
 {
-  BOOL result = FALSE;
-  char mediaPath[256];
-  GetProfileStringA("LEGO Island", "MediaPath", "", mediaPath, sizeof(mediaPath));
+	BOOL result = FALSE;
+	char mediaPath[256];
+	GetProfileStringA("LEGO Island", "MediaPath", "", mediaPath, sizeof(mediaPath));
 
-  BOOL failure = Lego()->Create(MxOmniCreateParam(mediaPath, (struct HWND__ *) m_windowHandle, m_videoParam, MxOmniCreateFlags())) == FAILURE;
-  if (!failure) {
-    VariableTable()->SetVariable("ACTOR_01", "");
-    TickleManager()->SetClientTickleInterval(VideoManager(), 10);
-    result = TRUE;
-  }
+	BOOL failure =
+		Lego()->Create(MxOmniCreateParam(mediaPath, (struct HWND__*) m_windowHandle, m_videoParam, MxOmniCreateFlags())
+		) == FAILURE;
+	if (!failure) {
+		VariableTable()->SetVariable("ACTOR_01", "");
+		TickleManager()->SetClientTickleInterval(VideoManager(), 10);
+		result = TRUE;
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: ISLE 0x401560
-void IsleApp::SetupVideoFlags(BOOL fullScreen, BOOL flipSurfaces, BOOL backBuffers,
-                           BOOL using8bit, BOOL using16bit, BOOL param_6, BOOL param_7,
-                           BOOL wideViewAngle, char *deviceId)
+void IsleApp::SetupVideoFlags(
+	BOOL fullScreen,
+	BOOL flipSurfaces,
+	BOOL backBuffers,
+	BOOL using8bit,
+	BOOL using16bit,
+	BOOL param_6,
+	BOOL param_7,
+	BOOL wideViewAngle,
+	char* deviceId
+)
 {
-  m_videoParam.flags().SetFullScreen(fullScreen);
-  m_videoParam.flags().SetFlipSurfaces(flipSurfaces);
-  m_videoParam.flags().SetBackBuffers(!backBuffers);
-  m_videoParam.flags().Set_f2bit0(!param_6);
-  m_videoParam.flags().Set_f1bit7(param_7);
-  m_videoParam.flags().SetWideViewAngle(wideViewAngle);
-  m_videoParam.flags().Set_f2bit1(1);
-  m_videoParam.SetDeviceName(deviceId);
-  if (using8bit) {
-    m_videoParam.flags().Set16Bit(0);
-  }
-  if (using16bit) {
-    m_videoParam.flags().Set16Bit(1);
-  }
+	m_videoParam.flags().SetFullScreen(fullScreen);
+	m_videoParam.flags().SetFlipSurfaces(flipSurfaces);
+	m_videoParam.flags().SetBackBuffers(!backBuffers);
+	m_videoParam.flags().Set_f2bit0(!param_6);
+	m_videoParam.flags().Set_f1bit7(param_7);
+	m_videoParam.flags().SetWideViewAngle(wideViewAngle);
+	m_videoParam.flags().Set_f2bit1(1);
+	m_videoParam.SetDeviceName(deviceId);
+	if (using8bit) {
+		m_videoParam.flags().Set16Bit(0);
+	}
+	if (using16bit) {
+		m_videoParam.flags().Set16Bit(1);
+	}
 }
 
 BOOL FindExistingInstance(void);
@@ -166,623 +175,672 @@ BOOL StartDirectSound(void);
 // OFFSET: ISLE 0x401610
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
-  // Look for another instance, if we find one, bring it to the foreground instead
-  if (!FindExistingInstance()) {
-    return 0;
-  }
+	// Look for another instance, if we find one, bring it to the foreground instead
+	if (!FindExistingInstance()) {
+		return 0;
+	}
 
-  // Attempt to create DirectSound instance
-  BOOL soundReady = FALSE;
-  for (int i = 0; i < 20; i++) {
-    if (StartDirectSound()) {
-      soundReady = TRUE;
-      break;
-    }
-    Sleep(500);
-  }
+	// Attempt to create DirectSound instance
+	BOOL soundReady = FALSE;
+	for (int i = 0; i < 20; i++) {
+		if (StartDirectSound()) {
+			soundReady = TRUE;
+			break;
+		}
+		Sleep(500);
+	}
 
-  // Throw error if sound unavailable
-  if (!soundReady) {
-    MessageBoxA(NULL, "\"LEGO\xAE Island\" is not detecting a DirectSound compatible sound card.  Please quit all other applications and try again.",
-      "Lego Island Error", MB_OK);
-    return 0;
-  }
+	// Throw error if sound unavailable
+	if (!soundReady) {
+		MessageBoxA(
+			NULL,
+			"\"LEGO\xAE Island\" is not detecting a DirectSound compatible sound card.  Please quit all other "
+			"applications and try again.",
+			"Lego Island Error",
+			MB_OK
+		);
+		return 0;
+	}
 
-  // Create global app instance
-  g_isle = new IsleApp();
+	// Create global app instance
+	g_isle = new IsleApp();
 
-  // Create window
-  if (g_isle->SetupWindow(hInstance, lpCmdLine) != SUCCESS) {
-    MessageBoxA(NULL, "\"LEGO\xAE Island\" failed to start.  Please quit all other applications and try again.", "LEGO\xAE Island Error", MB_OK);
-    return 0;
-  }
+	// Create window
+	if (g_isle->SetupWindow(hInstance, lpCmdLine) != SUCCESS) {
+		MessageBoxA(
+			NULL,
+			"\"LEGO\xAE Island\" failed to start.  Please quit all other applications and try again.",
+			"LEGO\xAE Island Error",
+			MB_OK
+		);
+		return 0;
+	}
 
-  // Get reference to window
-  HWND window;
-  if (g_isle->m_windowHandle) {
-    window = g_isle->m_windowHandle;
-  }
+	// Get reference to window
+	HWND window;
+	if (g_isle->m_windowHandle) {
+		window = g_isle->m_windowHandle;
+	}
 
-  // Load accelerators (this call actually achieves nothing - there is no "AppAccel" resource in the original - but we'll keep this for authenticity)
-  // This line may actually be here because it's in DFVIEW, an example project that ships with
-  // MSVC420, and was such a clean example of a Win32 app, that it was later adapted
-  // into an "ExeSkeleton" sample for MSVC600. It's quite possible Mindscape derived
-  // this app from that example since they no longer had the luxury of the
-  // MFC AppWizard which we know they used for the frontend used during development (ISLEMFC.EXE, MAIN.EXE, et al.)
-  LoadAcceleratorsA(hInstance, "AppAccel");
+	// Load accelerators (this call actually achieves nothing - there is no "AppAccel" resource in the original - but
+	// we'll keep this for authenticity) This line may actually be here because it's in DFVIEW, an example project that
+	// ships with MSVC420, and was such a clean example of a Win32 app, that it was later adapted into an "ExeSkeleton"
+	// sample for MSVC600. It's quite possible Mindscape derived this app from that example since they no longer had the
+	// luxury of the MFC AppWizard which we know they used for the frontend used during development (ISLEMFC.EXE,
+	// MAIN.EXE, et al.)
+	LoadAcceleratorsA(hInstance, "AppAccel");
 
-  MSG msg;
+	MSG msg;
 
-  while (!g_closed) {
-    while (!PeekMessageA(&msg, NULL, 0, 0, PM_NOREMOVE)) {
-      if (g_isle) {
-        g_isle->Tick(1);
-      }
-    }
+	while (!g_closed) {
+		while (!PeekMessageA(&msg, NULL, 0, 0, PM_NOREMOVE)) {
+			if (g_isle) {
+				g_isle->Tick(1);
+			}
+		}
 
-    if (g_isle) {
-      g_isle->Tick(0);
-    }
+		if (g_isle) {
+			g_isle->Tick(0);
+		}
 
-    while (!g_closed) {
-      if (!PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE)) {
-        break;
-      }
+		while (!g_closed) {
+			if (!PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE)) {
+				break;
+			}
 
-      MSG nextMsg;
-      if (!g_isle
-          || !g_isle->m_windowHandle
-          || msg.message != WM_MOUSEMOVE
-          || !PeekMessageA(&nextMsg, NULL, 0, 0, PM_NOREMOVE)
-          || nextMsg.message != WM_MOUSEMOVE) {
-        TranslateMessage(&msg);
-        DispatchMessageA(&msg);
-      }
+			MSG nextMsg;
+			if (!g_isle || !g_isle->m_windowHandle || msg.message != WM_MOUSEMOVE ||
+				!PeekMessageA(&nextMsg, NULL, 0, 0, PM_NOREMOVE) || nextMsg.message != WM_MOUSEMOVE) {
+				TranslateMessage(&msg);
+				DispatchMessageA(&msg);
+			}
 
-      if (g_reqEnableRMDevice) {
-        g_reqEnableRMDevice = 0;
-        VideoManager()->EnableRMDevice();
-        g_rmDisabled = 0;
-        Lego()->StopTimer();
-      }
+			if (g_reqEnableRMDevice) {
+				g_reqEnableRMDevice = 0;
+				VideoManager()->EnableRMDevice();
+				g_rmDisabled = 0;
+				Lego()->StopTimer();
+			}
 
-      if (g_closed) {
-        break;
-      }
+			if (g_closed) {
+				break;
+			}
 
-      if (g_mousedown && g_mousemoved && g_isle) {
-        g_isle->Tick(0);
-      }
+			if (g_mousedown && g_mousemoved && g_isle) {
+				g_isle->Tick(0);
+			}
 
-      if (g_mousemoved) {
-        g_mousemoved = FALSE;
-      }
-    }
-  }
+			if (g_mousemoved) {
+				g_mousemoved = FALSE;
+			}
+		}
+	}
 
-  DestroyWindow(window);
+	DestroyWindow(window);
 
-  return msg.wParam;
+	return msg.wParam;
 }
 
 // OFFSET: ISLE 0x401ca0
 BOOL FindExistingInstance(void)
 {
-  HWND hWnd = FindWindowA(WNDCLASS_NAME, WINDOW_TITLE);
-  if (hWnd) {
-    if (SetForegroundWindow(hWnd)) {
-      ShowWindow(hWnd, SW_RESTORE);
-    }
-    return 0;
-  }
-  return 1;
+	HWND hWnd = FindWindowA(WNDCLASS_NAME, WINDOW_TITLE);
+	if (hWnd) {
+		if (SetForegroundWindow(hWnd)) {
+			ShowWindow(hWnd, SW_RESTORE);
+		}
+		return 0;
+	}
+	return 1;
 }
 
 // OFFSET: ISLE 0x401ce0
 BOOL StartDirectSound(void)
 {
-  LPDIRECTSOUND lpDS = NULL;
-  HRESULT ret = DirectSoundCreate(NULL, &lpDS, NULL);
-  if (ret == DS_OK && lpDS != NULL) {
-    lpDS->Release();
-    return TRUE;
-  }
+	LPDIRECTSOUND lpDS = NULL;
+	HRESULT ret = DirectSoundCreate(NULL, &lpDS, NULL);
+	if (ret == DS_OK && lpDS != NULL) {
+		lpDS->Release();
+		return TRUE;
+	}
 
-  return FALSE;
+	return FALSE;
 }
 
 // OFFSET: ISLE 0x401d20
 LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-  NotificationId type;
-  unsigned char keyCode = 0;
+	NotificationId type;
+	unsigned char keyCode = 0;
 
-  if (!g_isle) {
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  }
+	if (!g_isle) {
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	}
 
-  switch (uMsg) {
-  case WM_PAINT:
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  case WM_ACTIVATE:
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  case WM_ACTIVATEAPP:
-    if (g_isle) {
-      if ((wParam != 0) && (g_isle->m_fullScreen)) {
-        MoveWindow(hWnd, g_windowRect.left, g_windowRect.top,
-                   (g_windowRect.right - g_windowRect.left) + 1,
-                   (g_windowRect.bottom - g_windowRect.top) + 1, TRUE);
-      }
-      g_isle->m_windowActive = wParam;
-    }
-    return DefWindowProcA(hWnd,uMsg,wParam,lParam);
-  case WM_CLOSE:
-    if (!g_closed && g_isle) {
-      if (g_isle) {
-        delete g_isle;
-      }
-      g_isle = NULL;
-      g_closed = TRUE;
-      return 0;
-    }
-    return DefWindowProcA(hWnd,uMsg,wParam,lParam);
-  case WM_GETMINMAXINFO:
-    ((MINMAXINFO*) lParam)->ptMaxTrackSize.x = (g_windowRect.right - g_windowRect.left) + 1;
-    ((MINMAXINFO*) lParam)->ptMaxTrackSize.y = (g_windowRect.bottom - g_windowRect.top) + 1;
-    ((MINMAXINFO*) lParam)->ptMinTrackSize.x = (g_windowRect.right - g_windowRect.left) + 1;
-    ((MINMAXINFO*) lParam)->ptMinTrackSize.y = (g_windowRect.bottom - g_windowRect.top) + 1;
-    return 0;
-  case WM_ENTERMENULOOP:
-    return DefWindowProcA(hWnd,uMsg,wParam,lParam);
-  case WM_SYSCOMMAND:
-    if (wParam == SC_SCREENSAVE) {
-      return 0;
-    }
-    if (wParam == SC_CLOSE && g_closed == 0) {
-      if (g_isle) {
-        if (g_rmDisabled) {
-          ShowWindow(g_isle->m_windowHandle, SW_RESTORE);
-        }
-        PostMessageA(g_isle->m_windowHandle, WM_CLOSE, 0, 0);
-        return 0;
-      }
-    } else if (g_isle && g_isle->m_fullScreen && (wParam == SC_MOVE || wParam == SC_KEYMENU)) {
-      return 0;
-    }
-    return DefWindowProcA(hWnd,uMsg,wParam,lParam);
-  case WM_EXITMENULOOP:
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  case WM_MOVING:
-    if (g_isle && g_isle->m_fullScreen) {
-      GetWindowRect(hWnd, (LPRECT) lParam);
-      return 0;
-    }
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  case WM_NCPAINT:
-    if (g_isle && g_isle->m_fullScreen) {
-      return 0;
-    }
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  case WM_DISPLAYCHANGE:
-    if (g_isle && VideoManager() && g_isle->m_fullScreen && VideoManager()->GetDirect3D() && VideoManager()->GetDirect3D()->GetDeviceModeFinder()) {
-      int targetWidth = LOWORD(lParam);
-      int targetHeight = HIWORD(lParam);
-      int targetDepth = wParam;
+	switch (uMsg) {
+	case WM_PAINT:
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_ACTIVATE:
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_ACTIVATEAPP:
+		if (g_isle) {
+			if ((wParam != 0) && (g_isle->m_fullScreen)) {
+				MoveWindow(
+					hWnd,
+					g_windowRect.left,
+					g_windowRect.top,
+					(g_windowRect.right - g_windowRect.left) + 1,
+					(g_windowRect.bottom - g_windowRect.top) + 1,
+					TRUE
+				);
+			}
+			g_isle->m_windowActive = wParam;
+		}
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_CLOSE:
+		if (!g_closed && g_isle) {
+			if (g_isle) {
+				delete g_isle;
+			}
+			g_isle = NULL;
+			g_closed = TRUE;
+			return 0;
+		}
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_GETMINMAXINFO:
+		((MINMAXINFO*) lParam)->ptMaxTrackSize.x = (g_windowRect.right - g_windowRect.left) + 1;
+		((MINMAXINFO*) lParam)->ptMaxTrackSize.y = (g_windowRect.bottom - g_windowRect.top) + 1;
+		((MINMAXINFO*) lParam)->ptMinTrackSize.x = (g_windowRect.right - g_windowRect.left) + 1;
+		((MINMAXINFO*) lParam)->ptMinTrackSize.y = (g_windowRect.bottom - g_windowRect.top) + 1;
+		return 0;
+	case WM_ENTERMENULOOP:
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_SYSCOMMAND:
+		if (wParam == SC_SCREENSAVE) {
+			return 0;
+		}
+		if (wParam == SC_CLOSE && g_closed == 0) {
+			if (g_isle) {
+				if (g_rmDisabled) {
+					ShowWindow(g_isle->m_windowHandle, SW_RESTORE);
+				}
+				PostMessageA(g_isle->m_windowHandle, WM_CLOSE, 0, 0);
+				return 0;
+			}
+		}
+		else if (g_isle && g_isle->m_fullScreen && (wParam == SC_MOVE || wParam == SC_KEYMENU)) {
+			return 0;
+		}
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_EXITMENULOOP:
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_MOVING:
+		if (g_isle && g_isle->m_fullScreen) {
+			GetWindowRect(hWnd, (LPRECT) lParam);
+			return 0;
+		}
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_NCPAINT:
+		if (g_isle && g_isle->m_fullScreen) {
+			return 0;
+		}
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_DISPLAYCHANGE:
+		if (g_isle && VideoManager() && g_isle->m_fullScreen && VideoManager()->GetDirect3D() &&
+			VideoManager()->GetDirect3D()->GetDeviceModeFinder()) {
+			int targetWidth = LOWORD(lParam);
+			int targetHeight = HIWORD(lParam);
+			int targetDepth = wParam;
 
-      if (g_waitingForTargetDepth) {
-        g_waitingForTargetDepth = 0;
-        g_targetDepth = targetDepth;
-      }
-      else {
-        BOOL valid = FALSE;
-        if (targetWidth == g_targetWidth && targetHeight == g_targetHeight && g_targetDepth == targetDepth) {
-          valid = TRUE;
-        }
+			if (g_waitingForTargetDepth) {
+				g_waitingForTargetDepth = 0;
+				g_targetDepth = targetDepth;
+			}
+			else {
+				BOOL valid = FALSE;
+				if (targetWidth == g_targetWidth && targetHeight == g_targetHeight && g_targetDepth == targetDepth) {
+					valid = TRUE;
+				}
 
-        if (g_rmDisabled) {
-          if (valid) {
-             g_reqEnableRMDevice = 1;
-          }
-        }
-        else if (!valid) {
-          g_rmDisabled = 1;
-          Lego()->StartTimer();
-          VideoManager()->DisableRMDevice();
-        }
-      }
-    }
-    return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-  case WM_SETCURSOR:
-    if (g_isle) {
-      HCURSOR hCursor = g_isle->m_cursorCurrent;
-      if (hCursor == g_isle->m_cursorBusy || hCursor == g_isle->m_cursorNo || !hCursor) {
-        SetCursor(hCursor);
-        return 0;
-      }
-    }
-    break;
-  case WM_KEYDOWN:
-    // While this probably should be (HIWORD(lParam) & KF_REPEAT), this seems
-    // to be what the assembly is actually doing
-    if (lParam & (KF_REPEAT << 16)) {
-      return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-    }
-    keyCode = wParam;
-    type = KEYDOWN;
-    break;
-  case WM_MOUSEMOVE:
-    g_mousemoved = 1;
-    type = MOUSEMOVE;
-    break;
-  case WM_TIMER:
-    type = TIMER;
-    break;
-  case WM_LBUTTONDOWN:
-    g_mousedown = 1;
-    type = MOUSEDOWN;
-    break;
-  case WM_LBUTTONUP:
-    g_mousedown = 0;
-    type = MOUSEUP;
-    break;
-  case 0x5400:
-    if (g_isle) {
-      g_isle->SetupCursor(wParam);
-      return 0;
-    }
-    break;
-  default:
-    return DefWindowProcA(hWnd,uMsg,wParam,lParam);
-  }
+				if (g_rmDisabled) {
+					if (valid) {
+						g_reqEnableRMDevice = 1;
+					}
+				}
+				else if (!valid) {
+					g_rmDisabled = 1;
+					Lego()->StartTimer();
+					VideoManager()->DisableRMDevice();
+				}
+			}
+		}
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	case WM_SETCURSOR:
+		if (g_isle) {
+			HCURSOR hCursor = g_isle->m_cursorCurrent;
+			if (hCursor == g_isle->m_cursorBusy || hCursor == g_isle->m_cursorNo || !hCursor) {
+				SetCursor(hCursor);
+				return 0;
+			}
+		}
+		break;
+	case WM_KEYDOWN:
+		// While this probably should be (HIWORD(lParam) & KF_REPEAT), this seems
+		// to be what the assembly is actually doing
+		if (lParam & (KF_REPEAT << 16)) {
+			return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+		}
+		keyCode = wParam;
+		type = KEYDOWN;
+		break;
+	case WM_MOUSEMOVE:
+		g_mousemoved = 1;
+		type = MOUSEMOVE;
+		break;
+	case WM_TIMER:
+		type = TIMER;
+		break;
+	case WM_LBUTTONDOWN:
+		g_mousedown = 1;
+		type = MOUSEDOWN;
+		break;
+	case WM_LBUTTONUP:
+		g_mousedown = 0;
+		type = MOUSEUP;
+		break;
+	case 0x5400:
+		if (g_isle) {
+			g_isle->SetupCursor(wParam);
+			return 0;
+		}
+		break;
+	default:
+		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
+	}
 
-  if (g_isle) {
-    if (InputManager()) {
-      InputManager()->QueueEvent(type, wParam, LOWORD(lParam), HIWORD(lParam), keyCode);
-    }
-    if (g_isle && g_isle->m_drawCursor && type == MOUSEMOVE) {
-      int x = LOWORD(lParam);
-      int y = HIWORD(lParam);
-      if (x >= 640) {
-        x = 639;
-      }
-      if (y >= 480) {
-        y = 479;
-      }
-      VideoManager()->MoveCursor(x,y);
-    }
-  }
+	if (g_isle) {
+		if (InputManager()) {
+			InputManager()->QueueEvent(type, wParam, LOWORD(lParam), HIWORD(lParam), keyCode);
+		}
+		if (g_isle && g_isle->m_drawCursor && type == MOUSEMOVE) {
+			int x = LOWORD(lParam);
+			int y = HIWORD(lParam);
+			if (x >= 640) {
+				x = 639;
+			}
+			if (y >= 480) {
+				y = 479;
+			}
+			VideoManager()->MoveCursor(x, y);
+		}
+	}
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: ISLE 0x4023e0
 MxResult IsleApp::SetupWindow(HINSTANCE hInstance, LPSTR lpCmdLine)
 {
-  WNDCLASSA wndclass;
-  ZeroMemory(&wndclass, sizeof(WNDCLASSA));
+	WNDCLASSA wndclass;
+	ZeroMemory(&wndclass, sizeof(WNDCLASSA));
 
-  LoadConfig();
+	LoadConfig();
 
-  SetupVideoFlags(m_fullScreen, m_flipSurfaces, m_backBuffersInVram, m_using8bit,
-                  m_using16bit, m_unk24, FALSE, m_wideViewAngle, m_deviceId);
+	SetupVideoFlags(
+		m_fullScreen,
+		m_flipSurfaces,
+		m_backBuffersInVram,
+		m_using8bit,
+		m_using16bit,
+		m_unk24,
+		FALSE,
+		m_wideViewAngle,
+		m_deviceId
+	);
 
-  MxOmni::SetSound3D(m_use3dSound);
+	MxOmni::SetSound3D(m_use3dSound);
 
-  srand(timeGetTime() / 1000);
-  SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, NULL, 0);
+	srand(timeGetTime() / 1000);
+	SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, NULL, 0);
 
-  ZeroMemory(&wndclass, sizeof(WNDCLASSA));
+	ZeroMemory(&wndclass, sizeof(WNDCLASSA));
 
-  wndclass.cbClsExtra = 0;
-  wndclass.style = CS_HREDRAW | CS_VREDRAW;
-  wndclass.lpfnWndProc = WndProc;
-  wndclass.cbWndExtra = 0;
-  wndclass.hIcon = LoadIconA(hInstance, MAKEINTRESOURCEA(APP_ICON));
-  wndclass.hCursor = m_cursorArrow = m_cursorCurrent = LoadCursorA(hInstance, MAKEINTRESOURCEA(ISLE_ARROW));
-  m_cursorBusy = LoadCursorA(hInstance, MAKEINTRESOURCEA(ISLE_BUSY));
-  m_cursorNo = LoadCursorA(hInstance, MAKEINTRESOURCEA(ISLE_NO));
-  wndclass.hInstance = hInstance;
-  wndclass.hbrBackground = (HBRUSH) GetStockObject(BLACK_BRUSH);
-  wndclass.lpszClassName = WNDCLASS_NAME;
+	wndclass.cbClsExtra = 0;
+	wndclass.style = CS_HREDRAW | CS_VREDRAW;
+	wndclass.lpfnWndProc = WndProc;
+	wndclass.cbWndExtra = 0;
+	wndclass.hIcon = LoadIconA(hInstance, MAKEINTRESOURCEA(APP_ICON));
+	wndclass.hCursor = m_cursorArrow = m_cursorCurrent = LoadCursorA(hInstance, MAKEINTRESOURCEA(ISLE_ARROW));
+	m_cursorBusy = LoadCursorA(hInstance, MAKEINTRESOURCEA(ISLE_BUSY));
+	m_cursorNo = LoadCursorA(hInstance, MAKEINTRESOURCEA(ISLE_NO));
+	wndclass.hInstance = hInstance;
+	wndclass.hbrBackground = (HBRUSH) GetStockObject(BLACK_BRUSH);
+	wndclass.lpszClassName = WNDCLASS_NAME;
 
-  if (!RegisterClassA(&wndclass)) {
-    return FAILURE;
-  }
+	if (!RegisterClassA(&wndclass)) {
+		return FAILURE;
+	}
 
-  if (m_fullScreen) {
-    AdjustWindowRectEx(&g_windowRect, WS_CAPTION | WS_SYSMENU, 0, WS_EX_APPWINDOW);
+	if (m_fullScreen) {
+		AdjustWindowRectEx(&g_windowRect, WS_CAPTION | WS_SYSMENU, 0, WS_EX_APPWINDOW);
 
-    m_windowHandle = CreateWindowExA(
-      WS_EX_APPWINDOW,
-      WNDCLASS_NAME,
-      WINDOW_TITLE,
-      WS_CAPTION | WS_SYSMENU,
-      g_windowRect.left,
-      g_windowRect.top,
-      g_windowRect.right - g_windowRect.left + 1,
-      g_windowRect.bottom - g_windowRect.top + 1,
-      NULL, NULL, hInstance, NULL
-    );
-  } else {
-    AdjustWindowRectEx(&g_windowRect, WS_CAPTION | WS_SYSMENU, 0, WS_EX_APPWINDOW);
+		m_windowHandle = CreateWindowExA(
+			WS_EX_APPWINDOW,
+			WNDCLASS_NAME,
+			WINDOW_TITLE,
+			WS_CAPTION | WS_SYSMENU,
+			g_windowRect.left,
+			g_windowRect.top,
+			g_windowRect.right - g_windowRect.left + 1,
+			g_windowRect.bottom - g_windowRect.top + 1,
+			NULL,
+			NULL,
+			hInstance,
+			NULL
+		);
+	}
+	else {
+		AdjustWindowRectEx(&g_windowRect, WS_CAPTION | WS_SYSMENU, 0, WS_EX_APPWINDOW);
 
-    m_windowHandle = CreateWindowExA(
-      WS_EX_APPWINDOW,
-      WNDCLASS_NAME,
-      WINDOW_TITLE,
-      WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX,
-      CW_USEDEFAULT,
-      CW_USEDEFAULT,
-      g_windowRect.right - g_windowRect.left + 1,
-      g_windowRect.bottom - g_windowRect.top + 1,
-      NULL, NULL, hInstance, NULL
-    );
-  }
+		m_windowHandle = CreateWindowExA(
+			WS_EX_APPWINDOW,
+			WNDCLASS_NAME,
+			WINDOW_TITLE,
+			WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX,
+			CW_USEDEFAULT,
+			CW_USEDEFAULT,
+			g_windowRect.right - g_windowRect.left + 1,
+			g_windowRect.bottom - g_windowRect.top + 1,
+			NULL,
+			NULL,
+			hInstance,
+			NULL
+		);
+	}
 
-  if (!m_windowHandle) {
-    return FAILURE;
-  }
+	if (!m_windowHandle) {
+		return FAILURE;
+	}
 
-  if (m_fullScreen) {
-    MoveWindow(m_windowHandle, g_windowRect.left, g_windowRect.top, (g_windowRect.right - g_windowRect.left) + 1, (g_windowRect.bottom - g_windowRect.top) + 1, TRUE);
-  }
+	if (m_fullScreen) {
+		MoveWindow(
+			m_windowHandle,
+			g_windowRect.left,
+			g_windowRect.top,
+			(g_windowRect.right - g_windowRect.left) + 1,
+			(g_windowRect.bottom - g_windowRect.top) + 1,
+			TRUE
+		);
+	}
 
-  ShowWindow(m_windowHandle, SW_SHOWNORMAL);
-  UpdateWindow(m_windowHandle);
-  if (!SetupLegoOmni()) {
-    return FAILURE;
-  }
+	ShowWindow(m_windowHandle, SW_SHOWNORMAL);
+	UpdateWindow(m_windowHandle);
+	if (!SetupLegoOmni()) {
+		return FAILURE;
+	}
 
-  GameState()->SetSavePath(m_savePath);
-  GameState()->SerializePlayersInfo(1);
-  GameState()->SerializeScoreHistory(1);
+	GameState()->SetSavePath(m_savePath);
+	GameState()->SerializePlayersInfo(1);
+	GameState()->SerializeScoreHistory(1);
 
-  int iVar10;
-  switch (m_islandQuality) {
-    case 0:
-      iVar10 = 1;
-      break;
-    case 1:
-      iVar10 = 2;
-      break;
-    default:
-      iVar10 = 100;
-  }
+	int iVar10;
+	switch (m_islandQuality) {
+	case 0:
+		iVar10 = 1;
+		break;
+	case 1:
+		iVar10 = 2;
+		break;
+	default:
+		iVar10 = 100;
+	}
 
-  int uVar1 = (m_islandTexture == 0);
-  LegoModelPresenter::configureLegoModelPresenter(uVar1);
-  LegoPartPresenter::configureLegoPartPresenter(uVar1,iVar10);
-  LegoWorldPresenter::configureLegoWorldPresenter(m_islandQuality);
-  LegoBuildingManager::configureLegoBuildingManager(m_islandQuality);
-  LegoROI::configureLegoROI(iVar10);
-  LegoAnimationManager::configureLegoAnimationManager(m_islandQuality);
-  if (LegoOmni::GetInstance()) {
-    if (LegoOmni::GetInstance()->GetInputManager()) {
-      LegoOmni::GetInstance()->GetInputManager()->m_useJoystick = m_useJoystick;
-      LegoOmni::GetInstance()->GetInputManager()->m_joystickIndex = m_joystickIndex;
-    }
-  }
-  if (m_fullScreen) {
-    MoveWindow(m_windowHandle, g_windowRect.left, g_windowRect.top, (g_windowRect.right - g_windowRect.left) + 1, (g_windowRect.bottom - g_windowRect.top) + 1, TRUE);
-  }
-  ShowWindow(m_windowHandle, SW_SHOWNORMAL);
-  UpdateWindow(m_windowHandle);
+	int uVar1 = (m_islandTexture == 0);
+	LegoModelPresenter::configureLegoModelPresenter(uVar1);
+	LegoPartPresenter::configureLegoPartPresenter(uVar1, iVar10);
+	LegoWorldPresenter::configureLegoWorldPresenter(m_islandQuality);
+	LegoBuildingManager::configureLegoBuildingManager(m_islandQuality);
+	LegoROI::configureLegoROI(iVar10);
+	LegoAnimationManager::configureLegoAnimationManager(m_islandQuality);
+	if (LegoOmni::GetInstance()) {
+		if (LegoOmni::GetInstance()->GetInputManager()) {
+			LegoOmni::GetInstance()->GetInputManager()->m_useJoystick = m_useJoystick;
+			LegoOmni::GetInstance()->GetInputManager()->m_joystickIndex = m_joystickIndex;
+		}
+	}
+	if (m_fullScreen) {
+		MoveWindow(
+			m_windowHandle,
+			g_windowRect.left,
+			g_windowRect.top,
+			(g_windowRect.right - g_windowRect.left) + 1,
+			(g_windowRect.bottom - g_windowRect.top) + 1,
+			TRUE
+		);
+	}
+	ShowWindow(m_windowHandle, SW_SHOWNORMAL);
+	UpdateWindow(m_windowHandle);
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: ISLE 0x402740
 BOOL IsleApp::ReadReg(LPCSTR name, LPSTR outValue, DWORD outSize)
 {
-  HKEY hKey;
-  DWORD valueType;
+	HKEY hKey;
+	DWORD valueType;
 
-  BOOL out = FALSE;
-  DWORD size = outSize;
-  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Mindscape\\LEGO Island", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-    if (RegQueryValueExA(hKey, name, NULL, &valueType, (LPBYTE) outValue, &size) == ERROR_SUCCESS) {
-      if (RegCloseKey(hKey) == ERROR_SUCCESS) {
-        out = TRUE;
-      }
-    }
-  }
+	BOOL out = FALSE;
+	DWORD size = outSize;
+	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Mindscape\\LEGO Island", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+		if (RegQueryValueExA(hKey, name, NULL, &valueType, (LPBYTE) outValue, &size) == ERROR_SUCCESS) {
+			if (RegCloseKey(hKey) == ERROR_SUCCESS) {
+				out = TRUE;
+			}
+		}
+	}
 
-  return out;
+	return out;
 }
 
 // OFFSET: ISLE 0x4027b0
-int IsleApp::ReadRegBool(LPCSTR name, BOOL *out)
+int IsleApp::ReadRegBool(LPCSTR name, BOOL* out)
 {
-  char buffer[256];
+	char buffer[256];
 
-  BOOL read = ReadReg(name, buffer, sizeof(buffer));
-  if (read) {
-    if (strcmp("YES", buffer) == 0) {
-      *out = TRUE;
-      return read;
-    }
+	BOOL read = ReadReg(name, buffer, sizeof(buffer));
+	if (read) {
+		if (strcmp("YES", buffer) == 0) {
+			*out = TRUE;
+			return read;
+		}
 
-    if (strcmp("NO", buffer) == 0) {
-      *out = FALSE;
-      return read;
-    }
+		if (strcmp("NO", buffer) == 0) {
+			*out = FALSE;
+			return read;
+		}
 
-    read = FALSE;
-  }
-  return read;
+		read = FALSE;
+	}
+	return read;
 }
 
 // OFFSET: ISLE 0x402880
-int IsleApp::ReadRegInt(LPCSTR name, int *out)
+int IsleApp::ReadRegInt(LPCSTR name, int* out)
 {
-  char buffer[256];
+	char buffer[256];
 
-  BOOL read = ReadReg(name, buffer, sizeof(buffer));
-  if (read) {
-    *out = atoi(buffer);
-  }
+	BOOL read = ReadReg(name, buffer, sizeof(buffer));
+	if (read) {
+		*out = atoi(buffer);
+	}
 
-  return read;
+	return read;
 }
 
 // OFFSET: ISLE 0x4028d0
 void IsleApp::LoadConfig()
 {
-  char buffer[1024];
+	char buffer[1024];
 
-  if (!ReadReg("diskpath", buffer, sizeof(buffer))) {
-    strcpy(buffer, MxOmni::GetHD());
-  }
+	if (!ReadReg("diskpath", buffer, sizeof(buffer))) {
+		strcpy(buffer, MxOmni::GetHD());
+	}
 
-  m_hdPath = new char[strlen(buffer) + 1];
-  strcpy(m_hdPath, buffer);
-  MxOmni::SetHD(m_hdPath);
+	m_hdPath = new char[strlen(buffer) + 1];
+	strcpy(m_hdPath, buffer);
+	MxOmni::SetHD(m_hdPath);
 
-  if (!ReadReg("cdpath", buffer, sizeof(buffer))) {
-    strcpy(buffer, MxOmni::GetCD());
-  }
+	if (!ReadReg("cdpath", buffer, sizeof(buffer))) {
+		strcpy(buffer, MxOmni::GetCD());
+	}
 
-  m_cdPath = new char[strlen(buffer) + 1];
-  strcpy(m_cdPath, buffer);
-  MxOmni::SetCD(m_cdPath);
+	m_cdPath = new char[strlen(buffer) + 1];
+	strcpy(m_cdPath, buffer);
+	MxOmni::SetCD(m_cdPath);
 
-  ReadRegBool("Flip Surfaces", &m_flipSurfaces);
-  ReadRegBool("Full Screen", &m_fullScreen);
-  ReadRegBool("Wide View Angle", &m_wideViewAngle);
-  ReadRegBool("3DSound", &m_use3dSound);
-  ReadRegBool("Music", &m_useMusic);
-  ReadRegBool("UseJoystick", &m_useJoystick);
-  ReadRegInt("JoystickIndex", &m_joystickIndex);
-  ReadRegBool("Draw Cursor", &m_drawCursor);
+	ReadRegBool("Flip Surfaces", &m_flipSurfaces);
+	ReadRegBool("Full Screen", &m_fullScreen);
+	ReadRegBool("Wide View Angle", &m_wideViewAngle);
+	ReadRegBool("3DSound", &m_use3dSound);
+	ReadRegBool("Music", &m_useMusic);
+	ReadRegBool("UseJoystick", &m_useJoystick);
+	ReadRegInt("JoystickIndex", &m_joystickIndex);
+	ReadRegBool("Draw Cursor", &m_drawCursor);
 
-  int backBuffersInVRAM;
-  if (ReadRegBool("Back Buffers in Video RAM",&backBuffersInVRAM)) {
-    m_backBuffersInVram = !backBuffersInVRAM;
-  }
+	int backBuffersInVRAM;
+	if (ReadRegBool("Back Buffers in Video RAM", &backBuffersInVRAM)) {
+		m_backBuffersInVram = !backBuffersInVRAM;
+	}
 
-  int bitDepth;
-  if (ReadRegInt("Display Bit Depth", &bitDepth)) {
-    if (bitDepth == 8) {
-      m_using8bit = TRUE;
-    } else if (bitDepth == 16) {
-      m_using16bit = TRUE;
-    }
-  }
+	int bitDepth;
+	if (ReadRegInt("Display Bit Depth", &bitDepth)) {
+		if (bitDepth == 8) {
+			m_using8bit = TRUE;
+		}
+		else if (bitDepth == 16) {
+			m_using16bit = TRUE;
+		}
+	}
 
-  if (!ReadReg("Island Quality", buffer, sizeof(buffer))) {
-    strcpy(buffer, "1");
-  }
-  m_islandQuality = atoi(buffer);
+	if (!ReadReg("Island Quality", buffer, sizeof(buffer))) {
+		strcpy(buffer, "1");
+	}
+	m_islandQuality = atoi(buffer);
 
-  if (!ReadReg("Island Texture", buffer, sizeof(buffer))) {
-    strcpy(buffer, "1");
-  }
-  m_islandTexture = atoi(buffer);
+	if (!ReadReg("Island Texture", buffer, sizeof(buffer))) {
+		strcpy(buffer, "1");
+	}
+	m_islandTexture = atoi(buffer);
 
-  if (ReadReg("3D Device ID", buffer, sizeof(buffer))) {
-    m_deviceId = new char[strlen(buffer) + 1];
-    strcpy(m_deviceId, buffer);
-  }
+	if (ReadReg("3D Device ID", buffer, sizeof(buffer))) {
+		m_deviceId = new char[strlen(buffer) + 1];
+		strcpy(m_deviceId, buffer);
+	}
 
-  if (ReadReg("savepath", buffer, sizeof(buffer))) {
-    m_savePath = new char[strlen(buffer) + 1];
-    strcpy(m_savePath, buffer);
-  }
+	if (ReadReg("savepath", buffer, sizeof(buffer))) {
+		m_savePath = new char[strlen(buffer) + 1];
+		strcpy(m_savePath, buffer);
+	}
 }
 
 // OFFSET: ISLE 0x402c20
 inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
 {
-  if (!this->m_windowActive) {
-    Sleep(0);
-    return;
-  }
+	if (!this->m_windowActive) {
+		Sleep(0);
+		return;
+	}
 
-  if (!Lego()) return;
-  if (!TickleManager()) return;
-  if (!Timer()) return;
+	if (!Lego())
+		return;
+	if (!TickleManager())
+		return;
+	if (!Timer())
+		return;
 
-  MxLong currentTime = Timer()->GetRealTime();
-  if (currentTime < g_lastFrameTime) {
-    g_lastFrameTime = -this->m_frameDelta;
-  }
+	MxLong currentTime = Timer()->GetRealTime();
+	if (currentTime < g_lastFrameTime) {
+		g_lastFrameTime = -this->m_frameDelta;
+	}
 
-  if (this->m_frameDelta + g_lastFrameTime < currentTime) {
-    if (!Lego()->IsTimerRunning()) {
-      TickleManager()->Tickle();
-    }
-    g_lastFrameTime = currentTime;
+	if (this->m_frameDelta + g_lastFrameTime < currentTime) {
+		if (!Lego()->IsTimerRunning()) {
+			TickleManager()->Tickle();
+		}
+		g_lastFrameTime = currentTime;
 
-    if (g_startupDelay == 0) {
-      return;
-    }
+		if (g_startupDelay == 0) {
+			return;
+		}
 
-    g_startupDelay--;
-    if (g_startupDelay != 0) {
-      return;
-    }
+		g_startupDelay--;
+		if (g_startupDelay != 0) {
+			return;
+		}
 
-    LegoOmni::GetInstance()->CreateBackgroundAudio();
-    BackgroundAudioManager()->Enable(this->m_useMusic);
+		LegoOmni::GetInstance()->CreateBackgroundAudio();
+		BackgroundAudioManager()->Enable(this->m_useMusic);
 
-    MxStreamController *stream = Streamer()->Open("\\lego\\scripts\\isle\\isle", 0);
-    MxDSAction ds;
+		MxStreamController* stream = Streamer()->Open("\\lego\\scripts\\isle\\isle", 0);
+		MxDSAction ds;
 
-    if (!stream) {
-      stream = Streamer()->Open("\\lego\\scripts\\nocd", 0);
-      if (!stream) {
-        return;
-      }
+		if (!stream) {
+			stream = Streamer()->Open("\\lego\\scripts\\nocd", 0);
+			if (!stream) {
+				return;
+			}
 
-      ds.SetAtomId(stream->GetAtom());
-      ds.SetUnknown24(-1);
-      ds.SetObjectId(0);
-      VideoManager()->EnableFullScreenMovie(TRUE, TRUE);
+			ds.SetAtomId(stream->GetAtom());
+			ds.SetUnknown24(-1);
+			ds.SetObjectId(0);
+			VideoManager()->EnableFullScreenMovie(TRUE, TRUE);
 
-      if (Start(&ds) != SUCCESS) {
-        return;
-      }
-    } else {
-      ds.SetAtomId(stream->GetAtom());
-      ds.SetUnknown24(-1);
-      ds.SetObjectId(0);
-      if (Start(&ds) != SUCCESS) {
-        return;
-      }
-      this->m_gameStarted = 1;
-    }
-    return;
-  }
+			if (Start(&ds) != SUCCESS) {
+				return;
+			}
+		}
+		else {
+			ds.SetAtomId(stream->GetAtom());
+			ds.SetUnknown24(-1);
+			ds.SetObjectId(0);
+			if (Start(&ds) != SUCCESS) {
+				return;
+			}
+			this->m_gameStarted = 1;
+		}
+		return;
+	}
 
-  if (sleepIfNotNextFrame != 0)
-    Sleep(0);
+	if (sleepIfNotNextFrame != 0)
+		Sleep(0);
 }
 
 // OFFSET: ISLE 0x402e80
 void IsleApp::SetupCursor(WPARAM wParam)
 {
-  switch (wParam) {
-  case 0:
-    m_cursorCurrent = m_cursorArrow;
-    break;
-  case 1:
-    m_cursorCurrent = m_cursorBusy;
-    break;
-  case 2:
-    m_cursorCurrent = m_cursorNo;
-    break;
-  case 0xB:
-    m_cursorCurrent = NULL;
-  case 3:
-  case 4:
-  case 5:
-  case 6:
-  case 7:
-  case 8:
-  case 9:
-  case 0xA:
-    break;
-  }
+	switch (wParam) {
+	case 0:
+		m_cursorCurrent = m_cursorArrow;
+		break;
+	case 1:
+		m_cursorCurrent = m_cursorBusy;
+		break;
+	case 2:
+		m_cursorCurrent = m_cursorNo;
+		break;
+	case 0xB:
+		m_cursorCurrent = NULL;
+	case 3:
+	case 4:
+	case 5:
+	case 6:
+	case 7:
+	case 8:
+	case 9:
+	case 0xA:
+		break;
+	}
 
-  SetCursor(m_cursorCurrent);
+	SetCursor(m_cursorCurrent);
 }

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -1,76 +1,83 @@
 #ifndef ISLEAPP_H
 #define ISLEAPP_H
 
-#include <windows.h>
-
 #include "mxtypes.h"
 #include "mxvideoparam.h"
 
-class IsleApp
-{
+#include <windows.h>
+
+class IsleApp {
 public:
-  IsleApp();
-  ~IsleApp();
+	IsleApp();
+	~IsleApp();
 
-  void Close();
+	void Close();
 
-  BOOL SetupLegoOmni();
-  void SetupVideoFlags(BOOL fullScreen, BOOL flipSurfaces, BOOL backBuffers,
-                       BOOL using8bit, BOOL using16bit, BOOL param_6, BOOL param_7,
-                       BOOL wideViewAngle, char *deviceId);
-  MxResult SetupWindow(HINSTANCE hInstance, LPSTR lpCmdLine);
+	BOOL SetupLegoOmni();
+	void SetupVideoFlags(
+		BOOL fullScreen,
+		BOOL flipSurfaces,
+		BOOL backBuffers,
+		BOOL using8bit,
+		BOOL using16bit,
+		BOOL param_6,
+		BOOL param_7,
+		BOOL wideViewAngle,
+		char* deviceId
+	);
+	MxResult SetupWindow(HINSTANCE hInstance, LPSTR lpCmdLine);
 
-  BOOL ReadReg(LPCSTR name, LPSTR outValue, DWORD outSize);
-  int ReadRegBool(LPCSTR name, BOOL *out);
-  int ReadRegInt(LPCSTR name, int *out);
+	BOOL ReadReg(LPCSTR name, LPSTR outValue, DWORD outSize);
+	int ReadRegBool(LPCSTR name, BOOL* out);
+	int ReadRegInt(LPCSTR name, int* out);
 
-  void LoadConfig();
-  void Tick(BOOL sleepIfNotNextFrame);
-  void SetupCursor(WPARAM wParam);
+	void LoadConfig();
+	void Tick(BOOL sleepIfNotNextFrame);
+	void SetupCursor(WPARAM wParam);
 
-  // private:
-  // 0
-  LPSTR m_hdPath;
-  LPSTR m_cdPath;
-  LPSTR m_deviceId;
-  LPSTR m_savePath;
+	// private:
+	// 0
+	LPSTR m_hdPath;
+	LPSTR m_cdPath;
+	LPSTR m_deviceId;
+	LPSTR m_savePath;
 
-  // 10
-  BOOL m_fullScreen;
-  BOOL m_flipSurfaces;
-  BOOL m_backBuffersInVram;
-  BOOL m_using8bit;
+	// 10
+	BOOL m_fullScreen;
+	BOOL m_flipSurfaces;
+	BOOL m_backBuffersInVram;
+	BOOL m_using8bit;
 
-  // 20
-  BOOL m_using16bit;
-  int m_unk24;
-  BOOL m_use3dSound;
-  BOOL m_useMusic;
+	// 20
+	BOOL m_using16bit;
+	int m_unk24;
+	BOOL m_use3dSound;
+	BOOL m_useMusic;
 
-  // 30
-  BOOL m_useJoystick;
-  int m_joystickIndex;
-  BOOL m_wideViewAngle;
-  int m_islandQuality;
+	// 30
+	BOOL m_useJoystick;
+	int m_joystickIndex;
+	BOOL m_wideViewAngle;
+	int m_islandQuality;
 
-  // 40
-  int m_islandTexture;
-  int m_gameStarted;
-  MxLong m_frameDelta;
+	// 40
+	int m_islandTexture;
+	int m_gameStarted;
+	MxLong m_frameDelta;
 
-  // 4c
-  MxVideoParam m_videoParam;
+	// 4c
+	MxVideoParam m_videoParam;
 
-  // 70
-  BOOL m_windowActive;
-  HWND m_windowHandle;
-  BOOL m_drawCursor;
-  HCURSOR m_cursorArrow;
+	// 70
+	BOOL m_windowActive;
+	HWND m_windowHandle;
+	BOOL m_drawCursor;
+	HCURSOR m_cursorArrow;
 
-  // 80
-  HCURSOR m_cursorBusy;
-  HCURSOR m_cursorNo;
-  HCURSOR m_cursorCurrent;
+	// 80
+	HCURSOR m_cursorBusy;
+	HCURSOR m_cursorNo;
+	HCURSOR m_cursorCurrent;
 };
 
 #endif // ISLEAPP_H

--- a/LEGO1/act1state.cpp
+++ b/LEGO1/act1state.cpp
@@ -3,6 +3,5 @@
 // OFFSET: LEGO1 0x100334b0 STUB
 Act1State::Act1State()
 {
-  // TODO
+	// TODO
 }
-

--- a/LEGO1/act1state.h
+++ b/LEGO1/act1state.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d7028
 // SIZE 0x26c
-class Act1State : public LegoState
-{
+class Act1State : public LegoState {
 public:
-  Act1State();
+	Act1State();
 
-  // OFFSET: LEGO1 0x100338a0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0154
-    return "Act1State";
-  };
+	// OFFSET: LEGO1 0x100338a0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0154
+		return "Act1State";
+	};
 
-  // OFFSET: LEGO1 0x100338b0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Act1State::ClassName()) || LegoState::IsA(name);
-  };
+	// OFFSET: LEGO1 0x100338b0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Act1State::ClassName()) || LegoState::IsA(name);
+	};
 };
 
 #endif // ACT1STATE_H

--- a/LEGO1/act2brick.cpp
+++ b/LEGO1/act2brick.cpp
@@ -3,27 +3,27 @@
 // OFFSET: LEGO1 0x1007a2b0 STUB
 Act2Brick::Act2Brick()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1007a470 STUB
 Act2Brick::~Act2Brick()
 {
-  // TODO
+	// TODO
 }
 
 // STUB OFFSET: LEGO1 0x1007a8c0 STUB
-MxLong Act2Brick::Notify(MxParam &p)
+MxLong Act2Brick::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1007a7f0 STUB
 MxResult Act2Brick::Tickle()
 {
-  // TODO
+	// TODO
 
-  return SUCCESS;
+	return SUCCESS;
 }

--- a/LEGO1/act2brick.h
+++ b/LEGO1/act2brick.h
@@ -5,28 +5,26 @@
 
 // VTABLE 0x100d9b60
 // SIZE 0x194
-class Act2Brick : public LegoPathActor
-{
+class Act2Brick : public LegoPathActor {
 public:
-  Act2Brick();
-  virtual ~Act2Brick() override; // vtable+0x0
+	Act2Brick();
+	virtual ~Act2Brick() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-  virtual MxResult Tickle() override; // vtable+0x08
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
+	virtual MxResult Tickle() override;         // vtable+0x08
 
-  // OFFSET: LEGO1 0x1007a360
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0438
-    return "Act2Brick";
-  }
+	// OFFSET: LEGO1 0x1007a360
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0438
+		return "Act2Brick";
+	}
 
-  // OFFSET: LEGO1 0x1007a370
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(Act2Brick::ClassName(), name) || LegoEntity::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1007a370
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(Act2Brick::ClassName(), name) || LegoEntity::IsA(name);
+	}
 };
 
 #endif // ACT2BRICK_H

--- a/LEGO1/act2policestation.cpp
+++ b/LEGO1/act2policestation.cpp
@@ -1,9 +1,9 @@
 #include "act2policestation.h"
 
 // OFFSET: LEGO1 0x1004e0e0 STUB
-MxLong Act2PoliceStation::Notify(MxParam &p)
+MxLong Act2PoliceStation::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/act2policestation.h
+++ b/LEGO1/act2policestation.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d53a8
 // SIZE 0x68
-class Act2PoliceStation : public LegoEntity
-{
+class Act2PoliceStation : public LegoEntity {
 public:
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x1000e200
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03fc
-    return "Act2PoliceStation";
-  }
+	// OFFSET: LEGO1 0x1000e200
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03fc
+		return "Act2PoliceStation";
+	}
 
-  // OFFSET: LEGO1 0x1000e210
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Act2PoliceStation::ClassName()) || LegoEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000e210
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Act2PoliceStation::ClassName()) || LegoEntity::IsA(name);
+	}
 };
 
 #endif // ACT2POLICESTATION_H

--- a/LEGO1/act3.cpp
+++ b/LEGO1/act3.cpp
@@ -5,11 +5,11 @@ DECOMP_SIZE_ASSERT(Act3, 0x4274)
 // OFFSET: LEGO1 0x10072270 STUB
 Act3::Act3()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100726a0 STUB
 Act3::~Act3()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/act3.h
+++ b/LEGO1/act3.h
@@ -5,32 +5,31 @@
 
 // VTABLE 0x100d9628
 // SIZE 0x4274
-class Act3 : public LegoWorld
-{
+class Act3 : public LegoWorld {
 public:
-  Act3();
+	Act3();
 
-  virtual ~Act3() override; // vtable+00
+	virtual ~Act3() override; // vtable+00
 
-  // OFFSET: LEGO1 0x10072510
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f013c
-    return "Act3";
-  }
+	// OFFSET: LEGO1 0x10072510
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f013c
+		return "Act3";
+	}
 
-  // OFFSET: LEGO1 0x10072520
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Act3::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10072520
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Act3::ClassName()) || LegoWorld::IsA(name);
+	}
 
-  inline void SetUnkown420c(MxEntity *p_entity) { m_unk420c = p_entity; }
-  protected:
-    undefined m_unkf8[0x4114];
-    MxEntity *m_unk420c;
-    undefined m_unk4210[0x64];
+	inline void SetUnkown420c(MxEntity* p_entity) { m_unk420c = p_entity; }
+
+protected:
+	undefined m_unkf8[0x4114];
+	MxEntity* m_unk420c;
+	undefined m_unk4210[0x64];
 };
-
 
 #endif // ACT3_H

--- a/LEGO1/act3actor.h
+++ b/LEGO1/act3actor.h
@@ -3,16 +3,14 @@
 
 // FIXME: Uncertain location. There are three vtables which eventually call this
 //        class' ClassName() function, but none of them call it directly.
-class Act3Actor
-{
+class Act3Actor {
 public:
-  // OFFSET: LEGO1 0x100431b0
-  inline virtual const char *ClassName() override
-  {
-    // 0x100f03ac
-    return "Act3Actor";
-  }
-
+	// OFFSET: LEGO1 0x100431b0
+	inline virtual const char* ClassName() override
+	{
+		// 0x100f03ac
+		return "Act3Actor";
+	}
 };
 
 #endif // ACT3ACTOR_H

--- a/LEGO1/act3shark.h
+++ b/LEGO1/act3shark.h
@@ -4,15 +4,14 @@
 #include "legoanimactor.h"
 
 // VTABLE 0x100d7920
-class Act3Shark : public LegoAnimActor
-{
+class Act3Shark : public LegoAnimActor {
 public:
-  // OFFSET: LEGO1 0x100430c0
-  inline virtual const char *ClassName() const override
-  {
-    // 0x100f03a0
-    return "Act3Shark";
-  }
+	// OFFSET: LEGO1 0x100430c0
+	inline virtual const char* ClassName() const override
+	{
+		// 0x100f03a0
+		return "Act3Shark";
+	}
 };
 
 #endif // ACT3SHARK_H

--- a/LEGO1/act3state.cpp
+++ b/LEGO1/act3state.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1000e2f0
 MxBool Act3State::VTable0x14()
 {
-  return FALSE;
+	return FALSE;
 }

--- a/LEGO1/act3state.h
+++ b/LEGO1/act3state.h
@@ -5,33 +5,28 @@
 
 // VTABLE 0x100d4fc8
 // SIZE 0xc
-class Act3State : public LegoState
-{
+class Act3State : public LegoState {
 public:
-  inline Act3State()
-  {
-    m_unk08 = 0;
-  }
+	inline Act3State() { m_unk08 = 0; }
 
-  // OFFSET: LEGO1 0x1000e300
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03f0
-    return "Act3State";
-  }
+	// OFFSET: LEGO1 0x1000e300
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03f0
+		return "Act3State";
+	}
 
-  // OFFSET: LEGO1 0x1000e310
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Act3State::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000e310
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Act3State::ClassName()) || LegoState::IsA(name);
+	}
 
-  virtual MxBool VTable0x14() override;
+	virtual MxBool VTable0x14() override;
 
 private:
-  // FIXME: May be part of LegoState? Uncertain...
-  MxU32 m_unk08;
-
+	// FIXME: May be part of LegoState? Uncertain...
+	MxU32 m_unk08;
 };
 
 #endif // ACT3STATE_H

--- a/LEGO1/ambulance.cpp
+++ b/LEGO1/ambulance.cpp
@@ -7,15 +7,15 @@ DECOMP_SIZE_ASSERT(Ambulance, 0x184);
 // OFFSET: LEGO1 0x10035ee0
 Ambulance::Ambulance()
 {
-  this->m_unk168 = 0;
-  this->m_unk16a = -1;
-  this->m_unk164 = 0;
-  this->m_unk16c = 0;
-  this->m_unk174 = -1;
-  this->m_unk16e = 0;
-  this->m_unk178 = -1;
-  this->m_unk170 = 0;
-  this->m_unk172 = 0;
-  this->m_unk13c = 40.0;
-  this->m_unk17c = 1.0;
+	this->m_unk168 = 0;
+	this->m_unk16a = -1;
+	this->m_unk164 = 0;
+	this->m_unk16c = 0;
+	this->m_unk174 = -1;
+	this->m_unk16e = 0;
+	this->m_unk178 = -1;
+	this->m_unk170 = 0;
+	this->m_unk172 = 0;
+	this->m_unk13c = 40.0;
+	this->m_unk17c = 1.0;
 }

--- a/LEGO1/ambulance.h
+++ b/LEGO1/ambulance.h
@@ -5,37 +5,37 @@
 
 // VTABLE 0x100d71a8
 // SIZE 0x184
-class Ambulance : public IslePathActor
-{
+class Ambulance : public IslePathActor {
 public:
-  Ambulance();
+	Ambulance();
 
-  // OFFSET: LEGO1 0x10035fa0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03c4
-    return "Ambulance";
-  }
+	// OFFSET: LEGO1 0x10035fa0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03c4
+		return "Ambulance";
+	}
 
-  // OFFSET: LEGO1 0x10035fb0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Ambulance::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10035fb0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Ambulance::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  // TODO: Ambulance fields
-  undefined m_unk160[4];
-  MxS32 m_unk164;
-  MxS16 m_unk168;
-  MxS16 m_unk16a;
-  MxS16 m_unk16c;
-  MxS16 m_unk16e;
-  MxS16 m_unk170;
-  MxS16 m_unk172;
-  MxS32 m_unk174;
-  MxS32 m_unk178;
-  MxFloat m_unk17c;
-  undefined m_unk180[4];
+	// TODO: Ambulance fields
+	undefined m_unk160[4];
+	MxS32 m_unk164;
+	MxS16 m_unk168;
+	MxS16 m_unk16a;
+	MxS16 m_unk16c;
+	MxS16 m_unk16e;
+	MxS16 m_unk170;
+	MxS16 m_unk172;
+	MxS32 m_unk174;
+	MxS32 m_unk178;
+	MxFloat m_unk17c;
+	undefined m_unk180[4];
 };
 
 #endif // AMBULANCE_H

--- a/LEGO1/ambulancemissionstate.cpp
+++ b/LEGO1/ambulancemissionstate.cpp
@@ -5,5 +5,5 @@ DECOMP_SIZE_ASSERT(AmbulanceMissionState, 0x24);
 // OFFSET: LEGO1 0x100373a0 STUB
 AmbulanceMissionState::AmbulanceMissionState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/ambulancemissionstate.h
+++ b/LEGO1/ambulancemissionstate.h
@@ -5,44 +5,48 @@
 
 // VTABLE 0x100d72a0
 // SIZE 0x24
-class AmbulanceMissionState : public LegoState
-{
+class AmbulanceMissionState : public LegoState {
 public:
-  AmbulanceMissionState();
+	AmbulanceMissionState();
 
-  // OFFSET: LEGO1 0x10037600
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f00e8
-    return "AmbulanceMissionState";
-  }
+	// OFFSET: LEGO1 0x10037600
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f00e8
+		return "AmbulanceMissionState";
+	}
 
-  // OFFSET: LEGO1 0x10037610
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, AmbulanceMissionState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10037610
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, AmbulanceMissionState::ClassName()) || LegoState::IsA(name);
+	}
 
-  inline MxU16 GetColor(MxU8 id)
-  {
-    switch (id)
-    {
-    case 1: return m_color1;
-    case 2: return m_color2;
-    case 3: return m_color3;
-    case 4: return m_color4;
-    case 5: return m_color5;
-    default: return 0;
-    }
-  }
+	inline MxU16 GetColor(MxU8 id)
+	{
+		switch (id) {
+		case 1:
+			return m_color1;
+		case 2:
+			return m_color2;
+		case 3:
+			return m_color3;
+		case 4:
+			return m_color4;
+		case 5:
+			return m_color5;
+		default:
+			return 0;
+		}
+	}
+
 protected:
-  undefined m_unk8[0x12];
-  MxU16 m_color1;
-  MxU16 m_color2;
-  MxU16 m_color3;
-  MxU16 m_color4;
-  MxU16 m_color5;
+	undefined m_unk8[0x12];
+	MxU16 m_color1;
+	MxU16 m_color2;
+	MxU16 m_color3;
+	MxU16 m_color4;
+	MxU16 m_color5;
 };
-
 
 #endif // AMBULANCEMISSIONSTATE_H

--- a/LEGO1/animstate.cpp
+++ b/LEGO1/animstate.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x10064ff0 STUB
 AnimState::AnimState()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10065150 STUB
 AnimState::~AnimState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/animstate.h
+++ b/LEGO1/animstate.h
@@ -5,25 +5,23 @@
 
 // VTABLE 0x100d8d80
 // SIZE 0x1c
-class AnimState : public LegoState
-{
+class AnimState : public LegoState {
 public:
-  AnimState();
-  virtual ~AnimState() override; // vtable+0x0
+	AnimState();
+	virtual ~AnimState() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10065070
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0460
-    return "AnimState";
-  }
+	// OFFSET: LEGO1 0x10065070
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0460
+		return "AnimState";
+	}
 
-  // OFFSET: LEGO1 0x10065080
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, AnimState::ClassName()) || LegoState::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10065080
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, AnimState::ClassName()) || LegoState::IsA(name);
+	}
 };
 
 #endif // ANIMSTATE_H

--- a/LEGO1/beachhouseentity.cpp
+++ b/LEGO1/beachhouseentity.cpp
@@ -1,9 +1,9 @@
 #include "beachhouseentity.h"
 
 // OFFSET: LEGO1 0x100150a0 STUB
-MxLong BeachHouseEntity::Notify(MxParam &p)
+MxLong BeachHouseEntity::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/beachhouseentity.h
+++ b/LEGO1/beachhouseentity.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d4a18
 // SIZE 0x68
-class BeachHouseEntity : public BuildingEntity
-{
+class BeachHouseEntity : public BuildingEntity {
 public:
-  virtual MxLong Notify(MxParam &p) override; // vtable+04
+	virtual MxLong Notify(MxParam& p) override; // vtable+04
 
-  // OFFSET: LEGO1 0x1000ee80
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0314
-    return "BeachHouseEntity";
-  }
+	// OFFSET: LEGO1 0x1000ee80
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0314
+		return "BeachHouseEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000ee90
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, BeachHouseEntity::ClassName()) || BuildingEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000ee90
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, BeachHouseEntity::ClassName()) || BuildingEntity::IsA(name);
+	}
 };
 
 #endif // BEACHHOUSEENTITY_H

--- a/LEGO1/bike.cpp
+++ b/LEGO1/bike.cpp
@@ -5,8 +5,7 @@ DECOMP_SIZE_ASSERT(Bike, 0x164);
 // OFFSET: LEGO1 0x10076670
 Bike::Bike()
 {
-  this->m_unk13c = 20.0;
-  this->m_unk150 = 3.0;
-  this->m_unk148 = 1;
+	this->m_unk13c = 20.0;
+	this->m_unk150 = 3.0;
+	this->m_unk148 = 1;
 }
-

--- a/LEGO1/bike.h
+++ b/LEGO1/bike.h
@@ -6,27 +6,26 @@
 
 // VTABLE 0x100d9808
 // SIZE 0x164
-class Bike : public IslePathActor
-{
+class Bike : public IslePathActor {
 public:
-  Bike();
+	Bike();
 
-  // OFFSET: LEGO1 0x100766f0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03d0
-    return "Bike";
-  }
+	// OFFSET: LEGO1 0x100766f0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03d0
+		return "Bike";
+	}
 
-  // OFFSET: LEGO1 0x10076700
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Bike::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10076700
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Bike::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  // TODO: Bike fields
-  undefined m_unk160[4];
+	// TODO: Bike fields
+	undefined m_unk160[4];
 };
-
 
 #endif // BIKE_H

--- a/LEGO1/buildingentity.cpp
+++ b/LEGO1/buildingentity.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x10014e20 STUB
 BuildingEntity::BuildingEntity()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10015030 STUB
 BuildingEntity::~BuildingEntity()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/buildingentity.h
+++ b/LEGO1/buildingentity.h
@@ -5,24 +5,23 @@
 
 // VTABLE 0x100d5c88
 // SIZE <= 0x68, hard to tell because it's always constructed as a derivative
-class BuildingEntity : public LegoEntity
-{
+class BuildingEntity : public LegoEntity {
 public:
-  BuildingEntity();
-  virtual ~BuildingEntity() override; // vtable+0x0
+	BuildingEntity();
+	virtual ~BuildingEntity() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10014f20
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f07e8
-    return "BuildingEntity";
-  }
+	// OFFSET: LEGO1 0x10014f20
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f07e8
+		return "BuildingEntity";
+	}
 
-  // OFFSET: LEGO1 0x10014f30
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, BuildingEntity::ClassName()) || LegoEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10014f30
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, BuildingEntity::ClassName()) || LegoEntity::IsA(name);
+	}
 };
 
 #endif // BUILDINGENTITY_H

--- a/LEGO1/bumpbouy.h
+++ b/LEGO1/bumpbouy.h
@@ -5,21 +5,20 @@
 #include "mxtypes.h"
 
 // VTABLE 0x100d6790
-class BumpBouy : public LegoAnimActor
-{
+class BumpBouy : public LegoAnimActor {
 public:
-  // OFFSET: LEGO1 0x100274e0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0394
-    return "BumpBouy";
-  }
+	// OFFSET: LEGO1 0x100274e0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0394
+		return "BumpBouy";
+	}
 
-  // OFFSET: LEGO1 0x10027500
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, BumpBouy::ClassName()) || LegoAnimActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10027500
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, BumpBouy::ClassName()) || LegoAnimActor::IsA(name);
+	}
 };
 
 #endif // BUMPBOUY_H

--- a/LEGO1/carrace.cpp
+++ b/LEGO1/carrace.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x10016a90 STUB
 CarRace::CarRace()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/carrace.h
+++ b/LEGO1/carrace.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d5e50
 // SIZE 0x154
-class CarRace : public LegoRace
-{
+class CarRace : public LegoRace {
 public:
-  CarRace();
+	CarRace();
 
-  // OFFSET: LEGO1 0x10016b20
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0528
-    return "CarRace";
-  }
+	// OFFSET: LEGO1 0x10016b20
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0528
+		return "CarRace";
+	}
 
-  // OFFSET: LEGO1 0x10016b30
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, CarRace::ClassName()) || LegoRace::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10016b30
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, CarRace::ClassName()) || LegoRace::IsA(name);
+	}
 };
 
 #endif // CARRACE_H

--- a/LEGO1/carracestate.h
+++ b/LEGO1/carracestate.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d4b70
 // SIZE 0x2c
-class CarRaceState : public RaceState
-{
+class CarRaceState : public RaceState {
 public:
-  // OFFSET: LEGO1 0x1000dd30
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f009c
-    return "CarRaceState";
-  }
+	// OFFSET: LEGO1 0x1000dd30
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f009c
+		return "CarRaceState";
+	}
 
-  // OFFSET: LEGO1 0x1000dd40
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, CarRaceState::ClassName()) || RaceState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000dd40
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, CarRaceState::ClassName()) || RaceState::IsA(name);
+	}
 };
 
 #endif // CARRACESTATE_H

--- a/LEGO1/compat.h
+++ b/LEGO1/compat.h
@@ -12,15 +12,18 @@
 #endif
 
 // DIsable "nonstandard extension used : 'bool'" warning spam
-#pragma warning( disable : 4237 )
+#pragma warning(disable : 4237)
 
 // Disable "identifier was truncated to '255' characters" warning.
 // Impossible to avoid this if using STL map or set.
 // This removes most (but not all) occurrences of the warning.
-#pragma warning( disable : 4786 )
+#pragma warning(disable : 4786)
 // To really remove *all* of the warnings, we have to employ the following,
 // obscure workaround from https://www.earthli.com/news/view_article.php?id=376
-static class msVC6_4786WorkAround { public: msVC6_4786WorkAround() {} } msVC6_4786WorkAround;
+static class msVC6_4786WorkAround {
+public:
+	msVC6_4786WorkAround() {}
+} msVC6_4786WorkAround;
 
 #define MSVC420_VERSION 1020
 

--- a/LEGO1/decomp.h
+++ b/LEGO1/decomp.h
@@ -2,7 +2,11 @@
 #define DECOMP_H
 
 #if defined(_MSC_VER)
-#define DECOMP_STATIC_ASSERT(V) namespace { typedef int foo[(V)?1:-1]; }
+#define DECOMP_STATIC_ASSERT(V)                                                                                        \
+	namespace                                                                                                          \
+	{                                                                                                                  \
+	typedef int foo[(V) ? 1 : -1];                                                                                     \
+	}
 #define DECOMP_SIZE_ASSERT(T, S) DECOMP_STATIC_ASSERT(sizeof(T) == S)
 #else
 #define DECOMP_STATIC_ASSERT(V)

--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -1,10 +1,10 @@
 #include "define.h"
 
 // 0x10101eac
-const char *g_parseExtraTokens = ":;";
+const char* g_parseExtraTokens = ":;";
 
 // 0x10101edc
-const char *g_strWORLD = "WORLD";
+const char* g_strWORLD = "WORLD";
 
 // 0x10102040
-const char *g_strACTION = "ACTION";
+const char* g_strACTION = "ACTION";

--- a/LEGO1/define.h
+++ b/LEGO1/define.h
@@ -1,8 +1,8 @@
 #ifndef DEFINE_H
 #define DEFINE_H
 
-extern const char *g_parseExtraTokens;
-extern const char *g_strWORLD;
-extern const char *g_strACTION;
+extern const char* g_parseExtraTokens;
+extern const char* g_strWORLD;
+extern const char* g_strACTION;
 
 #endif // DEFINE_H

--- a/LEGO1/dllmain.cpp
+++ b/LEGO1/dllmain.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x10091ee0
 __declspec(dllexport) BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
-  return TRUE;
+	return TRUE;
 }

--- a/LEGO1/doors.h
+++ b/LEGO1/doors.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d4788
 // SIZE 0x1f8
-class Doors : public LegoPathActor
-{
+class Doors : public LegoPathActor {
 public:
-  // OFFSET: LEGO1 0x1000e430
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03e8
-    return "Doors";
-  }
+	// OFFSET: LEGO1 0x1000e430
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03e8
+		return "Doors";
+	}
 
-  // OFFSET: LEGO1 0x1000e440
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Doors::ClassName()) || LegoPathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000e440
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Doors::ClassName()) || LegoPathActor::IsA(name);
+	}
 };
-
 
 #endif // DOORS_H

--- a/LEGO1/dunebuggy.cpp
+++ b/LEGO1/dunebuggy.cpp
@@ -7,6 +7,6 @@ DECOMP_SIZE_ASSERT(DuneBuggy, 0x16c);
 // OFFSET: LEGO1 0x10067bb0
 DuneBuggy::DuneBuggy()
 {
-  this->m_unk13c = 25.0;
-  this->m_unk164 = 1.0;
+	this->m_unk13c = 25.0;
+	this->m_unk164 = 1.0;
 }

--- a/LEGO1/dunebuggy.h
+++ b/LEGO1/dunebuggy.h
@@ -6,28 +6,28 @@
 
 // VTABLE 0x100d8f98
 // SIZE 0x16c
-class DuneBuggy : public IslePathActor
-{
+class DuneBuggy : public IslePathActor {
 public:
-  DuneBuggy();
+	DuneBuggy();
 
-  // OFFSET: LEGO1 0x10067c30
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0410
-    return "DuneBuggy";
-  }
+	// OFFSET: LEGO1 0x10067c30
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0410
+		return "DuneBuggy";
+	}
 
-  // OFFSET: LEGO1 0x10067c40
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, DuneBuggy::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10067c40
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, DuneBuggy::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  // TODO: Double check DuneBuggy field types
-  undefined4 m_unk160;
-  MxFloat m_unk164;
-  undefined4 m_unk168;
+	// TODO: Double check DuneBuggy field types
+	undefined4 m_unk160;
+	MxFloat m_unk164;
+	undefined4 m_unk168;
 };
 
 #endif // DUNEBUGGY_H

--- a/LEGO1/elevatorbottom.cpp
+++ b/LEGO1/elevatorbottom.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x10017e90 STUB
 ElevatorBottom::ElevatorBottom()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10018060 STUB
 ElevatorBottom::~ElevatorBottom()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10018150 STUB
-MxLong ElevatorBottom::Notify(MxParam &p)
+MxLong ElevatorBottom::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/elevatorbottom.h
+++ b/LEGO1/elevatorbottom.h
@@ -4,27 +4,25 @@
 #include "legoworld.h"
 
 // VTABLE 0x100d5f20
-class ElevatorBottom : public LegoWorld
-{
+class ElevatorBottom : public LegoWorld {
 public:
-  ElevatorBottom();
-  virtual ~ElevatorBottom() override; // vtable+0x0
+	ElevatorBottom();
+	virtual ~ElevatorBottom() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x10017f20
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f04ac
-    return "ElevatorBottom";
-  }
+	// OFFSET: LEGO1 0x10017f20
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f04ac
+		return "ElevatorBottom";
+	}
 
-  // OFFSET: LEGO1 0x10017f30
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ElevatorBottom::ClassName()) || LegoWorld::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10017f30
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ElevatorBottom::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // ELEVATORBOTTOM_H

--- a/LEGO1/extra.h
+++ b/LEGO1/extra.h
@@ -3,19 +3,18 @@
 
 // Items related to the Extra string of key-value pairs found in MxOb
 
-enum ExtraActionType
-{
-  ExtraActionType_opendisk = 1,
-  ExtraActionType_openram  = 2,
-  ExtraActionType_close    = 3,
-  ExtraActionType_start    = 4,
-  ExtraActionType_stop     = 5,
-  ExtraActionType_run      = 6,
-  ExtraActionType_exit     = 7,
-  ExtraActionType_enable   = 8,
-  ExtraActionType_disable  = 9,
-  ExtraActionType_notify   = 10,
-  ExtraActionType_unknown  = 11,
+enum ExtraActionType {
+	ExtraActionType_opendisk = 1,
+	ExtraActionType_openram = 2,
+	ExtraActionType_close = 3,
+	ExtraActionType_start = 4,
+	ExtraActionType_stop = 5,
+	ExtraActionType_run = 6,
+	ExtraActionType_exit = 7,
+	ExtraActionType_enable = 8,
+	ExtraActionType_disable = 9,
+	ExtraActionType_notify = 10,
+	ExtraActionType_unknown = 11,
 };
 
 #endif // EXTRA_H

--- a/LEGO1/gasstation.cpp
+++ b/LEGO1/gasstation.cpp
@@ -3,27 +3,27 @@
 // OFFSET: LEGO1 0x100046a0 STUB
 GasStation::GasStation()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100048c0 STUB
 GasStation::~GasStation()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10004a60 STUB
-MxLong GasStation::Notify(MxParam &p)
+MxLong GasStation::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10005c90 STUB
 MxResult GasStation::Tickle()
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/gasstation.h
+++ b/LEGO1/gasstation.h
@@ -6,28 +6,26 @@
 // VTABLE 0x100d4650
 // SIZE 0x128
 // Radio variable at 0x46, in constructor
-class GasStation : public LegoWorld
-{
+class GasStation : public LegoWorld {
 public:
-  GasStation();
-  virtual ~GasStation() override; // vtable+0x0
-  
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-  virtual MxResult Tickle() override; // vtable+0x8
+	GasStation();
+	virtual ~GasStation() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10004780
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0168
-    return "GasStation";
-  }
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
+	virtual MxResult Tickle() override;         // vtable+0x8
 
-  // OFFSET: LEGO1 0x10004790
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, GasStation::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10004780
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0168
+		return "GasStation";
+	}
 
+	// OFFSET: LEGO1 0x10004790
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, GasStation::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // GASSTATION_H

--- a/LEGO1/gasstationentity.h
+++ b/LEGO1/gasstationentity.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d5258
 // SIZE 0x68
-class GasStationEntity : public BuildingEntity
-{
+class GasStationEntity : public BuildingEntity {
 public:
-  // OFFSET: LEGO1 0x1000eb20
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0348
-    return "GasStationEntity";
-  }
+	// OFFSET: LEGO1 0x1000eb20
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0348
+		return "GasStationEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000eb30
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, GasStationEntity::ClassName()) || BuildingEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000eb30
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, GasStationEntity::ClassName()) || BuildingEntity::IsA(name);
+	}
 };
 
 #endif // GASSTATIONENTITY_H

--- a/LEGO1/gasstationstate.cpp
+++ b/LEGO1/gasstationstate.cpp
@@ -5,14 +5,14 @@ DECOMP_SIZE_ASSERT(GasStationState, 0x24);
 // OFFSET: LEGO1 0x10005eb0
 GasStationState::GasStationState()
 {
-  m_unk0x18 = 0;
-  m_unk0x1a = 0;
-  m_unk0x1c = 0;
-  m_unk0x1e = 0;
-  m_unk0x20 = 0;
+	m_unk0x18 = 0;
+	m_unk0x1a = 0;
+	m_unk0x1c = 0;
+	m_unk0x1e = 0;
+	m_unk0x20 = 0;
 
-  undefined4 *unk = m_unk0x08;
-  unk[0] = -1;
-  unk[1] = -1;
-  unk[2] = -1;
+	undefined4* unk = m_unk0x08;
+	unk[0] = -1;
+	unk[1] = -1;
+	unk[2] = -1;
 }

--- a/LEGO1/gasstationstate.h
+++ b/LEGO1/gasstationstate.h
@@ -5,32 +5,31 @@
 
 // VTABLE 0x100d46e0
 // SIZE 0x24
-class GasStationState : public LegoState
-{
+class GasStationState : public LegoState {
 public:
-  GasStationState();
+	GasStationState();
 
-  // OFFSET: LEGO1 0x100061d0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0174
-    return "GasStationState";
-  }
+	// OFFSET: LEGO1 0x100061d0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0174
+		return "GasStationState";
+	}
 
-  // OFFSET: LEGO1 0x100061e0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, GasStationState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100061e0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, GasStationState::ClassName()) || LegoState::IsA(name);
+	}
 
 private:
-  undefined4 m_unk0x08[3];
-  undefined4 m_unk0x14;
-  undefined2 m_unk0x18;
-  undefined2 m_unk0x1a;
-  undefined2 m_unk0x1c;
-  undefined2 m_unk0x1e;
-  undefined2 m_unk0x20;
+	undefined4 m_unk0x08[3];
+	undefined4 m_unk0x14;
+	undefined2 m_unk0x18;
+	undefined2 m_unk0x1a;
+	undefined2 m_unk0x1c;
+	undefined2 m_unk0x1e;
+	undefined2 m_unk0x20;
 };
 
 #endif // GASSTATIONSTATE_H

--- a/LEGO1/gifmanager.cpp
+++ b/LEGO1/gifmanager.cpp
@@ -6,20 +6,20 @@ DECOMP_SIZE_ASSERT(GifMap, 0x08);
 DECOMP_SIZE_ASSERT(GifManagerBase, 0x14);
 DECOMP_SIZE_ASSERT(GifManager, 0x30);
 
-GifMapEntry *DAT_100f0100;
+GifMapEntry* DAT_100f0100;
 
 // OFFSET: LEGO1 0x10001cc0
-GifMapEntry *GifMap::FindNode(const char *&string)
+GifMapEntry* GifMap::FindNode(const char*& string)
 {
-  GifMapEntry *ret = m_unk4;
-  GifMapEntry *current = ret->m_parent;
-  while (current != DAT_100f0100) {
-    if (strcmp(current->m_key, string) <= 0) {
-      ret = current;
-      current = current->m_right;
-    }
-    else
-      current = current->m_left;
-  }
-  return ret;
+	GifMapEntry* ret = m_unk4;
+	GifMapEntry* current = ret->m_parent;
+	while (current != DAT_100f0100) {
+		if (strcmp(current->m_key, string) <= 0) {
+			ret = current;
+			current = current->m_right;
+		}
+		else
+			current = current->m_left;
+	}
+	return ret;
 }

--- a/LEGO1/gifmanager.h
+++ b/LEGO1/gifmanager.h
@@ -4,70 +4,66 @@
 #include "decomp.h"
 #include "mxtypes.h"
 
-#include <ddraw.h>
 #include <d3drmobj.h>
+#include <ddraw.h>
 
-struct GifData
-{
+struct GifData {
 public:
-  const char *m_name;
-  LPDIRECTDRAWSURFACE m_surface;
-  LPDIRECTDRAWPALETTE m_palette;
-  LPDIRECT3DRMTEXTURE2 m_texture;
-  MxU8 *m_data;
+	const char* m_name;
+	LPDIRECTDRAWSURFACE m_surface;
+	LPDIRECTDRAWPALETTE m_palette;
+	LPDIRECT3DRMTEXTURE2 m_texture;
+	MxU8* m_data;
 };
 
-struct GifMapEntry
-{
+struct GifMapEntry {
 public:
-  GifMapEntry *m_right;
-  GifMapEntry *m_parent;
-  GifMapEntry *m_left;
-  const char *m_key;
-  GifData *m_value;
+	GifMapEntry* m_right;
+	GifMapEntry* m_parent;
+	GifMapEntry* m_left;
+	const char* m_key;
+	GifData* m_value;
 };
 
-class GifMap
-{
+class GifMap {
 public:
-  GifMapEntry *FindNode(const char *&string);
+	GifMapEntry* FindNode(const char*& string);
 
-  inline GifData *Get(const char *string) {
-    GifData *ret = NULL;
-    GifMapEntry *entry = FindNode(string);
-    if (((m_unk4 == entry || strcmp(string, entry->m_key) > 0) ? m_unk4 : entry) != entry)
-      ret = entry->m_value;
-    return ret;
-  }
+	inline GifData* Get(const char* string)
+	{
+		GifData* ret = NULL;
+		GifMapEntry* entry = FindNode(string);
+		if (((m_unk4 == entry || strcmp(string, entry->m_key) > 0) ? m_unk4 : entry) != entry)
+			ret = entry->m_value;
+		return ret;
+	}
 
-  undefined4 m_unk0;
-  GifMapEntry *m_unk4;
+	undefined4 m_unk0;
+	GifMapEntry* m_unk4;
 };
 
 // VTABLE 0x100d86d4
-class GifManagerBase 
-{
+class GifManagerBase {
 public:
-  // OFFSET: LEGO1 0x1005a310 STUB
-  virtual ~GifManagerBase() {} // vtable+00
+	// OFFSET: LEGO1 0x1005a310 STUB
+	virtual ~GifManagerBase() {} // vtable+00
 
-  inline GifData *Get(const char *name) { return m_unk8.Get(name); }
+	inline GifData* Get(const char* name) { return m_unk8.Get(name); }
 
 protected:
-  undefined4 m_unk0;
-  undefined4 m_unk4;
-  GifMap m_unk8;
+	undefined4 m_unk0;
+	undefined4 m_unk4;
+	GifMap m_unk8;
 };
 
 // VTABLE 0x100d86fc
-class GifManager : public GifManagerBase 
-{
+class GifManager : public GifManagerBase {
 public:
-  // OFFSET: LEGO1 0x1005a580 STUB
-  virtual ~GifManager() {} // vtable+00
+	// OFFSET: LEGO1 0x1005a580 STUB
+	virtual ~GifManager() {} // vtable+00
 
 protected:
-  undefined m_unk[0x1c];
+	undefined m_unk[0x1c];
 };
 
 #endif // GIFMANAGER_H

--- a/LEGO1/helicopter.cpp
+++ b/LEGO1/helicopter.cpp
@@ -1,4 +1,5 @@
 #include "helicopter.h"
+
 #include "act3.h"
 #include "legoanimationmanager.h"
 #include "legocontrolmanager.h"
@@ -12,65 +13,66 @@ DECOMP_SIZE_ASSERT(Helicopter, 0x230)
 // OFFSET: LEGO1 0x10001e60
 Helicopter::Helicopter()
 {
-  m_unk13c = 60;
+	m_unk13c = 60;
 }
 
 // OFFSET: LEGO1 0x10003230
 Helicopter::~Helicopter()
 {
-  ControlManager()->Unregister(this);
-  IslePathActor::Destroy(TRUE);
+	ControlManager()->Unregister(this);
+	IslePathActor::Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100032c0
-MxResult Helicopter::InitFromMxDSObject(MxDSObject &p_dsObject)
+MxResult Helicopter::InitFromMxDSObject(MxDSObject& p_dsObject)
 {
-  MxResult result = IslePathActor::InitFromMxDSObject(p_dsObject);
-  LegoWorld *world = GetCurrentWorld();
-  SetWorld(world);
-  if (world->IsA("Act3")) {
-    ((Act3 *)GetWorld())->SetUnkown420c(this);
-  }
-  world = GetWorld();
-  if (world) world->VTable0x58(this); 
-  GetState();
-  return result;
+	MxResult result = IslePathActor::InitFromMxDSObject(p_dsObject);
+	LegoWorld* world = GetCurrentWorld();
+	SetWorld(world);
+	if (world->IsA("Act3")) {
+		((Act3*) GetWorld())->SetUnkown420c(this);
+	}
+	world = GetWorld();
+	if (world)
+		world->VTable0x58(this);
+	GetState();
+	return result;
 }
 
 // OFFSET: LEGO1 0x10003320
 void Helicopter::GetState()
 {
-  m_state = (HelicopterState *)GameState()->GetState("HelicopterState");
-  if (!m_state) m_state = (HelicopterState *)GameState()->CreateState("HelicopterState");
+	m_state = (HelicopterState*) GameState()->GetState("HelicopterState");
+	if (!m_state)
+		m_state = (HelicopterState*) GameState()->CreateState("HelicopterState");
 }
 
 // OFFSET: LEGO1 0x10003360
 void Helicopter::VTable0xe4()
 {
-  if (!GameState()->GetUnknown10()) {
-    VTable0xe8(0x28, TRUE, 7);
-  }
-  IslePathActor::VTable0xe4();
-  if (!GameState()->GetUnknown10()) {
-    GameState()->SetUnknown424(0x3c);
-    if (GetCurrentVehicle()) {
-      if (GetCurrentVehicle()->IsA("IslePathActor")) {
-        ((IslePathActor *)GetCurrentVehicle())->VTable0xe8(0x37, TRUE, 7);
-      }
-    }
-  }
-  m_state->SetUnknown8(0);
-  FUN_1003ee00(m_unk22c, 0x16);
-  FUN_1003ee00(m_unk22c, 0x17);
-  FUN_1003ee00(m_unk22c, 0x18);
-  FUN_1003ee00(m_unk22c, 0x19);
-  FUN_1003ee00(m_unk22c, 0x1a);
-  FUN_1003ee00(m_unk22c, 0x1b);
-  FUN_1003ee00(m_unk22c, 0x1c);
-  FUN_1003ee00(m_unk22c, 0x1d);
-  FUN_1003ee00(m_unk22c, 0x1e);
-  FUN_1003ee00(m_unk22c, 0x1f);
-  AnimationManager()->FUN_1005f6d0(TRUE);
-  ControlManager()->Unregister(this);
+	if (!GameState()->GetUnknown10()) {
+		VTable0xe8(0x28, TRUE, 7);
+	}
+	IslePathActor::VTable0xe4();
+	if (!GameState()->GetUnknown10()) {
+		GameState()->SetUnknown424(0x3c);
+		if (GetCurrentVehicle()) {
+			if (GetCurrentVehicle()->IsA("IslePathActor")) {
+				((IslePathActor*) GetCurrentVehicle())->VTable0xe8(0x37, TRUE, 7);
+			}
+		}
+	}
+	m_state->SetUnknown8(0);
+	FUN_1003ee00(m_unk22c, 0x16);
+	FUN_1003ee00(m_unk22c, 0x17);
+	FUN_1003ee00(m_unk22c, 0x18);
+	FUN_1003ee00(m_unk22c, 0x19);
+	FUN_1003ee00(m_unk22c, 0x1a);
+	FUN_1003ee00(m_unk22c, 0x1b);
+	FUN_1003ee00(m_unk22c, 0x1c);
+	FUN_1003ee00(m_unk22c, 0x1d);
+	FUN_1003ee00(m_unk22c, 0x1e);
+	FUN_1003ee00(m_unk22c, 0x1f);
+	AnimationManager()->FUN_1005f6d0(TRUE);
+	ControlManager()->Unregister(this);
 }
-

--- a/LEGO1/helicopter.h
+++ b/LEGO1/helicopter.h
@@ -7,43 +7,42 @@
 
 // VTABLE 0x100d40f8
 // SIZE 0x230
-class Helicopter : public IslePathActor
-{
+class Helicopter : public IslePathActor {
 public:
-  Helicopter();
+	Helicopter();
 
-  // OFFSET: LEGO1 0x10003070
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0130
-    return "Helicopter";
-  }
+	// OFFSET: LEGO1 0x10003070
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0130
+		return "Helicopter";
+	}
 
-  // OFFSET: LEGO1 0x10003080
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Helicopter::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10003080
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Helicopter::ClassName()) || IslePathActor::IsA(name);
+	}
 
-  virtual MxResult InitFromMxDSObject(MxDSObject &p_dsObject) override; // vtable+0x18
-  virtual void VTable0xe4() override;
+	virtual MxResult InitFromMxDSObject(MxDSObject& p_dsObject) override; // vtable+0x18
+	virtual void VTable0xe4() override;
 
-  // OFFSET: LEGO1 0x10003210 TEMPLATE
-  // Helicopter::`scalar deleting destructor'
-  virtual ~Helicopter() override; // vtable+0x0
+	// OFFSET: LEGO1 0x10003210 TEMPLATE
+	// Helicopter::`scalar deleting destructor'
+	virtual ~Helicopter() override; // vtable+0x0
 
 protected:
-  MxMatrixData m_unk160;
-  MxMatrixData m_unk1a8;
-  undefined4 m_unk1f0;
-  MxVector4Data m_unk1f4;
-  MxVector4Data m_unk20c;
-  undefined4 m_unk224;
-  HelicopterState *m_state;
-  MxAtomId m_unk22c;
+	MxMatrixData m_unk160;
+	MxMatrixData m_unk1a8;
+	undefined4 m_unk1f0;
+	MxVector4Data m_unk1f4;
+	MxVector4Data m_unk20c;
+	undefined4 m_unk224;
+	HelicopterState* m_state;
+	MxAtomId m_unk22c;
 
 private:
-  void GetState();
+	void GetState();
 };
 
 #endif // HELICOPTER_H

--- a/LEGO1/helicopterstate.h
+++ b/LEGO1/helicopterstate.h
@@ -6,25 +6,25 @@
 
 // VTABLE 0x100d5418
 // SIZE 0xc
-class HelicopterState : public LegoState
-{
+class HelicopterState : public LegoState {
 public:
-  // OFFSET: LEGO1 0x1000e0d0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0144
-    return "HelicopterState";
-  }
+	// OFFSET: LEGO1 0x1000e0d0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0144
+		return "HelicopterState";
+	}
 
-  // OFFSET: LEGO1 0x1000e0e0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, HelicopterState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000e0e0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, HelicopterState::ClassName()) || LegoState::IsA(name);
+	}
 
-  inline void SetUnknown8(undefined4 p_unk8) { m_unk8 = p_unk8; }
-  protected:
-    undefined4 m_unk8;
+	inline void SetUnknown8(undefined4 p_unk8) { m_unk8 = p_unk8; }
+
+protected:
+	undefined4 m_unk8;
 };
 
 #endif // HELICOPTERSTATE_H

--- a/LEGO1/historybook.cpp
+++ b/LEGO1/historybook.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x100822f0 STUB
 HistoryBook::HistoryBook()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100824d0 STUB
 HistoryBook::~HistoryBook()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10082680 STUB
-MxLong HistoryBook::Notify(MxParam &p)
+MxLong HistoryBook::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/historybook.h
+++ b/LEGO1/historybook.h
@@ -5,26 +5,25 @@
 
 // VTABLE 0x100da328
 // SIZE 0x3e4
-class HistoryBook : public LegoWorld
-{
+class HistoryBook : public LegoWorld {
 public:
-  HistoryBook();
-  virtual ~HistoryBook() override; // vtable+0x0
+	HistoryBook();
+	virtual ~HistoryBook() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x10082390
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f04bc
-    return "HistoryBook";
-  }
+	// OFFSET: LEGO1 0x10082390
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f04bc
+		return "HistoryBook";
+	}
 
-  // OFFSET: LEGO1 0x100823a0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, HistoryBook::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100823a0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, HistoryBook::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // HISTORYBOOK_H

--- a/LEGO1/hospital.cpp
+++ b/LEGO1/hospital.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x100745e0 STUB
 Hospital::Hospital()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100747f0 STUB
 Hospital::~Hospital()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10074990 STUB
-MxLong Hospital::Notify(MxParam &p)
+MxLong Hospital::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/hospital.h
+++ b/LEGO1/hospital.h
@@ -5,27 +5,25 @@
 
 // VTABLE 0x100d9730
 // SIZE 0x12c
-class Hospital : public LegoWorld
-{
+class Hospital : public LegoWorld {
 public:
-  Hospital();
-  virtual ~Hospital() override; // vtable+0x0
-  
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x04
+	Hospital();
+	virtual ~Hospital() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x100746b0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0490
-    return "Hospital";
-  }
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x04
 
-  // OFFSET: LEGO1 0x100746c0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Hospital::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100746b0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0490
+		return "Hospital";
+	}
 
+	// OFFSET: LEGO1 0x100746c0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Hospital::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // HOSPITAL_H

--- a/LEGO1/hospitalentity.h
+++ b/LEGO1/hospitalentity.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d5068
 // SIZE 0x68
-class HospitalEntity : public BuildingEntity
-{
+class HospitalEntity : public BuildingEntity {
 public:
-  // OFFSET: LEGO1 0x1000ec40
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0338
-    return "HospitalEntity";
-  }
+	// OFFSET: LEGO1 0x1000ec40
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0338
+		return "HospitalEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000ec50
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, HospitalEntity::ClassName()) || BuildingEntity::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1000ec50
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, HospitalEntity::ClassName()) || BuildingEntity::IsA(name);
+	}
 };
 
 #endif // HOSPITALENTITY_H

--- a/LEGO1/hospitalstate.cpp
+++ b/LEGO1/hospitalstate.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x10076370 STUB
 HospitalState::HospitalState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/hospitalstate.h
+++ b/LEGO1/hospitalstate.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d97a0
 // SIZE 0x18
-class HospitalState : public LegoState
-{
+class HospitalState : public LegoState {
 public:
-  HospitalState();
+	HospitalState();
 
-  // OFFSET: LEGO1 0x10076400
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0480
-    return "HospitalState";
-  }
+	// OFFSET: LEGO1 0x10076400
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0480
+		return "HospitalState";
+	}
 
-  // OFFSET: LEGO1 0x10076410
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, HospitalState::ClassName()) || LegoState::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10076410
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, HospitalState::ClassName()) || LegoState::IsA(name);
+	}
 };
 
 #endif // HOSPITALSTATE_H

--- a/LEGO1/infocenter.cpp
+++ b/LEGO1/infocenter.cpp
@@ -3,27 +3,27 @@
 // OFFSET: LEGO1 0x1006ea20 STUB
 Infocenter::Infocenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1006ec90 STUB
 Infocenter::~Infocenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1006ef10 STUB
-MxLong Infocenter::Notify(MxParam &p)
+MxLong Infocenter::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10070af0 STUB
 MxResult Infocenter::Tickle()
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/infocenter.h
+++ b/LEGO1/infocenter.h
@@ -5,28 +5,26 @@
 
 // VTABLE 0x100d9338
 // SIZE 0x1d8
-class Infocenter : public LegoWorld
-{
+class Infocenter : public LegoWorld {
 public:
-  Infocenter();
-  virtual ~Infocenter() override;
+	Infocenter();
+	virtual ~Infocenter() override;
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-  virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
+	virtual MxResult Tickle() override;         // vtable+0x8
 
-  // OFFSET: LEGO1 0x1006eb40
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f04ec
-    return "Infocenter";
-  }
+	// OFFSET: LEGO1 0x1006eb40
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f04ec
+		return "Infocenter";
+	}
 
-  // OFFSET: LEGO1 0x1006eb50
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Infocenter::ClassName()) || LegoWorld::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1006eb50
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Infocenter::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // INFOCENTER_H

--- a/LEGO1/infocenterdoor.cpp
+++ b/LEGO1/infocenterdoor.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x10037730 STUB
 InfocenterDoor::InfocenterDoor()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100378f0 STUB
 InfocenterDoor::~InfocenterDoor()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100379e0 STUB
-MxLong InfocenterDoor::Notify(MxParam &p)
+MxLong InfocenterDoor::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/infocenterdoor.h
+++ b/LEGO1/infocenterdoor.h
@@ -5,27 +5,25 @@
 
 // VTABLE 0x100d72d8
 // SIZE 0xfc
-class InfocenterDoor : public LegoWorld
-{
+class InfocenterDoor : public LegoWorld {
 public:
-  InfocenterDoor();
-  virtual ~InfocenterDoor(); // vtable+0x0
-  
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	InfocenterDoor();
+	virtual ~InfocenterDoor(); // vtable+0x0
 
-  // OFFSET: LEGO1 0x100377b0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f049c
-    return "InfocenterDoor";
-  }
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x100377c0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, InfocenterDoor::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100377b0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f049c
+		return "InfocenterDoor";
+	}
 
+	// OFFSET: LEGO1 0x100377c0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, InfocenterDoor::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // INFOCENTERDOOR_H

--- a/LEGO1/infocenterentity.h
+++ b/LEGO1/infocenterentity.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d4b90
 // SIZE 0x68
-class InfoCenterEntity : public BuildingEntity
-{
+class InfoCenterEntity : public BuildingEntity {
 public:
-  // OFFSET: LEGO1 0x1000ea00
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f035c
-    return "InfoCenterEntity";
-  }
+	// OFFSET: LEGO1 0x1000ea00
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f035c
+		return "InfoCenterEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000ea10
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, InfoCenterEntity::ClassName()) || BuildingEntity::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1000ea10
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, InfoCenterEntity::ClassName()) || BuildingEntity::IsA(name);
+	}
 };
 
 #endif // INFOCENTERENTITY_H

--- a/LEGO1/infocenterstate.cpp
+++ b/LEGO1/infocenterstate.cpp
@@ -5,12 +5,11 @@ DECOMP_SIZE_ASSERT(InfocenterState, 0x94);
 // OFFSET: LEGO1 0x10071600 STUB
 InfocenterState::InfocenterState()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10071920 STUB
 InfocenterState::~InfocenterState()
 {
-  // TODO
+	// TODO
 }
-

--- a/LEGO1/infocenterstate.h
+++ b/LEGO1/infocenterstate.h
@@ -1,64 +1,62 @@
 #ifndef INFOCENTERSTATE_H
 #define INFOCENTERSTATE_H
 
-#include "legostate.h"
-
 #include "decomp.h"
+#include "legostate.h"
 
 // VTABLE 0x100d93a8
 // SIZE 0x94
-class InfocenterState : public LegoState
-{
+class InfocenterState : public LegoState {
 public:
-  InfocenterState();
-  virtual ~InfocenterState();
+	InfocenterState();
+	virtual ~InfocenterState();
 
-  // OFFSET: LEGO1 0x10071840
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f04dc
-    return "InfocenterState";
-  }
+	// OFFSET: LEGO1 0x10071840
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f04dc
+		return "InfocenterState";
+	}
 
-  // OFFSET: LEGO1 0x10071850
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, InfocenterState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10071850
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, InfocenterState::ClassName()) || LegoState::IsA(name);
+	}
 
-  inline MxU32 GetInfocenterBufferElement(MxS32 p_index) { return m_buffer[p_index]; }
+	inline MxU32 GetInfocenterBufferElement(MxS32 p_index) { return m_buffer[p_index]; }
 
 private:
-  // Members should be renamed with their offsets before use
-  /*
-    struct UnkStruct
-    {
-      undefined4 unk1;
-      undefined2 unk2;
-      undefined2 unk3;
-      undefined2 unk4;
-    };
+	// Members should be renamed with their offsets before use
+	/*
+	  struct UnkStruct
+	  {
+		undefined4 unk1;
+		undefined2 unk2;
+		undefined2 unk3;
+		undefined2 unk4;
+	  };
 
-    undefined2 unk1;
-    undefined2 unk2;
-    undefined4 unk3;
-    undefined4 padding1;
-    void *unk4;
-    undefined2 unk5;
-    undefined2 unk6;
-    undefined2 unk7;
-    undefined2 padding2;
-    void *unk8;
-    undefined2 unk9;
-    undefined2 unk10;
-    undefined2 unk11;
-    undefined2 padding3;
-    UnkStruct unk12[6];
-    undefined4 unk13;
-  */
+	  undefined2 unk1;
+	  undefined2 unk2;
+	  undefined4 unk3;
+	  undefined4 padding1;
+	  void *unk4;
+	  undefined2 unk5;
+	  undefined2 unk6;
+	  undefined2 unk7;
+	  undefined2 padding2;
+	  void *unk8;
+	  undefined2 unk9;
+	  undefined2 unk10;
+	  undefined2 unk11;
+	  undefined2 padding3;
+	  UnkStruct unk12[6];
+	  undefined4 unk13;
+	*/
 
-  undefined pad[0x70];
-  MxU32 m_buffer[7]; // 0x78
+	undefined pad[0x70];
+	MxU32 m_buffer[7]; // 0x78
 };
 
 #endif // INFOCENTERSTATE_H

--- a/LEGO1/isle.cpp
+++ b/LEGO1/isle.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x10030820 STUB
 Isle::Isle()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/isle.h
+++ b/LEGO1/isle.h
@@ -6,23 +6,22 @@
 // VTABLE 0x100d6fb8
 // SIZE 0x140
 // Radio at 0x12c
-class Isle : public LegoWorld
-{
+class Isle : public LegoWorld {
 public:
-  Isle();
+	Isle();
 
-  // OFFSET: LEGO1 0x10030910
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0458
-    return "Isle";
-  }
+	// OFFSET: LEGO1 0x10030910
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0458
+		return "Isle";
+	}
 
-  // OFFSET: LEGO1 0x10030920
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Isle::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10030920
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Isle::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // ISLE_H

--- a/LEGO1/isleactor.h
+++ b/LEGO1/isleactor.h
@@ -4,21 +4,20 @@
 #include "legoactor.h"
 
 // VTABLE 0x100d5178
-class IsleActor : public LegoActor
-{
+class IsleActor : public LegoActor {
 public:
-  // OFFSET: LEGO1 0x1000e660
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f07dc
-    return "IsleActor";
-  }
+	// OFFSET: LEGO1 0x1000e660
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f07dc
+		return "IsleActor";
+	}
 
-  // OFFSET: LEGO1 0x1000e670
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, IsleActor::ClassName()) || LegoActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000e670
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, IsleActor::ClassName()) || LegoActor::IsA(name);
+	}
 };
 
 #endif // ISLEACTOR_H

--- a/LEGO1/islepathactor.cpp
+++ b/LEGO1/islepathactor.cpp
@@ -6,68 +6,69 @@ DECOMP_SIZE_ASSERT(IslePathActor, 0x160)
 // OFFSET: LEGO1 0x10002df0 STUB
 void IslePathActor::VTable0xd0()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002e00 STUB
 void IslePathActor::VTable0xdc()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002e70 STUB
 void IslePathActor::VTable0xcc()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002e80 STUB
 void IslePathActor::VTable0xd4()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002e90 STUB
 void IslePathActor::VTable0xd8()
 {
-  // TODO
+	// TODO
 }
 // End header
 
 // OFFSET: LEGO1 0x1001a200
 IslePathActor::IslePathActor()
 {
-  this->m_pLegoWorld = NULL;
-  this->m_unk13c = 6.0;
-  this->m_unk15c = 1.0;
-  this->m_unk158 = 0;
+	this->m_pLegoWorld = NULL;
+	this->m_unk13c = 6.0;
+	this->m_unk15c = 1.0;
+	this->m_unk158 = 0;
 }
 
 // OFFSET: LEGO1 0x1001a280
-MxResult IslePathActor::InitFromMxDSObject(MxDSObject &p_dsObject) {
-  return MxEntity::InitFromMxDSObject(p_dsObject);
+MxResult IslePathActor::InitFromMxDSObject(MxDSObject& p_dsObject)
+{
+	return MxEntity::InitFromMxDSObject(p_dsObject);
 }
 
 // OFFSET: LEGO1 0x1001a350 STUB
 void IslePathActor::VTable0xe0()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1001a3f0 STUB
 void IslePathActor::VTable0xe4()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1001b2a0 STUB
 void IslePathActor::VTable0xe8(MxU32 p_1, MxBool p_2, MxU8 p_3)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1001b5b0 STUB
 void IslePathActor::VTable0xec()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/islepathactor.h
+++ b/LEGO1/islepathactor.h
@@ -7,49 +7,45 @@
 
 // VTABLE 0x100d4398
 // SIZE 0x160
-class IslePathActor : public LegoPathActor
-{
-public: 
-  IslePathActor();
+class IslePathActor : public LegoPathActor {
+public:
+	IslePathActor();
 
-  // OFFSET: LEGO1 0x10002ea0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0104
-    return "IslePathActor";
-  }
+	// OFFSET: LEGO1 0x10002ea0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0104
+		return "IslePathActor";
+	}
 
-  // OFFSET: LEGO1 0x10002eb0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, IslePathActor::ClassName()) || LegoPathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10002eb0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, IslePathActor::ClassName()) || LegoPathActor::IsA(name);
+	}
 
-  // OFFSET: LEGO1 0x10002ff0 TEMPLATE
-  // IslePathActor::`scalar deleting destructor'
-  inline virtual ~IslePathActor() override
-  {
-    IslePathActor::Destroy(TRUE);
-  }
+	// OFFSET: LEGO1 0x10002ff0 TEMPLATE
+	// IslePathActor::`scalar deleting destructor'
+	inline virtual ~IslePathActor() override { IslePathActor::Destroy(TRUE); }
 
-  virtual MxResult InitFromMxDSObject(MxDSObject &p_dsObject) override; // vtable+0x18
-  virtual void VTable0xcc(); // vtable+0xcc
-  virtual void VTable0xd0(); // vtable+0xd0
-  virtual void VTable0xd4(); // vtable+0xd4
-  virtual void VTable0xd8(); // vtable+0xd8
-  virtual void VTable0xdc(); // vtable+0xdc
-  virtual void VTable0xe0(); // vtable+0xe0
-  virtual void VTable0xe4(); // vtable+0xe4
-  virtual void VTable0xe8(MxU32 p_1, MxBool p_2, MxU8 p_3); // vtable+0xe8
-  virtual void VTable0xec(); // vtable+0xec
-  
-  inline void SetWorld(LegoWorld *p_world) { m_pLegoWorld = p_world; }
-  inline LegoWorld *GetWorld() { return m_pLegoWorld; }
-  
+	virtual MxResult InitFromMxDSObject(MxDSObject& p_dsObject) override; // vtable+0x18
+	virtual void VTable0xcc();                                            // vtable+0xcc
+	virtual void VTable0xd0();                                            // vtable+0xd0
+	virtual void VTable0xd4();                                            // vtable+0xd4
+	virtual void VTable0xd8();                                            // vtable+0xd8
+	virtual void VTable0xdc();                                            // vtable+0xdc
+	virtual void VTable0xe0();                                            // vtable+0xe0
+	virtual void VTable0xe4();                                            // vtable+0xe4
+	virtual void VTable0xe8(MxU32 p_1, MxBool p_2, MxU8 p_3);             // vtable+0xe8
+	virtual void VTable0xec();                                            // vtable+0xec
+
+	inline void SetWorld(LegoWorld* p_world) { m_pLegoWorld = p_world; }
+	inline LegoWorld* GetWorld() { return m_pLegoWorld; }
+
 private:
-  LegoWorld *m_pLegoWorld; // 0x154
-  MxFloat m_unk158;
-  MxFloat m_unk15c;
+	LegoWorld* m_pLegoWorld; // 0x154
+	MxFloat m_unk158;
+	MxFloat m_unk15c;
 };
 
 #endif // ISLEPATHACTOR_H

--- a/LEGO1/jetski.cpp
+++ b/LEGO1/jetski.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(Jetski, 0x164);
 // OFFSET: LEGO1 0x1007e3b0
 Jetski::Jetski()
 {
-  this->m_unk13c = 25.0;
-  this->m_unk150 = 2.0;
-  this->m_unk148 = 1;
+	this->m_unk13c = 25.0;
+	this->m_unk150 = 2.0;
+	this->m_unk148 = 1;
 }

--- a/LEGO1/jetski.h
+++ b/LEGO1/jetski.h
@@ -6,27 +6,26 @@
 
 // VTABLE 0x100d9ec8
 // SIZE 0x164
-class Jetski : public IslePathActor
-{
+class Jetski : public IslePathActor {
 public:
-  Jetski();
+	Jetski();
 
-  // OFFSET: LEGO1 0x1007e430
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03d8
-    return "Jetski";
-  }
+	// OFFSET: LEGO1 0x1007e430
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03d8
+		return "Jetski";
+	}
 
-  // OFFSET: LEGO1 0x1007e440
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Jetski::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1007e440
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Jetski::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  // TODO: Jetski fields
-  undefined m_unk160[4];
+	// TODO: Jetski fields
+	undefined m_unk160[4];
 };
-
 
 #endif // JETSKI_H

--- a/LEGO1/jetskirace.h
+++ b/LEGO1/jetskirace.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d4fe8
 // SIZE 0x144
-class JetskiRace : public LegoRace
-{
+class JetskiRace : public LegoRace {
 public:
+	// OFFSET: LEGO1 0x1000daf0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0530
+		return "JetskiRace";
+	}
 
-  // OFFSET: LEGO1 0x1000daf0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0530
-    return "JetskiRace";
-  }
-
-  // OFFSET: LEGO1 0x1000db00
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, JetskiRace::ClassName()) || LegoRace::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000db00
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, JetskiRace::ClassName()) || LegoRace::IsA(name);
+	}
 };
 
 #endif // JETSKIRACE_H

--- a/LEGO1/jetskiracestate.h
+++ b/LEGO1/jetskiracestate.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d4fa8
 // SIZE 0x2c
-class JetskiRaceState : public RaceState
-{
+class JetskiRaceState : public RaceState {
 public:
-  // OFFSET: LEGO1 0x1000dc40
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f00ac
-    return "JetskiRaceState";
-  }
+	// OFFSET: LEGO1 0x1000dc40
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f00ac
+		return "JetskiRaceState";
+	}
 
-  // OFFSET: LEGO1 0x1000dc50
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, JetskiRaceState::ClassName()) || RaceState::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1000dc50
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, JetskiRaceState::ClassName()) || RaceState::IsA(name);
+	}
 };
 
 #endif // JETSKIRACESTATE_H

--- a/LEGO1/jukebox.cpp
+++ b/LEGO1/jukebox.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1005d660 STUB
 JukeBox::JukeBox()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/jukebox.h
+++ b/LEGO1/jukebox.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d8958
 // SIZE 0x104
-class JukeBox : public LegoWorld
-{
+class JukeBox : public LegoWorld {
 public:
-  JukeBox();
+	JukeBox();
 
-  // OFFSET: LEGO1 0x1005d6f0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f02cc
-    return "JukeBox";
-  }
+	// OFFSET: LEGO1 0x1005d6f0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f02cc
+		return "JukeBox";
+	}
 
-  // OFFSET: LEGO1 0x1005d700
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, JukeBox::ClassName()) || LegoWorld::IsA(name);
-  }
-  
+	// OFFSET: LEGO1 0x1005d700
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, JukeBox::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // JUKEBOX_H

--- a/LEGO1/jukeboxentity.cpp
+++ b/LEGO1/jukeboxentity.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x10085bc0 STUB
 JukeBoxEntity::JukeBoxEntity()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10085dd0 STUB
 JukeBoxEntity::~JukeBoxEntity()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/jukeboxentity.h
+++ b/LEGO1/jukeboxentity.h
@@ -5,25 +5,23 @@
 
 // VTABLE 0x100da8a0
 // SIZE 0x6c
-class JukeBoxEntity : public LegoEntity
-{
+class JukeBoxEntity : public LegoEntity {
 public:
-  JukeBoxEntity();
-  virtual ~JukeBoxEntity() override; // vtable+0x0
+	JukeBoxEntity();
+	virtual ~JukeBoxEntity() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10085cc0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f02f0
-    return "JukeBoxEntity";
-  }
+	// OFFSET: LEGO1 0x10085cc0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f02f0
+		return "JukeBoxEntity";
+	}
 
-  // OFFSET: LEGO1 0x10085cd0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, JukeBoxEntity::ClassName()) || LegoEntity::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10085cd0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, JukeBoxEntity::ClassName()) || LegoEntity::IsA(name);
+	}
 };
 
 #endif // JUKEBOXENTITY_H

--- a/LEGO1/jukeboxstate.cpp
+++ b/LEGO1/jukeboxstate.cpp
@@ -1,6 +1,7 @@
 #include "jukeboxstate.h"
 
 // OFFSET: LEGO1 0x1000f300
-MxBool JukeBoxState::VTable0x14() {
-  return FALSE;
+MxBool JukeBoxState::VTable0x14()
+{
+	return FALSE;
 }

--- a/LEGO1/jukeboxstate.h
+++ b/LEGO1/jukeboxstate.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d4a90
 // SIZE 0x10
-class JukeBoxState : public LegoState
-{
+class JukeBoxState : public LegoState {
 public:
-  // OFFSET: LEGO1 0x1000f310
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f02bc
-    return "JukeBoxState";
-  }
+	// OFFSET: LEGO1 0x1000f310
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f02bc
+		return "JukeBoxState";
+	}
 
-  // OFFSET: LEGO1 0x1000f320
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, JukeBoxState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000f320
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, JukeBoxState::ClassName()) || LegoState::IsA(name);
+	}
 
-  virtual MxBool VTable0x14() override; // vtable+0x14
-
+	virtual MxBool VTable0x14() override; // vtable+0x14
 };
 
 #endif // JUKEBOXSTATE_H

--- a/LEGO1/lego3dmanager.h
+++ b/LEGO1/lego3dmanager.h
@@ -3,15 +3,14 @@
 
 #include "lego3dview.h"
 
-class Lego3DManager
-{
+class Lego3DManager {
 public:
-  inline Lego3DView *GetLego3DView() { return this->m_3dView; }
+	inline Lego3DView* GetLego3DView() { return this->m_3dView; }
 
 private:
-  int m_unk00;
-  int m_unk04;
-  Lego3DView *m_3dView;
+	int m_unk00;
+	int m_unk04;
+	Lego3DView* m_3dView;
 };
 
 #endif // LEGO3DMANAGER_H

--- a/LEGO1/lego3dview.h
+++ b/LEGO1/lego3dview.h
@@ -3,14 +3,13 @@
 
 #include "viewmanager.h"
 
-class Lego3DView
-{
+class Lego3DView {
 public:
-  inline ViewManager *GetViewManager() { return this->m_viewManager; }
+	inline ViewManager* GetViewManager() { return this->m_viewManager; }
 
 private:
-  char unknown[0x88];
-  ViewManager *m_viewManager;
+	char unknown[0x88];
+	ViewManager* m_viewManager;
 };
 
 #endif // LEGO3DVIEW_H

--- a/LEGO1/lego3dwavepresenter.h
+++ b/LEGO1/lego3dwavepresenter.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d52b0
 // SIZE 0xa0
-class Lego3DWavePresenter : public LegoWavePresenter
-{
+class Lego3DWavePresenter : public LegoWavePresenter {
 public:
-  // OFFSET: LEGO1 0x1000d890
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f058c
-    return "Lego3DWavePresenter";
-  }
+	// OFFSET: LEGO1 0x1000d890
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f058c
+		return "Lego3DWavePresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000d8a0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Lego3DWavePresenter::ClassName()) || MxWavePresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000d8a0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Lego3DWavePresenter::ClassName()) || MxWavePresenter::IsA(name);
+	}
 };
 
 #endif // LEGO3DWAVEPRESENTER_H

--- a/LEGO1/legoact2state.h
+++ b/LEGO1/legoact2state.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d4a70
 // SIZE 0x10
-class LegoAct2State : public LegoState
-{
+class LegoAct2State : public LegoState {
 public:
-  // OFFSET: LEGO1 0x1000df80
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0428
-    return "LegoAct2State";
-  }
+	// OFFSET: LEGO1 0x1000df80
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0428
+		return "LegoAct2State";
+	}
 
-  // OFFSET: LEGO1 0x1000df90
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoAct2State::ClassName()) || LegoState::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1000df90
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoAct2State::ClassName()) || LegoState::IsA(name);
+	}
 };
 
 #endif // LEGOACT2STATE_H

--- a/LEGO1/legoactioncontrolpresenter.h
+++ b/LEGO1/legoactioncontrolpresenter.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d5118
 // SIZE 0x68
-class LegoActionControlPresenter : public MxMediaPresenter
-{
+class LegoActionControlPresenter : public MxMediaPresenter {
 public:
-  // OFFSET: LEGO1 0x1000d0e0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f05bc
-    return "LegoActionControlPresenter";
-  }
+	// OFFSET: LEGO1 0x1000d0e0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f05bc
+		return "LegoActionControlPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000d0f0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoActionControlPresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000d0f0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoActionControlPresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOACTIONCONTROLPRESENTER_H

--- a/LEGO1/legoactor.cpp
+++ b/LEGO1/legoactor.cpp
@@ -6,37 +6,37 @@ DECOMP_SIZE_ASSERT(LegoActor, 0x78)
 // OFFSET: LEGO1 0x10002cc0 STUB
 void LegoActor::VTable0x50()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002cd0 STUB
 void LegoActor::VTable0x54()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002ce0 STUB
 void LegoActor::VTable0x58()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002cf0 STUB
 void LegoActor::VTable0x5c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d00 STUB
 void LegoActor::VTable0x60()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d10 STUB
 void LegoActor::VTable0x64()
 {
-  // TODO
+	// TODO
 }
 // End header
 

--- a/LEGO1/legoactor.h
+++ b/LEGO1/legoactor.h
@@ -6,34 +6,32 @@
 
 // VTABLE 0x100d6d68
 // SIZE 0x78
-class LegoActor : public LegoEntity
-{
+class LegoActor : public LegoEntity {
 public:
-  LegoActor();
+	LegoActor();
 
-  // OFFSET: LEGO1 0x1002d210
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0124
-    return "LegoActor";
-  }
+	// OFFSET: LEGO1 0x1002d210
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0124
+		return "LegoActor";
+	}
 
-  // OFFSET: LEGO1 0x1002d220
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoActor::ClassName()) || LegoEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1002d220
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoActor::ClassName()) || LegoEntity::IsA(name);
+	}
 
-  virtual void VTable0x50(); // vtable+0x50
-  virtual void VTable0x54(); // vtable+0x54
-  virtual void VTable0x58(); // vtable+0x58
-  virtual void VTable0x5c(); // vtable+0x5c
-  virtual void VTable0x60(); // vtable+0x60
-  virtual void VTable0x64(); // vtable+0x64
+	virtual void VTable0x50(); // vtable+0x50
+	virtual void VTable0x54(); // vtable+0x54
+	virtual void VTable0x58(); // vtable+0x58
+	virtual void VTable0x5c(); // vtable+0x5c
+	virtual void VTable0x60(); // vtable+0x60
+	virtual void VTable0x64(); // vtable+0x64
 
 private:
-  undefined unk68[0x10];
-
+	undefined unk68[0x10];
 };
 
 #endif // LEGOACTOR_H

--- a/LEGO1/legoactorpresenter.h
+++ b/LEGO1/legoactorpresenter.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d5320
 // SIZE 0x50
-class LegoActorPresenter : public LegoEntityPresenter
-{
+class LegoActorPresenter : public LegoEntityPresenter {
 public:
-  // OFFSET: LEGO1 0x1000cb10
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f06a4
-    return "LegoActorPresenter";
-  }
+	// OFFSET: LEGO1 0x1000cb10
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f06a4
+		return "LegoActorPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000cb20
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoActorPresenter::ClassName()) || LegoEntityPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000cb20
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoActorPresenter::ClassName()) || LegoEntityPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOACTORPRESENTER_H

--- a/LEGO1/legoanimactor.h
+++ b/LEGO1/legoanimactor.h
@@ -3,8 +3,7 @@
 
 #include "legopathactor.h"
 
-class LegoAnimActor : public LegoPathActor
-{
+class LegoAnimActor : public LegoPathActor {
 public:
 };
 

--- a/LEGO1/legoanimationmanager.cpp
+++ b/LEGO1/legoanimationmanager.cpp
@@ -6,45 +6,45 @@ int g_legoAnimationManagerConfig = 1;
 // OFFSET: LEGO1 0x1005eb50
 void LegoAnimationManager::configureLegoAnimationManager(int param_1)
 {
-  g_legoAnimationManagerConfig = param_1;
+	g_legoAnimationManagerConfig = param_1;
 }
 
 // OFFSET: LEGO1 0x1005eb60 STUB
 LegoAnimationManager::LegoAnimationManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005ed30 STUB
 LegoAnimationManager::~LegoAnimationManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005f130 STUB
 void LegoAnimationManager::Init()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005f6d0 STUB
 void LegoAnimationManager::FUN_1005f6d0(MxBool p)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100619f0 STUB
-MxLong LegoAnimationManager::Notify(MxParam &p)
+MxLong LegoAnimationManager::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10061cc0 STUB
 MxResult LegoAnimationManager::Tickle()
 {
-  // TODO
+	// TODO
 
-  return SUCCESS;
+	return SUCCESS;
 }

--- a/LEGO1/legoanimationmanager.h
+++ b/LEGO1/legoanimationmanager.h
@@ -5,35 +5,33 @@
 
 // VTABLE 0x100d8c18
 // SIZE 0x500
-class LegoAnimationManager : public MxCore
-{
+class LegoAnimationManager : public MxCore {
 public:
-  LegoAnimationManager();
-  virtual ~LegoAnimationManager() override; // vtable+0x0
+	LegoAnimationManager();
+	virtual ~LegoAnimationManager() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-  virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
+	virtual MxResult Tickle() override;         // vtable+0x8
 
-  // OFFSET: LEGO1 0x1005ec80
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f7508
-    return "LegoAnimationManager";
-  }
+	// OFFSET: LEGO1 0x1005ec80
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f7508
+		return "LegoAnimationManager";
+	}
 
-  // OFFSET: LEGO1 0x1005ec90
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1005ec90
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || MxCore::IsA(name);
+	}
 
-  void FUN_1005f6d0(MxBool p);
+	void FUN_1005f6d0(MxBool p);
 
-  __declspec(dllexport) static void configureLegoAnimationManager(int param_1);
-  
+	__declspec(dllexport) static void configureLegoAnimationManager(int param_1);
+
 private:
-  void Init();
-
+	void Init();
 };
 
 #endif // LEGOANIMATIONMANAGER_H

--- a/LEGO1/legoanimmmpresenter.cpp
+++ b/LEGO1/legoanimmmpresenter.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1004a8d0 STUB
 LegoAnimMMPresenter::LegoAnimMMPresenter()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoanimmmpresenter.h
+++ b/LEGO1/legoanimmmpresenter.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d7de8
 // SIZE 0x74
-class LegoAnimMMPresenter : public MxCompositePresenter
-{
+class LegoAnimMMPresenter : public MxCompositePresenter {
 public:
-  LegoAnimMMPresenter();
+	LegoAnimMMPresenter();
 
-  // OFFSET: LEGO1 0x1004a950
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f046c
-    return "LegoAnimMMPresenter";
-  }
+	// OFFSET: LEGO1 0x1004a950
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f046c
+		return "LegoAnimMMPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1004a960
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoAnimMMPresenter::ClassName()) || MxCompositePresenter::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1004a960
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoAnimMMPresenter::ClassName()) || MxCompositePresenter::IsA(name);
+	}
 };
 
 #endif // LEGOANIMMMPRESENTER_H

--- a/LEGO1/legoanimpresenter.cpp
+++ b/LEGO1/legoanimpresenter.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x10068420 STUB
 LegoAnimPresenter::LegoAnimPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100686f0 STUB
 void LegoAnimPresenter::Init()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoanimpresenter.h
+++ b/LEGO1/legoanimpresenter.h
@@ -4,27 +4,25 @@
 #include "mxvideopresenter.h"
 
 // VTABLE 0x100d90c8
-class LegoAnimPresenter : public MxVideoPresenter
-{
+class LegoAnimPresenter : public MxVideoPresenter {
 public:
-  LegoAnimPresenter();
+	LegoAnimPresenter();
 
-  // OFFSET: LEGO1 0x10068530
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f071c
-    return "LegoAnimPresenter";
-  }
+	// OFFSET: LEGO1 0x10068530
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f071c
+		return "LegoAnimPresenter";
+	}
 
-  // OFFSET: LEGO1 0x10068540
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoAnimPresenter::ClassName()) || MxVideoPresenter::IsA(name);
-  }
-  
+	// OFFSET: LEGO1 0x10068540
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoAnimPresenter::ClassName()) || MxVideoPresenter::IsA(name);
+	}
+
 private:
-  void Init();
-
+	void Init();
 };
 
 #endif // LEGOANIMPRESENTER_H

--- a/LEGO1/legobackgroundcolor.cpp
+++ b/LEGO1/legobackgroundcolor.cpp
@@ -1,56 +1,56 @@
 #include "legobackgroundcolor.h"
 
+#include "decomp.h"
 #include "legoomni.h"
 #include "legoutil.h"
 #include "legovideomanager.h"
-#include "decomp.h"
 
 DECOMP_SIZE_ASSERT(LegoBackgroundColor, 0x30)
 
-const char *g_delimiter = "\t";
-const char *g_set = "set";
-const char *g_reset = "reset";
+const char* g_delimiter = "\t";
+const char* g_set = "set";
+const char* g_reset = "reset";
 
 // OFFSET: LEGO1 0x1003bfb0
-LegoBackgroundColor::LegoBackgroundColor(const char *p_key, const char *p_value)
+LegoBackgroundColor::LegoBackgroundColor(const char* p_key, const char* p_value)
 {
-  m_key = p_key;
-  m_key.ToUpperCase();
-  SetValue(p_value);
+	m_key = p_key;
+	m_key.ToUpperCase();
+	SetValue(p_value);
 }
 
 // OFFSET: LEGO1 0x1003c070
-void LegoBackgroundColor::SetValue(const char *p_colorString)
+void LegoBackgroundColor::SetValue(const char* p_colorString)
 {
-  m_value = p_colorString;
-  m_value.ToLowerCase();
+	m_value = p_colorString;
+	m_value.ToLowerCase();
 
-  LegoVideoManager *videomanager = VideoManager();
-  if (!videomanager || !p_colorString)
-    return;
+	LegoVideoManager* videomanager = VideoManager();
+	if (!videomanager || !p_colorString)
+		return;
 
-  float converted_r, converted_g, converted_b;
-  char *colorStringCopy = strcpy(new char[strlen(p_colorString) + 1], p_colorString);
-  char *colorStringSplit = strtok(colorStringCopy, g_delimiter);
+	float converted_r, converted_g, converted_b;
+	char* colorStringCopy = strcpy(new char[strlen(p_colorString) + 1], p_colorString);
+	char* colorStringSplit = strtok(colorStringCopy, g_delimiter);
 
-  if (!strcmp(colorStringSplit, g_set)) {
-    colorStringSplit = strtok(0, g_delimiter);
-    if (colorStringSplit)
-      h = (float) (atoi(colorStringSplit) * 0.01);
-    colorStringSplit = strtok(0, g_delimiter);
-    if (colorStringSplit)
-      s = (float) (atoi(colorStringSplit) * 0.01);
-    colorStringSplit = strtok(0, g_delimiter);
-    if (colorStringSplit)
-      v = (float) (atoi(colorStringSplit) * 0.01);
+	if (!strcmp(colorStringSplit, g_set)) {
+		colorStringSplit = strtok(0, g_delimiter);
+		if (colorStringSplit)
+			h = (float) (atoi(colorStringSplit) * 0.01);
+		colorStringSplit = strtok(0, g_delimiter);
+		if (colorStringSplit)
+			s = (float) (atoi(colorStringSplit) * 0.01);
+		colorStringSplit = strtok(0, g_delimiter);
+		if (colorStringSplit)
+			v = (float) (atoi(colorStringSplit) * 0.01);
 
-    ConvertHSVToRGB(this->h, this->s, this->v, &converted_r, &converted_g, &converted_b);
-    videomanager->SetSkyColor(converted_r, converted_g, converted_b);
-  }
-  else if (!strcmp(colorStringSplit, g_reset)) {
-    ConvertHSVToRGB(this->h, this->s, this->v, &converted_r, &converted_g, &converted_b);
-    videomanager->SetSkyColor(converted_r, converted_g, converted_b);
-  }
+		ConvertHSVToRGB(this->h, this->s, this->v, &converted_r, &converted_g, &converted_b);
+		videomanager->SetSkyColor(converted_r, converted_g, converted_b);
+	}
+	else if (!strcmp(colorStringSplit, g_reset)) {
+		ConvertHSVToRGB(this->h, this->s, this->v, &converted_r, &converted_g, &converted_b);
+		videomanager->SetSkyColor(converted_r, converted_g, converted_b);
+	}
 
-  delete[] colorStringCopy;
+	delete[] colorStringCopy;
 }

--- a/LEGO1/legobackgroundcolor.h
+++ b/LEGO1/legobackgroundcolor.h
@@ -5,16 +5,15 @@
 
 // VTABLE 0x100d74a8
 // SIZE 0x30
-class LegoBackgroundColor : public MxVariable
-{
+class LegoBackgroundColor : public MxVariable {
 public:
-  __declspec(dllexport) LegoBackgroundColor(const char *p_key, const char *p_value);
-  virtual void SetValue(const char *p_colorString) override;
+	__declspec(dllexport) LegoBackgroundColor(const char* p_key, const char* p_value);
+	virtual void SetValue(const char* p_colorString) override;
 
 private:
-  float h;
-  float s;
-  float v;
+	float h;
+	float s;
+	float v;
 };
 
 #endif // LEGOBACKGROUNDCOLOR_H

--- a/LEGO1/legobuildingmanager.cpp
+++ b/LEGO1/legobuildingmanager.cpp
@@ -6,23 +6,23 @@ int g_buildingManagerConfig = 1;
 // OFFSET: LEGO1 0x1002f8c0 STUB
 LegoBuildingManager::LegoBuildingManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002f960 STUB
 LegoBuildingManager::~LegoBuildingManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002f9d0 STUB
 void LegoBuildingManager::Init()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002f8b0
 void LegoBuildingManager::configureLegoBuildingManager(int param_1)
 {
-  g_buildingManagerConfig = param_1;
+	g_buildingManagerConfig = param_1;
 }

--- a/LEGO1/legobuildingmanager.h
+++ b/LEGO1/legobuildingmanager.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d6f50
 // SIZE 0x30
-class LegoBuildingManager : public MxCore
-{
+class LegoBuildingManager : public MxCore {
 public:
-  LegoBuildingManager();
-  virtual ~LegoBuildingManager() override;
+	LegoBuildingManager();
+	virtual ~LegoBuildingManager() override;
 
-  // OFFSET: LEGO1 0x1002f930
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f37d0
-    return "LegoBuildingManager";
-  }
+	// OFFSET: LEGO1 0x1002f930
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f37d0
+		return "LegoBuildingManager";
+	}
 
-  __declspec(dllexport) static void configureLegoBuildingManager(int param_1);
+	__declspec(dllexport) static void configureLegoBuildingManager(int param_1);
 
 private:
-  void Init();
-
+	void Init();
 };
 
 #endif // LEGOBUILDINGMANAGER_H

--- a/LEGO1/legocachesound.cpp
+++ b/LEGO1/legocachesound.cpp
@@ -3,17 +3,17 @@
 // OFFSET: LEGO1 0x100064d0
 LegoCacheSound::LegoCacheSound()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x10006630 STUB
 LegoCacheSound::~LegoCacheSound()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100066d0 STUB
 void LegoCacheSound::Init()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legocachesound.h
+++ b/LEGO1/legocachesound.h
@@ -5,27 +5,26 @@
 
 // VTABLE 0x100d4718
 // SIZE 0x88
-class LegoCacheSound : public MxCore
-{
+class LegoCacheSound : public MxCore {
 public:
-  LegoCacheSound();
-  virtual ~LegoCacheSound() override; // vtable+0x0
+	LegoCacheSound();
+	virtual ~LegoCacheSound() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10006580
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f01c4
-    return "LegoCacheSound";
-  }
+	// OFFSET: LEGO1 0x10006580
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f01c4
+		return "LegoCacheSound";
+	}
 
-  // OFFSET: LEGO1 0x10006590
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoCacheSound::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10006590
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoCacheSound::ClassName()) || MxCore::IsA(name);
+	}
 
 private:
-  void Init();
+	void Init();
 };
 
 #endif // LEGOCACHESOUND_H

--- a/LEGO1/legocameracontroller.cpp
+++ b/LEGO1/legocameracontroller.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x10011d50 STUB
 LegoCameraController::LegoCameraController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10011f70 STUB
 LegoCameraController::~LegoCameraController()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legocameracontroller.h
+++ b/LEGO1/legocameracontroller.h
@@ -5,25 +5,23 @@
 
 // VTABLE 0x100d57b0
 // SIZE 0xc8
-class LegoCameraController : public MxCore
-{
+class LegoCameraController : public MxCore {
 public:
-  LegoCameraController();
-  virtual ~LegoCameraController() override; // vtable+0x0
+	LegoCameraController();
+	virtual ~LegoCameraController() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10011ec0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0850
-    return "LegoCameraController";
-  }
+	// OFFSET: LEGO1 0x10011ec0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0850
+		return "LegoCameraController";
+	}
 
-  // OFFSET: LEGO1 0x10011ed0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || MxCore::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10011ed0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || MxCore::IsA(name);
+	}
 };
 
 #endif // LEGOCAMERACONTROLLER_H

--- a/LEGO1/legocarbuild.cpp
+++ b/LEGO1/legocarbuild.cpp
@@ -3,27 +3,27 @@
 // OFFSET: LEGO1 0x100226d0 STUB
 LegoCarBuild::LegoCarBuild()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10022a80 STUB
 LegoCarBuild::~LegoCarBuild()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10024050 STUB
-MxLong LegoCarBuild::Notify(MxParam &p)
+MxLong LegoCarBuild::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100238b0 STUB
 MxResult LegoCarBuild::Tickle()
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/legocarbuild.h
+++ b/LEGO1/legocarbuild.h
@@ -5,27 +5,26 @@
 
 // VTABLE 0x100d6658
 // SIZE 0x34c
-class LegoCarBuild : public LegoWorld
-{
+class LegoCarBuild : public LegoWorld {
 public:
-  LegoCarBuild();
-  virtual ~LegoCarBuild() override;
+	LegoCarBuild();
+	virtual ~LegoCarBuild() override;
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-  virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
+	virtual MxResult Tickle() override;         // vtable+0x8
 
-  // OFFSET: LEGO1 0x10022940
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0504
-    return "LegoCarBuild";
-  }
+	// OFFSET: LEGO1 0x10022940
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0504
+		return "LegoCarBuild";
+	}
 
-  // OFFSET: LEGO1 0x10022950
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoCarBuild::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10022950
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoCarBuild::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // LEGOCARBUILD_H

--- a/LEGO1/legocarbuildanimpresenter.cpp
+++ b/LEGO1/legocarbuildanimpresenter.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x10078400 STUB
 LegoCarBuildAnimPresenter::LegoCarBuildAnimPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10078680 STUB
 LegoCarBuildAnimPresenter::~LegoCarBuildAnimPresenter()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legocarbuildanimpresenter.h
+++ b/LEGO1/legocarbuildanimpresenter.h
@@ -5,24 +5,23 @@
 
 // VTABLE 0x100d99e0
 // SIZE 0x150
-class LegoCarBuildAnimPresenter : public LegoAnimPresenter
-{
+class LegoCarBuildAnimPresenter : public LegoAnimPresenter {
 public:
-  LegoCarBuildAnimPresenter();
-  virtual ~LegoCarBuildAnimPresenter() override; // vtable+0x0
+	LegoCarBuildAnimPresenter();
+	virtual ~LegoCarBuildAnimPresenter() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10078510
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f05ec
-    return "LegoCarBuildAnimPresenter";
-  }
+	// OFFSET: LEGO1 0x10078510
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f05ec
+		return "LegoCarBuildAnimPresenter";
+	}
 
-  // OFFSET: LEGO1 0x10078520
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoCarBuildAnimPresenter::ClassName()) || LegoAnimPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10078520
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoCarBuildAnimPresenter::ClassName()) || LegoAnimPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOCARBUILDANIMPRESENTER_H

--- a/LEGO1/legocarraceactor.h
+++ b/LEGO1/legocarraceactor.h
@@ -4,21 +4,20 @@
 #include "legoraceactor.h"
 
 // VTABLE 0x100da0d8
-class LegoCarRaceActor : public LegoRaceActor
-{
+class LegoCarRaceActor : public LegoRaceActor {
 public:
-  // OFFSET: LEGO1 0x10081650
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0568
-    return "LegoCarRaceActor";
-  }
+	// OFFSET: LEGO1 0x10081650
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0568
+		return "LegoCarRaceActor";
+	}
 
-  // OFFSET: LEGO1 0x10081670
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10081670
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(name);
+	}
 };
 
 #endif // LEGOCARRACEACTOR_H

--- a/LEGO1/legocontrolmanager.cpp
+++ b/LEGO1/legocontrolmanager.cpp
@@ -3,31 +3,31 @@
 // OFFSET: LEGO1 0x10028520 STUB
 LegoControlManager::LegoControlManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10028d60 STUB
 LegoControlManager::~LegoControlManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10029600 STUB
 MxResult LegoControlManager::Tickle()
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10028e10 STUB
-void LegoControlManager::Register(MxCore *p_listener)
+void LegoControlManager::Register(MxCore* p_listener)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10028ea0 STUB
-void LegoControlManager::Unregister(MxCore *p_listener)
+void LegoControlManager::Unregister(MxCore* p_listener)
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legocontrolmanager.h
+++ b/LEGO1/legocontrolmanager.h
@@ -4,29 +4,28 @@
 #include "mxcore.h"
 
 // VTABLE 0x100d6a80
-class LegoControlManager : public MxCore
-{
+class LegoControlManager : public MxCore {
 public:
-  LegoControlManager();
-  virtual ~LegoControlManager() override; // vtable+0x0
+	LegoControlManager();
+	virtual ~LegoControlManager() override; // vtable+0x0
 
-  virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x8
 
-  // OFFSET: LEGO1 0x10028cb0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f31b8
-    return "LegoControlManager";
-  }
+	// OFFSET: LEGO1 0x10028cb0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f31b8
+		return "LegoControlManager";
+	}
 
-  // OFFSET: LEGO1 0x10028cc0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoControlManager::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10028cc0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoControlManager::ClassName()) || MxCore::IsA(name);
+	}
 
-  void Register(MxCore *p_listener);
-  void Unregister(MxCore *p_listener);
+	void Register(MxCore* p_listener);
+	void Unregister(MxCore* p_listener);
 };
 
 #endif // LEGOCONTROLMANAGER_H

--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -1,150 +1,149 @@
 #include "legoentity.h"
 
+#include "define.h"
 #include "legoomni.h"
 #include "legoutil.h"
-#include "define.h"
 
 DECOMP_SIZE_ASSERT(LegoEntity, 0x68)
 
 // OFFSET: LEGO1 0x1000c290
 LegoEntity::~LegoEntity()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100114f0 STUB
-MxLong LegoEntity::Notify(MxParam &p)
+MxLong LegoEntity::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100105f0
 void LegoEntity::Reset()
 {
-  m_vec1.Fill(0);
-  m_vec2.Fill(0);
-  m_unk50 = 0;
-  m_unk54 = 0;
-  m_unk58 = 0;
-  m_actionArgString = NULL;
-  m_unk10 = 0;
-  m_unk11 = 0;
-  m_actionType = ExtraActionType_unknown;
-  m_actionArgNumber = -1;
-  m_unk59 = 4;
+	m_vec1.Fill(0);
+	m_vec2.Fill(0);
+	m_unk50 = 0;
+	m_unk54 = 0;
+	m_unk58 = 0;
+	m_actionArgString = NULL;
+	m_unk10 = 0;
+	m_unk11 = 0;
+	m_actionType = ExtraActionType_unknown;
+	m_actionArgNumber = -1;
+	m_unk59 = 4;
 }
 
 // OFFSET: LEGO1 0x100107e0
-MxResult LegoEntity::InitFromMxDSObject(MxDSObject &p_dsObject)
+MxResult LegoEntity::InitFromMxDSObject(MxDSObject& p_dsObject)
 {
-  m_mxEntityId = p_dsObject.GetObjectId();
-  m_atom = p_dsObject.GetAtomId();
-  AddToCurrentWorld();
-  return SUCCESS;
+	m_mxEntityId = p_dsObject.GetObjectId();
+	m_atom = p_dsObject.GetAtomId();
+	AddToCurrentWorld();
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10010810 STUB
 void LegoEntity::Destroy(MxBool p_fromDestructor)
 {
-  if (m_unk54) {
-    // TODO
-  }
+	if (m_unk54) {
+		// TODO
+	}
 
-  delete[] m_actionArgString;
-  Reset();
+	delete[] m_actionArgString;
+	Reset();
 }
 
 // OFFSET: LEGO1 0x10010880 STUB
 void LegoEntity::AddToCurrentWorld()
 {
-  LegoWorld* world = GetCurrentWorld();
-  if (world != NULL && world != (LegoWorld*)this)
-  {
-    // TODO: world->vtable58(this);
-  }
+	LegoWorld* world = GetCurrentWorld();
+	if (world != NULL && world != (LegoWorld*) this) {
+		// TODO: world->vtable58(this);
+	}
 }
 
 // OFFSET: LEGO1 0x10010e10
-void LegoEntity::ParseAction(char *p_extra)
+void LegoEntity::ParseAction(char* p_extra)
 {
-  char copy[1024];
-  char actionValue[1024];
-  strcpy(copy, p_extra);
+	char copy[1024];
+	char actionValue[1024];
+	strcpy(copy, p_extra);
 
-  if (KeyValueStringParse(actionValue, g_strACTION, copy)) {
-    m_actionType = MatchActionString(strtok(actionValue, g_parseExtraTokens));
+	if (KeyValueStringParse(actionValue, g_strACTION, copy)) {
+		m_actionType = MatchActionString(strtok(actionValue, g_parseExtraTokens));
 
-    if (m_actionType != ExtraActionType_exit) {
-      char *token = strtok(NULL, g_parseExtraTokens);
+		if (m_actionType != ExtraActionType_exit) {
+			char* token = strtok(NULL, g_parseExtraTokens);
 
-      m_actionArgString = new char[strlen(token) + 1];
-      strcpy(m_actionArgString, token);
+			m_actionArgString = new char[strlen(token) + 1];
+			strcpy(m_actionArgString, token);
 
-      if (m_actionType != ExtraActionType_run) {
-        m_actionArgNumber = atoi(strtok(NULL, g_parseExtraTokens));
-      }
-    }
-  }
+			if (m_actionType != ExtraActionType_run) {
+				m_actionArgNumber = atoi(strtok(NULL, g_parseExtraTokens));
+			}
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100108a0 STUB
 void LegoEntity::VTable0x24()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10010790 STUB
 void LegoEntity::VTable0x28()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10010650 STUB
 void LegoEntity::VTable0x2c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10010f10 STUB
 void LegoEntity::VTable0x34()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10011070 STUB
 void LegoEntity::VTable0x38()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10011300 STUB
 void LegoEntity::VTable0x3c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10011360 STUB
 void LegoEntity::VTable0x40()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100113c0 STUB
 void LegoEntity::VTable0x44()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10011420 STUB
 void LegoEntity::VTable0x48()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10011470 STUB
 void LegoEntity::VTable0x4c()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -1,74 +1,73 @@
 #ifndef LEGOENTITY_H
 #define LEGOENTITY_H
 
+#include "decomp.h"
+#include "extra.h"
+#include "mxdsobject.h"
 #include "mxentity.h"
 #include "mxvector.h"
-#include "extra.h"
-#include "decomp.h"
-#include "mxdsobject.h"
 
 // VTABLE 0x100d4858
 // SIZE 0x68 (probably)
-class LegoEntity : public MxEntity
-{
+class LegoEntity : public MxEntity {
 public:
-  // Inlined at 0x100853f7
-  inline LegoEntity()
-  {
-    // TODO
-  }
+	// Inlined at 0x100853f7
+	inline LegoEntity()
+	{
+		// TODO
+	}
 
-  __declspec(dllexport) virtual ~LegoEntity() override; // vtable+0x0
+	__declspec(dllexport) virtual ~LegoEntity() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x1000c2f0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0064
-    return "LegoEntity";
-  }
+	// OFFSET: LEGO1 0x1000c2f0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0064
+		return "LegoEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000c300
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoEntity::ClassName()) || MxEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000c300
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoEntity::ClassName()) || MxEntity::IsA(name);
+	}
 
-  virtual MxResult InitFromMxDSObject(MxDSObject &p_dsObject); // vtable+0x18
-  virtual void Destroy(MxBool p_fromDestructor); // vtable+0x1c
-  virtual void ParseAction(char *); // vtable+0x20
-  virtual void VTable0x24(); // vtable+0x24
-  virtual void VTable0x28(); // vtable+0x28
-  virtual void VTable0x2c(); // vtable+0x2c
-  // OFFSET: LEGO1 0x10001090
-  virtual void VTable0x30(undefined4 p_unk50) { m_unk50 = p_unk50; } // vtable+0x30
-  virtual void VTable0x34(); // vtable+0x34
-  virtual void VTable0x38(); // vtable+0x38
-  virtual void VTable0x3c(); // vtable+0x3c
-  virtual void VTable0x40(); // vtable+0x40
-  virtual void VTable0x44(); // vtable+0x44
-  virtual void VTable0x48(); // vtable+0x48
-  virtual void VTable0x4c(); // vtable+0x4c
+	virtual MxResult InitFromMxDSObject(MxDSObject& p_dsObject); // vtable+0x18
+	virtual void Destroy(MxBool p_fromDestructor);               // vtable+0x1c
+	virtual void ParseAction(char*);                             // vtable+0x20
+	virtual void VTable0x24();                                   // vtable+0x24
+	virtual void VTable0x28();                                   // vtable+0x28
+	virtual void VTable0x2c();                                   // vtable+0x2c
+	// OFFSET: LEGO1 0x10001090
+	virtual void VTable0x30(undefined4 p_unk50) { m_unk50 = p_unk50; } // vtable+0x30
+	virtual void VTable0x34();                                         // vtable+0x34
+	virtual void VTable0x38();                                         // vtable+0x38
+	virtual void VTable0x3c();                                         // vtable+0x3c
+	virtual void VTable0x40();                                         // vtable+0x40
+	virtual void VTable0x44();                                         // vtable+0x44
+	virtual void VTable0x48();                                         // vtable+0x48
+	virtual void VTable0x4c();                                         // vtable+0x4c
 
 protected:
-  void Reset();
-  void AddToCurrentWorld();
+	void Reset();
+	void AddToCurrentWorld();
 
-  undefined m_unk10;
-  undefined m_unk11;
-  MxVector3Data m_vec1; // 0x14
-  MxVector3Data m_vec2; // 0x28
-  MxVector3Data m_vec3; // 0x3c
-  undefined4 m_unk50;
-  undefined4 m_unk54;
-  undefined m_unk58;
-  undefined m_unk59;
-  // For tokens from the extra string that look like this:
-  // "Action:openram;\lego\scripts\Race\CarRaceR;0"
-  ExtraActionType m_actionType; // 0x5c
-  char *m_actionArgString; // 0x60
-  MxS32 m_actionArgNumber; // 0x64
+	undefined m_unk10;
+	undefined m_unk11;
+	MxVector3Data m_vec1; // 0x14
+	MxVector3Data m_vec2; // 0x28
+	MxVector3Data m_vec3; // 0x3c
+	undefined4 m_unk50;
+	undefined4 m_unk54;
+	undefined m_unk58;
+	undefined m_unk59;
+	// For tokens from the extra string that look like this:
+	// "Action:openram;\lego\scripts\Race\CarRaceR;0"
+	ExtraActionType m_actionType; // 0x5c
+	char* m_actionArgString;      // 0x60
+	MxS32 m_actionArgNumber;      // 0x64
 };
 
 #endif // LEGOENTITY_H

--- a/LEGO1/legoentitypresenter.cpp
+++ b/LEGO1/legoentitypresenter.cpp
@@ -3,17 +3,17 @@
 // OFFSET: LEGO1 0x10053440
 LegoEntityPresenter::LegoEntityPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100535d0 STUB
 LegoEntityPresenter::~LegoEntityPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100535c0 STUB
 void LegoEntityPresenter::Init()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoentitypresenter.h
+++ b/LEGO1/legoentitypresenter.h
@@ -4,29 +4,26 @@
 #include "mxcompositepresenter.h"
 
 // VTABLE 0x100d8398
-class LegoEntityPresenter : public MxCompositePresenter
-{
+class LegoEntityPresenter : public MxCompositePresenter {
 public:
-  LegoEntityPresenter();
-  virtual ~LegoEntityPresenter() override; // vtable+0x0
+	LegoEntityPresenter();
+	virtual ~LegoEntityPresenter() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x100534b0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f06b8
-    return "LegoEntityPresenter";
-  }
+	// OFFSET: LEGO1 0x100534b0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f06b8
+		return "LegoEntityPresenter";
+	}
 
-  // OFFSET: LEGO1 0x100534c0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoEntityPresenter::ClassName()) || MxCompositePresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100534c0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoEntityPresenter::ClassName()) || MxCompositePresenter::IsA(name);
+	}
 
 private:
-  void Init();
-  
+	void Init();
 };
-
 
 #endif // LEGOENTITYPRESENTER_H

--- a/LEGO1/legoextraactor.h
+++ b/LEGO1/legoextraactor.h
@@ -4,21 +4,20 @@
 #include "legoanimactor.h"
 
 // VTABLE 0x100d6c10
-class LegoExtraActor : public LegoAnimActor
-{
+class LegoExtraActor : public LegoAnimActor {
 public:
-  // OFFSET: LEGO1 0x1002b7a0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f3204
-    return "LegoExtraActor";
-  }
+	// OFFSET: LEGO1 0x1002b7a0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f3204
+		return "LegoExtraActor";
+	}
 
-  // OFFSET: LEGO1 0x1002b7c0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoExtraActor::ClassName()) || LegoAnimActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1002b7c0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoExtraActor::ClassName()) || LegoAnimActor::IsA(name);
+	}
 };
 
 #endif // LEGOEXTRAACTOR_H

--- a/LEGO1/legoflctexturepresenter.cpp
+++ b/LEGO1/legoflctexturepresenter.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1005de80 STUB
 LegoFlcTexturePresenter::LegoFlcTexturePresenter()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoflctexturepresenter.h
+++ b/LEGO1/legoflctexturepresenter.h
@@ -5,18 +5,16 @@
 
 // VTABLE 0x100d89e0
 // SIZE 0x70
-class LegoFlcTexturePresenter : public MxFlcPresenter
-{
+class LegoFlcTexturePresenter : public MxFlcPresenter {
 public:
-  LegoFlcTexturePresenter();
+	LegoFlcTexturePresenter();
 
-  // OFFSET: LEGO1 0x1005def0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0634
-    return "LegoFlcTexturePresenter";
-  }
-
+	// OFFSET: LEGO1 0x1005def0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0634
+		return "LegoFlcTexturePresenter";
+	}
 };
 
 #endif // LEGOFLCTEXTUREPRESENTER_H

--- a/LEGO1/legofullscreenmovie.cpp
+++ b/LEGO1/legofullscreenmovie.cpp
@@ -1,43 +1,43 @@
 #include "legofullscreenmovie.h"
 
+#include "decomp.h"
 #include "legoomni.h"
 #include "legovideomanager.h"
 #include "mxtypes.h"
-#include "decomp.h"
 
 DECOMP_SIZE_ASSERT(LegoFullScreenMovie, 0x24)
 
 // 0x100f3be8
-const char *g_str_enable = "enable";
+const char* g_str_enable = "enable";
 
 // 0x100f3bf4
-const char *g_str_disable = "disable";
+const char* g_str_disable = "disable";
 
 // OFFSET: LEGO1 0x1003c500
-LegoFullScreenMovie::LegoFullScreenMovie(const char *p_key, const char *p_value)
+LegoFullScreenMovie::LegoFullScreenMovie(const char* p_key, const char* p_value)
 {
-  m_key = p_key;
-  m_key.ToUpperCase();
-  SetValue(p_value);
+	m_key = p_key;
+	m_key.ToUpperCase();
+	SetValue(p_value);
 }
 
 // OFFSET: LEGO1 0x1003c5c0
-void LegoFullScreenMovie::SetValue(const char *p_option)
+void LegoFullScreenMovie::SetValue(const char* p_option)
 {
-  m_value = p_option;
-  m_value.ToLowerCase();
+	m_value = p_option;
+	m_value.ToLowerCase();
 
-  LegoVideoManager *videomanager = VideoManager();
-  if (videomanager) {
+	LegoVideoManager* videomanager = VideoManager();
+	if (videomanager) {
 
-    if (!strcmp(m_value.GetData(), g_str_enable)) {
-      videomanager->EnableFullScreenMovie(TRUE);
-      return;
-    }
+		if (!strcmp(m_value.GetData(), g_str_enable)) {
+			videomanager->EnableFullScreenMovie(TRUE);
+			return;
+		}
 
-    if (!strcmp(m_value.GetData(), g_str_disable)) {
-      videomanager->EnableFullScreenMovie(FALSE);
-      return;
-    }
-  }
+		if (!strcmp(m_value.GetData(), g_str_disable)) {
+			videomanager->EnableFullScreenMovie(FALSE);
+			return;
+		}
+	}
 }

--- a/LEGO1/legofullscreenmovie.h
+++ b/LEGO1/legofullscreenmovie.h
@@ -5,11 +5,10 @@
 
 // VTABLE 0x100d74b8
 // SIZE 0x24
-class LegoFullScreenMovie : public MxVariable
-{
+class LegoFullScreenMovie : public MxVariable {
 public:
-  LegoFullScreenMovie(const char *p_key, const char *p_value);
-  virtual void SetValue(const char *p_option) override;
+	LegoFullScreenMovie(const char* p_key, const char* p_value);
+	virtual void SetValue(const char* p_option) override;
 };
 
 #endif // LEGOFULLSCREENMOVIE_H

--- a/LEGO1/legogamestate.cpp
+++ b/LEGO1/legogamestate.cpp
@@ -1,248 +1,220 @@
 #include "legogamestate.h"
 
+#include "infocenterstate.h"
 #include "legoomni.h"
 #include "legostate.h"
-#include "infocenterstate.h"
 #include "legostream.h"
 #include "mxobjectfactory.h"
-#include "mxvariabletable.h"
 #include "mxstring.h"
+#include "mxvariabletable.h"
 
 // Based on the highest dword offset (0x42c) referenced in the constructor.
 // There may be other members that come after.
 DECOMP_SIZE_ASSERT(LegoGameState, 0x430)
 
 // GLOBAL OFFSET: LEGO1 0x100f3e40
-const char *g_fileExtensionGS = ".GS";
+const char* g_fileExtensionGS = ".GS";
 
 // GLOBAL OFFSET: LEGO1 0x100f3e58
 ColorStringStruct g_colorSaveData[43] = {
-  {"c_dbbkfny0", "lego red"},
-  {"c_dbbkxly0", "lego white"},
-  {"c_chbasey0", "lego black"},
-  {"c_chbacky0", "lego black"},
-  {"c_chdishy0", "lego white"},
-  {"c_chhorny0", "lego black"},
-  {"c_chljety1", "lego black"},
-  {"c_chrjety1", "lego black"},
-  {"c_chmidly0", "lego black"},
-  {"c_chmotry0", "lego blue"},
-  {"c_chsidly0", "lego black"},
-  {"c_chsidry0", "lego black"},
-  {"c_chstuty0", "lego black"},
-  {"c_chtaily0", "lego black"},
-  {"c_chwindy1", "lego black"},
-  {"c_dbfbrdy0", "lego red"},
-  {"c_dbflagy0", "lego yellow"},
-  {"c_dbfrfny4", "lego red"},
-  {"c_dbfrxly0", "lego white"},
-  {"c_dbhndly0", "lego white"},
-  {"c_dbltbry0", "lego white"},
-  {"c_jsdashy0", "lego white"},
-  {"c_jsexhy0",  "lego black"},
-  {"c_jsfrnty5", "lego black"},
-  {"c_jshndly0", "lego red"},
-  {"c_jslsidy0", "lego black"},
-  {"c_jsrsidy0", "lego black"},
-  {"c_jsskiby0", "lego red"},
-  {"c_jswnshy5", "lego white"},
-  {"c_rcbacky6", "lego green"},
-  {"c_rcedgey0", "lego green"},
-  {"c_rcfrmey0", "lego red"},
-  {"c_rcfrnty6", "lego green"},
-  {"c_rcmotry0", "lego white"},
-  {"c_rcsidey0", "lego green"},
-  {"c_rcstery0", "lego white"},
-  {"c_rcstrpy0", "lego yellow"},
-  {"c_rctailya", "lego white"},
-  {"c_rcwhl1y0", "lego white"},
-  {"c_rcwhl2y0", "lego white"},
-  {"c_jsbasey0", "lego white"},
-  {"c_chblady0", "lego black"},
-  {"c_chseaty0", "lego white"},
+	{"c_dbbkfny0", "lego red"},    {"c_dbbkxly0", "lego white"},  {"c_chbasey0", "lego black"},
+	{"c_chbacky0", "lego black"},  {"c_chdishy0", "lego white"},  {"c_chhorny0", "lego black"},
+	{"c_chljety1", "lego black"},  {"c_chrjety1", "lego black"},  {"c_chmidly0", "lego black"},
+	{"c_chmotry0", "lego blue"},   {"c_chsidly0", "lego black"},  {"c_chsidry0", "lego black"},
+	{"c_chstuty0", "lego black"},  {"c_chtaily0", "lego black"},  {"c_chwindy1", "lego black"},
+	{"c_dbfbrdy0", "lego red"},    {"c_dbflagy0", "lego yellow"}, {"c_dbfrfny4", "lego red"},
+	{"c_dbfrxly0", "lego white"},  {"c_dbhndly0", "lego white"},  {"c_dbltbry0", "lego white"},
+	{"c_jsdashy0", "lego white"},  {"c_jsexhy0", "lego black"},   {"c_jsfrnty5", "lego black"},
+	{"c_jshndly0", "lego red"},    {"c_jslsidy0", "lego black"},  {"c_jsrsidy0", "lego black"},
+	{"c_jsskiby0", "lego red"},    {"c_jswnshy5", "lego white"},  {"c_rcbacky6", "lego green"},
+	{"c_rcedgey0", "lego green"},  {"c_rcfrmey0", "lego red"},    {"c_rcfrnty6", "lego green"},
+	{"c_rcmotry0", "lego white"},  {"c_rcsidey0", "lego green"},  {"c_rcstery0", "lego white"},
+	{"c_rcstrpy0", "lego yellow"}, {"c_rctailya", "lego white"},  {"c_rcwhl1y0", "lego white"},
+	{"c_rcwhl2y0", "lego white"},  {"c_jsbasey0", "lego white"},  {"c_chblady0", "lego black"},
+	{"c_chseaty0", "lego white"},
 };
 
 // NOTE: This offset = the end of the variables table, the last entry
 // in that table is a special entry, the string "END_OF_VARIABLES"
 // GLOBAL OFFSET: LEGO1 0x100f3e50
-extern const char *s_endOfVariables;
+extern const char* s_endOfVariables;
 
 // OFFSET: LEGO1 0x10039550
 LegoGameState::LegoGameState()
 {
-  // TODO
-  m_stateCount = 0;
-  m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
-  VariableTable()->SetVariable(m_backgroundColor);
+	// TODO
+	m_stateCount = 0;
+	m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
+	VariableTable()->SetVariable(m_backgroundColor);
 
-  m_tempBackgroundColor = new LegoBackgroundColor("tempBackgroundcolor", "set 56 54 68");
-  VariableTable()->SetVariable(m_tempBackgroundColor);
+	m_tempBackgroundColor = new LegoBackgroundColor("tempBackgroundcolor", "set 56 54 68");
+	VariableTable()->SetVariable(m_tempBackgroundColor);
 
-  m_fullScreenMovie = new LegoFullScreenMovie("fsmovie", "disable");
-  VariableTable()->SetVariable(m_fullScreenMovie);
+	m_fullScreenMovie = new LegoFullScreenMovie("fsmovie", "disable");
+	VariableTable()->SetVariable(m_fullScreenMovie);
 
-  VariableTable()->SetVariable("lightposition", "2");
-  SerializeScoreHistory(1);
+	VariableTable()->SetVariable("lightposition", "2");
+	SerializeScoreHistory(1);
 }
 
 // OFFSET: LEGO1 0x10039720 STUB
 LegoGameState::~LegoGameState()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10039c60 STUB
 MxResult LegoGameState::Load(MxULong)
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1003a170
-void LegoGameState::GetFileSavePath(MxString *p_outPath, MxULong p_slotn)
+void LegoGameState::GetFileSavePath(MxString* p_outPath, MxULong p_slotn)
 {
-  char baseForSlot[2] = "0";
-  char path[1024] = "";
+	char baseForSlot[2] = "0";
+	char path[1024] = "";
 
-  // Save path base
-  if (m_savePath != NULL)
-    strcpy(path, m_savePath);
+	// Save path base
+	if (m_savePath != NULL)
+		strcpy(path, m_savePath);
 
-  // Slot: "G0", "G1", ...
-  strcat(path, "G");
-  baseForSlot[0] += p_slotn;
-  strcat(path, baseForSlot);
+	// Slot: "G0", "G1", ...
+	strcat(path, "G");
+	baseForSlot[0] += p_slotn;
+	strcat(path, baseForSlot);
 
-  // Extension: ".GS"
-  strcat(path, g_fileExtensionGS);
-  *p_outPath = MxString(path);
+	// Extension: ".GS"
+	strcat(path, g_fileExtensionGS);
+	*p_outPath = MxString(path);
 }
 
 // OFFSET: LEGO1 0x1003a020
-MxResult LegoGameState::WriteEndOfVariables(LegoStream *p_stream)
+MxResult LegoGameState::WriteEndOfVariables(LegoStream* p_stream)
 {
-  MxU8 len = strlen(s_endOfVariables);
-  if (p_stream->Write(&len, 1) == SUCCESS)
-    return p_stream->Write(s_endOfVariables, len);
-  return FAILURE;
+	MxU8 len = strlen(s_endOfVariables);
+	if (p_stream->Write(&len, 1) == SUCCESS)
+		return p_stream->Write(s_endOfVariables, len);
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x10039980
 MxResult LegoGameState::Save(MxULong p_slot)
 {
-  MxResult result;
-  InfocenterState *infocenterState = (InfocenterState *)GameState()->GetState("InfocenterState");
-  if (!infocenterState || infocenterState->GetInfocenterBufferElement(0) == 0)
-    result = SUCCESS;
-  else {
-    result = FAILURE;
-    MxVariableTable *variableTable = VariableTable();
-    MxString savePath;
-    GetFileSavePath(&savePath, p_slot);
-    LegoFileStream fileStream;
-    if (fileStream.Open(savePath.GetData(), LegoStream::WriteBit) != FAILURE) {
-      MxU32 maybeVersion = 0x1000C;
-      fileStream.Write(&maybeVersion, 4);
-      fileStream.Write(&m_unk24, 2);
-      fileStream.Write(&m_unk10, 2);
-      fileStream.Write(&m_unkC, 1);
+	MxResult result;
+	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
+	if (!infocenterState || infocenterState->GetInfocenterBufferElement(0) == 0)
+		result = SUCCESS;
+	else {
+		result = FAILURE;
+		MxVariableTable* variableTable = VariableTable();
+		MxString savePath;
+		GetFileSavePath(&savePath, p_slot);
+		LegoFileStream fileStream;
+		if (fileStream.Open(savePath.GetData(), LegoStream::WriteBit) != FAILURE) {
+			MxU32 maybeVersion = 0x1000C;
+			fileStream.Write(&maybeVersion, 4);
+			fileStream.Write(&m_unk24, 2);
+			fileStream.Write(&m_unk10, 2);
+			fileStream.Write(&m_unkC, 1);
 
-      for (MxS32 i = 0; i < sizeof(g_colorSaveData) / sizeof(g_colorSaveData[0]); ++i) {
-        if (LegoStream::WriteVariable(&fileStream, variableTable, g_colorSaveData[i].m_targetName) == FAILURE)
-          return result;
-      }
+			for (MxS32 i = 0; i < sizeof(g_colorSaveData) / sizeof(g_colorSaveData[0]); ++i) {
+				if (LegoStream::WriteVariable(&fileStream, variableTable, g_colorSaveData[i].m_targetName) == FAILURE)
+					return result;
+			}
 
-      if (LegoStream::WriteVariable(&fileStream, variableTable, "backgroundcolor") != FAILURE) {
-        if (LegoStream::WriteVariable(&fileStream, variableTable, "lightposition") != FAILURE) {
-          WriteEndOfVariables(&fileStream);
+			if (LegoStream::WriteVariable(&fileStream, variableTable, "backgroundcolor") != FAILURE) {
+				if (LegoStream::WriteVariable(&fileStream, variableTable, "lightposition") != FAILURE) {
+					WriteEndOfVariables(&fileStream);
 
-          // TODO: Calls down to more aggregate writing functions
-          return SUCCESS;
-        }
-      }
-    }
-  }
-  return result;
+					// TODO: Calls down to more aggregate writing functions
+					return SUCCESS;
+				}
+			}
+		}
+	}
+	return result;
 }
 
 // OFFSET: LEGO1 0x1003a2e0 STUB
 void LegoGameState::SerializePlayersInfo(MxS16 p)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1003cdd0 STUB
 void LegoGameState::SerializeScoreHistory(MxS16 p)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10039f00
-void LegoGameState::SetSavePath(char *p_savePath)
+void LegoGameState::SetSavePath(char* p_savePath)
 {
-  if (m_savePath != NULL)
-    delete[] m_savePath;
+	if (m_savePath != NULL)
+		delete[] m_savePath;
 
-  if (p_savePath) {
-    m_savePath = new char[strlen(p_savePath) + 1];
-    strcpy(m_savePath, p_savePath);
-  }
-  else
-    m_savePath = NULL;
+	if (p_savePath) {
+		m_savePath = new char[strlen(p_savePath) + 1];
+		strcpy(m_savePath, p_savePath);
+	}
+	else
+		m_savePath = NULL;
 }
 
 // OFFSET: LEGO1 0x1003bbb0
-LegoState *LegoGameState::GetState(COMPAT_CONST char *p_stateName)
+LegoState* LegoGameState::GetState(COMPAT_CONST char* p_stateName)
 {
-  for (MxS32 i = 0; i < m_stateCount; ++i)
-    if (m_stateArray[i]->IsA(p_stateName))
-      return m_stateArray[i];
-  return NULL;
+	for (MxS32 i = 0; i < m_stateCount; ++i)
+		if (m_stateArray[i]->IsA(p_stateName))
+			return m_stateArray[i];
+	return NULL;
 }
 
 // OFFSET: LEGO1 0x1003bc00
-LegoState *LegoGameState::CreateState(COMPAT_CONST char *p_stateName)
+LegoState* LegoGameState::CreateState(COMPAT_CONST char* p_stateName)
 {
-  LegoState* newState = (LegoState*)ObjectFactory()->Create(p_stateName);
-  RegisterState(newState);
+	LegoState* newState = (LegoState*) ObjectFactory()->Create(p_stateName);
+	RegisterState(newState);
 
-  return newState;
+	return newState;
 }
 
 // OFFSET: LEGO1 0x1003bc30
-void LegoGameState::RegisterState(LegoState *p_state)
+void LegoGameState::RegisterState(LegoState* p_state)
 {
-  MxS32 targetIndex;
-  for (targetIndex = 0; targetIndex < m_stateCount; ++targetIndex)
-    if (m_stateArray[targetIndex]->IsA(p_state->ClassName()))
-      break;
+	MxS32 targetIndex;
+	for (targetIndex = 0; targetIndex < m_stateCount; ++targetIndex)
+		if (m_stateArray[targetIndex]->IsA(p_state->ClassName()))
+			break;
 
-  if (targetIndex == m_stateCount) {
-    LegoState **newBuffer = new LegoState*[m_stateCount + 1];
+	if (targetIndex == m_stateCount) {
+		LegoState** newBuffer = new LegoState*[m_stateCount + 1];
 
-    if (m_stateCount != 0) {
-      memcpy(newBuffer, m_stateArray, m_stateCount * sizeof(LegoState*));
-      delete[] m_stateArray;
-    }
+		if (m_stateCount != 0) {
+			memcpy(newBuffer, m_stateArray, m_stateCount * sizeof(LegoState*));
+			delete[] m_stateArray;
+		}
 
-    newBuffer[m_stateCount++] = p_state;
-    m_stateArray = newBuffer;
-    return;
-  }
+		newBuffer[m_stateCount++] = p_state;
+		m_stateArray = newBuffer;
+		return;
+	}
 
-  if (m_stateArray[targetIndex])
-    delete m_stateArray[targetIndex];
-  m_stateArray[targetIndex] = p_state;
+	if (m_stateArray[targetIndex])
+		delete m_stateArray[targetIndex];
+	m_stateArray[targetIndex] = p_state;
 }
 
 // OFFSET: LEGO1 0x1003a720 STUB
 void LegoGameState::FUN_1003a720(MxU32 p_unk)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1003b060 STUB
 void LegoGameState::HandleAction(MxU32 p_unk)
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legogamestate.h
+++ b/LEGO1/legogamestate.h
@@ -2,62 +2,60 @@
 #define LEGOGAMESTATE_H
 
 #include "decomp.h"
-#include "mxtypes.h"
 #include "legobackgroundcolor.h"
 #include "legofullscreenmovie.h"
+#include "mxtypes.h"
 
 class LegoState;
 class LegoStream;
 class MxVariable;
 class MxString;
 
-struct ColorStringStruct
-{
-  const char *m_targetName;
-  const char *m_colorName;
+struct ColorStringStruct {
+	const char* m_targetName;
+	const char* m_colorName;
 };
 
 // SIZE 0x430 (at least)
-class LegoGameState
-{
+class LegoGameState {
 public:
-  __declspec(dllexport) LegoGameState();
-  __declspec(dllexport) ~LegoGameState();
-  __declspec(dllexport) MxResult Load(MxULong);
-  __declspec(dllexport) MxResult Save(MxULong p);
-  __declspec(dllexport) void SerializePlayersInfo(MxS16 p);
-  __declspec(dllexport) void SerializeScoreHistory(MxS16 p);
-  __declspec(dllexport) void SetSavePath(char *p);
+	__declspec(dllexport) LegoGameState();
+	__declspec(dllexport) ~LegoGameState();
+	__declspec(dllexport) MxResult Load(MxULong);
+	__declspec(dllexport) MxResult Save(MxULong p);
+	__declspec(dllexport) void SerializePlayersInfo(MxS16 p);
+	__declspec(dllexport) void SerializeScoreHistory(MxS16 p);
+	__declspec(dllexport) void SetSavePath(char* p);
 
-  LegoState *GetState(COMPAT_CONST char *p_stateName);
-  LegoState *CreateState(COMPAT_CONST char *p_stateName);
+	LegoState* GetState(COMPAT_CONST char* p_stateName);
+	LegoState* CreateState(COMPAT_CONST char* p_stateName);
 
-  void GetFileSavePath(MxString *p_outPath, MxULong p_slotn);
-  void FUN_1003a720(MxU32 p_unk);
-  void HandleAction(MxU32 p_unk);
+	void GetFileSavePath(MxString* p_outPath, MxULong p_slotn);
+	void FUN_1003a720(MxU32 p_unk);
+	void HandleAction(MxU32 p_unk);
 
-  inline MxU32 GetUnknown10() { return m_unk10; }
-  inline void SetUnknown424(undefined4 p_unk424) { m_unk424 = p_unk424; }
-
-private:
-  void RegisterState(LegoState *p_state);
-  MxResult WriteEndOfVariables(LegoStream *p_stream);
+	inline MxU32 GetUnknown10() { return m_unk10; }
+	inline void SetUnknown424(undefined4 p_unk424) { m_unk424 = p_unk424; }
 
 private:
-  char *m_savePath; // 0x0
-  MxS16 m_stateCount;
-  LegoState **m_stateArray;
-  MxU8 m_unkC;
-  MxU32 m_unk10;
-  undefined4 m_unk0x14;
-  LegoBackgroundColor *m_backgroundColor; // 0x18
-  LegoBackgroundColor *m_tempBackgroundColor; // 0x1c
-  LegoFullScreenMovie *m_fullScreenMovie; // 0x20
-  MxU16 m_unk24; // 0x24
-  undefined m_unk28[1020];
-  undefined4 m_unk424;
-  undefined4 m_unk428;
-  undefined4 m_unk42c;
+	void RegisterState(LegoState* p_state);
+	MxResult WriteEndOfVariables(LegoStream* p_stream);
+
+private:
+	char* m_savePath; // 0x0
+	MxS16 m_stateCount;
+	LegoState** m_stateArray;
+	MxU8 m_unkC;
+	MxU32 m_unk10;
+	undefined4 m_unk0x14;
+	LegoBackgroundColor* m_backgroundColor;     // 0x18
+	LegoBackgroundColor* m_tempBackgroundColor; // 0x1c
+	LegoFullScreenMovie* m_fullScreenMovie;     // 0x20
+	MxU16 m_unk24;                              // 0x24
+	undefined m_unk28[1020];
+	undefined4 m_unk424;
+	undefined4 m_unk428;
+	undefined4 m_unk42c;
 };
 
 #endif // LEGOGAMESTATE_H

--- a/LEGO1/legohideanimpresenter.cpp
+++ b/LEGO1/legohideanimpresenter.cpp
@@ -3,7 +3,7 @@
 // OFFSET: LEGO1 0x1006d7e0
 LegoHideAnimPresenter::LegoHideAnimPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x1006da50 STUB

--- a/LEGO1/legohideanimpresenter.h
+++ b/LEGO1/legohideanimpresenter.h
@@ -5,27 +5,25 @@
 
 // VTABLE 0x100d9278
 // SIZE 0xc4
-class LegoHideAnimPresenter : public LegoLoopingAnimPresenter
-{
+class LegoHideAnimPresenter : public LegoLoopingAnimPresenter {
 public:
-  LegoHideAnimPresenter();
+	LegoHideAnimPresenter();
 
-  // OFFSET: LEGO1 0x1006d880
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f06cc
-    return "LegoHideAnimPresenter";
-  }
+	// OFFSET: LEGO1 0x1006d880
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f06cc
+		return "LegoHideAnimPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1006d890
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || LegoAnimPresenter::IsA(name);
-  }
-  
+	// OFFSET: LEGO1 0x1006d890
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || LegoAnimPresenter::IsA(name);
+	}
+
 private:
-  void Init();
-
+	void Init();
 };
 
 #endif // LEGOHIDEANIMPRESENTER_H

--- a/LEGO1/legoinputmanager.cpp
+++ b/LEGO1/legoinputmanager.cpp
@@ -1,7 +1,7 @@
 #include "legoinputmanager.h"
+
 #include "legocontrolmanager.h"
 #include "legoomni.h"
-
 #include "mxautolocker.h"
 
 DECOMP_SIZE_ASSERT(LegoInputManager, 0x338);
@@ -9,224 +9,231 @@ DECOMP_SIZE_ASSERT(LegoInputManager, 0x338);
 // OFFSET: LEGO1 0x1005b790
 LegoInputManager::LegoInputManager()
 {
-  m_unk0x5c = NULL;
-  m_world = NULL;
-  m_camera = NULL;
-  m_unk0x68 = NULL;
-  m_unk0x80 = 0;
-  m_timer = 0;
-  m_unk0x6c = 0;
-  m_unk0x70 = 0;
-  m_controlManager = NULL;
-  m_unk0x81 = 0;
-  m_unk0x88 = FALSE;
-  m_directInput = NULL;
-  m_directInputDevice = NULL;
-  m_unk0x94 = 0;
-  m_unk0x195 = 0;
-  m_joyid = -1;
-  m_joystickIndex = -1;
-  m_useJoystick = FALSE;
-  m_unk0x335 = FALSE;
-  m_unk0x336 = FALSE;
-  m_unk0x74 = 0x19;
-  m_timeout = 1000;
+	m_unk0x5c = NULL;
+	m_world = NULL;
+	m_camera = NULL;
+	m_unk0x68 = NULL;
+	m_unk0x80 = 0;
+	m_timer = 0;
+	m_unk0x6c = 0;
+	m_unk0x70 = 0;
+	m_controlManager = NULL;
+	m_unk0x81 = 0;
+	m_unk0x88 = FALSE;
+	m_directInput = NULL;
+	m_directInputDevice = NULL;
+	m_unk0x94 = 0;
+	m_unk0x195 = 0;
+	m_joyid = -1;
+	m_joystickIndex = -1;
+	m_useJoystick = FALSE;
+	m_unk0x335 = FALSE;
+	m_unk0x336 = FALSE;
+	m_unk0x74 = 0x19;
+	m_timeout = 1000;
 }
 
 // OFFSET: LEGO1 0x1005b8b0 STUB
 MxResult LegoInputManager::Tickle()
 {
-  // TODO
-  return SUCCESS;
+	// TODO
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1005b8f0
 LegoInputManager::~LegoInputManager()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x1005bfe0
 void LegoInputManager::Destroy()
 {
-  ReleaseDX();
+	ReleaseDX();
 
-  if (m_unk0x5c) 
-    delete m_unk0x5c;
-  m_unk0x5c = NULL;
+	if (m_unk0x5c)
+		delete m_unk0x5c;
+	m_unk0x5c = NULL;
 
-  if (m_unk0x68) 
-    delete m_unk0x68;
-  m_unk0x68 = NULL;
+	if (m_unk0x68)
+		delete m_unk0x68;
+	m_unk0x68 = NULL;
 
-  if (m_controlManager)
-    delete m_controlManager;
+	if (m_controlManager)
+		delete m_controlManager;
 }
 
 // OFFSET: LEGO1 0x1005c030
 void LegoInputManager::CreateAndAcquireKeyboard(HWND hwnd)
 {
-  HINSTANCE hinstance = (HINSTANCE) GetWindowLong(hwnd, GWL_HINSTANCE);
-  HRESULT hresult = DirectInputCreate(hinstance, 0x500, &m_directInput, NULL); // 0x500 for DX5
+	HINSTANCE hinstance = (HINSTANCE) GetWindowLong(hwnd, GWL_HINSTANCE);
+	HRESULT hresult = DirectInputCreate(hinstance, 0x500, &m_directInput, NULL); // 0x500 for DX5
 
-  if (hresult == DI_OK) {
-    HRESULT createdeviceresult = m_directInput->CreateDevice(GUID_SysKeyboard, &m_directInputDevice, NULL);
-    if (createdeviceresult == DI_OK) {
-      m_directInputDevice->SetCooperativeLevel(hwnd, DISCL_NONEXCLUSIVE | DISCL_FOREGROUND);
-      m_directInputDevice->SetDataFormat(&c_dfDIKeyboard);
-      m_directInputDevice->Acquire();
-    }
-  }
+	if (hresult == DI_OK) {
+		HRESULT createdeviceresult = m_directInput->CreateDevice(GUID_SysKeyboard, &m_directInputDevice, NULL);
+		if (createdeviceresult == DI_OK) {
+			m_directInputDevice->SetCooperativeLevel(hwnd, DISCL_NONEXCLUSIVE | DISCL_FOREGROUND);
+			m_directInputDevice->SetDataFormat(&c_dfDIKeyboard);
+			m_directInputDevice->Acquire();
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x1005c0a0
 void LegoInputManager::ReleaseDX()
 {
-  if (m_directInputDevice != NULL) {
-    m_directInputDevice->Unacquire();
-    m_directInputDevice->Release();
-    m_directInputDevice = NULL;
-  }
+	if (m_directInputDevice != NULL) {
+		m_directInputDevice->Unacquire();
+		m_directInputDevice->Release();
+		m_directInputDevice = NULL;
+	}
 
-  if (m_directInput != NULL) {
-    m_directInput->Release();
-    m_directInput = NULL;
-  }
+	if (m_directInput != NULL) {
+		m_directInput->Release();
+		m_directInput = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x1005c240
 MxResult LegoInputManager::GetJoystickId()
 {
-  JOYINFOEX joyinfoex;
+	JOYINFOEX joyinfoex;
 
-  if (m_useJoystick != FALSE) {
-    MxS32 joyid = m_joystickIndex;
-    if (joyid >= 0) {
-      joyinfoex.dwSize = 0x34;
-      joyinfoex.dwFlags = 0xFF;
+	if (m_useJoystick != FALSE) {
+		MxS32 joyid = m_joystickIndex;
+		if (joyid >= 0) {
+			joyinfoex.dwSize = 0x34;
+			joyinfoex.dwFlags = 0xFF;
 
-      if (joyGetPosEx(joyid, &joyinfoex) == JOYERR_NOERROR && joyGetDevCaps(joyid, &m_joyCaps, 0x194) == JOYERR_NOERROR) {
-        m_joyid = joyid;
-        return SUCCESS;
-      }
-    }
+			if (joyGetPosEx(joyid, &joyinfoex) == JOYERR_NOERROR &&
+				joyGetDevCaps(joyid, &m_joyCaps, 0x194) == JOYERR_NOERROR) {
+				m_joyid = joyid;
+				return SUCCESS;
+			}
+		}
 
-    for (joyid = JOYSTICKID1; joyid < 16; joyid++) {
-      joyinfoex.dwSize = 0x34;
-      joyinfoex.dwFlags = 0xFF;
-      if (joyGetPosEx(joyid, &joyinfoex) == JOYERR_NOERROR && joyGetDevCaps(joyid, &m_joyCaps, 0x194) == JOYERR_NOERROR) {
-        m_joyid = joyid;
-        return SUCCESS;
-      }
-    }
-  }
+		for (joyid = JOYSTICKID1; joyid < 16; joyid++) {
+			joyinfoex.dwSize = 0x34;
+			joyinfoex.dwFlags = 0xFF;
+			if (joyGetPosEx(joyid, &joyinfoex) == JOYERR_NOERROR &&
+				joyGetDevCaps(joyid, &m_joyCaps, 0x194) == JOYERR_NOERROR) {
+				m_joyid = joyid;
+				return SUCCESS;
+			}
+		}
+	}
 
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x1005c320
-MxResult LegoInputManager::GetJoystickState(MxU32 *joystick_x, MxU32 *joystick_y, DWORD *buttons_state, MxU32 *pov_position)
+MxResult LegoInputManager::GetJoystickState(
+	MxU32* joystick_x,
+	MxU32* joystick_y,
+	DWORD* buttons_state,
+	MxU32* pov_position
+)
 {
-  if (m_useJoystick != FALSE) {
-    if (m_joyid < 0 && GetJoystickId() == -1) {
-      m_useJoystick = FALSE;
-      return FAILURE;
-    }
+	if (m_useJoystick != FALSE) {
+		if (m_joyid < 0 && GetJoystickId() == -1) {
+			m_useJoystick = FALSE;
+			return FAILURE;
+		}
 
-    JOYINFOEX joyinfoex;
-    joyinfoex.dwSize = 0x34;
-    joyinfoex.dwFlags = JOY_RETURNX | JOY_RETURNY | JOY_RETURNBUTTONS;
-    MxU32 capabilities = m_joyCaps.wCaps;
+		JOYINFOEX joyinfoex;
+		joyinfoex.dwSize = 0x34;
+		joyinfoex.dwFlags = JOY_RETURNX | JOY_RETURNY | JOY_RETURNBUTTONS;
+		MxU32 capabilities = m_joyCaps.wCaps;
 
-    if ((capabilities & JOYCAPS_HASPOV) != 0) {
-      joyinfoex.dwFlags = JOY_RETURNX | JOY_RETURNY | JOY_RETURNPOV | JOY_RETURNBUTTONS;
+		if ((capabilities & JOYCAPS_HASPOV) != 0) {
+			joyinfoex.dwFlags = JOY_RETURNX | JOY_RETURNY | JOY_RETURNPOV | JOY_RETURNBUTTONS;
 
-      if ((capabilities & JOYCAPS_POVCTS) != 0)
-        joyinfoex.dwFlags = JOY_RETURNX | JOY_RETURNY | JOY_RETURNPOV | JOY_RETURNBUTTONS | JOY_RETURNPOVCTS;
-    }
+			if ((capabilities & JOYCAPS_POVCTS) != 0)
+				joyinfoex.dwFlags = JOY_RETURNX | JOY_RETURNY | JOY_RETURNPOV | JOY_RETURNBUTTONS | JOY_RETURNPOVCTS;
+		}
 
-    MMRESULT mmresult = joyGetPosEx(m_joyid, &joyinfoex);
-    
-    if (mmresult == MMSYSERR_NOERROR) {
-      *buttons_state = joyinfoex.dwButtons;
-      MxU32 xmin = m_joyCaps.wXmin;
-      MxU32 ymax = m_joyCaps.wYmax;
-      MxU32 ymin = m_joyCaps.wYmin;
-      MxS32 ydiff = ymax - ymin;
-      *joystick_x = ((joyinfoex.dwXpos - xmin) * 100) / (m_joyCaps.wXmax - xmin);
-      *joystick_y = ((joyinfoex.dwYpos - m_joyCaps.wYmin) * 100) / ydiff;
-      if ((m_joyCaps.wCaps & (JOYCAPS_POV4DIR | JOYCAPS_POVCTS)) != 0) {
-        if (joyinfoex.dwPOV == JOY_POVCENTERED) {
-          *pov_position = (MxU32) -1;
-          return SUCCESS;
-        }
-        *pov_position = joyinfoex.dwPOV / 100;
-        return SUCCESS;
-      }
-      else {
-        *pov_position = (MxU32) -1;
-        return SUCCESS;
-      }
-    }
-  }
-  return FAILURE;
+		MMRESULT mmresult = joyGetPosEx(m_joyid, &joyinfoex);
+
+		if (mmresult == MMSYSERR_NOERROR) {
+			*buttons_state = joyinfoex.dwButtons;
+			MxU32 xmin = m_joyCaps.wXmin;
+			MxU32 ymax = m_joyCaps.wYmax;
+			MxU32 ymin = m_joyCaps.wYmin;
+			MxS32 ydiff = ymax - ymin;
+			*joystick_x = ((joyinfoex.dwXpos - xmin) * 100) / (m_joyCaps.wXmax - xmin);
+			*joystick_y = ((joyinfoex.dwYpos - m_joyCaps.wYmin) * 100) / ydiff;
+			if ((m_joyCaps.wCaps & (JOYCAPS_POV4DIR | JOYCAPS_POVCTS)) != 0) {
+				if (joyinfoex.dwPOV == JOY_POVCENTERED) {
+					*pov_position = (MxU32) -1;
+					return SUCCESS;
+				}
+				*pov_position = joyinfoex.dwPOV / 100;
+				return SUCCESS;
+			}
+			else {
+				*pov_position = (MxU32) -1;
+				return SUCCESS;
+			}
+		}
+	}
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x1005c470 STUB
-void LegoInputManager::Register(MxCore *)
+void LegoInputManager::Register(MxCore*)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005c5c0 STUB
-void LegoInputManager::UnRegister(MxCore *)
+void LegoInputManager::UnRegister(MxCore*)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005c700
-void LegoInputManager::SetCamera(LegoCameraController *p_camera)
+void LegoInputManager::SetCamera(LegoCameraController* p_camera)
 {
-  m_camera = p_camera;
+	m_camera = p_camera;
 }
 
 // OFFSET: LEGO1 0x1005c710
 void LegoInputManager::ClearCamera()
 {
-  m_camera = NULL;
+	m_camera = NULL;
 }
 
 // OFFSET: LEGO1 0x1005c720
-void LegoInputManager::SetWorld(LegoWorld *p_world)
+void LegoInputManager::SetWorld(LegoWorld* p_world)
 {
-  m_world = p_world;
+	m_world = p_world;
 }
 
 // OFFSET: LEGO1 0x1005c730
 void LegoInputManager::ClearWorld()
 {
-  m_world = NULL;
+	m_world = NULL;
 }
 
 // OFFSET: LEGO1 0x1005c740 STUB
 void LegoInputManager::QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005cfb0
 void LegoInputManager::SetTimer()
 {
-  LegoOmni* omni = LegoOmni::GetInstance();
-  UINT timer = ::SetTimer(omni->GetWindowHandle(), 1, m_timeout, NULL);
-  m_timer = timer;
+	LegoOmni* omni = LegoOmni::GetInstance();
+	UINT timer = ::SetTimer(omni->GetWindowHandle(), 1, m_timeout, NULL);
+	m_timer = timer;
 }
 
 // OFFSET: LEGO1 0x1005cfd0
 void LegoInputManager::KillTimer()
 {
-  if (m_timer != 0) {
-    LegoOmni* omni = LegoOmni::GetInstance();
-    ::KillTimer(omni->GetWindowHandle(), m_timer);
-  }
+	if (m_timer != 0) {
+		LegoOmni* omni = LegoOmni::GetInstance();
+		::KillTimer(omni->GetWindowHandle(), m_timer);
+	}
 }

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -3,83 +3,81 @@
 
 #include "decomp.h"
 #include "legoworld.h"
-#include "mxpresenter.h"
 #include "mxlist.h"
+#include "mxpresenter.h"
 
 #include <dinput.h>
 
-enum NotificationId
-{
-  NONE = 0,
-  KEYDOWN = 7,
-  MOUSEUP = 8,
-  MOUSEDOWN = 9,
-  MOUSEMOVE = 10,
-  TIMER = 15
+enum NotificationId {
+	NONE = 0,
+	KEYDOWN = 7,
+	MOUSEUP = 8,
+	MOUSEDOWN = 9,
+	MOUSEMOVE = 10,
+	TIMER = 15
 };
 
 class LegoControlManager;
 
 // VTABLE 0x100d8760
 // SIZE 0x338
-class LegoInputManager : public MxPresenter
-{
+class LegoInputManager : public MxPresenter {
 public:
-  LegoInputManager();
-  virtual ~LegoInputManager() override;
+	LegoInputManager();
+	virtual ~LegoInputManager() override;
 
-  __declspec(dllexport) void QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5);
-  __declspec(dllexport) void Register(MxCore *);
-  __declspec(dllexport) void UnRegister(MxCore *);
+	__declspec(dllexport) void QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5);
+	__declspec(dllexport) void Register(MxCore*);
+	__declspec(dllexport) void UnRegister(MxCore*);
 
-  virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x8
 
-  void Destroy();
-  void CreateAndAcquireKeyboard(HWND hwnd);
-  void ReleaseDX();
-  MxResult GetJoystickId();
-  MxResult GetJoystickState(MxU32 *joystick_x, MxU32 *joystick_y, DWORD *buttons_state, MxU32 *pov_position);
-  void SetTimer();
-  void KillTimer();
-  void SetCamera(LegoCameraController *p_camera);
-  void ClearCamera();
-  void SetWorld(LegoWorld *p_world);
-  void ClearWorld();
+	void Destroy();
+	void CreateAndAcquireKeyboard(HWND hwnd);
+	void ReleaseDX();
+	MxResult GetJoystickId();
+	MxResult GetJoystickState(MxU32* joystick_x, MxU32* joystick_y, DWORD* buttons_state, MxU32* pov_position);
+	void SetTimer();
+	void KillTimer();
+	void SetCamera(LegoCameraController* p_camera);
+	void ClearCamera();
+	void SetWorld(LegoWorld* p_world);
+	void ClearWorld();
 
-  inline void SetUnknown88(MxBool p_unk0x88) { m_unk0x88 = p_unk0x88; }
-  inline void SetUnknown336(MxBool p_unk0x336) { m_unk0x336 = p_unk0x336; }
+	inline void SetUnknown88(MxBool p_unk0x88) { m_unk0x88 = p_unk0x88; }
+	inline void SetUnknown336(MxBool p_unk0x336) { m_unk0x336 = p_unk0x336; }
 
-  inline LegoControlManager *GetControlManager() { return m_controlManager; }
-  inline LegoWorld *GetWorld() { return m_world; }
+	inline LegoControlManager* GetControlManager() { return m_controlManager; }
+	inline LegoWorld* GetWorld() { return m_world; }
 
-//private:
-  MxCriticalSection m_criticalSection;
-  MxList<undefined4> *m_unk0x5c; // list or hash table
-  LegoCameraController *m_camera;
-  LegoWorld *m_world;
-  MxList<undefined4> *m_unk0x68; // list or hash table
-  undefined4 m_unk0x6c;
-  undefined4 m_unk0x70;
-  undefined4 m_unk0x74;
-  UINT m_timer;
-  UINT m_timeout;
-  undefined m_unk0x80;
-  undefined m_unk0x81;
-  LegoControlManager* m_controlManager;
-  MxBool m_unk0x88;
-  IDirectInput *m_directInput;
-  IDirectInputDevice *m_directInputDevice;
-  undefined m_unk0x94;
-  undefined4 m_unk0x98;
-  undefined m_unk0x9c[0xF8];
-  undefined m_unk0x194;
-  MxBool m_unk0x195;
-  MxS32 m_joyid;
-  MxS32 m_joystickIndex;
-  JOYCAPS m_joyCaps;
-  MxBool m_useJoystick;
-  MxBool m_unk0x335;
-  MxBool m_unk0x336;
+	// private:
+	MxCriticalSection m_criticalSection;
+	MxList<undefined4>* m_unk0x5c; // list or hash table
+	LegoCameraController* m_camera;
+	LegoWorld* m_world;
+	MxList<undefined4>* m_unk0x68; // list or hash table
+	undefined4 m_unk0x6c;
+	undefined4 m_unk0x70;
+	undefined4 m_unk0x74;
+	UINT m_timer;
+	UINT m_timeout;
+	undefined m_unk0x80;
+	undefined m_unk0x81;
+	LegoControlManager* m_controlManager;
+	MxBool m_unk0x88;
+	IDirectInput* m_directInput;
+	IDirectInputDevice* m_directInputDevice;
+	undefined m_unk0x94;
+	undefined4 m_unk0x98;
+	undefined m_unk0x9c[0xF8];
+	undefined m_unk0x194;
+	MxBool m_unk0x195;
+	MxS32 m_joyid;
+	MxS32 m_joystickIndex;
+	JOYCAPS m_joyCaps;
+	MxBool m_useJoystick;
+	MxBool m_unk0x335;
+	MxBool m_unk0x336;
 };
 
 #endif // LEGOINPUTMANAGER_H

--- a/LEGO1/legojetski.h
+++ b/LEGO1/legojetski.h
@@ -4,23 +4,20 @@
 #include "legojetskiraceactor.h"
 
 // VTABLE 0x100d5a40
-class LegoJetski : public LegoJetskiRaceActor
-{
+class LegoJetski : public LegoJetskiRaceActor {
 public:
-  // OFFSET: LEGO1 0x10013e80
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f053c
-    return "LegoJetski";
-  }
+	// OFFSET: LEGO1 0x10013e80
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f053c
+		return "LegoJetski";
+	}
 
-  // OFFSET: LEGO1 0x10013ea0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoJetski::ClassName()) || LegoJetskiRaceActor::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10013ea0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoJetski::ClassName()) || LegoJetskiRaceActor::IsA(name);
+	}
 };
-
 
 #endif // LEGOJETSKI_H

--- a/LEGO1/legojetskiraceactor.h
+++ b/LEGO1/legojetskiraceactor.h
@@ -4,21 +4,20 @@
 #include "legocarraceactor.h"
 
 // VTABLE 0x100da240
-class LegoJetskiRaceActor : public LegoCarRaceActor
-{
+class LegoJetskiRaceActor : public LegoCarRaceActor {
 public:
-  // OFFSET: LEGO1 0x10081d80
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0554
-    return "LegoJetskiRaceActor";
-  }
+	// OFFSET: LEGO1 0x10081d80
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0554
+		return "LegoJetskiRaceActor";
+	}
 
-  // OFFSET: LEGO1 0x10081da0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoJetskiRaceActor::ClassName()) || LegoCarRaceActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10081da0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoJetskiRaceActor::ClassName()) || LegoCarRaceActor::IsA(name);
+	}
 };
 
 #endif // LEGOJETSKIRACEACTOR_H

--- a/LEGO1/legoloadcachesoundpresenter.cpp
+++ b/LEGO1/legoloadcachesoundpresenter.cpp
@@ -3,17 +3,17 @@
 // OFFSET: LEGO1 0x10018340
 LegoLoadCacheSoundPresenter::LegoLoadCacheSoundPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x10018480 STUB
 LegoLoadCacheSoundPresenter::~LegoLoadCacheSoundPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100184e0 STUB
 void LegoLoadCacheSoundPresenter::Init()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoloadcachesoundpresenter.h
+++ b/LEGO1/legoloadcachesoundpresenter.h
@@ -5,22 +5,20 @@
 
 // VTABLE 0x100d5fa8
 // SIZE 0x90
-class LegoLoadCacheSoundPresenter : public MxWavePresenter
-{
+class LegoLoadCacheSoundPresenter : public MxWavePresenter {
 public:
-  LegoLoadCacheSoundPresenter();
-  virtual ~LegoLoadCacheSoundPresenter() override;
+	LegoLoadCacheSoundPresenter();
+	virtual ~LegoLoadCacheSoundPresenter() override;
 
-  // OFFSET: LEGO1 0x10018450
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f05a0
-    return "LegoLoadCacheSoundPresenter";
-  }
+	// OFFSET: LEGO1 0x10018450
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f05a0
+		return "LegoLoadCacheSoundPresenter";
+	}
 
 private:
-  void Init();
-
+	void Init();
 };
 
 #endif // LEGOLOADCACHESOUNDPRESENTER_H

--- a/LEGO1/legolocomotionanimpresenter.cpp
+++ b/LEGO1/legolocomotionanimpresenter.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x1006cdd0
 LegoLocomotionAnimPresenter::LegoLocomotionAnimPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x1006d0b0 STUB
 void LegoLocomotionAnimPresenter::Init()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legolocomotionanimpresenter.h
+++ b/LEGO1/legolocomotionanimpresenter.h
@@ -4,27 +4,25 @@
 #include "legoloopinganimpresenter.h"
 
 // VTABLE 0x100d9170
-class LegoLocomotionAnimPresenter : public LegoLoopingAnimPresenter
-{
+class LegoLocomotionAnimPresenter : public LegoLoopingAnimPresenter {
 public:
-  LegoLocomotionAnimPresenter();
+	LegoLocomotionAnimPresenter();
 
-  // OFFSET: LEGO1 0x1006ce50
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f06e4
-    return "LegoLocomotionAnimPresenter";
-  }
+	// OFFSET: LEGO1 0x1006ce50
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f06e4
+		return "LegoLocomotionAnimPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1006ce60
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || LegoLoopingAnimPresenter::IsA(name);
-  }
-  
+	// OFFSET: LEGO1 0x1006ce60
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || LegoLoopingAnimPresenter::IsA(name);
+	}
+
 private:
-  void Init();
-
+	void Init();
 };
 
 #endif // LEGOLOCOMOTIONANIMPRESENTER_H

--- a/LEGO1/legoloopinganimpresenter.h
+++ b/LEGO1/legoloopinganimpresenter.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d4900
 // SIZE 0xc0 (discovered through inlined constructor at 0x10009ecd)
-class LegoLoopingAnimPresenter : public LegoAnimPresenter
-{
+class LegoLoopingAnimPresenter : public LegoAnimPresenter {
 public:
-  // OFFSET: LEGO1 0x1000c9a0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0700
-    return "LegoLoopingAnimPresenter";
-  }
+	// OFFSET: LEGO1 0x1000c9a0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0700
+		return "LegoLoopingAnimPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000c9b0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || LegoAnimPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000c9b0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || LegoAnimPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOLOOPINGANIMPRESENTER_H

--- a/LEGO1/legometerpresenter.h
+++ b/LEGO1/legometerpresenter.h
@@ -5,10 +5,9 @@
 
 // VTABLE 0x100d7ac8
 // SIZE 0x94 (from 0x1000a163)
-class LegoMeterPresenter : public MxStillPresenter
-{
+class LegoMeterPresenter : public MxStillPresenter {
 public:
-  // MxStillPresenter's `::ClassName` and `::IsA` are used.
+	// MxStillPresenter's `::ClassName` and `::IsA` are used.
 };
 
 #endif // LEGOMETERPRESENTER_H

--- a/LEGO1/legomodelpresenter.cpp
+++ b/LEGO1/legomodelpresenter.cpp
@@ -6,5 +6,5 @@ int g_modelPresenterConfig = 1;
 // OFFSET: LEGO1 0x1007f660
 void LegoModelPresenter::configureLegoModelPresenter(int param_1)
 {
-  g_modelPresenterConfig = param_1;
+	g_modelPresenterConfig = param_1;
 }

--- a/LEGO1/legomodelpresenter.h
+++ b/LEGO1/legomodelpresenter.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d4e50
 // SIZE 0x6c (discovered through inline constructor at 0x10009ae6)
-class LegoModelPresenter : public MxVideoPresenter
-{
+class LegoModelPresenter : public MxVideoPresenter {
 public:
-  __declspec(dllexport) static void configureLegoModelPresenter(int param_1);
+	__declspec(dllexport) static void configureLegoModelPresenter(int param_1);
 
-  // OFFSET: LEGO1 0x1000ccb0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f067c
-    return "LegoModelPresenter";
-  }
+	// OFFSET: LEGO1 0x1000ccb0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f067c
+		return "LegoModelPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000ccc0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoModelPresenter::ClassName()) || MxVideoPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000ccc0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoModelPresenter::ClassName()) || MxVideoPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOMODELPRESENTER_H

--- a/LEGO1/legonavcontroller.cpp
+++ b/LEGO1/legonavcontroller.cpp
@@ -1,8 +1,8 @@
 #include "legonavcontroller.h"
 
 #include "legoomni.h"
-#include "legovideomanager.h"
 #include "legoutil.h"
+#include "legovideomanager.h"
 
 // 0x100f4c28
 int g_mouseDeadzone = 40;
@@ -30,67 +30,85 @@ float g_turnSensitivity = 0.4f;
 MxBool g_turnUseVelocity = FALSE;
 
 // OFFSET: LEGO1 0x10054d40
-void LegoNavController::GetDefaults(int *p_mouseDeadzone, float *p_movementMaxSpeed, float *p_turnMaxSpeed,
-                                    float *p_movementMaxAccel, float *p_turnMaxAccel, float *p_movementDecel,
-                                    float *p_turnDecel, float *p_movementMinAccel, float *p_turnMinAccel,
-                                    float *p_turnSensitivity, MxBool *p_turnUseVelocity)
+void LegoNavController::GetDefaults(
+	int* p_mouseDeadzone,
+	float* p_movementMaxSpeed,
+	float* p_turnMaxSpeed,
+	float* p_movementMaxAccel,
+	float* p_turnMaxAccel,
+	float* p_movementDecel,
+	float* p_turnDecel,
+	float* p_movementMinAccel,
+	float* p_turnMinAccel,
+	float* p_turnSensitivity,
+	MxBool* p_turnUseVelocity
+)
 {
-  *p_mouseDeadzone = g_mouseDeadzone;
-  *p_movementMaxSpeed = g_movementMaxSpeed;
-  *p_turnMaxSpeed = g_turnMaxSpeed;
-  *p_movementMaxAccel = g_movementMaxAccel;
-  *p_turnMaxAccel = g_turnMaxAccel;
-  *p_movementDecel = g_movementDecel;
-  *p_turnDecel = g_turnDecel;
-  *p_movementMinAccel = g_movementMinAccel;
-  *p_turnMinAccel = g_turnMinAccel;
-  *p_turnSensitivity = g_turnSensitivity;
-  *p_turnUseVelocity = g_turnUseVelocity;
+	*p_mouseDeadzone = g_mouseDeadzone;
+	*p_movementMaxSpeed = g_movementMaxSpeed;
+	*p_turnMaxSpeed = g_turnMaxSpeed;
+	*p_movementMaxAccel = g_movementMaxAccel;
+	*p_turnMaxAccel = g_turnMaxAccel;
+	*p_movementDecel = g_movementDecel;
+	*p_turnDecel = g_turnDecel;
+	*p_movementMinAccel = g_movementMinAccel;
+	*p_turnMinAccel = g_turnMinAccel;
+	*p_turnSensitivity = g_turnSensitivity;
+	*p_turnUseVelocity = g_turnUseVelocity;
 }
 
 // OFFSET: LEGO1 0x10054dd0
-void LegoNavController::SetDefaults(int p_mouseDeadzone, float p_movementMaxSpeed, float p_turnMaxSpeed,
-                                    float p_movementMaxAccel, float p_turnMaxAccel, float p_movementDecel,
-                                    float p_turnDecel, float p_movementMinAccel, float p_turnMinAccel,
-                                    float p_turnSensitivity, MxBool p_turnUseVelocity)
+void LegoNavController::SetDefaults(
+	int p_mouseDeadzone,
+	float p_movementMaxSpeed,
+	float p_turnMaxSpeed,
+	float p_movementMaxAccel,
+	float p_turnMaxAccel,
+	float p_movementDecel,
+	float p_turnDecel,
+	float p_movementMinAccel,
+	float p_turnMinAccel,
+	float p_turnSensitivity,
+	MxBool p_turnUseVelocity
+)
 {
-  g_mouseDeadzone = p_mouseDeadzone;
-  g_movementMaxSpeed = p_movementMaxSpeed;
-  g_turnMaxSpeed = p_turnMaxSpeed;
-  g_movementMaxAccel = p_movementMaxAccel;
-  g_turnMaxAccel = p_turnMaxAccel;
-  g_movementDecel = p_movementDecel;
-  g_turnDecel = p_turnDecel;
-  g_movementMinAccel = p_movementMinAccel;
-  g_turnMinAccel = p_turnMinAccel;
-  g_turnSensitivity = p_turnSensitivity;
-  g_turnUseVelocity = p_turnUseVelocity;
+	g_mouseDeadzone = p_mouseDeadzone;
+	g_movementMaxSpeed = p_movementMaxSpeed;
+	g_turnMaxSpeed = p_turnMaxSpeed;
+	g_movementMaxAccel = p_movementMaxAccel;
+	g_turnMaxAccel = p_turnMaxAccel;
+	g_movementDecel = p_movementDecel;
+	g_turnDecel = p_turnDecel;
+	g_movementMinAccel = p_movementMinAccel;
+	g_turnMinAccel = p_turnMinAccel;
+	g_turnSensitivity = p_turnSensitivity;
+	g_turnUseVelocity = p_turnUseVelocity;
 }
 
 // OFFSET: LEGO1 0x10054ac0
 LegoNavController::LegoNavController()
 {
-  ResetToDefault();
+	ResetToDefault();
 
-  this->unk_18 = 0.0f;
-  this->unk_1C = 0.0f;
-  this->m_targetMovementSpeed = 0.0f;
-  this->m_targetTurnSpeed = 0.0f;
-  this->m_movementAccel = 0.0f;
-  this->m_turnAccel = 0.0f;
-  this->m_trackDefault = FALSE;
-  this->m_unk5D = FALSE;
-  this->m_unk6C = FALSE;
-  this->m_unk64 = 0;
-  this->m_unk68 = 0;
-  this->m_unk60 = 0;
+	this->unk_18 = 0.0f;
+	this->unk_1C = 0.0f;
+	this->m_targetMovementSpeed = 0.0f;
+	this->m_targetTurnSpeed = 0.0f;
+	this->m_movementAccel = 0.0f;
+	this->m_turnAccel = 0.0f;
+	this->m_trackDefault = FALSE;
+	this->m_unk5D = FALSE;
+	this->m_unk6C = FALSE;
+	this->m_unk64 = 0;
+	this->m_unk68 = 0;
+	this->m_unk60 = 0;
 
-  MxTimer *timer = Timer();
-  this->m_time = timer->GetTime();
+	MxTimer* timer = Timer();
+	this->m_time = timer->GetTime();
 
-  // TODO: InputManager()
-  // LegoInputManager* inputManager = InputManager();
-  // inputManager->Register(this);
+	// TODO: InputManager()
+	// LegoInputManager* inputManager = InputManager();
+	// inputManager->Register(this);
 }
 
 // TODO: InputManager()
@@ -104,99 +122,106 @@ LegoNavController::LegoNavController()
 // OFFSET: LEGO1 0x10054ca0
 void LegoNavController::SetControlMax(int p_hMax, int p_vMax)
 {
-  this->m_hMax = p_hMax;
-  this->m_vMax = p_vMax;
+	this->m_hMax = p_hMax;
+	this->m_vMax = p_vMax;
 
-  if (VideoManager()->GetVideoParam().flags().GetFullScreen()) {
-    this->m_hMax = 640;
-    this->m_vMax = 480;
-  }
+	if (VideoManager()->GetVideoParam().flags().GetFullScreen()) {
+		this->m_hMax = 640;
+		this->m_vMax = 480;
+	}
 }
 
 // OFFSET: LEGO1 0x10054cd0
 void LegoNavController::ResetToDefault()
 {
-  this->m_mouseDeadzone = g_mouseDeadzone;
-  this->m_zeroThreshold = g_zeroThreshold;
-  this->m_turnMaxAccel = g_turnMaxAccel;
-  this->m_movementMaxAccel = g_movementMaxAccel;
-  this->m_turnMinAccel = g_turnMinAccel;
-  this->m_movementMinAccel = g_movementMinAccel;
-  this->m_turnDecel = g_turnDecel;
-  this->m_movementDecel = g_movementDecel;
-  this->m_turnMaxSpeed = g_turnMaxSpeed;
-  this->m_movementMaxSpeed = g_movementMaxSpeed;
-  this->m_turnUseVelocity = g_turnUseVelocity;
-  this->m_turnSensitivity = g_turnSensitivity;
+	this->m_mouseDeadzone = g_mouseDeadzone;
+	this->m_zeroThreshold = g_zeroThreshold;
+	this->m_turnMaxAccel = g_turnMaxAccel;
+	this->m_movementMaxAccel = g_movementMaxAccel;
+	this->m_turnMinAccel = g_turnMinAccel;
+	this->m_movementMinAccel = g_movementMinAccel;
+	this->m_turnDecel = g_turnDecel;
+	this->m_movementDecel = g_movementDecel;
+	this->m_turnMaxSpeed = g_turnMaxSpeed;
+	this->m_movementMaxSpeed = g_movementMaxSpeed;
+	this->m_turnUseVelocity = g_turnUseVelocity;
+	this->m_turnSensitivity = g_turnSensitivity;
 }
 
 // OFFSET: LEGO1 0x10054e40
 void LegoNavController::SetTargets(int p_hPos, int p_vPos, MxBool p_accel)
 {
-  if (this->m_trackDefault != FALSE)
-    ResetToDefault();
+	if (this->m_trackDefault != FALSE)
+		ResetToDefault();
 
-  if (p_accel != FALSE) {
-    this->m_targetTurnSpeed = CalculateNewTargetSpeed(p_hPos, this->m_hMax / 2, this->m_turnMaxSpeed);
-    this->m_targetMovementSpeed = CalculateNewTargetSpeed(this->m_vMax - p_vPos, this->m_vMax / 2, this->m_movementMaxSpeed);
-    this->m_turnAccel = CalculateNewAccel(p_hPos, this->m_hMax / 2, this->m_turnMaxAccel, (int)this->m_turnMinAccel);
-    this->m_movementAccel = CalculateNewAccel(this->m_vMax - p_vPos, this->m_vMax / 2, this->m_movementMaxAccel, (int)this->m_movementMinAccel);
-  }
-  else {
-    this->m_targetTurnSpeed = 0.0f;
-    this->m_targetMovementSpeed = 0.0f;
-    this->m_movementAccel = this->m_movementDecel;
-    this->m_turnAccel = this->m_turnDecel;
-  }
+	if (p_accel != FALSE) {
+		this->m_targetTurnSpeed = CalculateNewTargetSpeed(p_hPos, this->m_hMax / 2, this->m_turnMaxSpeed);
+		this->m_targetMovementSpeed =
+			CalculateNewTargetSpeed(this->m_vMax - p_vPos, this->m_vMax / 2, this->m_movementMaxSpeed);
+		this->m_turnAccel =
+			CalculateNewAccel(p_hPos, this->m_hMax / 2, this->m_turnMaxAccel, (int) this->m_turnMinAccel);
+		this->m_movementAccel = CalculateNewAccel(
+			this->m_vMax - p_vPos,
+			this->m_vMax / 2,
+			this->m_movementMaxAccel,
+			(int) this->m_movementMinAccel
+		);
+	}
+	else {
+		this->m_targetTurnSpeed = 0.0f;
+		this->m_targetMovementSpeed = 0.0f;
+		this->m_movementAccel = this->m_movementDecel;
+		this->m_turnAccel = this->m_turnDecel;
+	}
 }
 
 // OFFSET: LEGO1 0x10054f10
 float LegoNavController::CalculateNewTargetSpeed(int p_pos, int p_center, float p_maxSpeed)
 {
-  float result;
-  int diff = p_pos - p_center;
+	float result;
+	int diff = p_pos - p_center;
 
-  if (diff > this->m_mouseDeadzone)
-    result = (diff - m_mouseDeadzone) * p_maxSpeed / (p_center - m_mouseDeadzone);
-  else if (diff < -m_mouseDeadzone)
-    result = (diff + m_mouseDeadzone) * p_maxSpeed / (p_center - m_mouseDeadzone);
-  else
-    result = 0.0f;
+	if (diff > this->m_mouseDeadzone)
+		result = (diff - m_mouseDeadzone) * p_maxSpeed / (p_center - m_mouseDeadzone);
+	else if (diff < -m_mouseDeadzone)
+		result = (diff + m_mouseDeadzone) * p_maxSpeed / (p_center - m_mouseDeadzone);
+	else
+		result = 0.0f;
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x10054f90
 float LegoNavController::CalculateNewAccel(int p_pos, int p_center, float p_maxAccel, int p_minAccel)
 {
-  float result;
-  int diff = p_pos - p_center;
+	float result;
+	int diff = p_pos - p_center;
 
-  result = Abs(diff) * p_maxAccel / p_center;
+	result = Abs(diff) * p_maxAccel / p_center;
 
-  if (result < p_minAccel)
-    result = (float) p_minAccel;
+	if (result < p_minAccel)
+		result = (float) p_minAccel;
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x10054fe0
 float LegoNavController::CalculateNewVel(float p_targetVel, float p_currentVel, float p_accel, float p_time)
 {
-  float newVel = p_currentVel;
+	float newVel = p_currentVel;
 
-  float velDiff = p_targetVel - p_currentVel;
-  int vSign = velDiff > 0 ? 1 : -1;
+	float velDiff = p_targetVel - p_currentVel;
+	int vSign = velDiff > 0 ? 1 : -1;
 
-  if (Abs(velDiff) > this->m_zeroThreshold) {
-    float deltaVel = p_accel * p_time;
-    newVel = p_currentVel + (deltaVel * vSign);
+	if (Abs(velDiff) > this->m_zeroThreshold) {
+		float deltaVel = p_accel * p_time;
+		newVel = p_currentVel + (deltaVel * vSign);
 
-    if (vSign > 0)
-      newVel = Min(newVel, p_targetVel);
-    else
-      newVel = Max(newVel, p_targetVel);
-  }
+		if (vSign > 0)
+			newVel = Min(newVel, p_targetVel);
+		else
+			newVel = Max(newVel, p_targetVel);
+	}
 
-  return newVel;
+	return newVel;
 }

--- a/LEGO1/legonavcontroller.h
+++ b/LEGO1/legonavcontroller.h
@@ -7,70 +7,87 @@
 
 // VTABLE 0x100d85b8
 // SIZE 0x70
-class LegoNavController : public MxCore
-{
+class LegoNavController : public MxCore {
 public:
-  __declspec(dllexport) static void GetDefaults(int *p_mouseDeadzone, float *p_movementMaxSpeed, float *p_turnMaxSpeed,
-                                                float *p_movementMaxAccel, float *p_turnMaxAccel, float *p_movementDecel,
-                                                float *p_turnDecel, float *p_movementMinAccel, float *p_turnMinAccel,
-                                                float *p_rotationSensitivity, MxBool *p_turnUseVelocity);
-  __declspec(dllexport) static void SetDefaults(int p_mouseDeadzone, float p_movementMaxSpeed, float p_turnMaxSpeed,
-                                                float p_movementMaxAccel, float p_turnMaxAccel, float p_movementDecel,
-                                                float p_turnDecel, float p_movementMinAccel, float p_turnMinAccel,
-                                                float p_rotationSensitivity, MxBool p_turnUseVelocity);
+	__declspec(dllexport) static void GetDefaults(
+		int* p_mouseDeadzone,
+		float* p_movementMaxSpeed,
+		float* p_turnMaxSpeed,
+		float* p_movementMaxAccel,
+		float* p_turnMaxAccel,
+		float* p_movementDecel,
+		float* p_turnDecel,
+		float* p_movementMinAccel,
+		float* p_turnMinAccel,
+		float* p_rotationSensitivity,
+		MxBool* p_turnUseVelocity
+	);
+	__declspec(dllexport) static void SetDefaults(
+		int p_mouseDeadzone,
+		float p_movementMaxSpeed,
+		float p_turnMaxSpeed,
+		float p_movementMaxAccel,
+		float p_turnMaxAccel,
+		float p_movementDecel,
+		float p_turnDecel,
+		float p_movementMinAccel,
+		float p_turnMinAccel,
+		float p_rotationSensitivity,
+		MxBool p_turnUseVelocity
+	);
 
-  LegoNavController();
-  // virtual ~LegoNavController(); // vtable+0x0
+	LegoNavController();
+	// virtual ~LegoNavController(); // vtable+0x0
 
-  // OFFSET: LEGO1 0x10054b80
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f66d8
-    return "LegoNavController";
-  }
+	// OFFSET: LEGO1 0x10054b80
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f66d8
+		return "LegoNavController";
+	}
 
-  // OFFSET: LEGO1 0x10054b90
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10054b90
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || MxCore::IsA(name);
+	}
 
-  void SetControlMax(int p_hMax, int p_vMax);
-  void ResetToDefault();
-  void SetTargets(int p_hPos, int p_vPos, MxBool p_accel);
-  float CalculateNewTargetSpeed(int p_pos, int p_center, float p_maxSpeed);
-  float CalculateNewAccel(int p_pos, int p_center, float p_maxAccel, int p_minAccel);
-  float CalculateNewVel(float p_targetVel, float p_currentVel, float p_accel, float p_time);
+	void SetControlMax(int p_hMax, int p_vMax);
+	void ResetToDefault();
+	void SetTargets(int p_hPos, int p_vPos, MxBool p_accel);
+	float CalculateNewTargetSpeed(int p_pos, int p_center, float p_maxSpeed);
+	float CalculateNewAccel(int p_pos, int p_center, float p_maxAccel, int p_minAccel);
+	float CalculateNewVel(float p_targetVel, float p_currentVel, float p_accel, float p_time);
 
 private:
-  int m_hMax;
-  int m_vMax;
-  int m_mouseDeadzone;
-  float m_zeroThreshold;
-  float unk_18;
-  float unk_1C;
-  float m_targetMovementSpeed;
-  float m_targetTurnSpeed;
-  float m_movementMaxSpeed;
-  float m_turnMaxSpeed;
-  float m_movementAccel;
-  float m_turnAccel;
-  float m_movementMaxAccel;
-  float m_turnMaxAccel;
-  float m_movementMinAccel;
-  float m_turnMinAccel;
-  float m_movementDecel;
-  float m_turnDecel;
-  float m_turnSensitivity;
-  MxBool m_turnUseVelocity;
-  int m_time;
-  MxBool m_trackDefault;
-  MxBool m_unk5D;
-  char m_unk5E[2];
-  int m_unk60;
-  int m_unk64;
-  int m_unk68;
-  MxBool m_unk6C;
+	int m_hMax;
+	int m_vMax;
+	int m_mouseDeadzone;
+	float m_zeroThreshold;
+	float unk_18;
+	float unk_1C;
+	float m_targetMovementSpeed;
+	float m_targetTurnSpeed;
+	float m_movementMaxSpeed;
+	float m_turnMaxSpeed;
+	float m_movementAccel;
+	float m_turnAccel;
+	float m_movementMaxAccel;
+	float m_turnMaxAccel;
+	float m_movementMinAccel;
+	float m_turnMinAccel;
+	float m_movementDecel;
+	float m_turnDecel;
+	float m_turnSensitivity;
+	MxBool m_turnUseVelocity;
+	int m_time;
+	MxBool m_trackDefault;
+	MxBool m_unk5D;
+	char m_unk5E[2];
+	int m_unk60;
+	int m_unk64;
+	int m_unk68;
+	MxBool m_unk6C;
 };
 
 #endif // LEGONAVCONTROLLER_H

--- a/LEGO1/legoobjectfactory.cpp
+++ b/LEGO1/legoobjectfactory.cpp
@@ -1,7 +1,7 @@
 #include "legoobjectfactory.h"
 
-#include "infocenterstate.h"
 #include "decomp.h"
+#include "infocenterstate.h"
 
 // TODO: Uncomment once we have all the relevant types ready
 // DECOMP_SIZE_ASSERT(LegoObjectFactory, 0x1c8);
@@ -10,25 +10,29 @@
 LegoObjectFactory::LegoObjectFactory()
 {
 #define X(V) this->m_id##V = MxAtomId(#V, LookupMode_Exact);
-  FOR_LEGOOBJECTFACTORY_OBJECTS(X)
+	FOR_LEGOOBJECTFACTORY_OBJECTS(X)
 #undef X
 }
 
 // OFFSET: LEGO1 0x10009a90
-MxCore *LegoObjectFactory::Create(const char *p_name)
+MxCore* LegoObjectFactory::Create(const char* p_name)
 {
-  MxAtomId atom(p_name, LookupMode_Exact);
+	MxAtomId atom(p_name, LookupMode_Exact);
 
-#define X(V) if (this->m_id##V == atom) { return new V; } else
-  FOR_LEGOOBJECTFACTORY_OBJECTS(X)
+#define X(V)                                                                                                           \
+	if (this->m_id##V == atom) {                                                                                       \
+		return new V;                                                                                                  \
+	}                                                                                                                  \
+	else
+	FOR_LEGOOBJECTFACTORY_OBJECTS(X)
 #undef X
-  {
-    return MxObjectFactory::Create(p_name);
-  }
+	{
+		return MxObjectFactory::Create(p_name);
+	}
 }
 
 // OFFSET: LEGO1 0x1000fb30 STUB
-void LegoObjectFactory::Destroy(MxCore *p_object)
+void LegoObjectFactory::Destroy(MxCore* p_object)
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoobjectfactory.h
+++ b/LEGO1/legoobjectfactory.h
@@ -3,19 +3,17 @@
 
 #include "mxobjectfactory.h"
 
-#define FOR_LEGOOBJECTFACTORY_OBJECTS(X) \
-  X(InfocenterState)
+#define FOR_LEGOOBJECTFACTORY_OBJECTS(X) X(InfocenterState)
 
 // VTABLE 0x100d4768
-class LegoObjectFactory : public MxObjectFactory
-{
+class LegoObjectFactory : public MxObjectFactory {
 public:
-  LegoObjectFactory();
-  virtual MxCore *Create(const char *p_name) override; // vtable 0x14
-  virtual void Destroy(MxCore *p_object) override; // vtable 0x18
+	LegoObjectFactory();
+	virtual MxCore* Create(const char* p_name) override; // vtable 0x14
+	virtual void Destroy(MxCore* p_object) override;     // vtable 0x18
 private:
 #define X(V) MxAtomId m_id##V;
-  FOR_LEGOOBJECTFACTORY_OBJECTS(X)
+	FOR_LEGOOBJECTFACTORY_OBJECTS(X)
 #undef X
 };
 

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -1,373 +1,373 @@
 #include "legoomni.h"
 
+#include "legogamestate.h"
+#include "legoinputmanager.h"
+#include "legoobjectfactory.h"
+#include "legoutil.h"
+#include "legoworld.h"
 #include "mxbackgroundaudiomanager.h"
 #include "mxdsfile.h"
-#include "legogamestate.h"
-#include "legoutil.h"
-#include "legoobjectfactory.h"
-#include "legoinputmanager.h"
-#include "legoworld.h"
 
 // 0x100f4588
-MxAtomId *g_nocdSourceName = NULL;
+MxAtomId* g_nocdSourceName = NULL;
 
 // 0x100f456c
-MxAtomId *g_jukeboxScript = NULL;
+MxAtomId* g_jukeboxScript = NULL;
 
 // 0x101020e8
-void (*g_omniUserMessage)(const char *,int);
+void (*g_omniUserMessage)(const char*, int);
 
 // OFFSET: LEGO1 0x10058a00
 LegoOmni::LegoOmni()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x10058b50
 LegoOmni::~LegoOmni()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x1005b560
 void LegoOmni::CreateBackgroundAudio()
 {
-  if (m_bkgAudioManager)
-    m_bkgAudioManager->Create(*g_jukeboxScript, 100);
+	if (m_bkgAudioManager)
+		m_bkgAudioManager->Create(*g_jukeboxScript, 100);
 }
 
 // OFFSET: LEGO1 0x1005af10 STUB
-void LegoOmni::RemoveWorld(const MxAtomId &p1, MxLong p2)
+void LegoOmni::RemoveWorld(const MxAtomId& p1, MxLong p2)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005b400 STUB
-int LegoOmni::GetCurrPathInfo(LegoPathBoundary **,int &)
+int LegoOmni::GetCurrPathInfo(LegoPathBoundary**, int&)
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100b6ff0
-void MakeSourceName(char *p_output, const char *p_input)
+void MakeSourceName(char* p_output, const char* p_input)
 {
-  const char *cln = strchr(p_input, ':');
-  if (cln) {
-    p_input = cln + 1;
-  }
+	const char* cln = strchr(p_input, ':');
+	if (cln) {
+		p_input = cln + 1;
+	}
 
-  strcpy(p_output, p_input);
+	strcpy(p_output, p_input);
 
-  strlwr(p_output);
+	strlwr(p_output);
 
-  char *extLoc = strstr(p_output, ".si");
-  if (extLoc) {
-    *extLoc = 0;
-  }
+	char* extLoc = strstr(p_output, ".si");
+	if (extLoc) {
+		*extLoc = 0;
+	}
 }
 
 // OFFSET: LEGO1 0x100b7050
-MxBool KeyValueStringParse(char *p_outputValue, const char *p_key, const char *p_source)
+MxBool KeyValueStringParse(char* p_outputValue, const char* p_key, const char* p_source)
 {
-  MxBool didMatch = FALSE;
+	MxBool didMatch = FALSE;
 
-  MxS16 len = strlen(p_source);
-  char *temp = new char[len + 1];
-  strcpy(temp, p_source);
+	MxS16 len = strlen(p_source);
+	char* temp = new char[len + 1];
+	strcpy(temp, p_source);
 
-  char *token = strtok(temp, ", \t\r\n:");
-  while (token) {
-    len -= (strlen(token) + 1);
+	char* token = strtok(temp, ", \t\r\n:");
+	while (token) {
+		len -= (strlen(token) + 1);
 
-    if (strcmpi(token, p_key) == 0) {
-      if (p_outputValue && len > 0) {
-        char *cur = &token[strlen(p_key)];
-        cur++;
-        while (*cur != ',') {
-          if (*cur == ' ' || *cur == '\0' || *cur == '\t' || *cur == '\n' || *cur == '\r')
-            break;
-          *p_outputValue++ = *cur++;
-        }
-        *p_outputValue = '\0';
-      }
+		if (strcmpi(token, p_key) == 0) {
+			if (p_outputValue && len > 0) {
+				char* cur = &token[strlen(p_key)];
+				cur++;
+				while (*cur != ',') {
+					if (*cur == ' ' || *cur == '\0' || *cur == '\t' || *cur == '\n' || *cur == '\r')
+						break;
+					*p_outputValue++ = *cur++;
+				}
+				*p_outputValue = '\0';
+			}
 
-      didMatch = TRUE;
-      break;
-    }
+			didMatch = TRUE;
+			break;
+		}
 
-    token = strtok(NULL, ", \t\r\n:");
-  }
+		token = strtok(NULL, ", \t\r\n:");
+	}
 
-  delete[] temp;
-  return didMatch;
+	delete[] temp;
+	return didMatch;
 }
 
 // OFFSET: LEGO1 0x100b7210
-void SetOmniUserMessage(void (*p_userMsg)(const char *,int))
+void SetOmniUserMessage(void (*p_userMsg)(const char*, int))
 {
-  g_omniUserMessage = p_userMsg;
+	g_omniUserMessage = p_userMsg;
 }
 
 // OFFSET: LEGO1 0x100acf50
 MxResult Start(MxDSAction* p_dsAction)
 {
-  return MxOmni::GetInstance()->Start(p_dsAction);
+	return MxOmni::GetInstance()->Start(p_dsAction);
 }
 
 // OFFSET: LEGO1 0x1005ad10
-LegoOmni *LegoOmni::GetInstance()
+LegoOmni* LegoOmni::GetInstance()
 {
-  return (LegoOmni *)MxOmni::GetInstance();
+	return (LegoOmni*) MxOmni::GetInstance();
 }
 
 // OFFSET: LEGO1 0x1005ac90
 void LegoOmni::CreateInstance()
 {
-  MxOmni::DestroyInstance();
-  MxOmni::SetInstance(new LegoOmni());
+	MxOmni::DestroyInstance();
+	MxOmni::SetInstance(new LegoOmni());
 }
 
 // OFFSET: LEGO1 0x10015700
-LegoOmni *Lego()
+LegoOmni* Lego()
 {
-  return (LegoOmni *)MxOmni::GetInstance();
+	return (LegoOmni*) MxOmni::GetInstance();
 }
 
 // OFFSET: LEGO1 0x10015710
-LegoSoundManager *SoundManager()
+LegoSoundManager* SoundManager()
 {
-  return LegoOmni::GetInstance()->GetSoundManager();
+	return LegoOmni::GetInstance()->GetSoundManager();
 }
 
 // OFFSET: LEGO1 0x10015720
-LegoVideoManager *VideoManager()
+LegoVideoManager* VideoManager()
 {
-  return LegoOmni::GetInstance()->GetVideoManager();
+	return LegoOmni::GetInstance()->GetVideoManager();
 }
 
 // OFFSET: LEGO1 0x10015730
-MxBackgroundAudioManager *BackgroundAudioManager()
+MxBackgroundAudioManager* BackgroundAudioManager()
 {
-  return LegoOmni::GetInstance()->GetBackgroundAudioManager();
+	return LegoOmni::GetInstance()->GetBackgroundAudioManager();
 }
 
 // OFFSET: LEGO1 0x10015740
-LegoInputManager *InputManager()
+LegoInputManager* InputManager()
 {
-  return LegoOmni::GetInstance()->GetInputManager();
+	return LegoOmni::GetInstance()->GetInputManager();
 }
 
 // OFFSET: LEGO1 0x10015750
-LegoControlManager *ControlManager()
+LegoControlManager* ControlManager()
 {
-  return LegoOmni::GetInstance()->GetInputManager()->GetControlManager();
+	return LegoOmni::GetInstance()->GetInputManager()->GetControlManager();
 }
 
 // OFFSET: LEGO1 0x10015760
-LegoGameState *GameState()
+LegoGameState* GameState()
 {
-  return LegoOmni::GetInstance()->GetGameState();
+	return LegoOmni::GetInstance()->GetGameState();
 }
 
 // OFFSET: LEGO1 0x10015770
-LegoAnimationManager *AnimationManager()
+LegoAnimationManager* AnimationManager()
 {
-  return LegoOmni::GetInstance()->GetAnimationManager();
+	return LegoOmni::GetInstance()->GetAnimationManager();
 }
 
 // OFFSET: LEGO1 0x10015780
-LegoNavController *NavController()
+LegoNavController* NavController()
 {
-  return LegoOmni::GetInstance()->GetNavController();
+	return LegoOmni::GetInstance()->GetNavController();
 }
 
 // OFFSET: LEGO1 0x10015790
-LegoWorld *GetCurrentVehicle()
+LegoWorld* GetCurrentVehicle()
 {
-  return LegoOmni::GetInstance()->GetCurrentVehicle();
+	return LegoOmni::GetInstance()->GetCurrentVehicle();
 }
 
 // OFFSET: LEGO1 0x100157a0
-LegoWorld *GetCurrentWorld()
+LegoWorld* GetCurrentWorld()
 {
-  return LegoOmni::GetInstance()->GetCurrentWorld();
+	return LegoOmni::GetInstance()->GetCurrentWorld();
 }
 
 // OFFSET: LEGO1 0x100157e0
-LegoPlantManager *PlantManager()
+LegoPlantManager* PlantManager()
 {
-  return LegoOmni::GetInstance()->GetLegoPlantManager();
+	return LegoOmni::GetInstance()->GetLegoPlantManager();
 }
 
 // OFFSET: LEGO1 0x100157f0
-LegoBuildingManager *BuildingManager()
+LegoBuildingManager* BuildingManager()
 {
-  return LegoOmni::GetInstance()->GetLegoBuildingManager();
+	return LegoOmni::GetInstance()->GetLegoBuildingManager();
 }
 
 // OFFSET: LEGO1 0x10015800
-GifManager *GetGifManager()
+GifManager* GetGifManager()
 {
-  return LegoOmni::GetInstance()->GetGifManager();
+	return LegoOmni::GetInstance()->GetGifManager();
 }
 
 // OFFSET: LEGO1 0x10015900
-MxTransitionManager *TransitionManager()
+MxTransitionManager* TransitionManager()
 {
-  return LegoOmni::GetInstance()->GetTransitionManager();
+	return LegoOmni::GetInstance()->GetTransitionManager();
 }
 
 // OFFSET: LEGO1 0x100c0280
-MxDSObject *CreateStreamObject(MxDSFile *p_file, MxS16 p_ofs)
+MxDSObject* CreateStreamObject(MxDSFile* p_file, MxS16 p_ofs)
 {
-  char *buf;
-  _MMCKINFO tmp_chunk;
+	char* buf;
+	_MMCKINFO tmp_chunk;
 
-  if (p_file->Seek(((MxLong*)p_file->GetBuffer())[p_ofs], 0)) {
-    return NULL;
-  }
+	if (p_file->Seek(((MxLong*) p_file->GetBuffer())[p_ofs], 0)) {
+		return NULL;
+	}
 
-  if (p_file->Read((MxU8*)&tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'S', 't')) {
-    if (p_file->Read((MxU8*)&tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'O', 'b')) {
+	if (p_file->Read((MxU8*) &tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'S', 't')) {
+		if (p_file->Read((MxU8*) &tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'O', 'b')) {
 
-      buf = new char[tmp_chunk.cksize];
-      if (!buf) {
-        return NULL;
-      }
+			buf = new char[tmp_chunk.cksize];
+			if (!buf) {
+				return NULL;
+			}
 
-      if (p_file->Read((MxU8*)buf, tmp_chunk.cksize) != 0) {
-        return NULL;
-      }
+			if (p_file->Read((MxU8*) buf, tmp_chunk.cksize) != 0) {
+				return NULL;
+			}
 
-      // Save a copy so we can clean up properly, because
-      // this function will alter the pointer value.
-      char *copy = buf;
-      MxDSObject *obj = DeserializeDSObjectDispatch(&buf, -1);
-      delete[] copy;
-      return obj;
-    }
-    return NULL;
-  }
+			// Save a copy so we can clean up properly, because
+			// this function will alter the pointer value.
+			char* copy = buf;
+			MxDSObject* obj = DeserializeDSObjectDispatch(&buf, -1);
+			delete[] copy;
+			return obj;
+		}
+		return NULL;
+	}
 
-  return NULL;
+	return NULL;
 }
 
 // OFFSET: LEGO1 0x10053430
-const char *GetNoCD_SourceName()
+const char* GetNoCD_SourceName()
 {
-  return g_nocdSourceName->GetInternal();
+	return g_nocdSourceName->GetInternal();
 }
 
 // OFFSET: LEGO1 0x1005b5f0
-MxLong LegoOmni::Notify(MxParam &p)
+MxLong LegoOmni::Notify(MxParam& p)
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1003dd70 STUB
-LegoROI *PickROI(MxLong,MxLong)
+LegoROI* PickROI(MxLong, MxLong)
 {
-  // TODO
-  return NULL;
+	// TODO
+	return NULL;
 }
 
 // OFFSET: LEGO1 0x1003ddc0 STUB
-LegoEntity *PickEntity(MxLong,MxLong)
+LegoEntity* PickEntity(MxLong, MxLong)
 {
-  // TODO
-  return NULL;
+	// TODO
+	return NULL;
 }
 
 // OFFSET: LEGO1 0x10058bd0
 void LegoOmni::Init()
 {
-  MxOmni::Init();
-  m_unk68 = 0;
-  m_inputMgr = NULL;
-  m_unk6c = 0;
-  m_gifManager = NULL;
-  m_unk78 = 0;
-  m_currentWorld = NULL;
-  m_unk80 = FALSE;
-  m_currentVehicle = NULL;
-  m_unkLegoSaveDataWriter = NULL;
-  m_plantManager = NULL;
-  m_gameState = NULL;
-  m_animationManager = NULL;
-  m_buildingManager = NULL;
-  m_bkgAudioManager = NULL;
-  m_unk13c = TRUE;
-  m_transitionManager = NULL;
+	MxOmni::Init();
+	m_unk68 = 0;
+	m_inputMgr = NULL;
+	m_unk6c = 0;
+	m_gifManager = NULL;
+	m_unk78 = 0;
+	m_currentWorld = NULL;
+	m_unk80 = FALSE;
+	m_currentVehicle = NULL;
+	m_unkLegoSaveDataWriter = NULL;
+	m_plantManager = NULL;
+	m_gameState = NULL;
+	m_animationManager = NULL;
+	m_buildingManager = NULL;
+	m_bkgAudioManager = NULL;
+	m_unk13c = TRUE;
+	m_transitionManager = NULL;
 }
 
 // OFFSET: LEGO1 0x10058e70 STUB
-MxResult LegoOmni::Create(MxOmniCreateParam &p)
+MxResult LegoOmni::Create(MxOmniCreateParam& p)
 {
-  MxOmni::Create(p);
+	MxOmni::Create(p);
 
-  m_objectFactory = new LegoObjectFactory();
-  m_gameState = new LegoGameState();
-  m_bkgAudioManager = new MxBackgroundAudioManager();
+	m_objectFactory = new LegoObjectFactory();
+	m_gameState = new LegoGameState();
+	m_bkgAudioManager = new MxBackgroundAudioManager();
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10058c30 STUB
 void LegoOmni::Destroy()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005b580
 MxResult LegoOmni::Start(MxDSAction* action)
 {
-  MxResult result = MxOmni::Start(action);
-  this->m_action.SetAtomId(action->GetAtomId());
-  this->m_action.SetObjectId(action->GetObjectId());
-  this->m_action.SetUnknown24(action->GetUnknown24());
-  return result;
+	MxResult result = MxOmni::Start(action);
+	this->m_action.SetAtomId(action->GetAtomId());
+	this->m_action.SetObjectId(action->GetObjectId());
+	this->m_action.SetUnknown24(action->GetUnknown24());
+	return result;
 }
 
 // OFFSET: LEGO1 0x1005b1d0 STUB
-MxResult LegoOmni::DeleteObject(MxDSAction &ds)
+MxResult LegoOmni::DeleteObject(MxDSAction& ds)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x1005b3c0 STUB
-MxBool LegoOmni::DoesEntityExist(MxDSAction &ds)
+MxBool LegoOmni::DoesEntityExist(MxDSAction& ds)
 {
-  // TODO
-  return TRUE;
+	// TODO
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1005b2f0 STUB
 int LegoOmni::Vtable0x30(char*, int, MxCore*)
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1005b3a0
-void LegoOmni::NotifyCurrentEntity(MxNotificationParam *p_param)
+void LegoOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
 {
-  if (m_currentWorld)
-    NotificationManager()->Send(m_currentWorld, p_param);
+	if (m_currentWorld)
+		NotificationManager()->Send(m_currentWorld, p_param);
 }
 
 // OFFSET: LEGO1 0x1005b640
 void LegoOmni::StartTimer()
 {
-  MxOmni::StartTimer();
-  SetAppCursor(2);
+	MxOmni::StartTimer();
+	SetAppCursor(2);
 }
 
 // OFFSET: LEGO1 0x1005b650
 void LegoOmni::StopTimer()
 {
-  MxOmni::StopTimer();
-  SetAppCursor(0);
+	MxOmni::StopTimer();
+	SetAppCursor(0);
 }

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -2,8 +2,8 @@
 #define LEGOOMNI_H
 
 #include "compat.h"
-#include "mxomni.h"
 #include "mxdsaction.h"
+#include "mxomni.h"
 
 class GifManager;
 class Isle;
@@ -28,102 +28,101 @@ class MxTransitionManager;
 
 // VTABLE 0x100d8638
 // SIZE: 0x140
-class LegoOmni : public MxOmni
-{
+class LegoOmni : public MxOmni {
 public:
-  __declspec(dllexport) void CreateBackgroundAudio();
-  __declspec(dllexport) void RemoveWorld(const MxAtomId &p1, MxLong p2);
-  __declspec(dllexport) static int GetCurrPathInfo(LegoPathBoundary **,int &);
-  __declspec(dllexport) static void CreateInstance();
-  __declspec(dllexport) static LegoOmni *GetInstance();
+	__declspec(dllexport) void CreateBackgroundAudio();
+	__declspec(dllexport) void RemoveWorld(const MxAtomId& p1, MxLong p2);
+	__declspec(dllexport) static int GetCurrPathInfo(LegoPathBoundary**, int&);
+	__declspec(dllexport) static void CreateInstance();
+	__declspec(dllexport) static LegoOmni* GetInstance();
 
-  LegoOmni();
-  virtual ~LegoOmni(); // vtable+00
+	LegoOmni();
+	virtual ~LegoOmni(); // vtable+00
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+04
+	virtual MxLong Notify(MxParam& p) override; // vtable+04
 
-  // OFFSET: LEGO1 0x10058aa0
-  inline virtual const char *ClassName() const override // vtable+0c
-  {
-    // 0x100f671c
-    return "LegoOmni";
-  }
+	// OFFSET: LEGO1 0x10058aa0
+	inline virtual const char* ClassName() const override // vtable+0c
+	{
+		// 0x100f671c
+		return "LegoOmni";
+	}
 
-  // OFFSET: LEGO1 0x10058ab0
-  inline virtual MxBool IsA(const char *name) const override // vtable+10
-  {
-    return !strcmp(name, LegoOmni::ClassName()) || MxOmni::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10058ab0
+	inline virtual MxBool IsA(const char* name) const override // vtable+10
+	{
+		return !strcmp(name, LegoOmni::ClassName()) || MxOmni::IsA(name);
+	}
 
-  virtual void Init() override; // vtable+14
-  virtual MxResult Create(MxOmniCreateParam &p) override; // vtable+18
-  virtual void Destroy() override; // vtable+1c
-  virtual MxResult Start(MxDSAction* action) override; // vtable+20
-  virtual MxResult DeleteObject(MxDSAction &ds) override; // vtable+24
-  virtual MxBool DoesEntityExist(MxDSAction &ds) override; // vtable+28
-  virtual int Vtable0x30(char*, int, MxCore*) override; // vtable+30
-  virtual void NotifyCurrentEntity(MxNotificationParam *p_param) override; //vtable+34
-  virtual void StartTimer() override; // vtable+38
-  virtual void StopTimer() override; //vtable+3c
+	virtual void Init() override;                                            // vtable+14
+	virtual MxResult Create(MxOmniCreateParam& p) override;                  // vtable+18
+	virtual void Destroy() override;                                         // vtable+1c
+	virtual MxResult Start(MxDSAction* action) override;                     // vtable+20
+	virtual MxResult DeleteObject(MxDSAction& ds) override;                  // vtable+24
+	virtual MxBool DoesEntityExist(MxDSAction& ds) override;                 // vtable+28
+	virtual int Vtable0x30(char*, int, MxCore*) override;                    // vtable+30
+	virtual void NotifyCurrentEntity(MxNotificationParam* p_param) override; // vtable+34
+	virtual void StartTimer() override;                                      // vtable+38
+	virtual void StopTimer() override;                                       // vtable+3c
 
-  LegoVideoManager *GetVideoManager() { return (LegoVideoManager *)m_videoManager; }
-  LegoSoundManager *GetSoundManager() { return (LegoSoundManager *)m_soundManager; }
-  
-  LegoInputManager *GetInputManager() { return m_inputMgr; }
-  GifManager *GetGifManager() { return m_gifManager; }
-  LegoWorld *GetCurrentWorld() { return m_currentWorld; }
-  LegoNavController *GetNavController() { return m_navController; }
-  LegoWorld *GetCurrentVehicle() { return m_currentVehicle; }
-  LegoPlantManager *GetLegoPlantManager() { return m_plantManager; }
-  LegoAnimationManager *GetAnimationManager() { return m_animationManager; }
-  LegoBuildingManager *GetLegoBuildingManager() { return m_buildingManager; }
-  LegoGameState *GetGameState() { return m_gameState; }
-  MxBackgroundAudioManager *GetBackgroundAudioManager() { return m_bkgAudioManager; }
-  MxTransitionManager *GetTransitionManager() { return m_transitionManager; }
+	LegoVideoManager* GetVideoManager() { return (LegoVideoManager*) m_videoManager; }
+	LegoSoundManager* GetSoundManager() { return (LegoSoundManager*) m_soundManager; }
+
+	LegoInputManager* GetInputManager() { return m_inputMgr; }
+	GifManager* GetGifManager() { return m_gifManager; }
+	LegoWorld* GetCurrentWorld() { return m_currentWorld; }
+	LegoNavController* GetNavController() { return m_navController; }
+	LegoWorld* GetCurrentVehicle() { return m_currentVehicle; }
+	LegoPlantManager* GetLegoPlantManager() { return m_plantManager; }
+	LegoAnimationManager* GetAnimationManager() { return m_animationManager; }
+	LegoBuildingManager* GetLegoBuildingManager() { return m_buildingManager; }
+	LegoGameState* GetGameState() { return m_gameState; }
+	MxBackgroundAudioManager* GetBackgroundAudioManager() { return m_bkgAudioManager; }
+	MxTransitionManager* GetTransitionManager() { return m_transitionManager; }
 
 private:
-  undefined4 m_unk68;
-  undefined4 m_unk6c;
-  LegoInputManager *m_inputMgr; // 0x70
-  GifManager *m_gifManager;
-  undefined4 m_unk78;
-  LegoWorld *m_currentWorld;
-  MxBool m_unk80;
-  LegoNavController *m_navController; // 0x84
-  LegoWorld *m_currentVehicle; // 0x88
-  LegoUnkSaveDataWriter *m_unkLegoSaveDataWriter;
-  LegoPlantManager *m_plantManager; // 0x90
-  LegoAnimationManager *m_animationManager;
-  LegoBuildingManager* m_buildingManager; // 0x98
-  LegoGameState *m_gameState; // 0x9c
-  MxDSAction m_action;
-  MxBackgroundAudioManager *m_bkgAudioManager; // 0x134
-  MxTransitionManager *m_transitionManager; // 0x138
-  MxBool m_unk13c;
+	undefined4 m_unk68;
+	undefined4 m_unk6c;
+	LegoInputManager* m_inputMgr; // 0x70
+	GifManager* m_gifManager;
+	undefined4 m_unk78;
+	LegoWorld* m_currentWorld;
+	MxBool m_unk80;
+	LegoNavController* m_navController; // 0x84
+	LegoWorld* m_currentVehicle;        // 0x88
+	LegoUnkSaveDataWriter* m_unkLegoSaveDataWriter;
+	LegoPlantManager* m_plantManager; // 0x90
+	LegoAnimationManager* m_animationManager;
+	LegoBuildingManager* m_buildingManager; // 0x98
+	LegoGameState* m_gameState;             // 0x9c
+	MxDSAction m_action;
+	MxBackgroundAudioManager* m_bkgAudioManager; // 0x134
+	MxTransitionManager* m_transitionManager;    // 0x138
+	MxBool m_unk13c;
 };
 
-__declspec(dllexport) MxBackgroundAudioManager *BackgroundAudioManager();
-__declspec(dllexport) MxDSObject *CreateStreamObject(MxDSFile *, MxS16);
-__declspec(dllexport) LegoGameState *GameState();
-__declspec(dllexport) const char *GetNoCD_SourceName();
-__declspec(dllexport) LegoInputManager *InputManager();
-__declspec(dllexport) LegoOmni *Lego();
-__declspec(dllexport) void MakeSourceName(char *, const char *);
-__declspec(dllexport) LegoEntity *PickEntity(MxLong,MxLong);
-__declspec(dllexport) LegoROI *PickROI(MxLong,MxLong);
-__declspec(dllexport) void SetOmniUserMessage(void (*)(const char *, int));
-__declspec(dllexport) LegoSoundManager *SoundManager();
+__declspec(dllexport) MxBackgroundAudioManager* BackgroundAudioManager();
+__declspec(dllexport) MxDSObject* CreateStreamObject(MxDSFile*, MxS16);
+__declspec(dllexport) LegoGameState* GameState();
+__declspec(dllexport) const char* GetNoCD_SourceName();
+__declspec(dllexport) LegoInputManager* InputManager();
+__declspec(dllexport) LegoOmni* Lego();
+__declspec(dllexport) void MakeSourceName(char*, const char*);
+__declspec(dllexport) LegoEntity* PickEntity(MxLong, MxLong);
+__declspec(dllexport) LegoROI* PickROI(MxLong, MxLong);
+__declspec(dllexport) void SetOmniUserMessage(void (*)(const char*, int));
+__declspec(dllexport) LegoSoundManager* SoundManager();
 __declspec(dllexport) MxResult Start(MxDSAction*);
-__declspec(dllexport) MxTransitionManager *TransitionManager();
-__declspec(dllexport) LegoVideoManager *VideoManager();
+__declspec(dllexport) MxTransitionManager* TransitionManager();
+__declspec(dllexport) LegoVideoManager* VideoManager();
 
-LegoAnimationManager *AnimationManager();
-LegoBuildingManager *BuildingManager();
-LegoControlManager *ControlManager();
-LegoWorld  *GetCurrentVehicle();
-LegoPlantManager *PlantManager();
-MxBool KeyValueStringParse(char *, const char *, const char *);
-LegoWorld *GetCurrentWorld();
-GifManager *GetGifManager();
+LegoAnimationManager* AnimationManager();
+LegoBuildingManager* BuildingManager();
+LegoControlManager* ControlManager();
+LegoWorld* GetCurrentVehicle();
+LegoPlantManager* PlantManager();
+MxBool KeyValueStringParse(char*, const char*, const char*);
+LegoWorld* GetCurrentWorld();
+GifManager* GetGifManager();
 
 #endif // LEGOOMNI_H

--- a/LEGO1/legopalettepresenter.cpp
+++ b/LEGO1/legopalettepresenter.cpp
@@ -5,17 +5,17 @@ DECOMP_SIZE_ASSERT(LegoPalettePresenter, 0x68)
 // OFFSET: LEGO1 0x10079e50
 LegoPalettePresenter::LegoPalettePresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x1007a070 STUB
 LegoPalettePresenter::~LegoPalettePresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1007a0d0
 void LegoPalettePresenter::Init()
 {
-  this->m_unk64 = 0;
+	this->m_unk64 = 0;
 }

--- a/LEGO1/legopalettepresenter.h
+++ b/LEGO1/legopalettepresenter.h
@@ -6,30 +6,28 @@
 
 // VTABLE 0x100d9aa0
 // SIZE 0x68
-class LegoPalettePresenter : public MxVideoPresenter
-{
+class LegoPalettePresenter : public MxVideoPresenter {
 public:
-  LegoPalettePresenter();
-  virtual ~LegoPalettePresenter(); // vtable+0x0
+	LegoPalettePresenter();
+	virtual ~LegoPalettePresenter(); // vtable+0x0
 
-  // OFFSET: LEGO1 0x10079f30
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f061c
-    return "LegoPalettePresenter";
-  }
+	// OFFSET: LEGO1 0x10079f30
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f061c
+		return "LegoPalettePresenter";
+	}
 
-  // OFFSET: LEGO1 0x10079f40
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ClassName()) || MxVideoPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10079f40
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ClassName()) || MxVideoPresenter::IsA(name);
+	}
 
 private:
-  void Init();
+	void Init();
 
-  undefined4 m_unk64;
+	undefined4 m_unk64;
 };
-
 
 #endif // LEGOPALETTEPRESENTER_H

--- a/LEGO1/legopartpresenter.cpp
+++ b/LEGO1/legopartpresenter.cpp
@@ -9,6 +9,6 @@ int g_partPresenterConfig2 = 100;
 // OFFSET: LEGO1 0x1007c990
 void LegoPartPresenter::configureLegoPartPresenter(int param_1, int param_2)
 {
-  g_partPresenterConfig1 = param_1;
-  g_partPresenterConfig2 = param_2;
+	g_partPresenterConfig1 = param_1;
+	g_partPresenterConfig2 = param_2;
 }

--- a/LEGO1/legopartpresenter.h
+++ b/LEGO1/legopartpresenter.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d4df0
 // SIZE 0x54 (from inlined construction at 0x10009fac)
-class LegoPartPresenter : public MxMediaPresenter
-{
+class LegoPartPresenter : public MxMediaPresenter {
 public:
-  // OFFSET: LEGO1 0x1000cf70
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f05d8
-    return "LegoPartPresenter";
-  }
+	// OFFSET: LEGO1 0x1000cf70
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f05d8
+		return "LegoPartPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000cf80
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoPartPresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000cf80
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoPartPresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 
-  __declspec(dllexport) static void configureLegoPartPresenter(int param_1, int param_2);
+	__declspec(dllexport) static void configureLegoPartPresenter(int param_1, int param_2);
 };
 
 #endif // LEGOPARTPRESENTER_H

--- a/LEGO1/legopathactor.cpp
+++ b/LEGO1/legopathactor.cpp
@@ -6,162 +6,162 @@ DECOMP_SIZE_ASSERT(LegoPathActor, 0x154)
 // OFFSET: LEGO1 0x10002d20 STUB
 void LegoPathActor::VTable0x78()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d30 STUB
 void LegoPathActor::VTable0x7c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d40 STUB
 void LegoPathActor::VTable0x90()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d50 STUB
 void LegoPathActor::VTable0x94()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d60 STUB
 void LegoPathActor::VTable0xa0()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d70 STUB
 void LegoPathActor::VTable0xac()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d80 STUB
 void LegoPathActor::VTable0xb0()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002d90 STUB
 void LegoPathActor::VTable0xb4()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002da0 STUB
 void LegoPathActor::VTable0xb8()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002db0 STUB
 void LegoPathActor::VTable0xbc()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002dc0 STUB
 void LegoPathActor::VTable0xc0()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002dd0 STUB
 void LegoPathActor::VTable0xc4()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10002de0 STUB
 void LegoPathActor::VTable0xc8()
 {
-  // TODO
+	// TODO
 }
 // End header
 
 // OFFSET: LEGO1 0x1002d700 STUB
 LegoPathActor::LegoPathActor()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002d820 STUB
 LegoPathActor::~LegoPathActor()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002d8d0 STUB
 void LegoPathActor::VTable0x80()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002d9c0 STUB
 void LegoPathActor::VTable0x88()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002de10 STUB
 void LegoPathActor::VTable0x84()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002e100 STUB
 void LegoPathActor::VTable0x8c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002e740 STUB
 void LegoPathActor::VTable0x74()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002e790 STUB
 void LegoPathActor::VTable0x70()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002e8b0 STUB
 void LegoPathActor::VTable0x98()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002e8d0 STUB
 void LegoPathActor::VTable0x6c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002ebe0 STUB
 void LegoPathActor::VTable0x68()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002f1b0 STUB
 void LegoPathActor::VTable0x9c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002f650 STUB
 void LegoPathActor::VTable0xa4()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1002f700 STUB
 void LegoPathActor::VTable0xa8()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legopathactor.h
+++ b/LEGO1/legopathactor.h
@@ -6,61 +6,60 @@
 
 // VTABLE 0x100d6e28
 // SIZE 0x154 (from inlined construction at 0x1000a346)
-class LegoPathActor : public LegoActor
-{
+class LegoPathActor : public LegoActor {
 public:
-  LegoPathActor();
+	LegoPathActor();
 
-  virtual ~LegoPathActor() override;
+	virtual ~LegoPathActor() override;
 
-  // OFFSET: LEGO1 0x1000c430
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0114
-    return "LegoPathActor";
-  }
+	// OFFSET: LEGO1 0x1000c430
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0114
+		return "LegoPathActor";
+	}
 
-  // OFFSET: LEGO1 0x1000c440
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoPathActor::ClassName()) || LegoActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000c440
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoPathActor::ClassName()) || LegoActor::IsA(name);
+	}
 
-  virtual void VTable0x68(); // vtable+0x68
-  virtual void VTable0x6c(); // vtable+0x6c
-  virtual void VTable0x70(); // vtable+0x70
-  virtual void VTable0x74(); // vtable+0x74
-  virtual void VTable0x78(); // vtable+0x78
-  virtual void VTable0x7c(); // vtable+0x7c
-  virtual void VTable0x80(); // vtable+0x80
-  virtual void VTable0x84(); // vtable+0x84
-  virtual void VTable0x88(); // vtable+0x88
-  virtual void VTable0x8c(); // vtable+0x8c
-  virtual void VTable0x90(); // vtable+0x90
-  virtual void VTable0x94(); // vtable+0x94
-  virtual void VTable0x98(); // vtable+0x98
-  virtual void VTable0x9c(); // vtable+0x9c
-  virtual void VTable0xa0(); // vtable+0xa0
-  virtual void VTable0xa4(); // vtable+0xa4
-  virtual void VTable0xa8(); // vtable+0xa8
-  virtual void VTable0xac(); // vtable+0xac
-  virtual void VTable0xb0(); // vtable+0xb0
-  virtual void VTable0xb4(); // vtable+0xb4
-  virtual void VTable0xb8(); // vtable+0xb8
-  virtual void VTable0xbc(); // vtable+0xbc
-  virtual void VTable0xc0(); // vtable+0xc0
-  virtual void VTable0xc4(); // vtable+0xc4
-  virtual void VTable0xc8(); // vtable+0xc8
-  
+	virtual void VTable0x68(); // vtable+0x68
+	virtual void VTable0x6c(); // vtable+0x6c
+	virtual void VTable0x70(); // vtable+0x70
+	virtual void VTable0x74(); // vtable+0x74
+	virtual void VTable0x78(); // vtable+0x78
+	virtual void VTable0x7c(); // vtable+0x7c
+	virtual void VTable0x80(); // vtable+0x80
+	virtual void VTable0x84(); // vtable+0x84
+	virtual void VTable0x88(); // vtable+0x88
+	virtual void VTable0x8c(); // vtable+0x8c
+	virtual void VTable0x90(); // vtable+0x90
+	virtual void VTable0x94(); // vtable+0x94
+	virtual void VTable0x98(); // vtable+0x98
+	virtual void VTable0x9c(); // vtable+0x9c
+	virtual void VTable0xa0(); // vtable+0xa0
+	virtual void VTable0xa4(); // vtable+0xa4
+	virtual void VTable0xa8(); // vtable+0xa8
+	virtual void VTable0xac(); // vtable+0xac
+	virtual void VTable0xb0(); // vtable+0xb0
+	virtual void VTable0xb4(); // vtable+0xb4
+	virtual void VTable0xb8(); // vtable+0xb8
+	virtual void VTable0xbc(); // vtable+0xbc
+	virtual void VTable0xc0(); // vtable+0xc0
+	virtual void VTable0xc4(); // vtable+0xc4
+	virtual void VTable0xc8(); // vtable+0xc8
+
 protected:
-  // TODO: the types
-  undefined unk78[0xc4];
-  MxFloat m_unk13c;
-  MxS32 m_unk140;
-  MxS32 m_unk144;
-  undefined m_unk148;
-  MxS32 m_unk14c;
-  MxFloat m_unk150;
+	// TODO: the types
+	undefined unk78[0xc4];
+	MxFloat m_unk13c;
+	MxS32 m_unk140;
+	MxS32 m_unk144;
+	undefined m_unk148;
+	MxS32 m_unk14c;
+	MxFloat m_unk150;
 };
 
 #endif // LEGOPATHACTOR_H

--- a/LEGO1/legopathboundary.h
+++ b/LEGO1/legopathboundary.h
@@ -1,9 +1,6 @@
 #ifndef LEGOPATHBOUNDARH_H
 #define LEGOPATHBOUNDARH_H
 
-class LegoPathBoundary
-{
-  
-};
+class LegoPathBoundary {};
 
 #endif // LEGOPATHBOUNDARH_H

--- a/LEGO1/legopathcontroller.cpp
+++ b/LEGO1/legopathcontroller.cpp
@@ -3,18 +3,18 @@
 // OFFSET: LEGO1 0x10044f40 STUB
 LegoPathController::LegoPathController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10045740 STUB
 LegoPathController::~LegoPathController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10045c10 STUB
 MxResult LegoPathController::Tickle()
 {
-  // TODO
-  return SUCCESS;
+	// TODO
+	return SUCCESS;
 }

--- a/LEGO1/legopathcontroller.h
+++ b/LEGO1/legopathcontroller.h
@@ -5,27 +5,25 @@
 
 // VTABLE 0x100d7d60
 // SIZE 0x40
-class LegoPathController : public MxCore
-{
+class LegoPathController : public MxCore {
 public:
-  LegoPathController();
-  virtual ~LegoPathController() override;
+	LegoPathController();
+	virtual ~LegoPathController() override;
 
-  virtual MxResult Tickle() override; // vtable+08
+	virtual MxResult Tickle() override; // vtable+08
 
-  // OFFSET: LEGO1 0x10045110
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f11b8
-    return "LegoPathController";
-  }
+	// OFFSET: LEGO1 0x10045110
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f11b8
+		return "LegoPathController";
+	}
 
-  // OFFSET: LEGO1 0x10045120
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoPathController::ClassName()) || MxCore::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10045120
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoPathController::ClassName()) || MxCore::IsA(name);
+	}
 };
 
 #endif // LEGOPATHCONTROLLER_H

--- a/LEGO1/legopathpresenter.cpp
+++ b/LEGO1/legopathpresenter.cpp
@@ -1,4 +1,5 @@
 #include "legopathpresenter.h"
+
 #include "legoomni.h"
 #include "legovideomanager.h"
 #include "mxautolocker.h"
@@ -8,60 +9,59 @@ DECOMP_SIZE_ASSERT(LegoPathPresenter, 0x54);
 // OFFSET: LEGO1 0x100448d0
 LegoPathPresenter::LegoPathPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x10044ab0
 void LegoPathPresenter::Init()
 {
-
 }
 
 // OFFSET: LEGO1 0x10044b40
 MxResult LegoPathPresenter::AddToManager()
 {
-  MxResult status = FAILURE;
+	MxResult status = FAILURE;
 
-  if (VideoManager()) {
-    VideoManager()->AddPresenter(*this);
-    status = SUCCESS;
-  }
+	if (VideoManager()) {
+		VideoManager()->AddPresenter(*this);
+		status = SUCCESS;
+	}
 
-  return status;
+	return status;
 }
 
 // OFFSET: LEGO1 0x10044b70
 void LegoPathPresenter::Destroy(MxBool p_fromDestructor)
 {
-  if (VideoManager())
-    VideoManager()->RemovePresenter(*this);
+	if (VideoManager())
+		VideoManager()->RemovePresenter(*this);
 
-  {
-    MxAutoLocker lock(&this->m_criticalSection);
-    Init();
-  }
+	{
+		MxAutoLocker lock(&this->m_criticalSection);
+		Init();
+	}
 
-  if (!p_fromDestructor)
-    MxMediaPresenter::Destroy(FALSE);
+	if (!p_fromDestructor)
+		MxMediaPresenter::Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x10044c10
 void LegoPathPresenter::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x10044d40
 void LegoPathPresenter::RepeatingTickle()
 {
-  if (this->m_action->GetDuration() == -1)
-    return;
+	if (this->m_action->GetDuration() == -1)
+		return;
 
-  EndAction();
+	EndAction();
 }
 
 // OFFSET: LEGO1 0x10044d60 STUB
 void LegoPathPresenter::ParseExtra()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legopathpresenter.h
+++ b/LEGO1/legopathpresenter.h
@@ -5,36 +5,35 @@
 
 // VTABLE 0x100d7c10
 // SIZE 0x54
-class LegoPathPresenter : public MxMediaPresenter
-{
+class LegoPathPresenter : public MxMediaPresenter {
 public:
-  LegoPathPresenter();
+	LegoPathPresenter();
 
-  // OFFSET: LEGO1 0x100449a0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0690
-    return "LegoPathPresenter";
-  }
+	// OFFSET: LEGO1 0x100449a0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0690
+		return "LegoPathPresenter";
+	}
 
-  // OFFSET: LEGO1 0x100449b0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoPathPresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100449b0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoPathPresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 
-  virtual void RepeatingTickle() override;  // vtable+0x24
-  virtual void ParseExtra() override;       // vtable+0x30
-  virtual MxResult AddToManager() override; // vtable+0x34
-  virtual void Destroy() override;          // vtable+0x38
+	virtual void RepeatingTickle() override;  // vtable+0x24
+	virtual void ParseExtra() override;       // vtable+0x30
+	virtual MxResult AddToManager() override; // vtable+0x34
+	virtual void Destroy() override;          // vtable+0x38
 
 private:
-  void Init();
+	void Init();
 
 protected:
-  void Destroy(MxBool p_fromDestructor);
+	void Destroy(MxBool p_fromDestructor);
 
-  MxAtomId m_atomId; // 0x50
+	MxAtomId m_atomId; // 0x50
 };
 
 #endif // LEGOPATHPRESENTER_H

--- a/LEGO1/legophonemepresenter.cpp
+++ b/LEGO1/legophonemepresenter.cpp
@@ -5,16 +5,16 @@ DECOMP_SIZE_ASSERT(LegoPhonemePresenter, 0x88);
 // OFFSET: LEGO1 0x1004e180
 LegoPhonemePresenter::LegoPhonemePresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x1004e3b0
 void LegoPhonemePresenter::Init()
 {
-  m_unk68 = 0;
-  m_unk6c = 0;
-  m_unk70 = 0;
-  m_unk84 = 0;
+	m_unk68 = 0;
+	m_unk6c = 0;
+	m_unk70 = 0;
+	m_unk84 = 0;
 }
 
 // OFFSET: LEGO1 0x1004e340

--- a/LEGO1/legophonemepresenter.h
+++ b/LEGO1/legophonemepresenter.h
@@ -8,26 +8,25 @@
 
 // VTABLE 0x100d8040
 // SIZE 0x88
-class LegoPhonemePresenter : public MxFlcPresenter
-{
+class LegoPhonemePresenter : public MxFlcPresenter {
 public:
-  LegoPhonemePresenter();
-  virtual ~LegoPhonemePresenter() override; // vtable+0x0
+	LegoPhonemePresenter();
+	virtual ~LegoPhonemePresenter() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x1004e310
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f064c
-    return "LegoPhonemePresenter";
-  }
+	// OFFSET: LEGO1 0x1004e310
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f064c
+		return "LegoPhonemePresenter";
+	}
 
 private:
-  void Init();
-  int m_unk68;
-  int m_unk6c;
-  undefined m_unk70;
-  MxString m_string; // 0x74
-  undefined m_unk84;
+	void Init();
+	int m_unk68;
+	int m_unk6c;
+	undefined m_unk70;
+	MxString m_string; // 0x74
+	undefined m_unk84;
 };
 
 #endif // LEGOPHONEMEPRESENTER_H

--- a/LEGO1/legoplantmanager.cpp
+++ b/LEGO1/legoplantmanager.cpp
@@ -3,25 +3,25 @@
 // OFFSET: LEGO1 0x10026220
 LegoPlantManager::LegoPlantManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100262c0 STUB
 LegoPlantManager::~LegoPlantManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10026e00 STUB
 MxResult LegoPlantManager::Tickle()
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10026330 STUB
 void LegoPlantManager::Init()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoplantmanager.h
+++ b/LEGO1/legoplantmanager.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d6758
 // SIZE 0x2c
-class LegoPlantManager : public MxCore
-{
+class LegoPlantManager : public MxCore {
 public:
-  LegoPlantManager();
-  virtual ~LegoPlantManager() override; // vtable+0x0
+	LegoPlantManager();
+	virtual ~LegoPlantManager() override; // vtable+0x0
 
-  virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x8
 
-  // OFFSET: LEGO1 0x10026290
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f318c
-    return "LegoPlantManager";
-  }
+	// OFFSET: LEGO1 0x10026290
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f318c
+		return "LegoPlantManager";
+	}
 
 private:
-  void Init();
-  
+	void Init();
 };
 
 #endif // LEGOPLANTMANAGER_H

--- a/LEGO1/legorace.cpp
+++ b/LEGO1/legorace.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x10015aa0 STUB
 LegoRace::LegoRace()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10015d40 STUB
 LegoRace::~LegoRace()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10015e00 STUB
-MxLong LegoRace::Notify(MxParam &p)
+MxLong LegoRace::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/legorace.h
+++ b/LEGO1/legorace.h
@@ -4,26 +4,25 @@
 #include "legoworld.h"
 
 // VTABLE 0x100d5db0
-class LegoRace : public LegoWorld
-{
+class LegoRace : public LegoWorld {
 public:
-  LegoRace();
-  virtual ~LegoRace() override; // vtable+0x0
+	LegoRace();
+	virtual ~LegoRace() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x10015ba0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f07c4
-    return "LegoRace";
-  }
+	// OFFSET: LEGO1 0x10015ba0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f07c4
+		return "LegoRace";
+	}
 
-  // OFFSET: LEGO1 0x10015bb0
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoRace::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10015bb0
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoRace::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // LEGORACE_H

--- a/LEGO1/legoraceactor.h
+++ b/LEGO1/legoraceactor.h
@@ -4,22 +4,20 @@
 #include "legoanimactor.h"
 
 // VTABLE 0x100d5b88
-class LegoRaceActor : public LegoAnimActor
-{
+class LegoRaceActor : public LegoAnimActor {
 public:
-  // OFFSET: LEGO1 0x10014af0
-  inline const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0bf4
-    return "LegoRaceActor";
-  }
+	// OFFSET: LEGO1 0x10014af0
+	inline const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0bf4
+		return "LegoRaceActor";
+	}
 
-  // OFFSET: LEGO1 0x10014b10
-  inline MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoRaceActor::ClassName()) || LegoAnimActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10014b10
+	inline MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoRaceActor::ClassName()) || LegoAnimActor::IsA(name);
+	}
 };
-
 
 #endif // LEGORACEACTOR_H

--- a/LEGO1/legoroi.cpp
+++ b/LEGO1/legoroi.cpp
@@ -6,12 +6,11 @@ int g_roiConfig = 100;
 // OFFSET: LEGO1 0x100a9e10
 void LegoROI::SetDisplayBB(int p_displayBB)
 {
-  // Intentionally empty function
+	// Intentionally empty function
 }
 
 // OFFSET: LEGO1 0x100a81c0
 void LegoROI::configureLegoROI(int p_roi)
 {
-  g_roiConfig = p_roi;
+	g_roiConfig = p_roi;
 }
-

--- a/LEGO1/legoroi.h
+++ b/LEGO1/legoroi.h
@@ -1,11 +1,10 @@
 #ifndef LEGOROI_H
 #define LEGOROI_H
 
-class LegoROI
-{
+class LegoROI {
 public:
-  __declspec(dllexport) void SetDisplayBB(int p_displayBB);
-  __declspec(dllexport) static void configureLegoROI(int p_roi);
+	__declspec(dllexport) void SetDisplayBB(int p_displayBB);
+	__declspec(dllexport) static void configureLegoROI(int p_roi);
 };
 
 #endif // LEGOROI_H

--- a/LEGO1/legosoundmanager.cpp
+++ b/LEGO1/legosoundmanager.cpp
@@ -1,48 +1,48 @@
 #include "legosoundmanager.h"
+
 #include "mxautolocker.h"
 
 // OFFSET: LEGO1 0x100298a0
 LegoSoundManager::LegoSoundManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x10029940
 LegoSoundManager::~LegoSoundManager()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x1002a390
 void LegoSoundManager::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100299b0 STUB
 void LegoSoundManager::Destroy(MxBool p_fromDestructor)
 {
-
 }
 
 // OFFSET: LEGO1 0x100299f0 STUB
 MxResult LegoSoundManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100299a0
 void LegoSoundManager::Init()
 {
-  unk0x40 = 0;
-  unk0x3c = 0;
+	unk0x40 = 0;
+	unk0x3c = 0;
 }
 
 // OFFSET: LEGO1 0x1002a3a0 STUB
 MxResult LegoSoundManager::Tickle()
 {
-  MxMediaManager::Tickle();
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxMediaManager::Tickle();
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  return 0; // TODO: call something in unk0x40
+	return 0; // TODO: call something in unk0x40
 }

--- a/LEGO1/legosoundmanager.h
+++ b/LEGO1/legosoundmanager.h
@@ -5,22 +5,21 @@
 
 // VTABLE 0x100d6b10
 // SIZE 0x44
-class LegoSoundManager : public MxSoundManager
-{
+class LegoSoundManager : public MxSoundManager {
 public:
-  LegoSoundManager();
-  virtual ~LegoSoundManager() override;
+	LegoSoundManager();
+	virtual ~LegoSoundManager() override;
 
-  virtual MxResult Tickle() override; // vtable+08
-  virtual void Destroy() override; // vtable+18
-  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread) override; //vtable+0x30
+	virtual MxResult Tickle() override;                                           // vtable+08
+	virtual void Destroy() override;                                              // vtable+18
+	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread) override; // vtable+0x30
 
 private:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 
-  undefined4 unk0x3c;
-  undefined4 unk0x40;
+	undefined4 unk0x3c;
+	undefined4 unk0x40;
 };
 
 #endif // LEGOSOUNDMANAGER_H

--- a/LEGO1/legostate.cpp
+++ b/LEGO1/legostate.cpp
@@ -8,33 +8,35 @@ LegoState::~LegoState()
 }
 
 // OFFSET: LEGO1 0x10005f90
-MxBool LegoState::VTable0x14() {
-  return TRUE;
+MxBool LegoState::VTable0x14()
+{
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x10005fa0
-MxBool LegoState::SetFlag() {
-  return FALSE;
+MxBool LegoState::SetFlag()
+{
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x10005fb0
-MxResult LegoState::VTable0x1C(LegoFileStream *p_legoFileStream)
+MxResult LegoState::VTable0x1C(LegoFileStream* p_legoFileStream)
 {
-  if (p_legoFileStream->IsWriteMode()) {
-    p_legoFileStream->FUN_10006030(this->ClassName());
-  }
-  return SUCCESS;
+	if (p_legoFileStream->IsWriteMode()) {
+		p_legoFileStream->FUN_10006030(this->ClassName());
+	}
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10006030
-LegoFileStream *LegoFileStream::FUN_10006030(MxString p_str)
+LegoFileStream* LegoFileStream::FUN_10006030(MxString p_str)
 {
-  const char *data = p_str.GetData();
-  MxU32 fullLength = strlen(data);
+	const char* data = p_str.GetData();
+	MxU32 fullLength = strlen(data);
 
-  MxU16 limitedLength = fullLength;
-  Write(&limitedLength, sizeof(limitedLength));
-  Write(data, (MxS16) fullLength);
+	MxU16 limitedLength = fullLength;
+	Write(&limitedLength, sizeof(limitedLength));
+	Write(data, (MxS16) fullLength);
 
-  return this;
+	return this;
 }

--- a/LEGO1/legostate.h
+++ b/LEGO1/legostate.h
@@ -2,33 +2,31 @@
 #define LEGOSTATE_H
 
 #include "decomp.h"
-
+#include "legostream.h"
 #include "mxcore.h"
 #include "mxstring.h"
-#include "legostream.h"
 
 // VTABLE 0x100d46c0
-class LegoState : public MxCore
-{
+class LegoState : public MxCore {
 public:
-  virtual ~LegoState() override; // vtable+0x00
+	virtual ~LegoState() override; // vtable+0x00
 
-  // OFFSET: LEGO1 0x100060d0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f01b8
-    return "LegoState";
-  }
+	// OFFSET: LEGO1 0x100060d0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f01b8
+		return "LegoState";
+	}
 
-  // OFFSET: LEGO1 0x100060e0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoState::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100060e0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoState::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxBool VTable0x14(); // vtable+0x14
-  virtual MxBool SetFlag(); // vtable+0x18
-  virtual MxResult VTable0x1C(LegoFileStream *p_legoFileStream); // vtable+0x1C
+	virtual MxBool VTable0x14();                                   // vtable+0x14
+	virtual MxBool SetFlag();                                      // vtable+0x18
+	virtual MxResult VTable0x1C(LegoFileStream* p_legoFileStream); // vtable+0x1C
 };
 
 #endif // LEGOSTATE_H

--- a/LEGO1/legostream.cpp
+++ b/LEGO1/legostream.cpp
@@ -1,16 +1,16 @@
 
 #include "legostream.h"
 
+#include "mxvariabletable.h"
+
 #include <cstdio>
 #include <string>
-
-#include "mxvariabletable.h"
 
 // This is a pointer to the end of the global variable name table, which has
 // the text "END_OF_VARIABLES" in it.
 // TODO: make s_endOfVariables reference the actual end of the variable array.
 // GLOBAL OFFSET: LEGO1 0x100f3e50
-const char *s_endOfVariables = "END_OF_VARIABLES";
+const char* s_endOfVariables = "END_OF_VARIABLES";
 
 // Very likely but not certain sizes.
 // The classes are only used on the stack in functions we have not 100% matched
@@ -22,155 +22,151 @@ DECOMP_SIZE_ASSERT(LegoMemoryStream, 0x10);
 // OFFSET: LEGO1 0x10045ae0
 MxBool LegoStream::IsWriteMode()
 {
-  return m_mode == LEGOSTREAM_MODE_WRITE;
+	return m_mode == LEGOSTREAM_MODE_WRITE;
 }
 
 // OFFSET: LEGO1 0x10045af0
 MxBool LegoStream::IsReadMode()
 {
-  return m_mode == LEGOSTREAM_MODE_READ;
+	return m_mode == LEGOSTREAM_MODE_READ;
 }
 
 // OFFSET: LEGO1 0x100991c0
-LegoFileStream::LegoFileStream()
-  : LegoStream()
+LegoFileStream::LegoFileStream() : LegoStream()
 {
-  m_hFile = NULL;
+	m_hFile = NULL;
 }
 
 // OFFSET: LEGO1 0x10099250
 LegoFileStream::~LegoFileStream()
 {
-  if (m_hFile != NULL)
-    fclose(m_hFile);
+	if (m_hFile != NULL)
+		fclose(m_hFile);
 }
 
 // OFFSET: LEGO1 0x100992c0
 MxResult LegoFileStream::Read(void* p_buffer, MxU32 p_size)
 {
-  if (m_hFile == NULL)
-    return FAILURE;
+	if (m_hFile == NULL)
+		return FAILURE;
 
-  return (fread(p_buffer, 1, p_size, m_hFile) == p_size) ? SUCCESS : FAILURE;
+	return (fread(p_buffer, 1, p_size, m_hFile) == p_size) ? SUCCESS : FAILURE;
 }
 
 // OFFSET: LEGO1 0x10099300
 MxResult LegoFileStream::Write(const void* p_buffer, MxU32 p_size)
 {
-  if (m_hFile == NULL)
-    return FAILURE;
+	if (m_hFile == NULL)
+		return FAILURE;
 
-  return (fwrite(p_buffer, 1, p_size, m_hFile) == p_size) ? SUCCESS : FAILURE;
+	return (fwrite(p_buffer, 1, p_size, m_hFile) == p_size) ? SUCCESS : FAILURE;
 }
 
 // OFFSET: LEGO1 0x10099340
 MxResult LegoFileStream::Tell(MxU32* p_offset)
 {
-  if (m_hFile == NULL)
-    return FAILURE;
+	if (m_hFile == NULL)
+		return FAILURE;
 
-  int got = ftell(m_hFile);
-  if (got == -1)
-    return FAILURE;
+	int got = ftell(m_hFile);
+	if (got == -1)
+		return FAILURE;
 
-  *p_offset = got;
-  return SUCCESS;
+	*p_offset = got;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10099370
 MxResult LegoFileStream::Seek(MxU32 p_offset)
 {
-  if (m_hFile == NULL)
-    return FAILURE;
+	if (m_hFile == NULL)
+		return FAILURE;
 
-  return (fseek(m_hFile, p_offset, 0) == 0) ? SUCCESS : FAILURE;
+	return (fseek(m_hFile, p_offset, 0) == 0) ? SUCCESS : FAILURE;
 }
 
 // OFFSET: LEGO1 0x100993a0
 MxResult LegoFileStream::Open(const char* p_filename, OpenFlags p_mode)
 {
-  char modeString[4];
+	char modeString[4];
 
-  if (m_hFile != NULL)
-    fclose(m_hFile);
-  
-  modeString[0] = '\0';
-  if (p_mode & ReadBit)
-  {
-    m_mode = LEGOSTREAM_MODE_READ;
-    strcat(modeString, "r");
-  }
+	if (m_hFile != NULL)
+		fclose(m_hFile);
 
-  if (p_mode & WriteBit)
-  {
-    if (m_mode != LEGOSTREAM_MODE_READ)
-      m_mode = LEGOSTREAM_MODE_WRITE;
-    strcat(modeString, "w");
-  }
+	modeString[0] = '\0';
+	if (p_mode & ReadBit) {
+		m_mode = LEGOSTREAM_MODE_READ;
+		strcat(modeString, "r");
+	}
 
-  if ((p_mode & 4) != 0)
-    strcat(modeString, "b");
-  else
-    strcat(modeString, "t");
+	if (p_mode & WriteBit) {
+		if (m_mode != LEGOSTREAM_MODE_READ)
+			m_mode = LEGOSTREAM_MODE_WRITE;
+		strcat(modeString, "w");
+	}
 
-  return (m_hFile = fopen(p_filename, modeString)) ? SUCCESS : FAILURE;
+	if ((p_mode & 4) != 0)
+		strcat(modeString, "b");
+	else
+		strcat(modeString, "t");
+
+	return (m_hFile = fopen(p_filename, modeString)) ? SUCCESS : FAILURE;
 }
 
 // OFFSET: LEGO1 0x10099080
-LegoMemoryStream::LegoMemoryStream(char* p_buffer)
-  : LegoStream()
+LegoMemoryStream::LegoMemoryStream(char* p_buffer) : LegoStream()
 {
-  m_buffer = p_buffer;
-  m_offset = 0;
+	m_buffer = p_buffer;
+	m_offset = 0;
 }
 
 // OFFSET: LEGO1 0x10099160
 MxResult LegoMemoryStream::Read(void* p_buffer, MxU32 p_size)
 {
-  memcpy(p_buffer, m_buffer + m_offset, p_size);
-  m_offset += p_size;
-  return SUCCESS;
+	memcpy(p_buffer, m_buffer + m_offset, p_size);
+	m_offset += p_size;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10099190
 MxResult LegoMemoryStream::Write(const void* p_buffer, MxU32 p_size)
 {
-  memcpy(m_buffer + m_offset, p_buffer, p_size);
-  m_offset += p_size;
-  return SUCCESS;
+	memcpy(m_buffer + m_offset, p_buffer, p_size);
+	m_offset += p_size;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100994a0
 MxResult LegoMemoryStream::Tell(MxU32* p_offset)
 {
-  *p_offset = m_offset;
-  return SUCCESS;
+	*p_offset = m_offset;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100994b0
 MxResult LegoMemoryStream::Seek(MxU32 p_offset)
 {
-  m_offset = p_offset;
-  return SUCCESS;
+	m_offset = p_offset;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10039f70
 MxResult LegoStream::WriteVariable(LegoStream* p_stream, MxVariableTable* p_from, const char* p_variableName)
 {
-  MxResult result = FAILURE;
-  const char *variableValue = p_from->GetVariable(p_variableName);
+	MxResult result = FAILURE;
+	const char* variableValue = p_from->GetVariable(p_variableName);
 
-  if (variableValue) {
-    MxU8 length = strlen(p_variableName);
-    if (p_stream->Write((char*)&length, 1) == SUCCESS) {
-      if (p_stream->Write(p_variableName, length) == SUCCESS) {
-        length = strlen(variableValue);
-        if (p_stream->Write((char*)&length, 1) == SUCCESS)
-          result = p_stream->Write((char *)variableValue, length);
-      }
-    }
-  }
-  return result;
+	if (variableValue) {
+		MxU8 length = strlen(p_variableName);
+		if (p_stream->Write((char*) &length, 1) == SUCCESS) {
+			if (p_stream->Write(p_variableName, length) == SUCCESS) {
+				length = strlen(variableValue);
+				if (p_stream->Write((char*) &length, 1) == SUCCESS)
+					result = p_stream->Write((char*) variableValue, length);
+			}
+		}
+	}
+	return result;
 }
 
 // 95% match, just some instruction ordering differences on the call to
@@ -178,27 +174,27 @@ MxResult LegoStream::WriteVariable(LegoStream* p_stream, MxVariableTable* p_from
 // OFFSET: LEGO1 0x1003a080
 MxS32 LegoStream::ReadVariable(LegoStream* p_stream, MxVariableTable* p_to)
 {
-  MxS32 result = 1;
-  MxU8 length;
+	MxS32 result = 1;
+	MxU8 length;
 
-  if (p_stream->Read((char*)&length, 1) == SUCCESS) {
-    char nameBuffer[256];
-    if (p_stream->Read(nameBuffer, length) == SUCCESS) {
-      nameBuffer[length] = '\0';
-      if (strcmp(nameBuffer, s_endOfVariables) == 0)
-        // 2 -> "This was the last entry, done reading."
-        result = 2;
-      else {
-        if (p_stream->Read((char*)&length, 1) == SUCCESS) {
-          char valueBuffer[256];
-          if (p_stream->Read(valueBuffer, length) == SUCCESS) {
-            result = 0;
-            valueBuffer[length] = '\0';
-            p_to->SetVariable(nameBuffer, valueBuffer);
-          }
-        }
-      }
-    }
-  }
-  return result;
+	if (p_stream->Read((char*) &length, 1) == SUCCESS) {
+		char nameBuffer[256];
+		if (p_stream->Read(nameBuffer, length) == SUCCESS) {
+			nameBuffer[length] = '\0';
+			if (strcmp(nameBuffer, s_endOfVariables) == 0)
+				// 2 -> "This was the last entry, done reading."
+				result = 2;
+			else {
+				if (p_stream->Read((char*) &length, 1) == SUCCESS) {
+					char valueBuffer[256];
+					if (p_stream->Read(valueBuffer, length) == SUCCESS) {
+						result = 0;
+						valueBuffer[length] = '\0';
+						p_to->SetVariable(nameBuffer, valueBuffer);
+					}
+				}
+			}
+		}
+	}
+	return result;
 }

--- a/LEGO1/legostream.h
+++ b/LEGO1/legostream.h
@@ -3,8 +3,8 @@
 
 #include "compat.h"
 #include "decomp.h"
-#include "mxtypes.h"
 #include "mxstring.h"
+#include "mxtypes.h"
 
 #include <iosfwd>
 
@@ -14,69 +14,65 @@
 class MxVariableTable;
 
 // VTABLE 0x100d7d80
-class LegoStream
-{
+class LegoStream {
 public:
-  LegoStream() : m_mode(0) {}
-  inline virtual ~LegoStream() {};
+	LegoStream() : m_mode(0) {}
+	inline virtual ~LegoStream(){};
 
-  virtual MxResult Read(void* p_buffer, MxU32 p_size) = 0;
-  virtual MxResult Write(const void* p_buffer, MxU32 p_size) = 0;
-  virtual MxResult Tell(MxU32* p_offset) = 0;
-  virtual MxResult Seek(MxU32 p_offset) = 0;
+	virtual MxResult Read(void* p_buffer, MxU32 p_size) = 0;
+	virtual MxResult Write(const void* p_buffer, MxU32 p_size) = 0;
+	virtual MxResult Tell(MxU32* p_offset) = 0;
+	virtual MxResult Seek(MxU32 p_offset) = 0;
 
-  virtual MxBool IsWriteMode();
-  virtual MxBool IsReadMode();
+	virtual MxBool IsWriteMode();
+	virtual MxBool IsReadMode();
 
-  enum OpenFlags
-  {
-    ReadBit = 1,
-    WriteBit = 2,
-    BinaryBit = 4,
-  };
+	enum OpenFlags {
+		ReadBit = 1,
+		WriteBit = 2,
+		BinaryBit = 4,
+	};
 
-  static MxResult __stdcall WriteVariable(LegoStream* p_stream, MxVariableTable* p_from, const char* p_variableName);
-  static MxS32 __stdcall ReadVariable(LegoStream* p_stream, MxVariableTable* p_to);
+	static MxResult __stdcall WriteVariable(LegoStream* p_stream, MxVariableTable* p_from, const char* p_variableName);
+	static MxS32 __stdcall ReadVariable(LegoStream* p_stream, MxVariableTable* p_to);
 
 protected:
-  MxU8 m_mode;
+	MxU8 m_mode;
 };
 
 // VTABLE 0x100db730
-class LegoFileStream : public LegoStream
-{
+class LegoFileStream : public LegoStream {
 public:
-  LegoFileStream();
-  virtual ~LegoFileStream();
+	LegoFileStream();
+	virtual ~LegoFileStream();
 
-  MxResult Read(void* p_buffer, MxU32 p_size) override;
-  MxResult Write(const void* p_buffer, MxU32 p_size) override;
-  MxResult Tell(MxU32* p_offset) override;
-  MxResult Seek(MxU32 p_offset) override;
+	MxResult Read(void* p_buffer, MxU32 p_size) override;
+	MxResult Write(const void* p_buffer, MxU32 p_size) override;
+	MxResult Tell(MxU32* p_offset) override;
+	MxResult Seek(MxU32 p_offset) override;
 
-  MxResult Open(const char* p_filename, OpenFlags p_mode);
+	MxResult Open(const char* p_filename, OpenFlags p_mode);
 
-  LegoFileStream *FUN_10006030(MxString p_str);
+	LegoFileStream* FUN_10006030(MxString p_str);
 
 private:
-  FILE *m_hFile;
+	FILE* m_hFile;
 };
 
 // VTABLE 0x100db710
-class LegoMemoryStream : public LegoStream
-{
+class LegoMemoryStream : public LegoStream {
 public:
-  LegoMemoryStream(char* p_buffer);
-  ~LegoMemoryStream() {}
+	LegoMemoryStream(char* p_buffer);
+	~LegoMemoryStream() {}
 
-  MxResult Read(void* p_buffer, MxU32 p_size) override;
-  MxResult Write(const void* p_buffer, MxU32 p_size) override;
-  MxResult Tell(MxU32* p_offset) override;
-  MxResult Seek(MxU32 p_offset) override;
+	MxResult Read(void* p_buffer, MxU32 p_size) override;
+	MxResult Write(const void* p_buffer, MxU32 p_size) override;
+	MxResult Tell(MxU32* p_offset) override;
+	MxResult Seek(MxU32 p_offset) override;
 
 private:
-  char *m_buffer;
-  MxU32 m_offset;
+	char* m_buffer;
+	MxU32 m_offset;
 };
 
 #endif // LEGOSTREAM_H

--- a/LEGO1/legotexturepresenter.cpp
+++ b/LEGO1/legotexturepresenter.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1004eb40 STUB
 LegoTexturePresenter::~LegoTexturePresenter()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legotexturepresenter.h
+++ b/LEGO1/legotexturepresenter.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d4d90
 // SIZE 0x54 (from inlined construction at 0x10009bb5)
-class LegoTexturePresenter : public MxMediaPresenter
-{
+class LegoTexturePresenter : public MxMediaPresenter {
 public:
-  virtual ~LegoTexturePresenter() override;
+	virtual ~LegoTexturePresenter() override;
 
-  // OFFSET: LEGO1 0x1000ce50
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0664
-    return "LegoTexturePresenter";
-  }
+	// OFFSET: LEGO1 0x1000ce50
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0664
+		return "LegoTexturePresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000ce60
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoTexturePresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1000ce60
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoTexturePresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOTEXTUREPRESENTER_H

--- a/LEGO1/legounksavedatawriter.cpp
+++ b/LEGO1/legounksavedatawriter.cpp
@@ -1,5 +1,6 @@
 
 #include "legounksavedatawriter.h"
+
 #include "legogamestate.h"
 #include "legostream.h"
 
@@ -9,40 +10,40 @@ DECOMP_SIZE_ASSERT(LegoSaveDataEntry3, 0x108);
 LegoSaveDataEntry3 g_saveData3[66];
 
 // OFFSET: LEGO1 0x10083310
-MxResult LegoUnkSaveDataWriter::WriteSaveData3(LegoStream *p_stream)
+MxResult LegoUnkSaveDataWriter::WriteSaveData3(LegoStream* p_stream)
 {
-  MxResult result = FAILURE;
+	MxResult result = FAILURE;
 
-  // This should probably be a for loop but I can't figure out how to
-  // make it match as a for loop.
-  LegoSaveDataEntry3 *entry = g_saveData3;
-  const LegoSaveDataEntry3 *end = &g_saveData3[66];
+	// This should probably be a for loop but I can't figure out how to
+	// make it match as a for loop.
+	LegoSaveDataEntry3* entry = g_saveData3;
+	const LegoSaveDataEntry3* end = &g_saveData3[66];
 
-  while (TRUE) {
-    if (p_stream->Write(&entry->m_savePart1, 4) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart2, 4) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart3, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_currentFrame, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart5, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart6, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart7, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart8, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart9, 1) != SUCCESS)
-      break;
-    if (p_stream->Write(&entry->m_savePart10, 1) != SUCCESS)
-      break;
-    if (++entry >= end) {
-      result = SUCCESS;
-      break;
-    }
-  }
-  return result;
+	while (TRUE) {
+		if (p_stream->Write(&entry->m_savePart1, 4) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart2, 4) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart3, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_currentFrame, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart5, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart6, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart7, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart8, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart9, 1) != SUCCESS)
+			break;
+		if (p_stream->Write(&entry->m_savePart10, 1) != SUCCESS)
+			break;
+		if (++entry >= end) {
+			result = SUCCESS;
+			break;
+		}
+	}
+	return result;
 }

--- a/LEGO1/legounksavedatawriter.h
+++ b/LEGO1/legounksavedatawriter.h
@@ -1,40 +1,38 @@
 #ifndef LEGOUNKSAVEDATAWRITER_H
 #define LEGOUNKSAVEDATAWRITER_H
 
-#include "mxtypes.h"
 #include "decomp.h"
+#include "mxtypes.h"
 
 class LegoStream;
 
-struct LegoSaveDataEntry3
-{
-  char *m_name;
-  void *m_unk0x04;
-  void *m_unk0x08;
-  MxS32 m_savePart1;
-  MxS32 m_savePart2;
-  MxU8 m_savePart3;
-  undefined4 m_unk0x18[6];
-  MxU8 m_frameOffsetInDwords; // 0x30
-  MxS32 *m_pFrameData;
-  MxU8 m_currentFrame;
-  undefined4 m_unk0x3c[2];
-  MxU8 m_savePart5; // 0x44
-  undefined4 m_unk0x48[5];
-  MxU8 m_savePart6; // 0x5c
-  undefined4 m_unk0x60[11];
-  MxU8 m_savePart7; // 0x8c
-  undefined4 m_unk0x90[5];
-  MxU8 m_savePart8; // 0xa4
-  undefined4 m_unk0xa8[17];
-  MxU8 m_savePart9; // 0xec
-  undefined4 m_unk0xf0[5];
-  MxU8 m_savePart10; // 0x104
+struct LegoSaveDataEntry3 {
+	char* m_name;
+	void* m_unk0x04;
+	void* m_unk0x08;
+	MxS32 m_savePart1;
+	MxS32 m_savePart2;
+	MxU8 m_savePart3;
+	undefined4 m_unk0x18[6];
+	MxU8 m_frameOffsetInDwords; // 0x30
+	MxS32* m_pFrameData;
+	MxU8 m_currentFrame;
+	undefined4 m_unk0x3c[2];
+	MxU8 m_savePart5; // 0x44
+	undefined4 m_unk0x48[5];
+	MxU8 m_savePart6; // 0x5c
+	undefined4 m_unk0x60[11];
+	MxU8 m_savePart7; // 0x8c
+	undefined4 m_unk0x90[5];
+	MxU8 m_savePart8; // 0xa4
+	undefined4 m_unk0xa8[17];
+	MxU8 m_savePart9; // 0xec
+	undefined4 m_unk0xf0[5];
+	MxU8 m_savePart10; // 0x104
 };
 
-class LegoUnkSaveDataWriter 
-{
-  MxResult WriteSaveData3(LegoStream *p_stream);
+class LegoUnkSaveDataWriter {
+	MxResult WriteSaveData3(LegoStream* p_stream);
 };
 
 #endif // LEGOUNKSAVEDATAWRITER_H

--- a/LEGO1/legoutil.cpp
+++ b/LEGO1/legoutil.cpp
@@ -6,111 +6,109 @@
 #include <string.h>
 
 // OFFSET: LEGO1 0x1003e300
-ExtraActionType MatchActionString(const char *p_str) {
-  ExtraActionType result = ExtraActionType_unknown;
+ExtraActionType MatchActionString(const char* p_str)
+{
+	ExtraActionType result = ExtraActionType_unknown;
 
-  if (!strcmpi("openram", p_str))
-    result = ExtraActionType_openram;
-  else if (!strcmpi("opendisk", p_str))
-    result = ExtraActionType_opendisk;
-  else if (!strcmpi("close", p_str))
-    result = ExtraActionType_close;
-  else if (!strcmpi("start", p_str))
-    result = ExtraActionType_start;
-  else if (!strcmpi("stop", p_str))
-    result = ExtraActionType_stop;
-  else if (!strcmpi("run", p_str))
-    result = ExtraActionType_run;
-  else if (!strcmpi("exit", p_str))
-    result = ExtraActionType_exit;
-  else if (!strcmpi("enable", p_str))
-    result = ExtraActionType_enable;
-  else if (!strcmpi("disable", p_str))
-    result = ExtraActionType_disable;
-  else if (!strcmpi("notify", p_str))
-    result = ExtraActionType_notify;
+	if (!strcmpi("openram", p_str))
+		result = ExtraActionType_openram;
+	else if (!strcmpi("opendisk", p_str))
+		result = ExtraActionType_opendisk;
+	else if (!strcmpi("close", p_str))
+		result = ExtraActionType_close;
+	else if (!strcmpi("start", p_str))
+		result = ExtraActionType_start;
+	else if (!strcmpi("stop", p_str))
+		result = ExtraActionType_stop;
+	else if (!strcmpi("run", p_str))
+		result = ExtraActionType_run;
+	else if (!strcmpi("exit", p_str))
+		result = ExtraActionType_exit;
+	else if (!strcmpi("enable", p_str))
+		result = ExtraActionType_enable;
+	else if (!strcmpi("disable", p_str))
+		result = ExtraActionType_disable;
+	else if (!strcmpi("notify", p_str))
+		result = ExtraActionType_notify;
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x1003eae0
-void ConvertHSVToRGB(float h, float s, float v, float *r_out, float *b_out, float *g_out)
+void ConvertHSVToRGB(float h, float s, float v, float* r_out, float* b_out, float* g_out)
 {
-  double calc;
-  double p;
-  MxLong hue_index;
-  double v9;
-  double v12;
-  double v13;
+	double calc;
+	double p;
+	MxLong hue_index;
+	double v9;
+	double v12;
+	double v13;
 
-  double s_dbl = s;
+	double s_dbl = s;
 
-  if (s > 0.5f)
-    calc = (1.0f - v) * s + v;
-  else
-    calc = (v + 1.0) * s_dbl;
-  if (calc <= 0.0)
-  {
-    *g_out = 0.0f;
-    *b_out = 0.0f;
-    *r_out = 0.0f;
-    return;
-  }
-  p = s * 2.0f - calc;
-  hue_index = h * 6.0;
-  v9 = (h * 6.0 - (float)hue_index) * ((calc - p) / calc) * calc;
-  v12 = p + v9;
-  v13 = calc - v9;
-  switch (hue_index)
-  {
-  case 0:
-    *r_out = calc;
-    *b_out = v12;
-    *g_out = p;
-    break;
-  case 1:
-    *r_out = v13;
-    *b_out = calc;
-    *g_out = p;
-    break;
-  case 2:
-    *r_out = p;
-    *b_out = calc;
-    *g_out = v12;
-    break;
-  case 3:
-    *r_out = p;
-    *b_out = v13;
-    *g_out = calc;
-    break;
-  case 4:
-    *r_out = v12;
-    *b_out = p;
-    *g_out = calc;
-    break;
-  case 5:
-    *r_out = calc;
-    *b_out = p;
-    *g_out = v13;
-    break;
-  case 6:
-    *r_out = calc;
-    *b_out = p;
-    *g_out = v13;
-    break;
-  default:
-    return;
-  }
+	if (s > 0.5f)
+		calc = (1.0f - v) * s + v;
+	else
+		calc = (v + 1.0) * s_dbl;
+	if (calc <= 0.0) {
+		*g_out = 0.0f;
+		*b_out = 0.0f;
+		*r_out = 0.0f;
+		return;
+	}
+	p = s * 2.0f - calc;
+	hue_index = h * 6.0;
+	v9 = (h * 6.0 - (float) hue_index) * ((calc - p) / calc) * calc;
+	v12 = p + v9;
+	v13 = calc - v9;
+	switch (hue_index) {
+	case 0:
+		*r_out = calc;
+		*b_out = v12;
+		*g_out = p;
+		break;
+	case 1:
+		*r_out = v13;
+		*b_out = calc;
+		*g_out = p;
+		break;
+	case 2:
+		*r_out = p;
+		*b_out = calc;
+		*g_out = v12;
+		break;
+	case 3:
+		*r_out = p;
+		*b_out = v13;
+		*g_out = calc;
+		break;
+	case 4:
+		*r_out = v12;
+		*b_out = p;
+		*g_out = calc;
+		break;
+	case 5:
+		*r_out = calc;
+		*b_out = p;
+		*g_out = v13;
+		break;
+	case 6:
+		*r_out = calc;
+		*b_out = p;
+		*g_out = v13;
+		break;
+	default:
+		return;
+	}
 }
 
 // OFFSET: LEGO1 0x1003ee00 STUB
-void FUN_1003ee00(MxAtomId &p_atomId, MxS32 p_id)
+void FUN_1003ee00(MxAtomId& p_atomId, MxS32 p_id)
 {
-
 }
 
 // OFFSET: LEGO1 0x1003ef40
 void SetAppCursor(WPARAM p_wparam)
 {
-  PostMessageA(MxOmni::GetInstance()->GetWindowHandle(), 0x5400, p_wparam, 0);
+	PostMessageA(MxOmni::GetInstance()->GetWindowHandle(), 0x5400, p_wparam, 0);
 }

--- a/LEGO1/legoutil.h
+++ b/LEGO1/legoutil.h
@@ -1,61 +1,61 @@
 #ifndef LEGOUTIL_H
 #define LEGOUTIL_H
 
-#include <windows.h>
-
 #include "extra.h"
 #include "mxatomid.h"
+
+#include <windows.h>
 
 template <class T>
 inline T Abs(T p_t)
 {
-  return p_t < 0 ? -p_t : p_t;
+	return p_t < 0 ? -p_t : p_t;
 }
 
 template <class T>
 inline T Min(T p_t1, T p_t2)
 {
-  return p_t1 < p_t2 ? p_t1 : p_t2;
+	return p_t1 < p_t2 ? p_t1 : p_t2;
 }
 
 template <class T>
 inline T Max(T p_t1, T p_t2)
 {
-  return p_t1 > p_t2 ? p_t1 : p_t2;
+	return p_t1 > p_t2 ? p_t1 : p_t2;
 }
 
 template <class T>
-inline void GetScalar(char **p_source, T& p_dest)
+inline void GetScalar(char** p_source, T& p_dest)
 {
-  p_dest = *(T*) *p_source;
-  *p_source += sizeof(T);
+	p_dest = *(T*) *p_source;
+	*p_source += sizeof(T);
 }
 
 template <class T>
-inline T GetScalar(T **p_source)
+inline T GetScalar(T** p_source)
 {
-  T val = **p_source;
-  *p_source += 1;
-  return val;
+	T val = **p_source;
+	*p_source += 1;
+	return val;
 }
 
 template <class T>
-inline void GetDouble(char **p_source, T& p_dest)
+inline void GetDouble(char** p_source, T& p_dest)
 {
-  p_dest = *(double*) *p_source;
-  *p_source += sizeof(double);
+	p_dest = *(double*) *p_source;
+	*p_source += sizeof(double);
 }
 
 template <class T>
-inline void GetString(char **p_source, const char *p_dest, T *p_obj, void (T::*p_setter)(const char*))
+inline void GetString(char** p_source, const char* p_dest, T* p_obj, void (T::*p_setter)(const char*))
 {
-  (p_obj->*p_setter)(*p_source);
-  *p_source += strlen(p_dest) + 1;
+	(p_obj->*p_setter)(*p_source);
+	*p_source += strlen(p_dest) + 1;
 }
 
-ExtraActionType MatchActionString(const char *);
+ExtraActionType MatchActionString(const char*);
 void ConvertHSVToRGB(float r, float g, float b, float* out_r, float* out_g, float* out_b);
-void FUN_1003ee00(MxAtomId &p_atomId, MxS32 p_id);
+void FUN_1003ee00(MxAtomId& p_atomId, MxS32 p_id);
 void SetAppCursor(WPARAM p_wparam);
 
 #endif // LEGOUTIL_H

--- a/LEGO1/legovehiclebuildstate.cpp
+++ b/LEGO1/legovehiclebuildstate.cpp
@@ -8,18 +8,18 @@ DECOMP_SIZE_ASSERT(LegoVehicleBuildState::UnkStruct, 0xc);
 // OFFSET: LEGO1 0x10025f30
 LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
 {
-  this->m_className = p_classType;
-  this->m_unk4c = 0;
-  this->m_unk4d = 0;
-  this->m_unk4e = 0;
-  this->m_placedPartCount = 0;
+	this->m_className = p_classType;
+	this->m_unk4c = 0;
+	this->m_unk4d = 0;
+	this->m_unk4e = 0;
+	this->m_placedPartCount = 0;
 }
 
 // OFFSET: LEGO1 10017c00
 LegoVehicleBuildState::UnkStruct::UnkStruct()
 {
-  m_unk04 = 0;
-  m_unk00 = 0;
-  m_unk06 = 0;
-  m_unk08 = 0;
+	m_unk04 = 0;
+	m_unk00 = 0;
+	m_unk06 = 0;
+	m_unk08 = 0;
 }

--- a/LEGO1/legovehiclebuildstate.h
+++ b/LEGO1/legovehiclebuildstate.h
@@ -1,60 +1,57 @@
 #ifndef LEGOVEHICLEBUILDSTATE_H
 #define LEGOVEHICLEBUILDSTATE_H
 
+#include "decomp.h"
 #include "legostate.h"
 #include "mxstring.h"
-#include "decomp.h"
-
-#include "decomp.h"
 
 // VTABLE 0x100d66e0
 // SIZE 0x50 (from 1000acd7)
-class LegoVehicleBuildState : public LegoState
-{
+class LegoVehicleBuildState : public LegoState {
 public:
-  LegoVehicleBuildState(char* p_classType);
+	LegoVehicleBuildState(char* p_classType);
 
-  // OFFSET: LEGO1 0x10025ff0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    return this->m_className.GetData();
-  }
+	// OFFSET: LEGO1 0x10025ff0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		return this->m_className.GetData();
+	}
 
-  // OFFSET: LEGO1 0x10026000
-  inline virtual MxBool IsA(const char *p_name) const override // vtable+0x10
-  {
-    return !strcmp(p_name, this->m_className.GetData()) || LegoState::IsA(p_name);
-  }
+	// OFFSET: LEGO1 0x10026000
+	inline virtual MxBool IsA(const char* p_name) const override // vtable+0x10
+	{
+		return !strcmp(p_name, this->m_className.GetData()) || LegoState::IsA(p_name);
+	}
 
 public:
-  struct UnkStruct
-  {
-    undefined4 m_unk00;
-    undefined2 m_unk04;
-    undefined2 m_unk06;
-    undefined2 m_unk08;
+	struct UnkStruct {
+		undefined4 m_unk00;
+		undefined2 m_unk04;
+		undefined2 m_unk06;
+		undefined2 m_unk08;
 
-    UnkStruct();
-  };
+		UnkStruct();
+	};
+
 private:
-  UnkStruct m_unk08[4]; // 0x08
+	UnkStruct m_unk08[4]; // 0x08
 
-  // This can be one of the following:
-  // * LegoRaceCarBuildState
-  // * LegoCopterBuildState
-  // * LegoDuneCarBuildState
-  // * LegoJetskiBuildState
-  MxString m_className; // 0x38
+	// This can be one of the following:
+	// * LegoRaceCarBuildState
+	// * LegoCopterBuildState
+	// * LegoDuneCarBuildState
+	// * LegoJetskiBuildState
+	MxString m_className; // 0x38
 
-  // Known States:
-  // * 1 == enter(ing) build screen
-  // * 3 == cutscene/dialogue
-  // * 6 == exit(ing) build screen
-  MxU32 m_animationState; // 0x48
-  undefined m_unk4c; // 0x4c
-  undefined m_unk4d; // 0x4d
-  undefined m_unk4e; // 0x4e
-  MxU8 m_placedPartCount; // 0x4f
+	// Known States:
+	// * 1 == enter(ing) build screen
+	// * 3 == cutscene/dialogue
+	// * 6 == exit(ing) build screen
+	MxU32 m_animationState; // 0x48
+	undefined m_unk4c;      // 0x4c
+	undefined m_unk4d;      // 0x4d
+	undefined m_unk4e;      // 0x4e
+	MxU8 m_placedPartCount; // 0x4f
 };
 
 #endif // LEGOVEHICLEBUILDSTATE_H

--- a/LEGO1/legovideomanager.cpp
+++ b/LEGO1/legovideomanager.cpp
@@ -5,67 +5,67 @@ DECOMP_SIZE_ASSERT(LegoVideoManager, 0x590);
 // OFFSET: LEGO1 0x1007aa20 STUB
 LegoVideoManager::LegoVideoManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1007ab40 STUB
 LegoVideoManager::~LegoVideoManager()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1007c560 STUB
 int LegoVideoManager::EnableRMDevice()
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1007c740 STUB
 int LegoVideoManager::DisableRMDevice()
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1007c300
 void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable)
 {
-  EnableFullScreenMovie(p_enable, TRUE);
+	EnableFullScreenMovie(p_enable, TRUE);
 }
 
 // OFFSET: LEGO1 0x1007c310 STUB
 void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable, MxBool p_scale)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1007b6a0
 void LegoVideoManager::MoveCursor(MxS32 p_cursorX, MxS32 p_cursorY)
 {
-  m_cursorX = p_cursorX;
-  m_cursorY = p_cursorY;
-  m_cursorMoved = TRUE;
+	m_cursorX = p_cursorX;
+	m_cursorY = p_cursorY;
+	m_cursorMoved = TRUE;
 
-  if (623 < p_cursorX)
-    m_cursorX = 623;
+	if (623 < p_cursorX)
+		m_cursorX = 623;
 
-  if (463 < p_cursorY)
-    m_cursorY = 463;
+	if (463 < p_cursorY)
+		m_cursorY = 463;
 }
 
 // OFFSET: LEGO1 0x1007c440
 void LegoVideoManager::SetSkyColor(float p_red, float p_green, float p_blue)
 {
-  PALETTEENTRY colorStrucure;
+	PALETTEENTRY colorStrucure;
 
-  colorStrucure.peRed = (p_red * 255.0f);
-  colorStrucure.peGreen = (p_green * 255.0f);
-  colorStrucure.peBlue = (p_blue * 255.0f);
-  colorStrucure.peFlags = -124;
-  m_videoParam.GetPalette()->SetSkyColor(&colorStrucure);
-  m_videoParam.GetPalette()->SetOverrideSkyColor(TRUE);
+	colorStrucure.peRed = (p_red * 255.0f);
+	colorStrucure.peGreen = (p_green * 255.0f);
+	colorStrucure.peBlue = (p_blue * 255.0f);
+	colorStrucure.peFlags = -124;
+	m_videoParam.GetPalette()->SetSkyColor(&colorStrucure);
+	m_videoParam.GetPalette()->SetOverrideSkyColor(TRUE);
 
-  // TODO 3d manager
-  //m_3dManager->m_pViewport->vtable1c(red, green, blue)
+	// TODO 3d manager
+	// m_3dManager->m_pViewport->vtable1c(red, green, blue)
 }

--- a/LEGO1/legovideomanager.h
+++ b/LEGO1/legovideomanager.h
@@ -1,50 +1,52 @@
 #ifndef LEGOVIDEOMANAGER_H
 #define LEGOVIDEOMANAGER_H
 
-#include "mxvideomanager.h"
-#include "mxdirect3d.h"
-#include "lego3dmanager.h"
 #include "decomp.h"
+#include "lego3dmanager.h"
+#include "mxdirect3d.h"
+#include "mxvideomanager.h"
 
 #include <ddraw.h>
 
 // VTABLE 0x100d9c88
 // SIZE 0x590
-class LegoVideoManager : public MxVideoManager
-{
+class LegoVideoManager : public MxVideoManager {
 public:
-  LegoVideoManager();
-  virtual ~LegoVideoManager() override;
+	LegoVideoManager();
+	virtual ~LegoVideoManager() override;
 
-  __declspec(dllexport) int EnableRMDevice();
-  __declspec(dllexport) int DisableRMDevice();
-  void EnableFullScreenMovie(MxBool p_enable);
-  __declspec(dllexport) void EnableFullScreenMovie(MxBool p_enable, MxBool p_scale);
-  __declspec(dllexport) void MoveCursor(int x, int y);
+	__declspec(dllexport) int EnableRMDevice();
+	__declspec(dllexport) int DisableRMDevice();
+	void EnableFullScreenMovie(MxBool p_enable);
+	__declspec(dllexport) void EnableFullScreenMovie(MxBool p_enable, MxBool p_scale);
+	__declspec(dllexport) void MoveCursor(int x, int y);
 
-  inline Lego3DManager *Get3DManager() { return this->m_3dManager; }
-  inline MxDirect3D *GetDirect3D() { return this->m_direct3d; }
+	inline Lego3DManager* Get3DManager() { return this->m_3dManager; }
+	inline MxDirect3D* GetDirect3D() { return this->m_direct3d; }
 
-  void SetSkyColor(float r, float g, float b);
-  inline void SetUnkE4(MxBool p_unk0xe4) { this->m_unk0xe4 = p_unk0xe4; }
+	void SetSkyColor(float r, float g, float b);
+	inline void SetUnkE4(MxBool p_unk0xe4) { this->m_unk0xe4 = p_unk0xe4; }
 
-  // OFFSET: LEGO1 0x1007c4c0
-  void OverrideSkyColor(MxBool p_shouldOverride) { this->m_videoParam.GetPalette()->SetOverrideSkyColor(p_shouldOverride);}
+	// OFFSET: LEGO1 0x1007c4c0
+	void OverrideSkyColor(MxBool p_shouldOverride)
+	{
+		this->m_videoParam.GetPalette()->SetOverrideSkyColor(p_shouldOverride);
+	}
 
 private:
-  undefined4 m_unk64;
-  Lego3DManager *m_3dManager;
-  undefined4 m_unk6c;
-  undefined4 m_unk70;
-  MxDirect3D *m_direct3d;
-  undefined m_pad0x78[0x6c];
-  MxBool m_unk0xe4;
-  undefined m_pad0xe8[0x41c];
-  MxBool m_cursorMoved; // 0x501
-  undefined m_pad0x502[0x8];
-  MxS32 m_cursorX; // 0x50c
-  MxS32 m_cursorY; // 0x510
-  undefined m_pad0x514[0x7c];
+	undefined4 m_unk64;
+	Lego3DManager* m_3dManager;
+	undefined4 m_unk6c;
+	undefined4 m_unk70;
+	MxDirect3D* m_direct3d;
+	undefined m_pad0x78[0x6c];
+	MxBool m_unk0xe4;
+	undefined m_pad0xe8[0x41c];
+	MxBool m_cursorMoved; // 0x501
+	undefined m_pad0x502[0x8];
+	MxS32 m_cursorX; // 0x50c
+	MxS32 m_cursorY; // 0x510
+	undefined m_pad0x514[0x7c];
 };
 
 #endif // LEGOVIDEOMANAGER_H

--- a/LEGO1/legoworld.cpp
+++ b/LEGO1/legoworld.cpp
@@ -1,6 +1,7 @@
 #include "legoworld.h"
-#include "legoomni.h"
+
 #include "legoinputmanager.h"
+#include "legoomni.h"
 #include "mxticklemanager.h"
 
 DECOMP_SIZE_ASSERT(LegoWorld, 0xf8);
@@ -10,37 +11,37 @@ MxBool g_isWorldActive;
 // OFFSET: LEGO1 0x1001ca40 STUB
 LegoWorld::LegoWorld()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1001dfa0 STUB
 LegoWorld::~LegoWorld()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10022340
 void LegoWorld::Stop()
 {
-  TickleManager()->UnregisterClient(this);
+	TickleManager()->UnregisterClient(this);
 }
 
 // OFFSET: LEGO1 0x1001f630 STUB
 void LegoWorld::VTable0x54()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10020220 STUB
-void LegoWorld::VTable0x58(MxCore *p_object)
+void LegoWorld::VTable0x58(MxCore* p_object)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1001d670
 MxBool LegoWorld::VTable0x5c()
 {
-  return FALSE; 
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x100010a0
@@ -51,38 +52,38 @@ void LegoWorld::VTable0x60()
 // OFFSET: LEGO1 0x1001d680
 MxBool LegoWorld::VTable0x64()
 {
-  return FALSE;
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x10021a70 STUB
-void LegoWorld::VTable0x68(MxBool p_add) 
+void LegoWorld::VTable0x68(MxBool p_add)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1001e0b0 STUB
-MxResult LegoWorld::SetAsCurrentWorld(MxDSObject &p_dsObject)
+MxResult LegoWorld::SetAsCurrentWorld(MxDSObject& p_dsObject)
 {
-  // TODO
-  return SUCCESS;
+	// TODO
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10015820 STUB
 void FUN_10015820(MxU32 p_unk1, MxU32 p_unk2)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10015910 STUB
 void FUN_10015910(MxU32 p_unk1)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100159c0
 void SetIsWorldActive(MxBool p_isWorldActive)
 {
-  if (!p_isWorldActive)
-    LegoOmni::GetInstance()->GetInputManager()->SetCamera(NULL);
-  g_isWorldActive = p_isWorldActive;
+	if (!p_isWorldActive)
+		LegoOmni::GetInstance()->GetInputManager()->SetCamera(NULL);
+	g_isWorldActive = p_isWorldActive;
 }

--- a/LEGO1/legoworld.h
+++ b/LEGO1/legoworld.h
@@ -1,46 +1,45 @@
 #ifndef LEGOWORLD_H
 #define LEGOWORLD_H
 
-#include "legoentity.h"
 #include "legocameracontroller.h"
+#include "legoentity.h"
 
 // VTABLE 0x100d6280
 // SIZE 0xf8
-class LegoWorld : public LegoEntity
-{
+class LegoWorld : public LegoEntity {
 public:
-  __declspec(dllexport) LegoWorld();
-  __declspec(dllexport) virtual ~LegoWorld(); // vtable+0x0
+	__declspec(dllexport) LegoWorld();
+	__declspec(dllexport) virtual ~LegoWorld(); // vtable+0x0
 
-  // OFFSET: LEGO1 0x1001d690
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0058
-    return "LegoWorld";
-  }
+	// OFFSET: LEGO1 0x1001d690
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0058
+		return "LegoWorld";
+	}
 
-  // OFFSET: LEGO1 0x1001d6a0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoWorld::ClassName()) || LegoEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1001d6a0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoWorld::ClassName()) || LegoEntity::IsA(name);
+	}
 
-  virtual void Stop(); // vtable+50
-  virtual void VTable0x54(); // vtable+54
-  virtual void VTable0x58(MxCore *p_object); // vtable+58
-  virtual MxBool VTable0x5c();  // vtable+5c
-  virtual void VTable0x60();  // vtable+60
-  virtual MxBool VTable0x64(); // vtable+64
-  virtual void VTable0x68(MxBool p_add); // vtable+68
+	virtual void Stop();                       // vtable+50
+	virtual void VTable0x54();                 // vtable+54
+	virtual void VTable0x58(MxCore* p_object); // vtable+58
+	virtual MxBool VTable0x5c();               // vtable+5c
+	virtual void VTable0x60();                 // vtable+60
+	virtual MxBool VTable0x64();               // vtable+64
+	virtual void VTable0x68(MxBool p_add);     // vtable+68
 
-  MxResult SetAsCurrentWorld(MxDSObject &p_dsObject);
+	MxResult SetAsCurrentWorld(MxDSObject& p_dsObject);
 
 protected:
-  undefined m_unk68[0x30];
-  LegoCameraController *m_camera;
-  undefined m_unk9c[0x5a];
-  undefined m_unkf6;
-  undefined m_unkf7;
+	undefined m_unk68[0x30];
+	LegoCameraController* m_camera;
+	undefined m_unk9c[0x5a];
+	undefined m_unkf6;
+	undefined m_unkf7;
 };
 
 void FUN_10015820(MxU32 p_unk1, MxU32 p_unk2);

--- a/LEGO1/legoworldpresenter.cpp
+++ b/LEGO1/legoworldpresenter.cpp
@@ -3,17 +3,17 @@
 // OFFSET: LEGO1 0x100665c0 STUB
 LegoWorldPresenter::LegoWorldPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10066770 STUB
 LegoWorldPresenter::~LegoWorldPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100665b0 STUB
 void LegoWorldPresenter::configureLegoWorldPresenter(int param_1)
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/legoworldpresenter.h
+++ b/LEGO1/legoworldpresenter.h
@@ -5,27 +5,25 @@
 
 // VTABLE 0x100d8ee0
 // SIZE 0x54
-class LegoWorldPresenter : public LegoEntityPresenter
-{
+class LegoWorldPresenter : public LegoEntityPresenter {
 public:
-  LegoWorldPresenter();
-  virtual ~LegoWorldPresenter() override; // vtable+0x0
+	LegoWorldPresenter();
+	virtual ~LegoWorldPresenter() override; // vtable+0x0
 
-  __declspec(dllexport) static void configureLegoWorldPresenter(int param_1);
+	__declspec(dllexport) static void configureLegoWorldPresenter(int param_1);
 
-  // OFFSET: LEGO1 0x10066630
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0608
-    return "LegoWorldPresenter";
-  }
+	// OFFSET: LEGO1 0x10066630
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0608
+		return "LegoWorldPresenter";
+	}
 
-  // OFFSET: LEGO1 0x10066640
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, LegoWorldPresenter::ClassName()) || LegoEntityPresenter::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x10066640
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, LegoWorldPresenter::ClassName()) || LegoEntityPresenter::IsA(name);
+	}
 };
 
 #endif // LEGOWORLDPRESENTER_H

--- a/LEGO1/motorcycle.cpp
+++ b/LEGO1/motorcycle.cpp
@@ -5,8 +5,8 @@ DECOMP_SIZE_ASSERT(Motorcycle, 0x16c);
 // OFFSET: LEGO1 0x100357b0
 Motorcycle::Motorcycle()
 {
-  this->m_unk13c = 40.0;
-  this->m_unk150 = 1.75;
-  this->m_unk148 = 1;
-  this->m_unk164 = 1.0;
+	this->m_unk13c = 40.0;
+	this->m_unk150 = 1.75;
+	this->m_unk148 = 1;
+	this->m_unk164 = 1.0;
 }

--- a/LEGO1/motorcycle.h
+++ b/LEGO1/motorcycle.h
@@ -6,27 +6,27 @@
 
 // VTABLE 0x100d7090
 // SIZE 0x16c
-class Motorcycle : public IslePathActor
-{
+class Motorcycle : public IslePathActor {
 public:
-  Motorcycle();
+	Motorcycle();
 
-  // OFFSET: LEGO1 0x10035840
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10035840
-    return "Motorcycle";
-  }
+	// OFFSET: LEGO1 0x10035840
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10035840
+		return "Motorcycle";
+	}
 
-  // OFFSET: LEGO1 0x10035850
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Motorcycle::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10035850
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Motorcycle::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  undefined m_unk160[4];
-  MxFloat m_unk164;
-  undefined m_unk168[4];
+	undefined m_unk160[4];
+	MxFloat m_unk164;
+	undefined m_unk168[4];
 };
 
 #endif // MOTORCYCLE_H

--- a/LEGO1/mxactionnotificationparam.cpp
+++ b/LEGO1/mxactionnotificationparam.cpp
@@ -4,13 +4,13 @@ DECOMP_SIZE_ASSERT(MxActionNotificationParam, 0x14)
 DECOMP_SIZE_ASSERT(MxEndActionNotificationParam, 0x14)
 
 // OFFSET: LEGO1 0x100510c0
-MxNotificationParam *MxActionNotificationParam::Clone()
+MxNotificationParam* MxActionNotificationParam::Clone()
 {
-  return new MxActionNotificationParam(this->m_type, this->m_sender, this->m_action, this->m_realloc);
+	return new MxActionNotificationParam(this->m_type, this->m_sender, this->m_action, this->m_realloc);
 }
 
 // OFFSET: LEGO1 0x10051270
-MxNotificationParam *MxEndActionNotificationParam::Clone()
+MxNotificationParam* MxEndActionNotificationParam::Clone()
 {
-  return new MxEndActionNotificationParam(MXSTREAMER_UNKNOWN, this->m_sender, this->m_action, this->m_realloc);
+	return new MxEndActionNotificationParam(MXSTREAMER_UNKNOWN, this->m_sender, this->m_action, this->m_realloc);
 }

--- a/LEGO1/mxactionnotificationparam.h
+++ b/LEGO1/mxactionnotificationparam.h
@@ -1,61 +1,67 @@
 #ifndef MXACTIONNOTIFICATIONPARAM_H
 #define MXACTIONNOTIFICATIONPARAM_H
 
-#include "mxnotificationparam.h"
 #include "mxdsaction.h"
+#include "mxnotificationparam.h"
 
 // VTABLE 0x100d8350
 // SIZE 0x14
-class MxActionNotificationParam : public MxNotificationParam
-{
+class MxActionNotificationParam : public MxNotificationParam {
 public:
-  inline MxActionNotificationParam(MxParamType p_type, MxCore *p_sender, MxDSAction *p_action, MxBool p_reallocAction) : MxNotificationParam(p_type, p_sender)
-  {
-    MxDSAction *oldAction = p_action;
-    this->m_realloc = p_reallocAction;
+	inline MxActionNotificationParam(MxParamType p_type, MxCore* p_sender, MxDSAction* p_action, MxBool p_reallocAction)
+		: MxNotificationParam(p_type, p_sender)
+	{
+		MxDSAction* oldAction = p_action;
+		this->m_realloc = p_reallocAction;
 
-    if (p_reallocAction)
-      this->m_action = new MxDSAction();
-    else {
-      this->m_action = oldAction;
-      return;
-    }
+		if (p_reallocAction)
+			this->m_action = new MxDSAction();
+		else {
+			this->m_action = oldAction;
+			return;
+		}
 
-    this->m_action->SetAtomId(oldAction->GetAtomId());
-    this->m_action->SetObjectId(oldAction->GetObjectId());
-    this->m_action->SetUnknown24(oldAction->GetUnknown24());
-  }
+		this->m_action->SetAtomId(oldAction->GetAtomId());
+		this->m_action->SetObjectId(oldAction->GetObjectId());
+		this->m_action->SetUnknown24(oldAction->GetUnknown24());
+	}
 
-  // OFFSET: LEGO1 0x10051050
-  inline virtual ~MxActionNotificationParam() override
-  {
-    if (!this->m_realloc)
-      return;
+	// OFFSET: LEGO1 0x10051050
+	inline virtual ~MxActionNotificationParam() override
+	{
+		if (!this->m_realloc)
+			return;
 
-    if (this->m_action)
-      delete this->m_action;
-  }
+		if (this->m_action)
+			delete this->m_action;
+	}
 
-  virtual MxNotificationParam *Clone() override; // vtable+0x4
+	virtual MxNotificationParam* Clone() override; // vtable+0x4
 
-  inline MxDSAction *GetAction() { return m_action; }
+	inline MxDSAction* GetAction() { return m_action; }
 
 protected:
-  MxDSAction *m_action; // 0xc
-  MxBool m_realloc; // 0x10
+	MxDSAction* m_action; // 0xc
+	MxBool m_realloc;     // 0x10
 };
 
 // VTABLE 0x100d8358
 // SIZE 0x14
-class MxEndActionNotificationParam : public MxActionNotificationParam
-{
+class MxEndActionNotificationParam : public MxActionNotificationParam {
 public:
-  inline MxEndActionNotificationParam(MxParamType p_type, MxCore *p_sender, MxDSAction *p_action, MxBool p_reallocAction)
-      : MxActionNotificationParam(p_type, p_sender, p_action, p_reallocAction) {}
+	inline MxEndActionNotificationParam(
+		MxParamType p_type,
+		MxCore* p_sender,
+		MxDSAction* p_action,
+		MxBool p_reallocAction
+	)
+		: MxActionNotificationParam(p_type, p_sender, p_action, p_reallocAction)
+	{
+	}
 
-  inline virtual ~MxEndActionNotificationParam() override {}; // 0x100513a0
+	inline virtual ~MxEndActionNotificationParam() override{}; // 0x100513a0
 
-  virtual MxNotificationParam *Clone() override; // vtable+0x4
+	virtual MxNotificationParam* Clone() override; // vtable+0x4
 };
 
 #endif

--- a/LEGO1/mxappnotificationparam.h
+++ b/LEGO1/mxappnotificationparam.h
@@ -1,22 +1,20 @@
 #ifndef MXAPPNOTIFICATIONPARAM_H
 #define MXAPPNOTIFICATIONPARAM_H
 
+#include "decomp.h"
 #include "mxnotificationparam.h"
 
-#include "decomp.h"
-
 // VTABLE 0x100d6aa0
-class MxAppNotificationParam : public MxNotificationParam
-{
+class MxAppNotificationParam : public MxNotificationParam {
 public:
-  inline MxAppNotificationParam() : MxNotificationParam((MxParamType) 0, NULL) {}
+	inline MxAppNotificationParam() : MxNotificationParam((MxParamType) 0, NULL) {}
 
-  virtual ~MxAppNotificationParam() override {} // vtable+0x0 (scalar deleting destructor)
-  inline MxU8 GetUnknown18() { return m_unk18; }
+	virtual ~MxAppNotificationParam() override {} // vtable+0x0 (scalar deleting destructor)
+	inline MxU8 GetUnknown18() { return m_unk18; }
 
 protected:
-  undefined m_unkc[0xc];
-  MxU8 m_unk18;
+	undefined m_unkc[0xc];
+	MxU8 m_unk18;
 };
 
 #endif // MXAPPNOTIFICATIONPARAM_H

--- a/LEGO1/mxatomid.cpp
+++ b/LEGO1/mxatomid.cpp
@@ -1,97 +1,97 @@
 #include "mxatomid.h"
+
 #include "mxomni.h"
 
 // OFFSET: LEGO1 0x100acf90
-MxAtomId::MxAtomId(const char *p_str, LookupMode p_mode)
+MxAtomId::MxAtomId(const char* p_str, LookupMode p_mode)
 {
-  if (!MxOmni::GetInstance())
-    return;
+	if (!MxOmni::GetInstance())
+		return;
 
-  if (!AtomIdCounterSet())
-    return;
+	if (!AtomIdCounterSet())
+		return;
 
-  MxAtomIdCounter *counter = GetCounter(p_str, p_mode);
-  m_internal = counter->GetKey()->GetData();
-  counter->Inc();
+	MxAtomIdCounter* counter = GetCounter(p_str, p_mode);
+	m_internal = counter->GetKey()->GetData();
+	counter->Inc();
 }
 
 // OFFSET: LEGO1 0x100acfd0
 MxAtomId::~MxAtomId()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x100acfe0
 void MxAtomId::Destroy()
 {
-  if (!m_internal)
-    return;
+	if (!m_internal)
+		return;
 
-  if (!MxOmni::GetInstance())
-    return;
+	if (!MxOmni::GetInstance())
+		return;
 
-  if (!AtomIdCounterSet())
-    return;
+	if (!AtomIdCounterSet())
+		return;
 
-  // The dtor is called on the counter object immediately,
-  // so this syntax should be correct.
-  MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(
-    &MxAtomIdCounter(m_internal)
-  );
-  
-  MxAtomIdCounter *counter = (MxAtomIdCounter*)(*it);
-  counter->Dec();
+	// The dtor is called on the counter object immediately,
+	// so this syntax should be correct.
+	MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(&MxAtomIdCounter(m_internal));
+
+	MxAtomIdCounter* counter = (MxAtomIdCounter*) (*it);
+	counter->Dec();
 }
 
 // OFFSET: LEGO1 0x100ad1c0
-MxAtomId &MxAtomId::operator=(const MxAtomId &p_atomId)
+MxAtomId& MxAtomId::operator=(const MxAtomId& p_atomId)
 {
-  if (m_internal)
-    Destroy();
+	if (m_internal)
+		Destroy();
 
-  if (p_atomId.m_internal && MxOmni::GetInstance() && AtomIdCounterSet()) {
-    MxAtomIdCounter *counter = GetCounter(p_atomId.m_internal, LookupMode_Exact);
-    counter->Inc();
-  }
+	if (p_atomId.m_internal && MxOmni::GetInstance() && AtomIdCounterSet()) {
+		MxAtomIdCounter* counter = GetCounter(p_atomId.m_internal, LookupMode_Exact);
+		counter->Inc();
+	}
 
-  m_internal = p_atomId.m_internal;
+	m_internal = p_atomId.m_internal;
 
-  return *this;
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100ad210
-MxAtomIdCounter* MxAtomId::GetCounter(const char *p_str, LookupMode p_mode)
+MxAtomIdCounter* MxAtomId::GetCounter(const char* p_str, LookupMode p_mode)
 {
-  MxAtomId _unused;
-  MxAtomIdCounter *counter = new MxAtomIdCounter(p_str);
+	MxAtomId _unused;
+	MxAtomIdCounter* counter = new MxAtomIdCounter(p_str);
 
-  switch (p_mode) {
-    case LookupMode_LowerCase:
-    case LookupMode_LowerCase2:
-      counter->GetKey()->ToLowerCase();
-      break;
-    case LookupMode_UpperCase:
-      counter->GetKey()->ToUpperCase();
-      break;
-  }
+	switch (p_mode) {
+	case LookupMode_LowerCase:
+	case LookupMode_LowerCase2:
+		counter->GetKey()->ToLowerCase();
+		break;
+	case LookupMode_UpperCase:
+		counter->GetKey()->ToUpperCase();
+		break;
+	}
 
-  MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(counter);
-  if (it != AtomIdCounterSet()->end()) {
-    // Counter already in the set. Delete temp value and return it.
-    delete counter;
-    counter = *it;
-  } else {
-    // Counter is not in the set. Add it.
-    AtomIdCounterSet()->insert(counter);
-  }
+	MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(counter);
+	if (it != AtomIdCounterSet()->end()) {
+		// Counter already in the set. Delete temp value and return it.
+		delete counter;
+		counter = *it;
+	}
+	else {
+		// Counter is not in the set. Add it.
+		AtomIdCounterSet()->insert(counter);
+	}
 
-  return counter;
+	return counter;
 }
 
 // OFFSET: LEGO1 0x100ad7e0
 void MxAtomId::Clear()
 {
-  // Reset but do not delete MxAtomId object.
-  Destroy();
-  m_internal = NULL;
+	// Reset but do not delete MxAtomId object.
+	Destroy();
+	m_internal = NULL;
 }

--- a/LEGO1/mxatomid.h
+++ b/LEGO1/mxatomid.h
@@ -1,43 +1,35 @@
 #ifndef MXATOMID_H
 #define MXATOMID_H
 
-#include "mxtypes.h"
 #include "mxatomidcounter.h"
+#include "mxtypes.h"
 
-enum LookupMode
-{
-  LookupMode_Exact = 0,
-  LookupMode_LowerCase = 1,
-  LookupMode_UpperCase = 2,
-  LookupMode_LowerCase2 = 3
+enum LookupMode {
+	LookupMode_Exact = 0,
+	LookupMode_LowerCase = 1,
+	LookupMode_UpperCase = 2,
+	LookupMode_LowerCase2 = 3
 };
 
-class MxAtomId
-{
+class MxAtomId {
 public:
-  __declspec(dllexport) MxAtomId(const char *, LookupMode);
-  __declspec(dllexport) MxAtomId &operator=(const MxAtomId &id);
-  __declspec(dllexport) ~MxAtomId();
+	__declspec(dllexport) MxAtomId(const char*, LookupMode);
+	__declspec(dllexport) MxAtomId& operator=(const MxAtomId& id);
+	__declspec(dllexport) ~MxAtomId();
 
-  MxAtomId()
-  {
-    this->m_internal = 0;
-  }
+	MxAtomId() { this->m_internal = 0; }
 
-  inline MxBool operator ==(const MxAtomId &other) const
-  {
-    return this->m_internal == other.m_internal;
-  }
+	inline MxBool operator==(const MxAtomId& other) const { return this->m_internal == other.m_internal; }
 
-  void Clear();
+	void Clear();
 
-  const char *GetInternal() const { return m_internal; }
+	const char* GetInternal() const { return m_internal; }
 
 private:
-  MxAtomIdCounter* GetCounter(const char *, LookupMode);
-  void Destroy();
+	MxAtomIdCounter* GetCounter(const char*, LookupMode);
+	void Destroy();
 
-  const char *m_internal;
+	const char* m_internal;
 };
 
 #endif // MXATOMID_H

--- a/LEGO1/mxatomidcounter.cpp
+++ b/LEGO1/mxatomidcounter.cpp
@@ -1,4 +1,5 @@
 #include "mxatomidcounter.h"
+
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxAtomIdCounter, 0x14);
@@ -7,12 +8,12 @@ DECOMP_SIZE_ASSERT(MxAtomIdCounterSet, 0x10);
 // OFFSET: LEGO1 0x100ad7f0
 void MxAtomIdCounter::Inc()
 {
-  m_value++;
+	m_value++;
 }
 
 // OFFSET: LEGO1 0x100ad800
 void MxAtomIdCounter::Dec()
 {
-  if (m_value)
-    m_value--;
+	if (m_value)
+		m_value--;
 }

--- a/LEGO1/mxatomidcounter.h
+++ b/LEGO1/mxatomidcounter.h
@@ -1,8 +1,8 @@
 #ifndef MXATOMIDCOUNTER_H
 #define MXATOMIDCOUNTER_H
 
-#include "mxstring.h"
 #include "compat.h" // STL
+#include "mxstring.h"
 
 // Counts the number of existing MxAtomId objects based
 // on the matching char* string. A <map> seems fit for purpose here:
@@ -14,36 +14,33 @@
 // for the combined key_value_pair, which doesn't seem possible with <map>.
 
 // SIZE: 0x14 (including padding)
-class MxAtomIdCounter
-{
+class MxAtomIdCounter {
 public:
-  // always inlined
-  MxAtomIdCounter(const char *p_str)
-  {
-    m_key = p_str;
-    m_value = 0;
-  }
+	// always inlined
+	MxAtomIdCounter(const char* p_str)
+	{
+		m_key = p_str;
+		m_value = 0;
+	}
 
-  void Inc();
-  void Dec();
-  inline MxString* GetKey() { return &m_key; };
-  inline MxU16 GetValue() { return m_value; };
+	void Inc();
+	void Dec();
+	inline MxString* GetKey() { return &m_key; };
+	inline MxU16 GetValue() { return m_value; };
 
 private:
-  MxString m_key;
-  MxU16 m_value;
+	MxString m_key;
+	MxU16 m_value;
 };
 
-struct MxAtomIdCounterCompare
-{
-  // OFFSET: LEGO1 0x100ad120
-  int operator()(MxAtomIdCounter* const & p_val0, MxAtomIdCounter* const & p_val1) const
-  {
-    return strcmp(p_val0->GetKey()->GetData(), p_val1->GetKey()->GetData()) > 0;
-  }
+struct MxAtomIdCounterCompare {
+	// OFFSET: LEGO1 0x100ad120
+	int operator()(MxAtomIdCounter* const& p_val0, MxAtomIdCounter* const& p_val1) const
+	{
+		return strcmp(p_val0->GetKey()->GetData(), p_val1->GetKey()->GetData()) > 0;
+	}
 };
 
-class MxAtomIdCounterSet : public set<MxAtomIdCounter*, MxAtomIdCounterCompare>
-{};
+class MxAtomIdCounterSet : public set<MxAtomIdCounter*, MxAtomIdCounterCompare> {};
 
-#endif //MXATOMIDCOUNTER_H
+#endif // MXATOMIDCOUNTER_H

--- a/LEGO1/mxaudiomanager.cpp
+++ b/LEGO1/mxaudiomanager.cpp
@@ -8,71 +8,71 @@ MxS32 MxAudioManager::g_unkCount = 0;
 // OFFSET: LEGO1 0x100b8d00
 MxAudioManager::MxAudioManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100b8d90
 MxAudioManager::~MxAudioManager()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100b8df0
 void MxAudioManager::Init()
 {
-  this->m_volume = 100;
+	this->m_volume = 100;
 }
 
 // OFFSET: LEGO1 0x10029910
 MxS32 MxAudioManager::GetVolume()
 {
-  return this->m_volume;
+	return this->m_volume;
 }
 
 // OFFSET: LEGO1 0x100b8ea0
 void MxAudioManager::SetVolume(MxS32 p_volume)
 {
-  this->m_criticalSection.Enter();
-  this->m_volume = p_volume;
-  this->m_criticalSection.Leave();
+	this->m_criticalSection.Enter();
+	this->m_volume = p_volume;
+	this->m_criticalSection.Leave();
 }
 
 // OFFSET: LEGO1 0x100b8e00
 void MxAudioManager::Destroy(MxBool p_fromDestructor)
 {
-  this->m_criticalSection.Enter();
-  g_unkCount--;
-  Init();
-  this->m_criticalSection.Leave();
+	this->m_criticalSection.Enter();
+	g_unkCount--;
+	Init();
+	this->m_criticalSection.Leave();
 
-  if (!p_fromDestructor)
-    MxMediaManager::Destroy();
+	if (!p_fromDestructor)
+		MxMediaManager::Destroy();
 }
 
 // OFFSET: LEGO1 0x100b8e40
 MxResult MxAudioManager::InitPresenters()
 {
-  MxResult result = FAILURE;
-  MxBool success = FALSE;
+	MxResult result = FAILURE;
+	MxBool success = FALSE;
 
-  if (MxMediaManager::InitPresenters() == SUCCESS) {
-    this->m_criticalSection.Enter();
-    success = TRUE;
-    result = SUCCESS;
-    g_unkCount++;
-  }
+	if (MxMediaManager::InitPresenters() == SUCCESS) {
+		this->m_criticalSection.Enter();
+		success = TRUE;
+		result = SUCCESS;
+		g_unkCount++;
+	}
 
-  if (result)
-    Destroy();
+	if (result)
+		Destroy();
 
-  if (success)
-    this->m_criticalSection.Leave();
+	if (success)
+		this->m_criticalSection.Leave();
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100b8e90
 void MxAudioManager::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }

--- a/LEGO1/mxaudiomanager.h
+++ b/LEGO1/mxaudiomanager.h
@@ -5,26 +5,25 @@
 #include "mxmediamanager.h"
 
 // VTABLE 0x100dc6e0
-class MxAudioManager : public MxMediaManager
-{
+class MxAudioManager : public MxMediaManager {
 public:
-  MxAudioManager();
-  virtual ~MxAudioManager() override;
+	MxAudioManager();
+	virtual ~MxAudioManager() override;
 
-  virtual MxResult InitPresenters() override; // vtable+14
-  virtual void Destroy() override; // vtable+18
-  virtual MxS32 GetVolume(); // vtable+28
-  virtual void SetVolume(MxS32 p_volume); // vtable+2c
+	virtual MxResult InitPresenters() override; // vtable+14
+	virtual void Destroy() override;            // vtable+18
+	virtual MxS32 GetVolume();                  // vtable+28
+	virtual void SetVolume(MxS32 p_volume);     // vtable+2c
 
 private:
-  void Destroy(MxBool p_fromDestructor);
+	void Destroy(MxBool p_fromDestructor);
 
-  static MxS32 g_unkCount;
+	static MxS32 g_unkCount;
 
 protected:
-  void Init();
+	void Init();
 
-  MxS32 m_volume; // 0x2c
+	MxS32 m_volume; // 0x2c
 };
 
 #endif // MXAUDIOMANAGER_H

--- a/LEGO1/mxaudiopresenter.cpp
+++ b/LEGO1/mxaudiopresenter.cpp
@@ -7,11 +7,11 @@ DECOMP_SIZE_ASSERT(MxAudioPresenter, 0x54);
 // OFFSET: LEGO1 0x1000d260
 undefined4 MxAudioPresenter::vtable5c()
 {
-  return this->m_unk50;
+	return this->m_unk50;
 }
 
 // OFFSET: LEGO1 0x1000d270
 void MxAudioPresenter::vtable60(undefined4 p_unk50)
 {
-  this->m_unk50 = p_unk50;
+	this->m_unk50 = p_unk50;
 }

--- a/LEGO1/mxaudiopresenter.h
+++ b/LEGO1/mxaudiopresenter.h
@@ -5,30 +5,27 @@
 #include "mxmediapresenter.h"
 
 // VTABLE 0x100d4c70
-class MxAudioPresenter : public MxMediaPresenter
-{
+class MxAudioPresenter : public MxMediaPresenter {
 public:
-  MxAudioPresenter() {
-    m_unk50 = 100;
-  }
+	MxAudioPresenter() { m_unk50 = 100; }
 
-  // OFFSET: LEGO1 0x1000d280
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f078c
-    return "MxAudioPresenter";
-  }
+	// OFFSET: LEGO1 0x1000d280
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f078c
+		return "MxAudioPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000d290
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxAudioPresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000d290
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxAudioPresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 
-  virtual undefined4 vtable5c();
-  virtual void vtable60(undefined4);
+	virtual undefined4 vtable5c();
+	virtual void vtable60(undefined4);
 
-  undefined4 m_unk50;
+	undefined4 m_unk50;
 };
 
 #endif // MXAUDIOPRESENTER_H

--- a/LEGO1/mxautolocker.cpp
+++ b/LEGO1/mxautolocker.cpp
@@ -1,16 +1,16 @@
 #include "mxautolocker.h"
 
 // OFFSET: LEGO1 0x100b8ed0
-MxAutoLocker::MxAutoLocker(MxCriticalSection *critsect)
+MxAutoLocker::MxAutoLocker(MxCriticalSection* critsect)
 {
-  this->m_criticalSection = critsect;
-  if (this->m_criticalSection != 0)
-    this->m_criticalSection->Enter();
+	this->m_criticalSection = critsect;
+	if (this->m_criticalSection != 0)
+		this->m_criticalSection->Enter();
 }
 
 // OFFSET: LEGO1 0x100b8ef0
 MxAutoLocker::~MxAutoLocker()
 {
-  if (this->m_criticalSection != 0)
-    this->m_criticalSection->Leave();
+	if (this->m_criticalSection != 0)
+		this->m_criticalSection->Leave();
 }

--- a/LEGO1/mxautolocker.h
+++ b/LEGO1/mxautolocker.h
@@ -3,13 +3,13 @@
 
 #include "mxcriticalsection.h"
 
-class MxAutoLocker
-{
+class MxAutoLocker {
 public:
-  MxAutoLocker(MxCriticalSection* cs);
-  ~MxAutoLocker();
+	MxAutoLocker(MxCriticalSection* cs);
+	~MxAutoLocker();
+
 private:
-  MxCriticalSection* m_criticalSection;
+	MxCriticalSection* m_criticalSection;
 };
 
 #endif // MXAUTOLOCKER_H

--- a/LEGO1/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/mxbackgroundaudiomanager.cpp
@@ -9,100 +9,100 @@ DECOMP_SIZE_ASSERT(MxBackgroundAudioManager, 0x150)
 // OFFSET: LEGO1 0x1007ea90
 MxBackgroundAudioManager::MxBackgroundAudioManager()
 {
-  NotificationManager()->Register(this);
-  m_unka0 = 0;
-  m_unk138 = 0;
-  m_unk13c = 0;
-  m_unk140 = 0;
-  m_unk144 = 0;
-  m_unk148 = 0;
-  m_musicEnabled = FALSE;
+	NotificationManager()->Register(this);
+	m_unka0 = 0;
+	m_unk138 = 0;
+	m_unk13c = 0;
+	m_unk140 = 0;
+	m_unk144 = 0;
+	m_unk148 = 0;
+	m_musicEnabled = FALSE;
 }
 
 // OFFSET: LEGO1 0x1007ec20
 MxBackgroundAudioManager::~MxBackgroundAudioManager()
 {
-  TickleManager()->UnregisterClient(this);
-  NotificationManager()->Unregister(this);
-  DestroyMusic();
+	TickleManager()->UnregisterClient(this);
+	NotificationManager()->Unregister(this);
+	DestroyMusic();
 }
 
 // OFFSET: LEGO1 0x1007f470
 void MxBackgroundAudioManager::Stop()
 {
-  if (m_action2.GetObjectId() != -1)
-    DeleteObject(m_action2);
+	if (m_action2.GetObjectId() != -1)
+		DeleteObject(m_action2);
 
-  m_unk138 = 0;
-  m_action2.SetAtomId(MxAtomId());
-  m_action2.SetObjectId(-1);
+	m_unk138 = 0;
+	m_action2.SetAtomId(MxAtomId());
+	m_action2.SetObjectId(-1);
 
-  if (m_action1.GetObjectId() != -1)
-    DeleteObject(m_action1);
+	if (m_action1.GetObjectId() != -1)
+		DeleteObject(m_action1);
 
-  m_unka0 = 0;
-  m_action1.SetAtomId(MxAtomId());
-  m_unk148 = 0;
-  m_action1.SetObjectId(-1);
-  m_unk13c = 0;
+	m_unka0 = 0;
+	m_action1.SetAtomId(MxAtomId());
+	m_unk148 = 0;
+	m_action1.SetObjectId(-1);
+	m_unk13c = 0;
 }
 
 // OFFSET: LEGO1 0x1007f5f0
 void MxBackgroundAudioManager::Enable(MxBool p)
 {
-  if (this->m_musicEnabled != p) {
-    this->m_musicEnabled = p;
-    if (!p) {
-      Stop();
-    }
-  }
+	if (this->m_musicEnabled != p) {
+		this->m_musicEnabled = p;
+		if (!p) {
+			Stop();
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x1007f650
 void MxBackgroundAudioManager::Init()
 {
-  this->m_unka0 = 0;
-  this->m_unk13c = 0;
+	this->m_unka0 = 0;
+	this->m_unk13c = 0;
 }
 
 // OFFSET: LEGO1 0x1007ece0
-MxResult MxBackgroundAudioManager::Create(MxAtomId &p_script, MxU32 p_frequencyMS)
+MxResult MxBackgroundAudioManager::Create(MxAtomId& p_script, MxU32 p_frequencyMS)
 {
-  MxResult result = OpenMusic(p_script);
+	MxResult result = OpenMusic(p_script);
 
-  if (result == SUCCESS) {
-    TickleManager()->RegisterClient(this, p_frequencyMS);
-    m_musicEnabled = TRUE;
-  }
+	if (result == SUCCESS) {
+		TickleManager()->RegisterClient(this, p_frequencyMS);
+		m_musicEnabled = TRUE;
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x1007ed20
-MxResult MxBackgroundAudioManager::OpenMusic(MxAtomId &p_script)
+MxResult MxBackgroundAudioManager::OpenMusic(MxAtomId& p_script)
 {
-  if (m_script.GetInternal())
-    DestroyMusic();
+	if (m_script.GetInternal())
+		DestroyMusic();
 
-  MxResult result = FAILURE;
+	MxResult result = FAILURE;
 
-  if (Streamer()->Open(p_script.GetInternal(), 0)) {
-    m_script = p_script;
-    result = SUCCESS;
-  }
+	if (Streamer()->Open(p_script.GetInternal(), 0)) {
+		m_script = p_script;
+		result = SUCCESS;
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x1007ed70
 void MxBackgroundAudioManager::DestroyMusic()
 {
-  if (m_script.GetInternal()) {
-    MxDSAction ds;
-    ds.SetAtomId(m_script);
-    ds.SetUnknown24(-2);
-    DeleteObject(ds);
-    Streamer()->Close(m_script.GetInternal());
-    m_musicEnabled = FALSE;
-  }
+	if (m_script.GetInternal()) {
+		MxDSAction ds;
+		ds.SetAtomId(m_script);
+		ds.SetUnknown24(-2);
+		DeleteObject(ds);
+		Streamer()->Close(m_script.GetInternal());
+		m_musicEnabled = FALSE;
+	}
 }

--- a/LEGO1/mxbackgroundaudiomanager.h
+++ b/LEGO1/mxbackgroundaudiomanager.h
@@ -3,49 +3,49 @@
 
 #include "mxcore.h"
 #include "mxdsaction.h"
-#include "mxtypes.h"
 #include "mxnotificationmanager.h"
+#include "mxtypes.h"
 
 // VTABLE 0x100d9fe8
 // SIZE 0x150
-class MxBackgroundAudioManager : public MxCore
-{
+class MxBackgroundAudioManager : public MxCore {
 public:
-  MxBackgroundAudioManager();
-  virtual ~MxBackgroundAudioManager() override;
+	MxBackgroundAudioManager();
+	virtual ~MxBackgroundAudioManager() override;
 
-  // OFFSET: LEGO1 0x1007eb70
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f7ac4
-    return "MxBackgroundAudioManager";
-  }
+	// OFFSET: LEGO1 0x1007eb70
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f7ac4
+		return "MxBackgroundAudioManager";
+	}
 
-  // OFFSET: LEGO1 0x1007eb80
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxBackgroundAudioManager::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1007eb80
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxBackgroundAudioManager::ClassName()) || MxCore::IsA(name);
+	}
 
-  __declspec(dllexport) void Enable(unsigned char p);
-  virtual MxResult Create(MxAtomId &p_script, MxU32 p_frequencyMS);
+	__declspec(dllexport) void Enable(unsigned char p);
+	virtual MxResult Create(MxAtomId& p_script, MxU32 p_frequencyMS);
 
-  void Stop();
+	void Stop();
+
 private:
-  void Init();
-  MxResult OpenMusic(MxAtomId &p_script);
-  void DestroyMusic();
+	void Init();
+	MxResult OpenMusic(MxAtomId& p_script);
+	void DestroyMusic();
 
-  MxBool m_musicEnabled; // 0x8
-  MxDSAction m_action1; // 0xc
-  MxS32 m_unka0;
-  MxDSAction m_action2; // 0xa4
-  MxS32 m_unk138;
-  MxS32 m_unk13c;
-  MxS32 m_unk140;
-  MxS32 m_unk144;
-  MxS16 m_unk148;
-  MxAtomId m_script;
+	MxBool m_musicEnabled; // 0x8
+	MxDSAction m_action1;  // 0xc
+	MxS32 m_unka0;
+	MxDSAction m_action2; // 0xa4
+	MxS32 m_unk138;
+	MxS32 m_unk13c;
+	MxS32 m_unk140;
+	MxS32 m_unk144;
+	MxS16 m_unk148;
+	MxAtomId m_script;
 };
 
 #endif // MXBACKGROUNDAUDIOMANAGER_H

--- a/LEGO1/mxbitmap.cpp
+++ b/LEGO1/mxbitmap.cpp
@@ -1,34 +1,35 @@
 #include "mxbitmap.h"
+
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxBitmap, 0x20);
 DECOMP_SIZE_ASSERT(MxBITMAPINFO, 0x428);
 
 // Bitmap header magic string "BM" (42 4d)
-// Sources: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader, DirectX Complete (1998)
-// GLOBAL: LEGO1 0x10102184
+// Sources: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader, DirectX Complete
+// (1998) GLOBAL: LEGO1 0x10102184
 MxU16 g_bitmapSignature = TWOCC('B', 'M');
 
 // OFFSET: LEGO1 0x100bc980
 MxBitmap::MxBitmap()
 {
-  this->m_info = NULL;
-  this->m_bmiHeader = NULL;
-  this->m_paletteData = NULL;
-  this->m_data = NULL;
-  this->m_isHighColor = FALSE;
-  this->m_palette = NULL;
+	this->m_info = NULL;
+	this->m_bmiHeader = NULL;
+	this->m_paletteData = NULL;
+	this->m_data = NULL;
+	this->m_isHighColor = FALSE;
+	this->m_palette = NULL;
 }
 
 // OFFSET: LEGO1 0x100bca10
 MxBitmap::~MxBitmap()
 {
-  if (this->m_info)
-    delete m_info;
-  if (this->m_data)
-    delete m_data;
-  if (this->m_palette)
-    delete m_palette;  
+	if (this->m_info)
+		delete m_info;
+	if (this->m_data)
+		delete m_data;
+	if (this->m_palette)
+		delete m_palette;
 }
 
 // Bit mask trick to round up to the nearest multiple of four.
@@ -36,7 +37,7 @@ MxBitmap::~MxBitmap()
 // https://learn.microsoft.com/en-us/windows/win32/medfound/image-stride
 inline MxLong AlignToFourByte(MxLong p_value)
 {
-  return (p_value + 3) & -4;
+	return (p_value + 3) & -4;
 }
 
 // Same as the one from legoutil.h, but flipped the other way
@@ -44,223 +45,217 @@ inline MxLong AlignToFourByte(MxLong p_value)
 // reimplemented Abs for only this file, that seems odd, right?
 inline MxLong _Abs(MxLong p_value)
 {
-  return p_value > 0 ? p_value : -p_value;
+	return p_value > 0 ? p_value : -p_value;
 }
 
 // OFFSET: LEGO1 0x100bcc40
-MxResult MxBitmap::ImportBitmap(MxBitmap *p_bitmap)
+MxResult MxBitmap::ImportBitmap(MxBitmap* p_bitmap)
 {
-  MxResult result = FAILURE;
+	MxResult result = FAILURE;
 
-  this->m_info = new MxBITMAPINFO;
-  if(this->m_info) {
-    MxLong height = _Abs(p_bitmap->m_bmiHeader->biHeight);
-    this->m_data = new MxU8[AlignToFourByte(p_bitmap->m_bmiHeader->biWidth) * height];
-    if(this->m_data) {
-      memcpy(this->m_info, p_bitmap->m_info, sizeof(*this->m_info));
-      height = _Abs(p_bitmap->m_bmiHeader->biHeight);
-      memcpy(this->m_data, p_bitmap->m_data, AlignToFourByte(p_bitmap->m_bmiHeader->biWidth) * height);
+	this->m_info = new MxBITMAPINFO;
+	if (this->m_info) {
+		MxLong height = _Abs(p_bitmap->m_bmiHeader->biHeight);
+		this->m_data = new MxU8[AlignToFourByte(p_bitmap->m_bmiHeader->biWidth) * height];
+		if (this->m_data) {
+			memcpy(this->m_info, p_bitmap->m_info, sizeof(*this->m_info));
+			height = _Abs(p_bitmap->m_bmiHeader->biHeight);
+			memcpy(this->m_data, p_bitmap->m_data, AlignToFourByte(p_bitmap->m_bmiHeader->biWidth) * height);
 
-      result = SUCCESS;
-      this->m_bmiHeader = &this->m_info->bmiHeader;
-      this->m_paletteData = this->m_info->bmiColors;
-    }
-  }
+			result = SUCCESS;
+			this->m_bmiHeader = &this->m_info->bmiHeader;
+			this->m_paletteData = this->m_info->bmiColors;
+		}
+	}
 
-  if (result != SUCCESS) {
-    if (this->m_info) {
-      delete this->m_info;
-      this->m_info = NULL;
-    }
+	if (result != SUCCESS) {
+		if (this->m_info) {
+			delete this->m_info;
+			this->m_info = NULL;
+		}
 
-    if (this->m_data) {
-      delete this->m_data;
-      this->m_data = NULL;
-    }
-  }
+		if (this->m_data) {
+			delete this->m_data;
+			this->m_data = NULL;
+		}
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100bcba0
-MxResult MxBitmap::ImportBitmapInfo(MxBITMAPINFO *p_info)
+MxResult MxBitmap::ImportBitmapInfo(MxBITMAPINFO* p_info)
 {
-  MxResult result = FAILURE;
-  MxLong width  = p_info->bmiHeader.biWidth;
-  MxLong height = p_info->bmiHeader.biHeight;
-  MxLong size = AlignToFourByte(width) * height;
+	MxResult result = FAILURE;
+	MxLong width = p_info->bmiHeader.biWidth;
+	MxLong height = p_info->bmiHeader.biHeight;
+	MxLong size = AlignToFourByte(width) * height;
 
-  this->m_info = new MxBITMAPINFO;
-  if (this->m_info) {
-    this->m_data = new MxU8[size];
-    if(this->m_data) {
-      memcpy(this->m_info, p_info, sizeof(*this->m_info));
-      this->m_bmiHeader = &this->m_info->bmiHeader;
-      this->m_paletteData = this->m_info->bmiColors;
-      result = SUCCESS;
-    }
-  }
+	this->m_info = new MxBITMAPINFO;
+	if (this->m_info) {
+		this->m_data = new MxU8[size];
+		if (this->m_data) {
+			memcpy(this->m_info, p_info, sizeof(*this->m_info));
+			this->m_bmiHeader = &this->m_info->bmiHeader;
+			this->m_paletteData = this->m_info->bmiColors;
+			result = SUCCESS;
+		}
+	}
 
-  if (result != SUCCESS) {
-    if (this->m_info) {
-      delete this->m_info;
-      this->m_info = NULL;
-    }
+	if (result != SUCCESS) {
+		if (this->m_info) {
+			delete this->m_info;
+			this->m_info = NULL;
+		}
 
-    if (this->m_data) {
-      delete this->m_data;
-      this->m_data = NULL;
-    }
-  }
+		if (this->m_data) {
+			delete this->m_data;
+			this->m_data = NULL;
+		}
+	}
 
-  return result;
+	return result;
 }
-
 
 // OFFSET: LEGO1 0x100bd450
 MxResult MxBitmap::ImportColorsToPalette(RGBQUAD* p_rgbquad, MxPalette* p_palette)
 {
-  MxResult ret = FAILURE;
-  PALETTEENTRY entries[256];
+	MxResult ret = FAILURE;
+	PALETTEENTRY entries[256];
 
-  if (p_palette) {
-    if (p_palette->GetEntries(entries))
-      return ret;
-  } else {
-    MxPalette local_pal;
-    if (local_pal.GetEntries(entries))
-      return ret;
-  }
+	if (p_palette) {
+		if (p_palette->GetEntries(entries))
+			return ret;
+	}
+	else {
+		MxPalette local_pal;
+		if (local_pal.GetEntries(entries))
+			return ret;
+	}
 
-  for (MxS32 i = 0; i < 256; i++) {
-    p_rgbquad[i].rgbRed      = entries[i].peRed;
-    p_rgbquad[i].rgbGreen    = entries[i].peGreen;
-    p_rgbquad[i].rgbBlue     = entries[i].peBlue;
-    p_rgbquad[i].rgbReserved = 0;
-  }
+	for (MxS32 i = 0; i < 256; i++) {
+		p_rgbquad[i].rgbRed = entries[i].peRed;
+		p_rgbquad[i].rgbGreen = entries[i].peGreen;
+		p_rgbquad[i].rgbBlue = entries[i].peBlue;
+		p_rgbquad[i].rgbReserved = 0;
+	}
 
-  ret = SUCCESS;
-  return ret;
+	ret = SUCCESS;
+	return ret;
 }
 
 // OFFSET: LEGO1 0x100bcaa0
-MxResult MxBitmap::SetSize(MxS32 p_width, MxS32 p_height, MxPalette *p_palette, MxBool p_isHighColor)
+MxResult MxBitmap::SetSize(MxS32 p_width, MxS32 p_height, MxPalette* p_palette, MxBool p_isHighColor)
 {
-  MxResult ret = FAILURE;
-  MxLong size = AlignToFourByte(p_width) * p_height;
+	MxResult ret = FAILURE;
+	MxLong size = AlignToFourByte(p_width) * p_height;
 
-  m_info = new MxBITMAPINFO;
-  if (m_info) {
-    m_data = new MxU8[size];
-    if (m_data) {
-      m_bmiHeader = &m_info->bmiHeader;
-      m_paletteData = m_info->bmiColors;
-      memset(&m_info->bmiHeader, 0, sizeof(m_info->bmiHeader));
+	m_info = new MxBITMAPINFO;
+	if (m_info) {
+		m_data = new MxU8[size];
+		if (m_data) {
+			m_bmiHeader = &m_info->bmiHeader;
+			m_paletteData = m_info->bmiColors;
+			memset(&m_info->bmiHeader, 0, sizeof(m_info->bmiHeader));
 
-      m_bmiHeader->biSize = sizeof(*m_bmiHeader); // should be 40 bytes
-      m_bmiHeader->biWidth = p_width;
-      m_bmiHeader->biHeight = p_height;
-      m_bmiHeader->biPlanes = 1;
-      m_bmiHeader->biBitCount = 8;
-      m_bmiHeader->biCompression = 0;
-      m_bmiHeader->biSizeImage = size;
+			m_bmiHeader->biSize = sizeof(*m_bmiHeader); // should be 40 bytes
+			m_bmiHeader->biWidth = p_width;
+			m_bmiHeader->biHeight = p_height;
+			m_bmiHeader->biPlanes = 1;
+			m_bmiHeader->biBitCount = 8;
+			m_bmiHeader->biCompression = 0;
+			m_bmiHeader->biSizeImage = size;
 
-      if (!ImportColorsToPalette(m_paletteData, p_palette)) {
-        if (!SetBitDepth(p_isHighColor)) {
-          ret = SUCCESS;
-        }
-      }
-    }
-  }
+			if (!ImportColorsToPalette(m_paletteData, p_palette)) {
+				if (!SetBitDepth(p_isHighColor)) {
+					ret = SUCCESS;
+				}
+			}
+		}
+	}
 
-  if (ret) {
-    if (m_info) {
-      delete m_info;
-      m_info = NULL;
-    }
+	if (ret) {
+		if (m_info) {
+			delete m_info;
+			m_info = NULL;
+		}
 
-    if (m_data) {
-      delete[] m_data;
-      m_data = NULL;
-    }
-  }
+		if (m_data) {
+			delete[] m_data;
+			m_data = NULL;
+		}
+	}
 
-  return ret;
+	return ret;
 }
 
 // OFFSET: LEGO1 0x100bcd60
 MxResult MxBitmap::LoadFile(HANDLE p_handle)
 {
-  MxResult result = FAILURE;
-  DWORD bytesRead;
-  BITMAPFILEHEADER hdr;
+	MxResult result = FAILURE;
+	DWORD bytesRead;
+	BITMAPFILEHEADER hdr;
 
-  BOOL ret = ReadFile(p_handle, &hdr, sizeof(hdr), &bytesRead, NULL);
-  if (ret && (hdr.bfType == g_bitmapSignature)) {
-    this->m_info = new MxBITMAPINFO;
-    if (this->m_info) {
-      ret = ReadFile(p_handle, this->m_info, sizeof(*this->m_info), &bytesRead, NULL);
-      if (ret && (this->m_info->bmiHeader.biBitCount == 8)) {
-        MxLong size = hdr.bfSize - (sizeof(MxBITMAPINFO) + sizeof(BITMAPFILEHEADER));
-        this->m_data = new MxU8[size];
-        if (this->m_data) {
-          ret = ReadFile(p_handle, this->m_data, size, &bytesRead, NULL);
-          if (ret) {
-            this->m_bmiHeader = &this->m_info->bmiHeader;
-            this->m_paletteData = this->m_info->bmiColors;
-            if (this->m_info->bmiHeader.biSizeImage == 0) {
-              MxLong height = _Abs(this->m_info->bmiHeader.biHeight);
-              this->m_info->bmiHeader.biSizeImage = AlignToFourByte(this->m_info->bmiHeader.biWidth) * height;
-            }
-            result = SUCCESS;
-          }
-        }
-      }
-    }
-  }
+	BOOL ret = ReadFile(p_handle, &hdr, sizeof(hdr), &bytesRead, NULL);
+	if (ret && (hdr.bfType == g_bitmapSignature)) {
+		this->m_info = new MxBITMAPINFO;
+		if (this->m_info) {
+			ret = ReadFile(p_handle, this->m_info, sizeof(*this->m_info), &bytesRead, NULL);
+			if (ret && (this->m_info->bmiHeader.biBitCount == 8)) {
+				MxLong size = hdr.bfSize - (sizeof(MxBITMAPINFO) + sizeof(BITMAPFILEHEADER));
+				this->m_data = new MxU8[size];
+				if (this->m_data) {
+					ret = ReadFile(p_handle, this->m_data, size, &bytesRead, NULL);
+					if (ret) {
+						this->m_bmiHeader = &this->m_info->bmiHeader;
+						this->m_paletteData = this->m_info->bmiColors;
+						if (this->m_info->bmiHeader.biSizeImage == 0) {
+							MxLong height = _Abs(this->m_info->bmiHeader.biHeight);
+							this->m_info->bmiHeader.biSizeImage =
+								AlignToFourByte(this->m_info->bmiHeader.biWidth) * height;
+						}
+						result = SUCCESS;
+					}
+				}
+			}
+		}
+	}
 
-  if (result != SUCCESS) {
-    if (this->m_info) {
-      delete this->m_info;
-      this->m_info = NULL;
-    }
+	if (result != SUCCESS) {
+		if (this->m_info) {
+			delete this->m_info;
+			this->m_info = NULL;
+		}
 
-    if (this->m_data) {
-      delete this->m_data;
-      this->m_data = NULL;
-    }
-  }
+		if (this->m_data) {
+			delete this->m_data;
+			this->m_data = NULL;
+		}
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100bcd10
-MxLong MxBitmap::Read(const char *p_filename)
+MxLong MxBitmap::Read(const char* p_filename)
 {
-  MxResult result = FAILURE;
-  HANDLE handle = CreateFileA(
-    p_filename,
-    GENERIC_READ,
-    FILE_SHARE_READ,
-    NULL,
-    OPEN_EXISTING,
-    FILE_ATTRIBUTE_NORMAL,
-    NULL
-  );
+	MxResult result = FAILURE;
+	HANDLE handle =
+		CreateFileA(p_filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
-  if (handle != INVALID_HANDLE_VALUE && !LoadFile(handle))
-    result = SUCCESS;
+	if (handle != INVALID_HANDLE_VALUE && !LoadFile(handle))
+		result = SUCCESS;
 
-  if (handle)
-    CloseHandle(handle);
+	if (handle)
+		CloseHandle(handle);
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x1004e0d0
 int MxBitmap::vtable28(int)
 {
-  return -1;
+	return -1;
 }
 
 // OFFSET: LEGO1 0x100bce70 STUB
@@ -274,104 +269,127 @@ void MxBitmap::vtable30(int, int, int, int, int, int, int)
 }
 
 // OFFSET: LEGO1 0x100bd1c0
-MxPalette *MxBitmap::CreatePalette()
+MxPalette* MxBitmap::CreatePalette()
 {
-  MxBool success = FALSE;
-  MxPalette *palette = NULL;
+	MxBool success = FALSE;
+	MxPalette* palette = NULL;
 
-  switch (this->m_isHighColor) {
-    case FALSE:
-      palette = new MxPalette(this->m_paletteData);
-      if (palette)
-        success = TRUE;
-      break;
+	switch (this->m_isHighColor) {
+	case FALSE:
+		palette = new MxPalette(this->m_paletteData);
+		if (palette)
+			success = TRUE;
+		break;
 
-    case TRUE:
-      palette = this->m_palette->Clone();
-      if (palette)
-        success = TRUE;
-      break;
-  }
+	case TRUE:
+		palette = this->m_palette->Clone();
+		if (palette)
+			success = TRUE;
+		break;
+	}
 
-  if (!success && palette) {
-    delete palette;
-    palette = NULL;
-  }
+	if (!success && palette) {
+		delete palette;
+		palette = NULL;
+	}
 
-  return palette;
+	return palette;
 }
 
 // OFFSET: LEGO1 0x100bd280
 void MxBitmap::ImportPalette(MxPalette* p_palette)
 {
-  // Odd to use a switch on a boolean, but it matches.
-  switch (this->m_isHighColor) {
-    case FALSE:
-      ImportColorsToPalette(this->m_paletteData, p_palette);
-      break;
-    
-    case TRUE:
-      if (this->m_palette) {
-        delete this->m_palette;
-      }
-      this->m_palette = p_palette->Clone();
-      break;
-  }
+	// Odd to use a switch on a boolean, but it matches.
+	switch (this->m_isHighColor) {
+	case FALSE:
+		ImportColorsToPalette(this->m_paletteData, p_palette);
+		break;
+
+	case TRUE:
+		if (this->m_palette) {
+			delete this->m_palette;
+		}
+		this->m_palette = p_palette->Clone();
+		break;
+	}
 }
 
 // OFFSET: LEGO1 0x100bd2d0
 MxResult MxBitmap::SetBitDepth(MxBool p_isHighColor)
 {
-  MxResult ret = FAILURE;
-  MxPalette *pal = NULL;
+	MxResult ret = FAILURE;
+	MxPalette* pal = NULL;
 
-  if (m_isHighColor == p_isHighColor) {
-    // no change: do nothing.
-    ret = SUCCESS;
-  } else {
-    switch (p_isHighColor) {
-      case FALSE:
-        ImportColorsToPalette(m_paletteData, m_palette);
-        if (m_palette)
-          delete m_palette;
+	if (m_isHighColor == p_isHighColor) {
+		// no change: do nothing.
+		ret = SUCCESS;
+	}
+	else {
+		switch (p_isHighColor) {
+		case FALSE:
+			ImportColorsToPalette(m_paletteData, m_palette);
+			if (m_palette)
+				delete m_palette;
 
-        m_palette = NULL;
-        break;
+			m_palette = NULL;
+			break;
 
-      case TRUE:
-        pal = NULL;
-        pal = new MxPalette(m_paletteData);
-        if (pal) {
-          m_palette = pal;
+		case TRUE:
+			pal = NULL;
+			pal = new MxPalette(m_paletteData);
+			if (pal) {
+				m_palette = pal;
 
-          // TODO: what is this? zeroing out top half of palette?
-          MxU16 *buf = (MxU16*)m_paletteData;
-          for (MxU16 i = 0; i < 256; i++) {
-            buf[i] = i;
-          }
+				// TODO: what is this? zeroing out top half of palette?
+				MxU16* buf = (MxU16*) m_paletteData;
+				for (MxU16 i = 0; i < 256; i++) {
+					buf[i] = i;
+				}
 
-          m_isHighColor = p_isHighColor;
-          ret = SUCCESS;
-        }
-        break;
-    }
-  }
+				m_isHighColor = p_isHighColor;
+				ret = SUCCESS;
+			}
+			break;
+		}
+	}
 
-  // If we were unsuccessful overall but did manage to alloc
-  // the MxPalette, free it.
-  if (ret && pal)
-    delete pal;
+	// If we were unsuccessful overall but did manage to alloc
+	// the MxPalette, free it.
+	if (ret && pal)
+		delete pal;
 
-  return ret;
+	return ret;
 }
 
 // OFFSET: LEGO1 0x100bd3e0
-MxResult MxBitmap::StretchBits(HDC p_hdc, MxS32 p_xSrc, MxS32 p_ySrc, MxS32 p_xDest, MxS32 p_yDest, MxS32 p_destWidth, MxS32 p_destHeight)
+MxResult MxBitmap::StretchBits(
+	HDC p_hdc,
+	MxS32 p_xSrc,
+	MxS32 p_ySrc,
+	MxS32 p_xDest,
+	MxS32 p_yDest,
+	MxS32 p_destWidth,
+	MxS32 p_destHeight
+)
 {
-  // Compression fix?
-  if ((this->m_bmiHeader->biCompression != BI_RGB_TOPDOWN) && (0 < this->m_bmiHeader->biHeight)) {
-    p_ySrc = (this->m_bmiHeader->biHeight - p_destHeight) - p_ySrc;
-  }
+	// Compression fix?
+	if ((this->m_bmiHeader->biCompression != BI_RGB_TOPDOWN) && (0 < this->m_bmiHeader->biHeight)) {
+		p_ySrc = (this->m_bmiHeader->biHeight - p_destHeight) - p_ySrc;
+	}
 
-  return StretchDIBits(p_hdc, p_xDest, p_yDest, p_destWidth, p_destHeight, p_xSrc, p_ySrc, p_destWidth, p_destHeight, this->m_data, (BITMAPINFO*)this->m_info, this->m_isHighColor, SRCCOPY);
+	return StretchDIBits(
+		p_hdc,
+		p_xDest,
+		p_yDest,
+		p_destWidth,
+		p_destHeight,
+		p_xSrc,
+		p_ySrc,
+		p_destWidth,
+		p_destHeight,
+		this->m_data,
+		(BITMAPINFO*) this->m_info,
+		this->m_isHighColor,
+		SRCCOPY
+	);
 }

--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -1,11 +1,11 @@
 #ifndef MXBITMAP_H
 #define MXBITMAP_H
 
-#include <stdlib.h>
-
 #include "mxcore.h"
 #include "mxpalette.h"
 #include "mxtypes.h"
+
+#include <stdlib.h>
 
 // The stock BITMAPINFO struct from wingdi.h only makes room for one color
 // in the palette. It seems like the expectation (if you use the struct)
@@ -17,8 +17,8 @@
 
 // SIZE 0x428
 struct MxBITMAPINFO {
-  BITMAPINFOHEADER    bmiHeader;
-  RGBQUAD             bmiColors[256];
+	BITMAPINFOHEADER bmiHeader;
+	RGBQUAD bmiColors[256];
 };
 
 // Non-standard value for biCompression in the BITMAPINFOHEADER struct.
@@ -26,44 +26,54 @@ struct MxBITMAPINFO {
 // You can specify that the bitmap has top-down order instead by providing
 // a negative number for biHeight. It could be that Mindscape decided on a
 // belt & suspenders approach here.
-#define BI_RGB_TOPDOWN      0x10
+#define BI_RGB_TOPDOWN 0x10
 
 // SIZE 0x20
 // VTABLE 0x100dc7b0
-class MxBitmap : public MxCore
-{
+class MxBitmap : public MxCore {
 public:
-  __declspec(dllexport) MxBitmap();
-  __declspec(dllexport) virtual ~MxBitmap(); // vtable+00
+	__declspec(dllexport) MxBitmap();
+	__declspec(dllexport) virtual ~MxBitmap(); // vtable+00
 
-  virtual MxResult ImportBitmap(MxBitmap *p_bitmap); // vtable+14
-  virtual MxResult ImportBitmapInfo(MxBITMAPINFO *p_info); // vtable+18
-  virtual MxResult SetSize(MxS32 p_width, MxS32 p_height, MxPalette *p_palette, MxBool); // vtable+1c
-  virtual MxResult LoadFile(HANDLE p_handle); // vtable+20
-  __declspec(dllexport) virtual MxLong Read(const char *p_filename); // vtable+24
-  virtual int vtable28(int);
-  virtual void vtable2c(int, int, int, int, int, int, int);
-  virtual void vtable30(int, int, int, int, int, int, int);
-  __declspec(dllexport) virtual MxPalette *CreatePalette(); // vtable+34
-  virtual void ImportPalette(MxPalette* p_palette); // vtable+38
-  virtual MxResult SetBitDepth(MxBool); // vtable+3c
-  virtual MxResult StretchBits(HDC p_hdc, MxS32 p_xSrc, MxS32 p_ySrc, MxS32 p_xDest, MxS32 p_yDest, MxS32 p_destWidth, MxS32 p_destHeight); // vtable+40
+	virtual MxResult ImportBitmap(MxBitmap* p_bitmap);                                     // vtable+14
+	virtual MxResult ImportBitmapInfo(MxBITMAPINFO* p_info);                               // vtable+18
+	virtual MxResult SetSize(MxS32 p_width, MxS32 p_height, MxPalette* p_palette, MxBool); // vtable+1c
+	virtual MxResult LoadFile(HANDLE p_handle);                                            // vtable+20
+	__declspec(dllexport) virtual MxLong Read(const char* p_filename);                     // vtable+24
+	virtual int vtable28(int);
+	virtual void vtable2c(int, int, int, int, int, int, int);
+	virtual void vtable30(int, int, int, int, int, int, int);
+	__declspec(dllexport) virtual MxPalette* CreatePalette(); // vtable+34
+	virtual void ImportPalette(MxPalette* p_palette);         // vtable+38
+	virtual MxResult SetBitDepth(MxBool);                     // vtable+3c
+	virtual MxResult StretchBits(
+		HDC p_hdc,
+		MxS32 p_xSrc,
+		MxS32 p_ySrc,
+		MxS32 p_xDest,
+		MxS32 p_yDest,
+		MxS32 p_destWidth,
+		MxS32 p_destHeight
+	); // vtable+40
 
-  inline BITMAPINFOHEADER *GetBmiHeader() const { return m_bmiHeader; }
-  inline MxLong GetBmiWidth() const { return m_bmiHeader->biWidth; }
-  inline MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
-  inline MxLong GetBmiHeightAbs() const { return m_bmiHeader->biHeight > 0 ? m_bmiHeader->biHeight : -m_bmiHeader->biHeight; }
-  inline MxU8 *GetBitmapData() const { return m_data; }
+	inline BITMAPINFOHEADER* GetBmiHeader() const { return m_bmiHeader; }
+	inline MxLong GetBmiWidth() const { return m_bmiHeader->biWidth; }
+	inline MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
+	inline MxLong GetBmiHeightAbs() const
+	{
+		return m_bmiHeader->biHeight > 0 ? m_bmiHeader->biHeight : -m_bmiHeader->biHeight;
+	}
+	inline MxU8* GetBitmapData() const { return m_data; }
 
 private:
-  MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);
+	MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);
 
-  MxBITMAPINFO *m_info; // 0x8
-  BITMAPINFOHEADER *m_bmiHeader; // 0xc
-  RGBQUAD *m_paletteData; // 0x10
-  MxU8 *m_data; // 0x14
-  MxBool m_isHighColor; // 0x18
-  MxPalette *m_palette; // 0x1c
+	MxBITMAPINFO* m_info;          // 0x8
+	BITMAPINFOHEADER* m_bmiHeader; // 0xc
+	RGBQUAD* m_paletteData;        // 0x10
+	MxU8* m_data;                  // 0x14
+	MxBool m_isHighColor;          // 0x18
+	MxPalette* m_palette;          // 0x1c
 };
 
 #endif // MXBITMAP_H

--- a/LEGO1/mxcompositemediapresenter.cpp
+++ b/LEGO1/mxcompositemediapresenter.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x10073ea0 STUB
 MxCompositeMediaPresenter::MxCompositeMediaPresenter()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/mxcompositemediapresenter.h
+++ b/LEGO1/mxcompositemediapresenter.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100dc618
 // SIZE 0x50
-class MxCompositeMediaPresenter : public MxCompositePresenter
-{
+class MxCompositeMediaPresenter : public MxCompositePresenter {
 public:
-  MxCompositeMediaPresenter();
+	MxCompositeMediaPresenter();
 
-  // OFFSET: LEGO1 0x10073f10
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f02d4
-    return "MxCompositeMediaPresenter";
-  }
+	// OFFSET: LEGO1 0x10073f10
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f02d4
+		return "MxCompositeMediaPresenter";
+	}
 
-  // OFFSET: LEGO1 0x10073f20
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxCompositeMediaPresenter::ClassName()) || MxCompositePresenter::IsA(name);
-  }
-  
+	// OFFSET: LEGO1 0x10073f20
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxCompositeMediaPresenter::ClassName()) || MxCompositePresenter::IsA(name);
+	}
 };
 
 #endif // MXCOMPOSITEMEDIAPRESENTER_H

--- a/LEGO1/mxcompositepresenter.cpp
+++ b/LEGO1/mxcompositepresenter.cpp
@@ -8,11 +8,11 @@ DECOMP_SIZE_ASSERT(MxCompositePresenter, 0x4c);
 // OFFSET: LEGO1 0x100b60b0
 MxCompositePresenter::MxCompositePresenter()
 {
-  NotificationManager()->Register(this);
+	NotificationManager()->Register(this);
 }
 
 // OFFSET: LEGO1 0x100b6390
 MxCompositePresenter::~MxCompositePresenter()
 {
-  NotificationManager()->Unregister(this);
+	NotificationManager()->Unregister(this);
 }

--- a/LEGO1/mxcompositepresenter.h
+++ b/LEGO1/mxcompositepresenter.h
@@ -6,26 +6,25 @@
 
 // VTABLE 0x100dc618
 // SIZE 0x4c
-class MxCompositePresenter : public MxPresenter
-{
+class MxCompositePresenter : public MxPresenter {
 public:
-  MxCompositePresenter();
-  virtual ~MxCompositePresenter() override; // vtable+0x0
+	MxCompositePresenter();
+	virtual ~MxCompositePresenter() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x100b6210
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0774
-    return "MxCompositePresenter";
-  }
+	// OFFSET: LEGO1 0x100b6210
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0774
+		return "MxCompositePresenter";
+	}
 
-  // OFFSET: LEGO1 0x100b6220
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxCompositePresenter::ClassName()) || MxPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100b6220
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxCompositePresenter::ClassName()) || MxPresenter::IsA(name);
+	}
 
-  MxUnkList m_list;
+	MxUnkList m_list;
 };
 
 #endif // MXCOMPOSITEPRESENTER_H

--- a/LEGO1/mxcontrolpresenter.cpp
+++ b/LEGO1/mxcontrolpresenter.cpp
@@ -5,10 +5,10 @@ DECOMP_SIZE_ASSERT(MxControlPresenter, 0x5c)
 // OFFSET: LEGO1 0x10043f50
 MxControlPresenter::MxControlPresenter()
 {
-  this->m_unk4c = 0;
-  this->m_unk4e = -1;
-  this->m_unk50 = 0;
-  this->m_unk52 = 0;
-  this->m_unk58 = 0;
-  this->m_unk54 = 0;
+	this->m_unk4c = 0;
+	this->m_unk4e = -1;
+	this->m_unk50 = 0;
+	this->m_unk52 = 0;
+	this->m_unk58 = 0;
+	this->m_unk54 = 0;
 }

--- a/LEGO1/mxcontrolpresenter.h
+++ b/LEGO1/mxcontrolpresenter.h
@@ -2,36 +2,34 @@
 #define MXCONTROLPRESENTER_H
 
 #include "decomp.h"
-
 #include "mxcompositepresenter.h"
 
 // VTABLE 0x100d7b88
 // SIZE 0x5c
-class MxControlPresenter : public MxCompositePresenter
-{
+class MxControlPresenter : public MxCompositePresenter {
 public:
-  MxControlPresenter();
+	MxControlPresenter();
 
-  // OFFSET: LEGO1 0x10044000
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0514
-    return "MxControlPresenter";
-  }
+	// OFFSET: LEGO1 0x10044000
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0514
+		return "MxControlPresenter";
+	}
 
-  // OFFSET: LEGO1 0x10044010
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxControlPresenter::ClassName()) || MxCompositePresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10044010
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxControlPresenter::ClassName()) || MxCompositePresenter::IsA(name);
+	}
+
 private:
-  undefined2 m_unk4c;
-  MxS16 m_unk4e;
-  undefined m_unk50;
-  undefined2 m_unk52;
-  undefined2 m_unk54;
-  undefined4 m_unk58;
+	undefined2 m_unk4c;
+	MxS16 m_unk4e;
+	undefined m_unk50;
+	undefined2 m_unk52;
+	undefined2 m_unk54;
+	undefined4 m_unk58;
 };
-
 
 #endif // MXCONTROLPRESENTER_H

--- a/LEGO1/mxcore.cpp
+++ b/LEGO1/mxcore.cpp
@@ -6,8 +6,8 @@ unsigned int g_mxcoreCount = 0;
 // OFFSET: LEGO1 0x100ae1a0
 MxCore::MxCore()
 {
-  m_id = g_mxcoreCount;
-  g_mxcoreCount++;
+	m_id = g_mxcoreCount;
+	g_mxcoreCount++;
 }
 
 // OFFSET: LEGO1 0x100ae1e0
@@ -16,13 +16,13 @@ MxCore::~MxCore()
 }
 
 // OFFSET: LEGO1 0x100ae1f0
-MxLong MxCore::Notify(MxParam &p)
+MxLong MxCore::Notify(MxParam& p)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10001f70
 MxResult MxCore::Tickle()
 {
-  return SUCCESS;
+	return SUCCESS;
 }

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -1,44 +1,39 @@
 #ifndef MXCORE_H
 #define MXCORE_H
 
-#include <string.h>
-
 #include "compat.h"
 #include "mxtypes.h"
+
+#include <string.h>
 
 class MxParam;
 
 // VTABLE 0x100dc0f8
 // SIZE 0x8
-class MxCore
-{
+class MxCore {
 public:
-  __declspec(dllexport) MxCore();
-  __declspec(dllexport) virtual ~MxCore(); // vtable+00
-  __declspec(dllexport) virtual MxResult Notify(MxParam &p); // vtable+04
-  virtual MxResult Tickle(); // vtable+08
+	__declspec(dllexport) MxCore();
+	__declspec(dllexport) virtual ~MxCore();                   // vtable+00
+	__declspec(dllexport) virtual MxResult Notify(MxParam& p); // vtable+04
+	virtual MxResult Tickle();                                 // vtable+08
 
-  // OFFSET: LEGO1 0x100144c0
-  inline virtual const char *ClassName() const // vtable+0c
-  {
-    // 0x100f007c
-    return "MxCore";
-  }
+	// OFFSET: LEGO1 0x100144c0
+	inline virtual const char* ClassName() const // vtable+0c
+	{
+		// 0x100f007c
+		return "MxCore";
+	}
 
-  // OFFSET: LEGO1 0x100140d0
-  inline virtual MxBool IsA(const char *name) const // vtable+10
-  {
-    return !strcmp(name, MxCore::ClassName());
-  }
+	// OFFSET: LEGO1 0x100140d0
+	inline virtual MxBool IsA(const char* name) const // vtable+10
+	{
+		return !strcmp(name, MxCore::ClassName());
+	}
 
-  inline MxU32 GetId()
-  {
-    return m_id;
-  }
+	inline MxU32 GetId() { return m_id; }
 
 private:
-  MxU32 m_id;
-
+	MxU32 m_id;
 };
 
 #endif // MXCORE_H

--- a/LEGO1/mxcriticalsection.cpp
+++ b/LEGO1/mxcriticalsection.cpp
@@ -8,72 +8,65 @@ int g_useMutex = 0;
 // OFFSET: LEGO1 0x100b6d20
 MxCriticalSection::MxCriticalSection()
 {
-  HANDLE mutex;
+	HANDLE mutex;
 
-  if (g_useMutex != 0)
-  {
-    mutex = CreateMutexA(NULL, FALSE, NULL);
-    this->m_mutex = mutex;
-    return;
-  }
+	if (g_useMutex != 0) {
+		mutex = CreateMutexA(NULL, FALSE, NULL);
+		this->m_mutex = mutex;
+		return;
+	}
 
-  InitializeCriticalSection(&this->m_criticalSection);
-  this->m_mutex = NULL;
+	InitializeCriticalSection(&this->m_criticalSection);
+	this->m_mutex = NULL;
 }
 
 // OFFSET: LEGO1 0x100b6d60
 MxCriticalSection::~MxCriticalSection()
 {
-  if (this->m_mutex != NULL)
-  {
-    CloseHandle(this->m_mutex);
-    return;
-  }
+	if (this->m_mutex != NULL) {
+		CloseHandle(this->m_mutex);
+		return;
+	}
 
-  DeleteCriticalSection(&this->m_criticalSection);
+	DeleteCriticalSection(&this->m_criticalSection);
 }
 
 // OFFSET: LEGO1 0x100b6e00
 void MxCriticalSection::SetDoMutex()
 {
-  g_useMutex = 1;
+	g_useMutex = 1;
 }
 
 // OFFSET: LEGO1 0x100b6d80
 void MxCriticalSection::Enter()
 {
-  DWORD result;
-  FILE *file;
+	DWORD result;
+	FILE* file;
 
-  if (this->m_mutex != NULL)
-  {
-    result = WaitForSingleObject(this->m_mutex, 5000);
-    if (result == WAIT_FAILED)
-    {
-      file = fopen("C:\\DEADLOCK.TXT", "a");
-      if (file != NULL)
-      {
-        fprintf(file, "mutex timeout occurred!\n");
-        fclose(file);
-      }
+	if (this->m_mutex != NULL) {
+		result = WaitForSingleObject(this->m_mutex, 5000);
+		if (result == WAIT_FAILED) {
+			file = fopen("C:\\DEADLOCK.TXT", "a");
+			if (file != NULL) {
+				fprintf(file, "mutex timeout occurred!\n");
+				fclose(file);
+			}
 
-      abort();
-    }
-  }
-  else
-  {
-    EnterCriticalSection(&this->m_criticalSection);
-  }
+			abort();
+		}
+	}
+	else {
+		EnterCriticalSection(&this->m_criticalSection);
+	}
 }
 
 // OFFSET: LEGO1 0x100b6de0
 void MxCriticalSection::Leave()
 {
-  if (this->m_mutex != NULL)
-  {
-    ReleaseMutex(this->m_mutex);
-    return;
-  }
+	if (this->m_mutex != NULL) {
+		ReleaseMutex(this->m_mutex);
+		return;
+	}
 
-  LeaveCriticalSection(&this->m_criticalSection);
+	LeaveCriticalSection(&this->m_criticalSection);
 }

--- a/LEGO1/mxcriticalsection.h
+++ b/LEGO1/mxcriticalsection.h
@@ -3,18 +3,17 @@
 
 #include <windows.h>
 
-class MxCriticalSection
-{
+class MxCriticalSection {
 public:
-  __declspec(dllexport) MxCriticalSection();
-  __declspec(dllexport) ~MxCriticalSection();
-  __declspec(dllexport) static void SetDoMutex();
-  void Enter();
-  void Leave();
+	__declspec(dllexport) MxCriticalSection();
+	__declspec(dllexport) ~MxCriticalSection();
+	__declspec(dllexport) static void SetDoMutex();
+	void Enter();
+	void Leave();
 
 private:
-  CRITICAL_SECTION m_criticalSection;
-  HANDLE m_mutex;
+	CRITICAL_SECTION m_criticalSection;
+	HANDLE m_mutex;
 };
 
 #endif // MXCRITICALSECTION_H

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -1,4 +1,5 @@
 #include "mxdirect3d.h"
+
 #include <stdio.h> // for vsprintf
 
 DECOMP_SIZE_ASSERT(MxDirect3D, 0x894);
@@ -8,184 +9,189 @@ DECOMP_SIZE_ASSERT(MxDeviceEnumerate, 0x198);
 // OFFSET: LEGO1 0x1009b0a0
 MxDirect3D::MxDirect3D()
 {
-  this->m_pDirect3d = NULL;
-  this->m_pDirect3dDevice = NULL;
-  this->m_unk88c = NULL;
-  this->m_pDeviceModeFinder = NULL;
+	this->m_pDirect3d = NULL;
+	this->m_pDirect3dDevice = NULL;
+	this->m_unk88c = NULL;
+	this->m_pDeviceModeFinder = NULL;
 }
 
 // OFFSET: LEGO1 0x1009b140
 MxDirect3D::~MxDirect3D()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x1009b1a0
 BOOL MxDirect3D::Create(
-  HWND hWnd,
-  BOOL fullscreen_1,
-  BOOL surface_fullscreen,
-  BOOL onlySystemMemory,
-  int width,
-  int height,
-  int bpp,
-  const PALETTEENTRY* pPaletteEntries,
-  int paletteEntryCount)
+	HWND hWnd,
+	BOOL fullscreen_1,
+	BOOL surface_fullscreen,
+	BOOL onlySystemMemory,
+	int width,
+	int height,
+	int bpp,
+	const PALETTEENTRY* pPaletteEntries,
+	int paletteEntryCount
+)
 {
-  BOOL success = FALSE;
+	BOOL success = FALSE;
 
-  BOOL ret = MxDirectDraw::Create(hWnd, fullscreen_1, surface_fullscreen,
-                                  onlySystemMemory, width, height, bpp,
-                                  pPaletteEntries, paletteEntryCount);
-  
-  if (ret && CreateIDirect3D() && D3DSetMode())
-    success = TRUE;
+	BOOL ret = MxDirectDraw::Create(
+		hWnd,
+		fullscreen_1,
+		surface_fullscreen,
+		onlySystemMemory,
+		width,
+		height,
+		bpp,
+		pPaletteEntries,
+		paletteEntryCount
+	);
 
-  if (!success)
-    FUN_1009D920();
+	if (ret && CreateIDirect3D() && D3DSetMode())
+		success = TRUE;
 
-  return success;
+	if (!success)
+		FUN_1009D920();
+
+	return success;
 }
 
 // OFFSET: LEGO1 0x1009b210
 void MxDirect3D::Destroy()
 {
-  if (this->m_pDirect3dDevice) {
-    this->m_pDirect3dDevice->Release();
-    this->m_pDirect3dDevice = NULL;
-  }
+	if (this->m_pDirect3dDevice) {
+		this->m_pDirect3dDevice->Release();
+		this->m_pDirect3dDevice = NULL;
+	}
 
-  if (this->m_pDirect3d) {
-    this->m_pDirect3d->Release();
-    this->m_pDirect3d = NULL;
-  }
+	if (this->m_pDirect3d) {
+		this->m_pDirect3d->Release();
+		this->m_pDirect3d = NULL;
+	}
 
-  if (this->m_pDeviceModeFinder) {
-    delete m_pDeviceModeFinder;
-    this->m_pDeviceModeFinder = NULL;
-  }
+	if (this->m_pDeviceModeFinder) {
+		delete m_pDeviceModeFinder;
+		this->m_pDeviceModeFinder = NULL;
+	}
 
-  // This should get deleted by MxDirectDraw::Destroy
-  if (m_pCurrentDeviceModesList) {
-    // delete m_pCurrentDeviceModesList; // missing?
-    m_pCurrentDeviceModesList = NULL;
-  }
+	// This should get deleted by MxDirectDraw::Destroy
+	if (m_pCurrentDeviceModesList) {
+		// delete m_pCurrentDeviceModesList; // missing?
+		m_pCurrentDeviceModesList = NULL;
+	}
 
-  MxDirectDraw::Destroy();
+	MxDirectDraw::Destroy();
 }
 
 // OFFSET: LEGO1 0x1009b290
 void MxDirect3D::Clear()
 {
-  if(this->m_pDirect3dDevice) {
-    this->m_pDirect3dDevice->Release();
-    this->m_pDirect3dDevice = NULL;
-  }
-  if(this->m_pDirect3d) {
-    this->m_pDirect3d->Release();
-    this->m_pDirect3d = NULL;
-  }
-  MxDirectDraw::DestroyButNotDirectDraw();
+	if (this->m_pDirect3dDevice) {
+		this->m_pDirect3dDevice->Release();
+		this->m_pDirect3dDevice = NULL;
+	}
+	if (this->m_pDirect3d) {
+		this->m_pDirect3d->Release();
+		this->m_pDirect3d = NULL;
+	}
+	MxDirectDraw::DestroyButNotDirectDraw();
 }
 
 // OFFSET: LEGO1 0x1009b2d0
 BOOL MxDirect3D::CreateIDirect3D()
 {
-  MxResult ret = IDirect3D_QueryInterface(m_pDirectDraw,
-                                          IID_IDirect3D2,
-                                          (LPVOID*)&m_pDirect3d);
+	MxResult ret = IDirect3D_QueryInterface(m_pDirectDraw, IID_IDirect3D2, (LPVOID*) &m_pDirect3d);
 
-  if (ret) {
-    Error("Creation of IDirect3D failed", ret);
-    return FALSE;
-  }
+	if (ret) {
+		Error("Creation of IDirect3D failed", ret);
+		return FALSE;
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009b310 STUB
 BOOL MxDirect3D::D3DSetMode()
 {
-  // TODO
-  //if (m_pDeviceModeFinder)
-  Error("This device cannot support the current display mode", 0);
-  OutputDebugString("MxDirect3D::D3DSetMode() front lock failed\n");
-  OutputDebugString("MxDirect3D::D3DSetMode() back lock failed\n");
-  return TRUE;
+	// TODO
+	// if (m_pDeviceModeFinder)
+	Error("This device cannot support the current display mode", 0);
+	OutputDebugString("MxDirect3D::D3DSetMode() front lock failed\n");
+	OutputDebugString("MxDirect3D::D3DSetMode() back lock failed\n");
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009b8b0
 MxDeviceModeFinder::MxDeviceModeFinder()
 {
-  memset(this, 0, sizeof(*this));
+	memset(this, 0, sizeof(*this));
 }
 
 // OFFSET: LEGO1 0x1009b8d0
 MxDeviceModeFinder::~MxDeviceModeFinder()
 {
-  if (m_deviceInfo) {
-    delete m_deviceInfo;
-    m_deviceInfo = NULL;
-  }
+	if (m_deviceInfo) {
+		delete m_deviceInfo;
+		m_deviceInfo = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x1009c070 STUB
 BOOL MxDeviceEnumerate::FUN_1009c070()
 {
-  // TODO
-  // HRESULT ret = DirectDrawCreate();
-  HRESULT ret = 0;
-  if (ret) {
-    MxDirect3D::BuildErrorString("GetCaps failed: %s\n",
-                                 EnumerateErrorToString(ret));
-  }
-  //IDirect3D2_EnumDevices
-  return TRUE;
+	// TODO
+	// HRESULT ret = DirectDrawCreate();
+	HRESULT ret = 0;
+	if (ret) {
+		MxDirect3D::BuildErrorString("GetCaps failed: %s\n", EnumerateErrorToString(ret));
+	}
+	// IDirect3D2_EnumDevices
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009c4c0
-void MxDirect3D::BuildErrorString(const char *p_format, ...)
+void MxDirect3D::BuildErrorString(const char* p_format, ...)
 {
-  va_list args;
-  char buf[512];
+	va_list args;
+	char buf[512];
 
-  va_start(args, p_format);
-  vsprintf(buf, p_format, args);
-  va_end(args);
-  
-  OutputDebugString(buf);
+	va_start(args, p_format);
+	vsprintf(buf, p_format, args);
+	va_end(args);
+
+	OutputDebugString(buf);
 }
 
 // OFFSET: LEGO1 0x1009c6c0
 MxResult MxDeviceEnumerate::_DoEnumerate()
 {
-  // TODO: what does ECX refer to in this context?
-  if (m_unk010_flag)
-    return FAILURE;
+	// TODO: what does ECX refer to in this context?
+	if (m_unk010_flag)
+		return FAILURE;
 
-  HRESULT ret = DirectDrawEnumerate(EnumerateCallback, this);
-  if (ret) {
-    MxDirect3D::BuildErrorString("DirectDrawEnumerate returned error %s\n",
-                                 EnumerateErrorToString(ret));
-    return FAILURE;
-  }
+	HRESULT ret = DirectDrawEnumerate(EnumerateCallback, this);
+	if (ret) {
+		MxDirect3D::BuildErrorString("DirectDrawEnumerate returned error %s\n", EnumerateErrorToString(ret));
+		return FAILURE;
+	}
 
-  m_unk010_flag = TRUE;
-  return SUCCESS;
+	m_unk010_flag = TRUE;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1009c710 STUB
-BOOL FAR PASCAL EnumerateCallback(GUID FAR *, LPSTR, LPSTR, LPVOID)
+BOOL FAR PASCAL EnumerateCallback(GUID FAR*, LPSTR, LPSTR, LPVOID)
 {
-  // TODO
-  return FALSE;
+	// TODO
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x1009c730 STUB
-const char *MxDeviceEnumerate::EnumerateErrorToString(HRESULT p_error)
+const char* MxDeviceEnumerate::EnumerateErrorToString(HRESULT p_error)
 {
-  // TODO: This is a list of error messages, similar to the function in
-  // MxDirectDraw, except that this one now contains the Direct3D errors.
-  // Probably just copied from a sample file in the dx5 sdk.
-  return "";
+	// TODO: This is a list of error messages, similar to the function in
+	// MxDirectDraw, except that this one now contains the Direct3D errors.
+	// Probably just copied from a sample file in the dx5 sdk.
+	return "";
 }

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -1,78 +1,76 @@
 #ifndef MXDIRECT3D_H
 #define MXDIRECT3D_H
 
+#include "decomp.h"
 #include "mxdirectdraw.h"
 #include "mxtypes.h"
-#include "decomp.h"
 
 #include <d3d.h>
 
 // SIZE 0xe4
-class MxDeviceModeFinder
-{
+class MxDeviceModeFinder {
 public:
-  MxDeviceModeFinder();
-  ~MxDeviceModeFinder();
+	MxDeviceModeFinder();
+	~MxDeviceModeFinder();
 
-  undefined4 m_unknown[56];
-  MxDirectDraw::DeviceModesInfo *m_deviceInfo; // +0xe0
+	undefined4 m_unknown[56];
+	MxDirectDraw::DeviceModesInfo* m_deviceInfo; // +0xe0
 };
 
 // VTABLE 0x100db814 (or 0x100d9cc8?)
 // SIZE 0x198
-class MxDeviceEnumerate
-{
+class MxDeviceEnumerate {
 public:
-  MxDeviceEnumerate();
-  virtual MxResult _DoEnumerate();
-  BOOL FUN_1009c070();
+	MxDeviceEnumerate();
+	virtual MxResult _DoEnumerate();
+	BOOL FUN_1009c070();
 
-  const char *EnumerateErrorToString(HRESULT p_error);
+	const char* EnumerateErrorToString(HRESULT p_error);
 
-  undefined4 m_unk004;
-  undefined4 m_unk008;
-  undefined4 m_unk00c;
-  MxBool m_unk010_flag; // +0x10
+	undefined4 m_unk004;
+	undefined4 m_unk008;
+	undefined4 m_unk00c;
+	MxBool m_unk010_flag; // +0x10
 
-  undefined4 m_unknown[97];
+	undefined4 m_unknown[97];
 };
 
 // VTABLE 0x100db800
 // SIZE 0x894
-class MxDirect3D : public MxDirectDraw
-{
+class MxDirect3D : public MxDirectDraw {
 public:
-  MxDirect3D();
+	MxDirect3D();
 
-  void Clear();
-  inline MxDeviceModeFinder *GetDeviceModeFinder() { return this->m_pDeviceModeFinder; };
+	void Clear();
+	inline MxDeviceModeFinder* GetDeviceModeFinder() { return this->m_pDeviceModeFinder; };
 
-  virtual ~MxDirect3D();
-  virtual BOOL Create(
-    HWND hWnd,
-    BOOL fullscreen_1,
-    BOOL surface_fullscreen,
-    BOOL onlySystemMemory,
-    int width,
-    int height,
-    int bpp,
-    const PALETTEENTRY* pPaletteEntries,
-    int paletteEntryCount);
-  virtual void Destroy();
+	virtual ~MxDirect3D();
+	virtual BOOL Create(
+		HWND hWnd,
+		BOOL fullscreen_1,
+		BOOL surface_fullscreen,
+		BOOL onlySystemMemory,
+		int width,
+		int height,
+		int bpp,
+		const PALETTEENTRY* pPaletteEntries,
+		int paletteEntryCount
+	);
+	virtual void Destroy();
 
-  BOOL CreateIDirect3D();
-  BOOL D3DSetMode();
+	BOOL CreateIDirect3D();
+	BOOL D3DSetMode();
 
-  static void BuildErrorString(const char *, ...);
+	static void BuildErrorString(const char*, ...);
 
 private:
-  MxDeviceModeFinder *m_pDeviceModeFinder; // +0x880
-  IDirect3D *m_pDirect3d; // +0x884
-  IDirect3DDevice *m_pDirect3dDevice;
-  undefined4 m_unk88c;
-  undefined4 m_unk890;
+	MxDeviceModeFinder* m_pDeviceModeFinder; // +0x880
+	IDirect3D* m_pDirect3d;                  // +0x884
+	IDirect3DDevice* m_pDirect3dDevice;
+	undefined4 m_unk88c;
+	undefined4 m_unk890;
 };
 
-BOOL FAR PASCAL EnumerateCallback(GUID FAR *, LPSTR, LPSTR, LPVOID);
+BOOL FAR PASCAL EnumerateCallback(GUID FAR*, LPSTR, LPSTR, LPVOID);
 
 #endif // MXDIRECT3D_H

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -1,4 +1,5 @@
 #include "mxdirectdraw.h"
+
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxDirectDraw, 0x880);
@@ -14,1216 +15,1118 @@ BOOL g_is_PALETTEINDEXED8 = 0;
 // OFFSET: LEGO1 0x1009DA20
 void EnableResizing(HWND hwnd, BOOL flag)
 {
-  static DWORD dwStyle;
+	static DWORD dwStyle;
 
-  if (!flag)
-  {
-    dwStyle = GetWindowLong(hwnd, GWL_STYLE);
-    if (dwStyle & WS_THICKFRAME)
-    {
-      SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) ^ WS_THICKFRAME);
-    }
-  }
-  else
-  {
-    SetWindowLong(hwnd, GWL_STYLE, dwStyle);
-  }
+	if (!flag) {
+		dwStyle = GetWindowLong(hwnd, GWL_STYLE);
+		if (dwStyle & WS_THICKFRAME) {
+			SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) ^ WS_THICKFRAME);
+		}
+	}
+	else {
+		SetWindowLong(hwnd, GWL_STYLE, dwStyle);
+	}
 }
 
 // OFFSET: LEGO1 0x1009efb0
 MxDirectDraw::DeviceModesInfo::DeviceModesInfo()
 {
-  memset(this, 0, sizeof(*this));
+	memset(this, 0, sizeof(*this));
 }
 
 // OFFSET: LEGO1 0x1009EFD0
 MxDirectDraw::DeviceModesInfo::~DeviceModesInfo()
 {
-  if (p_guid != NULL)
-  {
-    delete p_guid;
-  }
+	if (p_guid != NULL) {
+		delete p_guid;
+	}
 
-  if (m_mode_ARRAY != NULL)
-  {
-    delete m_mode_ARRAY;
-  }
+	if (m_mode_ARRAY != NULL) {
+		delete m_mode_ARRAY;
+	}
 }
 
 // OFFSET: LEGO1 0x1009D490
 MxDirectDraw::MxDirectDraw()
 {
-  m_pFrontBuffer = NULL;
-  m_pBackBuffer = NULL;
-  m_pZBuffer = NULL;
-  m_pClipper = NULL;
-  m_pPalette = NULL;
-  m_pDirectDraw = NULL;
-  m_pText1Surface = NULL;
-  m_pText2Surface = NULL;
-  m_hWndMain = NULL;
-  m_bIgnoreWM_SIZE = FALSE;
-  m_bPrimaryPalettized = FALSE;
-  m_bOnlySystemMemory = FALSE;
-  m_bFullScreen = FALSE;
-  m_bOnlySoftRender = FALSE;
-  m_pauseCount = 0;
-  m_pErrorHandler = NULL;
-  m_pFatalErrorHandler = NULL;
-  m_pErrorHandlerArg = NULL;
-  m_pFatalErrorHandlerArg = NULL;
-  m_pCurrentDeviceModesList = NULL;
-  m_bIsOnPrimaryDevice = TRUE;
-  m_hFont = NULL;
+	m_pFrontBuffer = NULL;
+	m_pBackBuffer = NULL;
+	m_pZBuffer = NULL;
+	m_pClipper = NULL;
+	m_pPalette = NULL;
+	m_pDirectDraw = NULL;
+	m_pText1Surface = NULL;
+	m_pText2Surface = NULL;
+	m_hWndMain = NULL;
+	m_bIgnoreWM_SIZE = FALSE;
+	m_bPrimaryPalettized = FALSE;
+	m_bOnlySystemMemory = FALSE;
+	m_bFullScreen = FALSE;
+	m_bOnlySoftRender = FALSE;
+	m_pauseCount = 0;
+	m_pErrorHandler = NULL;
+	m_pFatalErrorHandler = NULL;
+	m_pErrorHandlerArg = NULL;
+	m_pFatalErrorHandlerArg = NULL;
+	m_pCurrentDeviceModesList = NULL;
+	m_bIsOnPrimaryDevice = TRUE;
+	m_hFont = NULL;
 }
 
 // OFFSET: LEGO1 0x1009D530
 MxDirectDraw::~MxDirectDraw()
 {
-  Destroy();
+	Destroy();
 
-  if (m_pCurrentDeviceModesList != NULL)
-  {
-    delete m_pCurrentDeviceModesList;
-    m_pCurrentDeviceModesList = NULL;
-  }
+	if (m_pCurrentDeviceModesList != NULL) {
+		delete m_pCurrentDeviceModesList;
+		m_pCurrentDeviceModesList = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x1009d570
 int MxDirectDraw::GetPrimaryBitDepth()
 {
-  DWORD dwRGBBitCount;
-  LPDIRECTDRAW pDDraw;
-  DDSURFACEDESC ddsd;
+	DWORD dwRGBBitCount;
+	LPDIRECTDRAW pDDraw;
+	DDSURFACEDESC ddsd;
 
-  HRESULT result = DirectDrawCreate(NULL, &pDDraw, NULL);
-  dwRGBBitCount = 8;
-  if (!result)
-  {
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
+	HRESULT result = DirectDrawCreate(NULL, &pDDraw, NULL);
+	dwRGBBitCount = 8;
+	if (!result) {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
 
-    pDDraw->GetDisplayMode(&ddsd);
-    dwRGBBitCount = ddsd.ddpfPixelFormat.dwRGBBitCount;
-    g_is_PALETTEINDEXED8 = (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8) != 0;
-    pDDraw->Release();
-  }
+		pDDraw->GetDisplayMode(&ddsd);
+		dwRGBBitCount = ddsd.ddpfPixelFormat.dwRGBBitCount;
+		g_is_PALETTEINDEXED8 = (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8) != 0;
+		pDDraw->Release();
+	}
 
-  return dwRGBBitCount;
+	return dwRGBBitCount;
 }
 
 // OFFSET: LEGO1 0x1009D5E0
 BOOL MxDirectDraw::Create(
-  HWND hWnd,
-  BOOL fullscreen_1,
-  BOOL surface_fullscreen,
-  BOOL onlySystemMemory,
-  int width,
-  int height,
-  int bpp,
-  const PALETTEENTRY* pPaletteEntries,
-  int paletteEntryCount)
+	HWND hWnd,
+	BOOL fullscreen_1,
+	BOOL surface_fullscreen,
+	BOOL onlySystemMemory,
+	int width,
+	int height,
+	int bpp,
+	const PALETTEENTRY* pPaletteEntries,
+	int paletteEntryCount
+)
 {
-  m_hWndMain = hWnd;
+	m_hWndMain = hWnd;
 
-  CacheOriginalPaletteEntries();
+	CacheOriginalPaletteEntries();
 
-  if (!RecreateDirectDraw(&m_pCurrentDeviceModesList->p_guid))
-  {
-    return FALSE;
-  }
+	if (!RecreateDirectDraw(&m_pCurrentDeviceModesList->p_guid)) {
+		return FALSE;
+	}
 
-  m_bFlipSurfaces = surface_fullscreen;
-  m_bOnlySystemMemory = onlySystemMemory;
-  m_bIsOnPrimaryDevice = !m_pCurrentDeviceModesList->p_guid;
-  BOOL fullscreen = 1;
-  
-  if (m_bIsOnPrimaryDevice)
-  {
-    fullscreen = fullscreen_1;
-  }
+	m_bFlipSurfaces = surface_fullscreen;
+	m_bOnlySystemMemory = onlySystemMemory;
+	m_bIsOnPrimaryDevice = !m_pCurrentDeviceModesList->p_guid;
+	BOOL fullscreen = 1;
 
-  if (!SetPaletteEntries(pPaletteEntries, paletteEntryCount, fullscreen))
-  {
-    return FALSE;
-  }
+	if (m_bIsOnPrimaryDevice) {
+		fullscreen = fullscreen_1;
+	}
 
-  if (!DDInit(fullscreen))
-  {
-    return FALSE;
-  }
+	if (!SetPaletteEntries(pPaletteEntries, paletteEntryCount, fullscreen)) {
+		return FALSE;
+	}
 
-  if (!DDSetMode(width, height, bpp))
-  {
-    return FALSE;
-  }
+	if (!DDInit(fullscreen)) {
+		return FALSE;
+	}
 
-  return TRUE;
+	if (!DDSetMode(width, height, bpp)) {
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009D800
 void MxDirectDraw::Destroy()
 {
-  DestroyButNotDirectDraw();
+	DestroyButNotDirectDraw();
 
-  FUN_1009D920();
+	FUN_1009D920();
 
-  if (m_pDirectDraw != NULL)
-  {
-    m_pDirectDraw->Release();
-    m_pDirectDraw = NULL;
-  }
+	if (m_pDirectDraw != NULL) {
+		m_pDirectDraw->Release();
+		m_pDirectDraw = NULL;
+	}
 
-  m_bIsOnPrimaryDevice = TRUE;
+	m_bIsOnPrimaryDevice = TRUE;
 
-  if (m_pCurrentDeviceModesList != NULL)
-  {
-    delete m_pCurrentDeviceModesList;
-    m_pCurrentDeviceModesList = NULL;
-  }
+	if (m_pCurrentDeviceModesList != NULL) {
+		delete m_pCurrentDeviceModesList;
+		m_pCurrentDeviceModesList = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x1009D860
 void MxDirectDraw::DestroyButNotDirectDraw()
 {
-  RestoreOriginalPaletteEntries();
-  if (m_bFullScreen)
-  {
-    if (m_pDirectDraw != NULL)
-    {
-      m_bIgnoreWM_SIZE = TRUE;
-      m_pDirectDraw->RestoreDisplayMode();
-      m_bIgnoreWM_SIZE = FALSE;
-    }
-  }
+	RestoreOriginalPaletteEntries();
+	if (m_bFullScreen) {
+		if (m_pDirectDraw != NULL) {
+			m_bIgnoreWM_SIZE = TRUE;
+			m_pDirectDraw->RestoreDisplayMode();
+			m_bIgnoreWM_SIZE = FALSE;
+		}
+	}
 
-  if (m_pPalette)
-  {
-    m_pPalette->Release();
-    m_pPalette = NULL;
-  }
+	if (m_pPalette) {
+		m_pPalette->Release();
+		m_pPalette = NULL;
+	}
 
-  if (m_pClipper)
-  {
-    m_pClipper->Release();
-    m_pClipper = NULL;
-  }
+	if (m_pClipper) {
+		m_pClipper->Release();
+		m_pClipper = NULL;
+	}
 
-  if (m_pText1Surface)
-  {
-    m_pText1Surface->Release();
-    m_pText1Surface = NULL;
-  }
+	if (m_pText1Surface) {
+		m_pText1Surface->Release();
+		m_pText1Surface = NULL;
+	}
 
-  if (m_pText2Surface)
-  {
-    m_pText2Surface->Release();
-    m_pText2Surface = NULL;
-  }
+	if (m_pText2Surface) {
+		m_pText2Surface->Release();
+		m_pText2Surface = NULL;
+	}
 
-  if (m_pZBuffer)
-  {
-    m_pZBuffer->Release();
-    m_pZBuffer = NULL;
-  }
+	if (m_pZBuffer) {
+		m_pZBuffer->Release();
+		m_pZBuffer = NULL;
+	}
 
-  if (m_pBackBuffer)
-  {
-    m_pBackBuffer->Release();
-    m_pBackBuffer = NULL;
-  }
+	if (m_pBackBuffer) {
+		m_pBackBuffer->Release();
+		m_pBackBuffer = NULL;
+	}
 
-  if (m_pFrontBuffer)
-  {
-    m_pFrontBuffer->Release();
-    m_pFrontBuffer = NULL;
-  }
+	if (m_pFrontBuffer) {
+		m_pFrontBuffer->Release();
+		m_pFrontBuffer = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x1009e6a0
 int MxDirectDraw::Pause(int p_increment)
 {
-  if (p_increment)
-  {
-    m_pauseCount++;
+	if (p_increment) {
+		m_pauseCount++;
 
-    if (m_pauseCount > 1)
-    {
-      return TRUE;
-    }
+		if (m_pauseCount > 1) {
+			return TRUE;
+		}
 
-    if (!RestoreOriginalPaletteEntries())
-    {
-      return FALSE;
-    }
+		if (!RestoreOriginalPaletteEntries()) {
+			return FALSE;
+		}
 
-    if (m_bFullScreen)
-    {
-      if (!FlipToGDISurface())
-      {
-        return FALSE;
-      }
+		if (m_bFullScreen) {
+			if (!FlipToGDISurface()) {
+				return FALSE;
+			}
 
-      DrawMenuBar(m_hWndMain);
-      RedrawWindow(m_hWndMain, NULL, NULL, RDW_FRAME);
-    }
-  }
-  else
-  {
-    m_pauseCount--;
-    if (m_pauseCount > 0)
-    {
-      return TRUE;
-    }
-    else if (m_pauseCount < 0)
-    {
-      m_pauseCount = 0;
-    }
+			DrawMenuBar(m_hWndMain);
+			RedrawWindow(m_hWndMain, NULL, NULL, RDW_FRAME);
+		}
+	}
+	else {
+		m_pauseCount--;
+		if (m_pauseCount > 0) {
+			return TRUE;
+		}
+		else if (m_pauseCount < 0) {
+			m_pauseCount = 0;
+		}
 
-    if (!RestorePaletteEntries())
-    {
-      return FALSE;
-    }
-  }
+		if (!RestorePaletteEntries()) {
+			return FALSE;
+		}
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009E880
 const char* MxDirectDraw::ErrorToString(HRESULT error)
 {
-  switch(error) {
-    case DD_OK:
-      return "No error.\0";
-    case DDERR_ALREADYINITIALIZED:
-      return "This object is already initialized.\0";
-    case DDERR_BLTFASTCANTCLIP:
-      return "Return if a clipper object is attached to the source surface passed into a BltFast call.\0";
-    case DDERR_CANNOTATTACHSURFACE:
-      return "This surface can not be attached to the requested surface.\0";
-    case DDERR_CANNOTDETACHSURFACE:
-      return "This surface can not be detached from the requested surface.\0";
-    case DDERR_CANTCREATEDC:
-      return "Windows can not create any more DCs.\0";
-    case DDERR_CANTDUPLICATE:
-      return "Can't duplicate primary & 3D surfaces, or surfaces that are implicitly created.\0";
-    case DDERR_CLIPPERISUSINGHWND:
-      return "An attempt was made to set a cliplist for a clipper object that is already monitoring an hwnd.\0";
-    case DDERR_COLORKEYNOTSET:
-      return "No src color key specified for this operation.\0";
-    case DDERR_CURRENTLYNOTAVAIL:
-      return "Support is currently not available.\0";
-    case DDERR_DIRECTDRAWALREADYCREATED:
-      return "A DirectDraw object representing this driver has already been created for this process.\0";
-    case DDERR_EXCEPTION:
-      return "An exception was encountered while performing the requested operation.\0";
-    case DDERR_EXCLUSIVEMODEALREADYSET:
-      return "An attempt was made to set the cooperative level when it was already set to exclusive.\0";
-    case DDERR_GENERIC:
-      return "Generic failure.\0";
-    case DDERR_HEIGHTALIGN:
-      return "Height of rectangle provided is not a multiple of reqd alignment.\0";
-    case DDERR_HWNDALREADYSET:
-      return "The CooperativeLevel HWND has already been set. It can not be reset while the process has surfaces or palettes created.\0";
-    case DDERR_HWNDSUBCLASSED:
-      return "HWND used by DirectDraw CooperativeLevel has been subclassed, this prevents DirectDraw from restoring state.\0";
-    case DDERR_IMPLICITLYCREATED:
-      return "This surface can not be restored because it is an implicitly created surface.\0";
-    case DDERR_INCOMPATIBLEPRIMARY:
-      return "Unable to match primary surface creation request with existing primary surface.\0";
-    case DDERR_INVALIDCAPS:
-      return "One or more of the caps bits passed to the callback are incorrect.\0";
-    case DDERR_INVALIDCLIPLIST:
-      return "DirectDraw does not support the provided cliplist.\0";
-    case DDERR_INVALIDDIRECTDRAWGUID:
-      return "The GUID passed to DirectDrawCreate is not a valid DirectDraw driver identifier.\0";
-    case DDERR_INVALIDMODE:
-      return "DirectDraw does not support the requested mode.\0";
-    case DDERR_INVALIDOBJECT:
-      return "DirectDraw received a pointer that was an invalid DIRECTDRAW object.\0";
-    case DDERR_INVALIDPARAMS:
-      return "One or more of the parameters passed to the function are incorrect.\0";
-    case DDERR_INVALIDPIXELFORMAT:
-      return "The pixel format was invalid as specified.\0";
-    case DDERR_INVALIDPOSITION:
-      return "Returned when the position of the overlay on the destination is no longer legal for that destination.\0";
-    case DDERR_INVALIDRECT:
-      return "Rectangle provided was invalid.\0";
-    case DDERR_LOCKEDSURFACES:
-      return "Operation could not be carried out because one or more surfaces are locked.\0";
-    case DDERR_NO3D:
-      return "There is no 3D present.\0";
-    case DDERR_NOALPHAHW:
-      return "Operation could not be carried out because there is no alpha accleration hardware present or available.\0";
-    case DDERR_NOBLTHW:
-      return "No blitter hardware present.\0";
-    case DDERR_NOCLIPLIST:
-      return "No cliplist available.\0";
-    case DDERR_NOCLIPPERATTACHED:
-      return "No clipper object attached to surface object.\0";
-    case DDERR_NOCOLORCONVHW:
-      return "Operation could not be carried out because there is no color conversion hardware present or available.\0";
-    case DDERR_NOCOLORKEY:
-      return "Surface doesn't currently have a color key\0";
-    case DDERR_NOCOLORKEYHW:
-      return "Operation could not be carried out because there is no hardware support of the destination color key.\0";
-    case DDERR_NOCOOPERATIVELEVELSET:
-      return "Create function called without DirectDraw object method SetCooperativeLevel being called.\0";
-    case DDERR_NODC:
-      return "No DC was ever created for this surface.\0";
-    case DDERR_NODDROPSHW:
-      return "No DirectDraw ROP hardware.\0";
-    case DDERR_NODIRECTDRAWHW:
-      return "A hardware-only DirectDraw object creation was attempted but the driver did not support any hardware.\0";
-    case DDERR_NOEMULATION:
-      return "Software emulation not available.\0";
-    case DDERR_NOEXCLUSIVEMODE:
-      return "Operation requires the application to have exclusive mode but the application does not have exclusive mode.\0";
-    case DDERR_NOFLIPHW:
-      return "Flipping visible surfaces is not supported.\0";
-    case DDERR_NOGDI:
-      return "There is no GDI present.\0";
-    case DDERR_NOHWND:
-      return "Clipper notification requires an HWND or no HWND has previously been set as the CooperativeLevel HWND.\0";
-    case DDERR_NOMIRRORHW:
-      return "Operation could not be carried out because there is no hardware present or available.\0";
-    case DDERR_NOOVERLAYDEST:
-      return "Returned when GetOverlayPosition is called on an overlay that UpdateOverlay has never been called on to establish a destination.\0";
-    case DDERR_NOOVERLAYHW:
-      return "Operation could not be carried out because there is no overlay hardware present or available.\0";
-    case DDERR_NOPALETTEATTACHED:
-      return "No palette object attached to this surface.\0";
-    case DDERR_NOPALETTEHW:
-      return "No hardware support for 16 or 256 color palettes.\0";
-    case DDERR_NORASTEROPHW:
-      return "Operation could not be carried out because there is no appropriate raster op hardware present or available.\0";
-    case DDERR_NOROTATIONHW:
-      return "Operation could not be carried out because there is no rotation hardware present or available.\0";
-    case DDERR_NOSTRETCHHW:
-      return "Operation could not be carried out because there is no hardware support for stretching.\0";
-    case DDERR_NOT4BITCOLOR:
-      return "DirectDrawSurface is not in 4 bit color palette and the requested operation requires 4 bit color palette.\0";
-    case DDERR_NOT4BITCOLORINDEX:
-      return "DirectDrawSurface is not in 4 bit color index palette and the requested operation requires 4 bit color index palette.\0";
-    case DDERR_NOT8BITCOLOR:
-      return "DirectDrawSurface is not in 8 bit color mode and the requested operation requires 8 bit color.\0";
-    case DDERR_NOTAOVERLAYSURFACE:
-      return "Returned when an overlay member is called for a non-overlay surface.\0";
-    case DDERR_NOTEXTUREHW:
-      return "Operation could not be carried out because there is no texture mapping hardware present or available.\0";
-    case DDERR_NOTFLIPPABLE:
-      return "An attempt has been made to flip a surface that is not flippable.\0";
-    case DDERR_NOTFOUND:
-      return "Requested item was not found.\0";
-    case DDERR_NOTLOCKED:
-      return "Surface was not locked.  An attempt to unlock a surface that was not locked at all, or by this process, has been attempted.\0";
-    case DDERR_NOTPALETTIZED:
-      return "The surface being used is not a palette-based surface.\0";
-    case DDERR_NOVSYNCHW:
-      return "Operation could not be carried out because there is no hardware support for vertical blank synchronized operations.\0";
-    case DDERR_NOZBUFFERHW:
-      return "Operation could not be carried out because there is no hardware support for zbuffer blitting.\0";
-    case DDERR_NOZOVERLAYHW:
-      return "Overlay surfaces could not be z layered based on their BltOrder because the hardware does not support z layering of overlays.\0";
-    case DDERR_OUTOFCAPS:
-      return "The hardware needed for the requested operation has already been allocated.\0";
-    case DDERR_OUTOFMEMORY:
-      return "DirectDraw does not have enough memory to perform the operation.\0";
-    case DDERR_OUTOFVIDEOMEMORY:
-      return "DirectDraw does not have enough memory to perform the operation.\0";
-    case DDERR_OVERLAYCANTCLIP:
-      return "The hardware does not support clipped overlays.\0";
-    case DDERR_OVERLAYCOLORKEYONLYONEACTIVE:
-      return "Can only have ony color key active at one time for overlays.\0";
-    case DDERR_OVERLAYNOTVISIBLE:
-      return "Returned when GetOverlayPosition is called on a hidden overlay.\0";
-    case DDERR_PALETTEBUSY:
-      return "Access to this palette is being refused because the palette is already locked by another thread.\0";
-    case DDERR_PRIMARYSURFACEALREADYEXISTS:
-      return "This process already has created a primary surface.\0";
-    case DDERR_REGIONTOOSMALL:
-      return "Region passed to Clipper::GetClipList is too small.\0";
-    case DDERR_SURFACEALREADYATTACHED:
-      return "This surface is already attached to the surface it is being attached to.\0";
-    case DDERR_SURFACEALREADYDEPENDENT:
-      return "This surface is already a dependency of the surface it is being made a dependency of.\0";
-    case DDERR_SURFACEBUSY:
-      return "Access to this surface is being refused because the surface is already locked by another thread.\0";
-    case DDERR_SURFACEISOBSCURED:
-      return "Access to surface refused because the surface is obscured.\0";
-    case DDERR_SURFACELOST:
-      return "Access to this surface is being refused because the surface memory is gone. The DirectDrawSurface object representing this surface should have Restore called on it.\0";
-    case DDERR_SURFACENOTATTACHED:
-      return "The requested surface is not attached.\0";
-    case DDERR_TOOBIGHEIGHT:
-      return "Height requested by DirectDraw is too large.\0";
-    case DDERR_TOOBIGSIZE:
-      return "Size requested by DirectDraw is too large, but the individual height and width are OK.\0";
-    case DDERR_TOOBIGWIDTH:
-      return "Width requested by DirectDraw is too large.\0";
-    case DDERR_UNSUPPORTED:
-      return "Action not supported.\0";
-    case DDERR_UNSUPPORTEDFORMAT:
-      return "FOURCC format requested is unsupported by DirectDraw.\0";
-    case DDERR_UNSUPPORTEDMASK:
-      return "Bitmask in the pixel format requested is unsupported by DirectDraw.\0";
-    case DDERR_VERTICALBLANKINPROGRESS:
-      return "Vertical blank is in progress.\0";
-    case DDERR_WASSTILLDRAWING:
-      return "Informs DirectDraw that the previous Blt which is transfering information to or from this Surface is incomplete.\0";
-    case DDERR_WRONGMODE:
-      return "This surface can not be restored because it was created in a different mode.\0";
-    case DDERR_XALIGN:
-      return "Rectangle provided was not horizontally aligned on required boundary.\0";
-    default:
-      return "Unrecognized error value.\0";
-  }
+	switch (error) {
+	case DD_OK:
+		return "No error.\0";
+	case DDERR_ALREADYINITIALIZED:
+		return "This object is already initialized.\0";
+	case DDERR_BLTFASTCANTCLIP:
+		return "Return if a clipper object is attached to the source surface passed into a BltFast call.\0";
+	case DDERR_CANNOTATTACHSURFACE:
+		return "This surface can not be attached to the requested surface.\0";
+	case DDERR_CANNOTDETACHSURFACE:
+		return "This surface can not be detached from the requested surface.\0";
+	case DDERR_CANTCREATEDC:
+		return "Windows can not create any more DCs.\0";
+	case DDERR_CANTDUPLICATE:
+		return "Can't duplicate primary & 3D surfaces, or surfaces that are implicitly created.\0";
+	case DDERR_CLIPPERISUSINGHWND:
+		return "An attempt was made to set a cliplist for a clipper object that is already monitoring an hwnd.\0";
+	case DDERR_COLORKEYNOTSET:
+		return "No src color key specified for this operation.\0";
+	case DDERR_CURRENTLYNOTAVAIL:
+		return "Support is currently not available.\0";
+	case DDERR_DIRECTDRAWALREADYCREATED:
+		return "A DirectDraw object representing this driver has already been created for this process.\0";
+	case DDERR_EXCEPTION:
+		return "An exception was encountered while performing the requested operation.\0";
+	case DDERR_EXCLUSIVEMODEALREADYSET:
+		return "An attempt was made to set the cooperative level when it was already set to exclusive.\0";
+	case DDERR_GENERIC:
+		return "Generic failure.\0";
+	case DDERR_HEIGHTALIGN:
+		return "Height of rectangle provided is not a multiple of reqd alignment.\0";
+	case DDERR_HWNDALREADYSET:
+		return "The CooperativeLevel HWND has already been set. It can not be reset while the process has surfaces or "
+			   "palettes created.\0";
+	case DDERR_HWNDSUBCLASSED:
+		return "HWND used by DirectDraw CooperativeLevel has been subclassed, this prevents DirectDraw from restoring "
+			   "state.\0";
+	case DDERR_IMPLICITLYCREATED:
+		return "This surface can not be restored because it is an implicitly created surface.\0";
+	case DDERR_INCOMPATIBLEPRIMARY:
+		return "Unable to match primary surface creation request with existing primary surface.\0";
+	case DDERR_INVALIDCAPS:
+		return "One or more of the caps bits passed to the callback are incorrect.\0";
+	case DDERR_INVALIDCLIPLIST:
+		return "DirectDraw does not support the provided cliplist.\0";
+	case DDERR_INVALIDDIRECTDRAWGUID:
+		return "The GUID passed to DirectDrawCreate is not a valid DirectDraw driver identifier.\0";
+	case DDERR_INVALIDMODE:
+		return "DirectDraw does not support the requested mode.\0";
+	case DDERR_INVALIDOBJECT:
+		return "DirectDraw received a pointer that was an invalid DIRECTDRAW object.\0";
+	case DDERR_INVALIDPARAMS:
+		return "One or more of the parameters passed to the function are incorrect.\0";
+	case DDERR_INVALIDPIXELFORMAT:
+		return "The pixel format was invalid as specified.\0";
+	case DDERR_INVALIDPOSITION:
+		return "Returned when the position of the overlay on the destination is no longer legal for that "
+			   "destination.\0";
+	case DDERR_INVALIDRECT:
+		return "Rectangle provided was invalid.\0";
+	case DDERR_LOCKEDSURFACES:
+		return "Operation could not be carried out because one or more surfaces are locked.\0";
+	case DDERR_NO3D:
+		return "There is no 3D present.\0";
+	case DDERR_NOALPHAHW:
+		return "Operation could not be carried out because there is no alpha accleration hardware present or "
+			   "available.\0";
+	case DDERR_NOBLTHW:
+		return "No blitter hardware present.\0";
+	case DDERR_NOCLIPLIST:
+		return "No cliplist available.\0";
+	case DDERR_NOCLIPPERATTACHED:
+		return "No clipper object attached to surface object.\0";
+	case DDERR_NOCOLORCONVHW:
+		return "Operation could not be carried out because there is no color conversion hardware present or "
+			   "available.\0";
+	case DDERR_NOCOLORKEY:
+		return "Surface doesn't currently have a color key\0";
+	case DDERR_NOCOLORKEYHW:
+		return "Operation could not be carried out because there is no hardware support of the destination color "
+			   "key.\0";
+	case DDERR_NOCOOPERATIVELEVELSET:
+		return "Create function called without DirectDraw object method SetCooperativeLevel being called.\0";
+	case DDERR_NODC:
+		return "No DC was ever created for this surface.\0";
+	case DDERR_NODDROPSHW:
+		return "No DirectDraw ROP hardware.\0";
+	case DDERR_NODIRECTDRAWHW:
+		return "A hardware-only DirectDraw object creation was attempted but the driver did not support any "
+			   "hardware.\0";
+	case DDERR_NOEMULATION:
+		return "Software emulation not available.\0";
+	case DDERR_NOEXCLUSIVEMODE:
+		return "Operation requires the application to have exclusive mode but the application does not have exclusive "
+			   "mode.\0";
+	case DDERR_NOFLIPHW:
+		return "Flipping visible surfaces is not supported.\0";
+	case DDERR_NOGDI:
+		return "There is no GDI present.\0";
+	case DDERR_NOHWND:
+		return "Clipper notification requires an HWND or no HWND has previously been set as the CooperativeLevel "
+			   "HWND.\0";
+	case DDERR_NOMIRRORHW:
+		return "Operation could not be carried out because there is no hardware present or available.\0";
+	case DDERR_NOOVERLAYDEST:
+		return "Returned when GetOverlayPosition is called on an overlay that UpdateOverlay has never been called on "
+			   "to establish a destination.\0";
+	case DDERR_NOOVERLAYHW:
+		return "Operation could not be carried out because there is no overlay hardware present or available.\0";
+	case DDERR_NOPALETTEATTACHED:
+		return "No palette object attached to this surface.\0";
+	case DDERR_NOPALETTEHW:
+		return "No hardware support for 16 or 256 color palettes.\0";
+	case DDERR_NORASTEROPHW:
+		return "Operation could not be carried out because there is no appropriate raster op hardware present or "
+			   "available.\0";
+	case DDERR_NOROTATIONHW:
+		return "Operation could not be carried out because there is no rotation hardware present or available.\0";
+	case DDERR_NOSTRETCHHW:
+		return "Operation could not be carried out because there is no hardware support for stretching.\0";
+	case DDERR_NOT4BITCOLOR:
+		return "DirectDrawSurface is not in 4 bit color palette and the requested operation requires 4 bit color "
+			   "palette.\0";
+	case DDERR_NOT4BITCOLORINDEX:
+		return "DirectDrawSurface is not in 4 bit color index palette and the requested operation requires 4 bit color "
+			   "index palette.\0";
+	case DDERR_NOT8BITCOLOR:
+		return "DirectDrawSurface is not in 8 bit color mode and the requested operation requires 8 bit color.\0";
+	case DDERR_NOTAOVERLAYSURFACE:
+		return "Returned when an overlay member is called for a non-overlay surface.\0";
+	case DDERR_NOTEXTUREHW:
+		return "Operation could not be carried out because there is no texture mapping hardware present or "
+			   "available.\0";
+	case DDERR_NOTFLIPPABLE:
+		return "An attempt has been made to flip a surface that is not flippable.\0";
+	case DDERR_NOTFOUND:
+		return "Requested item was not found.\0";
+	case DDERR_NOTLOCKED:
+		return "Surface was not locked.  An attempt to unlock a surface that was not locked at all, or by this "
+			   "process, has been attempted.\0";
+	case DDERR_NOTPALETTIZED:
+		return "The surface being used is not a palette-based surface.\0";
+	case DDERR_NOVSYNCHW:
+		return "Operation could not be carried out because there is no hardware support for vertical blank "
+			   "synchronized operations.\0";
+	case DDERR_NOZBUFFERHW:
+		return "Operation could not be carried out because there is no hardware support for zbuffer blitting.\0";
+	case DDERR_NOZOVERLAYHW:
+		return "Overlay surfaces could not be z layered based on their BltOrder because the hardware does not support "
+			   "z layering of overlays.\0";
+	case DDERR_OUTOFCAPS:
+		return "The hardware needed for the requested operation has already been allocated.\0";
+	case DDERR_OUTOFMEMORY:
+		return "DirectDraw does not have enough memory to perform the operation.\0";
+	case DDERR_OUTOFVIDEOMEMORY:
+		return "DirectDraw does not have enough memory to perform the operation.\0";
+	case DDERR_OVERLAYCANTCLIP:
+		return "The hardware does not support clipped overlays.\0";
+	case DDERR_OVERLAYCOLORKEYONLYONEACTIVE:
+		return "Can only have ony color key active at one time for overlays.\0";
+	case DDERR_OVERLAYNOTVISIBLE:
+		return "Returned when GetOverlayPosition is called on a hidden overlay.\0";
+	case DDERR_PALETTEBUSY:
+		return "Access to this palette is being refused because the palette is already locked by another thread.\0";
+	case DDERR_PRIMARYSURFACEALREADYEXISTS:
+		return "This process already has created a primary surface.\0";
+	case DDERR_REGIONTOOSMALL:
+		return "Region passed to Clipper::GetClipList is too small.\0";
+	case DDERR_SURFACEALREADYATTACHED:
+		return "This surface is already attached to the surface it is being attached to.\0";
+	case DDERR_SURFACEALREADYDEPENDENT:
+		return "This surface is already a dependency of the surface it is being made a dependency of.\0";
+	case DDERR_SURFACEBUSY:
+		return "Access to this surface is being refused because the surface is already locked by another thread.\0";
+	case DDERR_SURFACEISOBSCURED:
+		return "Access to surface refused because the surface is obscured.\0";
+	case DDERR_SURFACELOST:
+		return "Access to this surface is being refused because the surface memory is gone. The DirectDrawSurface "
+			   "object representing this surface should have Restore called on it.\0";
+	case DDERR_SURFACENOTATTACHED:
+		return "The requested surface is not attached.\0";
+	case DDERR_TOOBIGHEIGHT:
+		return "Height requested by DirectDraw is too large.\0";
+	case DDERR_TOOBIGSIZE:
+		return "Size requested by DirectDraw is too large, but the individual height and width are OK.\0";
+	case DDERR_TOOBIGWIDTH:
+		return "Width requested by DirectDraw is too large.\0";
+	case DDERR_UNSUPPORTED:
+		return "Action not supported.\0";
+	case DDERR_UNSUPPORTEDFORMAT:
+		return "FOURCC format requested is unsupported by DirectDraw.\0";
+	case DDERR_UNSUPPORTEDMASK:
+		return "Bitmask in the pixel format requested is unsupported by DirectDraw.\0";
+	case DDERR_VERTICALBLANKINPROGRESS:
+		return "Vertical blank is in progress.\0";
+	case DDERR_WASSTILLDRAWING:
+		return "Informs DirectDraw that the previous Blt which is transfering information to or from this Surface is "
+			   "incomplete.\0";
+	case DDERR_WRONGMODE:
+		return "This surface can not be restored because it was created in a different mode.\0";
+	case DDERR_XALIGN:
+		return "Rectangle provided was not horizontally aligned on required boundary.\0";
+	default:
+		return "Unrecognized error value.\0";
+	}
 }
-
 
 // OFFSET: LEGO1 0x1009D6C0
 BOOL MxDirectDraw::CacheOriginalPaletteEntries()
 {
-  HDC DC;
+	HDC DC;
 
-  if (g_is_PALETTEINDEXED8)
-  {
-    DC = GetDC(0);
-    GetSystemPaletteEntries(DC, 0, _countof(m_originalPaletteEntries), m_originalPaletteEntries);
-    ReleaseDC(0, DC);
-  }
-  return TRUE;
+	if (g_is_PALETTEINDEXED8) {
+		DC = GetDC(0);
+		GetSystemPaletteEntries(DC, 0, _countof(m_originalPaletteEntries), m_originalPaletteEntries);
+		ReleaseDC(0, DC);
+	}
+	return TRUE;
 }
 
-
 // OFFSET: LEGO1 0x1009DD80
-HRESULT MxDirectDraw::CreateDDSurface(
-  LPDDSURFACEDESC a2,
-  LPDIRECTDRAWSURFACE* a3,
-  IUnknown* a4)
+HRESULT MxDirectDraw::CreateDDSurface(LPDDSURFACEDESC a2, LPDIRECTDRAWSURFACE* a3, IUnknown* a4)
 {
-  return m_pDirectDraw->CreateSurface(a2, a3, a4);
+	return m_pDirectDraw->CreateSurface(a2, a3, a4);
 }
 
 // OFFSET: LEGO1 0x1009E250
 BOOL MxDirectDraw::CreateTextSurfaces()
 {
-  HRESULT result;
-  DDCOLORKEY ddck;
-  DDSURFACEDESC ddsd;
-  HDC DC;
-  char dummyinfo[] = "000x000x00 (RAMP) 0000";
-  char dummyfps[] = "000.00 fps (000.00 fps (000.00 fps) 00000 tps)";
+	HRESULT result;
+	DDCOLORKEY ddck;
+	DDSURFACEDESC ddsd;
+	HDC DC;
+	char dummyinfo[] = "000x000x00 (RAMP) 0000";
+	char dummyfps[] = "000.00 fps (000.00 fps (000.00 fps) 00000 tps)";
 
-  if (m_hFont != NULL)
-  {
-    DeleteObject(m_hFont);
-  }
+	if (m_hFont != NULL) {
+		DeleteObject(m_hFont);
+	}
 
-  m_hFont = CreateFontA(m_currentMode.width <= 600 ? 12 : 24,
-    0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
-    ANSI_CHARSET,
-    OUT_DEFAULT_PRECIS,
-    CLIP_DEFAULT_PRECIS,
-    DEFAULT_QUALITY,
-    VARIABLE_PITCH,
-    "Arial");
+	m_hFont = CreateFontA(
+		m_currentMode.width <= 600 ? 12 : 24,
+		0,
+		0,
+		0,
+		FW_NORMAL,
+		FALSE,
+		FALSE,
+		FALSE,
+		ANSI_CHARSET,
+		OUT_DEFAULT_PRECIS,
+		CLIP_DEFAULT_PRECIS,
+		DEFAULT_QUALITY,
+		VARIABLE_PITCH,
+		"Arial"
+	);
 
-  DC = GetDC(NULL);
-  SelectObject(DC, m_hFont);
-  GetTextExtentPointA(DC, dummyfps, strlen(dummyfps), &m_text1SizeOnSurface);
-  GetTextExtentPointA(DC, dummyinfo, strlen(dummyinfo), &m_text2SizeOnSurface);
-  ReleaseDC(NULL, DC);
+	DC = GetDC(NULL);
+	SelectObject(DC, m_hFont);
+	GetTextExtentPointA(DC, dummyfps, strlen(dummyfps), &m_text1SizeOnSurface);
+	GetTextExtentPointA(DC, dummyinfo, strlen(dummyinfo), &m_text2SizeOnSurface);
+	ReleaseDC(NULL, DC);
 
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
-  ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
-  ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
-  if (m_bOnlySystemMemory)
-    ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
-  ddsd.dwHeight = m_text1SizeOnSurface.cy;
-  ddsd.dwWidth = m_text1SizeOnSurface.cx;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
+	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
+	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
+	if (m_bOnlySystemMemory)
+		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
+	ddsd.dwHeight = m_text1SizeOnSurface.cy;
+	ddsd.dwWidth = m_text1SizeOnSurface.cx;
 
-  result = CreateDDSurface(&ddsd, &m_pText1Surface, 0);
-  if (result != DD_OK)
-  {
-    Error("CreateSurface for text surface 1 failed", result);
-    return FALSE;
-  }
+	result = CreateDDSurface(&ddsd, &m_pText1Surface, 0);
+	if (result != DD_OK) {
+		Error("CreateSurface for text surface 1 failed", result);
+		return FALSE;
+	}
 
-  memset(&ddck, 0, sizeof(ddck));
-  m_pText1Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
-  if (!TextToTextSurface1(dummyfps))
-  {
-    return FALSE;
-  }
+	memset(&ddck, 0, sizeof(ddck));
+	m_pText1Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
+	if (!TextToTextSurface1(dummyfps)) {
+		return FALSE;
+	}
 
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
-  ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
-  ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
-  if (m_bOnlySystemMemory)
-    ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
-  ddsd.dwHeight = m_text2SizeOnSurface.cy;
-  ddsd.dwWidth = m_text2SizeOnSurface.cx;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
+	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
+	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
+	if (m_bOnlySystemMemory)
+		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
+	ddsd.dwHeight = m_text2SizeOnSurface.cy;
+	ddsd.dwWidth = m_text2SizeOnSurface.cx;
 
-  result = CreateDDSurface(&ddsd, &m_pText2Surface, 0);
-  if (result != DD_OK)
-  {
-    Error("CreateSurface for text surface 2 failed", result);
-    return FALSE;
-  }
+	result = CreateDDSurface(&ddsd, &m_pText2Surface, 0);
+	if (result != DD_OK) {
+		Error("CreateSurface for text surface 2 failed", result);
+		return FALSE;
+	}
 
-  memset(&ddck, 0, sizeof(ddck));
-  m_pText2Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
-  if (!TextToTextSurface2(dummyinfo))
-  {
-    return FALSE;
-  }
+	memset(&ddck, 0, sizeof(ddck));
+	m_pText2Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
+	if (!TextToTextSurface2(dummyinfo)) {
+		return FALSE;
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009E5E0
 BOOL MxDirectDraw::CreateZBuffer(DWORD memorytype, DWORD depth)
 {
-  HRESULT result; // eax
-  LPDIRECTDRAWSURFACE lpZBuffer; // [esp+8h] [ebp-70h] BYREF
-  DDSURFACEDESC ddsd;
+	HRESULT result;                // eax
+	LPDIRECTDRAWSURFACE lpZBuffer; // [esp+8h] [ebp-70h] BYREF
+	DDSURFACEDESC ddsd;
 
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
-  ddsd.dwHeight = m_currentMode.height;
-  ddsd.dwWidth = m_currentMode.width;
-  ddsd.dwZBufferBitDepth = depth;
-  ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS | DDSD_ZBUFFERBITDEPTH;
-  ddsd.ddsCaps.dwCaps = DDSCAPS_ZBUFFER | memorytype;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
+	ddsd.dwHeight = m_currentMode.height;
+	ddsd.dwWidth = m_currentMode.width;
+	ddsd.dwZBufferBitDepth = depth;
+	ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS | DDSD_ZBUFFERBITDEPTH;
+	ddsd.ddsCaps.dwCaps = DDSCAPS_ZBUFFER | memorytype;
 
-  result = CreateDDSurface(&ddsd, &lpZBuffer, 0);
-  if (result != DD_OK)
-  {
-    Error("CreateSurface for fullScreen Z-buffer failed", result);
-    return FALSE;
-  }
+	result = CreateDDSurface(&ddsd, &lpZBuffer, 0);
+	if (result != DD_OK) {
+		Error("CreateSurface for fullScreen Z-buffer failed", result);
+		return FALSE;
+	}
 
-  result = m_pBackBuffer->AddAttachedSurface(lpZBuffer);
-  if (result != DD_OK)
-  {
-    Error("AddAttachedBuffer failed for Z-Buffer", result);
-    return FALSE;
-  }
+	result = m_pBackBuffer->AddAttachedSurface(lpZBuffer);
+	if (result != DD_OK) {
+		Error("AddAttachedBuffer failed for Z-Buffer", result);
+		return FALSE;
+	}
 
-  m_pZBuffer = lpZBuffer;
-  return TRUE;
+	m_pZBuffer = lpZBuffer;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009DDF0
 BOOL MxDirectDraw::DDCreateSurfaces()
 {
-  HRESULT result;
-  DDSCAPS ddscaps;
-  DDSURFACEDESC ddsd;
+	HRESULT result;
+	DDSCAPS ddscaps;
+	DDSURFACEDESC ddsd;
 
-  if (m_bFlipSurfaces)
-  {
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
-    ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
-    ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX;
-    if (m_bOnlySystemMemory)
-    {
-      ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX | DDSCAPS_SYSTEMMEMORY;
-    }
-    ddsd.dwBackBufferCount = 1;
-    result = CreateDDSurface(&ddsd, &m_pFrontBuffer, 0);
-    if (result != DD_OK)
-    {
-      Error("CreateSurface for front/back fullScreen buffer failed", result);
-      return FALSE;
-    }
+	if (m_bFlipSurfaces) {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX;
+		if (m_bOnlySystemMemory) {
+			ddsd.ddsCaps.dwCaps =
+				DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX | DDSCAPS_SYSTEMMEMORY;
+		}
+		ddsd.dwBackBufferCount = 1;
+		result = CreateDDSurface(&ddsd, &m_pFrontBuffer, 0);
+		if (result != DD_OK) {
+			Error("CreateSurface for front/back fullScreen buffer failed", result);
+			return FALSE;
+		}
 
-    ddscaps.dwCaps = DDSCAPS_BACKBUFFER;
-    result = m_pFrontBuffer->GetAttachedSurface(&ddscaps, &m_pBackBuffer);
-    if (result != DD_OK)
-    {
-      Error("GetAttachedSurface failed to get back buffer", result);
-      return FALSE;
-    }
-    if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer))
-    {
-      return FALSE;
-    }
-  }
-  else
-  {
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
-    ddsd.dwFlags = DDSD_CAPS;
-    ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
-    result = CreateDDSurface(&ddsd, &m_pFrontBuffer, NULL);
-    if (result != DD_OK)
-    {
-      Error("CreateSurface for window front buffer failed", result);
-      return FALSE;
-    }
-    ddsd.dwHeight = m_currentMode.height;
-    ddsd.dwWidth = m_currentMode.width;
-    ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
-    ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE;
-    if (m_bOnlySystemMemory)
-      ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY;
-    result = CreateDDSurface(&ddsd, &m_pBackBuffer, NULL);
-    if (result != DD_OK)
-    {
-      Error("CreateSurface for window back buffer failed", result);
-      return FALSE;
-    }
+		ddscaps.dwCaps = DDSCAPS_BACKBUFFER;
+		result = m_pFrontBuffer->GetAttachedSurface(&ddscaps, &m_pBackBuffer);
+		if (result != DD_OK) {
+			Error("GetAttachedSurface failed to get back buffer", result);
+			return FALSE;
+		}
+		if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
+			return FALSE;
+		}
+	}
+	else {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwFlags = DDSD_CAPS;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
+		result = CreateDDSurface(&ddsd, &m_pFrontBuffer, NULL);
+		if (result != DD_OK) {
+			Error("CreateSurface for window front buffer failed", result);
+			return FALSE;
+		}
+		ddsd.dwHeight = m_currentMode.height;
+		ddsd.dwWidth = m_currentMode.width;
+		ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE;
+		if (m_bOnlySystemMemory)
+			ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY;
+		result = CreateDDSurface(&ddsd, &m_pBackBuffer, NULL);
+		if (result != DD_OK) {
+			Error("CreateSurface for window back buffer failed", result);
+			return FALSE;
+		}
 
-    if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer))
-    {
-      return FALSE;
-    }
+		if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
+			return FALSE;
+		}
 
-    result = m_pDirectDraw->CreateClipper(0, &m_pClipper, NULL);
-    if (result != DD_OK)
-    {
-      Error("CreateClipper failed", result);
-      return FALSE;
-    }
-    result = m_pClipper->SetHWnd(0, m_hWndMain);
-    if (result != DD_OK)
-    {
-      Error("Clipper SetHWnd failed", result);
-      return FALSE;
-    }
-    result = m_pFrontBuffer->SetClipper(m_pClipper);
-    if (result != DD_OK)
-    {
-      Error("SetClipper failed", result);
-      return FALSE;
-    }
-  }
+		result = m_pDirectDraw->CreateClipper(0, &m_pClipper, NULL);
+		if (result != DD_OK) {
+			Error("CreateClipper failed", result);
+			return FALSE;
+		}
+		result = m_pClipper->SetHWnd(0, m_hWndMain);
+		if (result != DD_OK) {
+			Error("Clipper SetHWnd failed", result);
+			return FALSE;
+		}
+		result = m_pFrontBuffer->SetClipper(m_pClipper);
+		if (result != DD_OK) {
+			Error("SetClipper failed", result);
+			return FALSE;
+		}
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009D960
 BOOL MxDirectDraw::DDInit(BOOL fullscreen)
 {
-  HRESULT result;
+	HRESULT result;
 
-  if (fullscreen)
-  {
-    m_bIgnoreWM_SIZE = 1;
-    result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN);
-    m_bIgnoreWM_SIZE = 0;
-  }
-  else
-  {
-    result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_NORMAL);
-  }
+	if (fullscreen) {
+		m_bIgnoreWM_SIZE = 1;
+		result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN);
+		m_bIgnoreWM_SIZE = 0;
+	}
+	else {
+		result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_NORMAL);
+	}
 
-  if (result != DD_OK)
-  {
-    Error("SetCooperativeLevel failed", result);
-    return FALSE;
-  }
+	if (result != DD_OK) {
+		Error("SetCooperativeLevel failed", result);
+		return FALSE;
+	}
 
-  m_bFullScreen = fullscreen;
+	m_bFullScreen = fullscreen;
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009DA80
 BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
 {
-  HRESULT result;
+	HRESULT result;
 
-  if (m_bFullScreen)
-  {
-    LPDIRECTDRAW lpDD;
+	if (m_bFullScreen) {
+		LPDIRECTDRAW lpDD;
 
-    EnableResizing(m_hWndMain, FALSE);
+		EnableResizing(m_hWndMain, FALSE);
 
-	  if (!m_bIsOnPrimaryDevice)
-    {
-      lpDD = NULL;
-      result = DirectDrawCreate(0, &lpDD, 0);
-      if (result == DD_OK)
-      {
-        result = lpDD->SetCooperativeLevel(m_hWndMain, DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT);
-        if (result == DD_OK)
-        {
-          lpDD->SetDisplayMode(width, height, 8);
-        }
-      }
-    }
+		if (!m_bIsOnPrimaryDevice) {
+			lpDD = NULL;
+			result = DirectDrawCreate(0, &lpDD, 0);
+			if (result == DD_OK) {
+				result = lpDD->SetCooperativeLevel(m_hWndMain, DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT);
+				if (result == DD_OK) {
+					lpDD->SetDisplayMode(width, height, 8);
+				}
+			}
+		}
 
-    if (!IsSupportedMode(width, height, bpp))
-    {
-      width = m_pCurrentDeviceModesList->m_mode_ARRAY[0].width;
-      height = m_pCurrentDeviceModesList->m_mode_ARRAY[0].height;
-      bpp = m_pCurrentDeviceModesList->m_mode_ARRAY[0].bitsPerPixel;
-    }
+		if (!IsSupportedMode(width, height, bpp)) {
+			width = m_pCurrentDeviceModesList->m_mode_ARRAY[0].width;
+			height = m_pCurrentDeviceModesList->m_mode_ARRAY[0].height;
+			bpp = m_pCurrentDeviceModesList->m_mode_ARRAY[0].bitsPerPixel;
+		}
 
-    m_bIgnoreWM_SIZE = TRUE;
-    result = m_pDirectDraw->SetDisplayMode(width, height, bpp);
-    m_bIgnoreWM_SIZE = FALSE;
-    if (result != DD_OK)
-    {
-      Error("SetDisplayMode failed", result);
-      return FALSE;
-    }
-  }
-  else
-  {
-    RECT rc;
-    DWORD dwStyle;
+		m_bIgnoreWM_SIZE = TRUE;
+		result = m_pDirectDraw->SetDisplayMode(width, height, bpp);
+		m_bIgnoreWM_SIZE = FALSE;
+		if (result != DD_OK) {
+			Error("SetDisplayMode failed", result);
+			return FALSE;
+		}
+	}
+	else {
+		RECT rc;
+		DWORD dwStyle;
 
-    if (!m_bIsOnPrimaryDevice)
-    {
-      Error("Attempt made enter a windowed mode on a DirectDraw device that is not the primary display", E_FAIL);
-      return FALSE;
-    }
+		if (!m_bIsOnPrimaryDevice) {
+			Error("Attempt made enter a windowed mode on a DirectDraw device that is not the primary display", E_FAIL);
+			return FALSE;
+		}
 
-    m_bIgnoreWM_SIZE = TRUE;
-    dwStyle = GetWindowLong(m_hWndMain, GWL_STYLE);
-    dwStyle &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED);
-    dwStyle |= WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED;
-    SetWindowLong(m_hWndMain, GWL_STYLE, dwStyle);
+		m_bIgnoreWM_SIZE = TRUE;
+		dwStyle = GetWindowLong(m_hWndMain, GWL_STYLE);
+		dwStyle &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED);
+		dwStyle |= WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED;
+		SetWindowLong(m_hWndMain, GWL_STYLE, dwStyle);
 
-    SetRect(&rc, 0, 0, width - 1, height - 1);
-    AdjustWindowRectEx(
-      &rc,
-      GetWindowLong(m_hWndMain, GWL_STYLE),
-      GetMenu(m_hWndMain) != NULL,
-      GetWindowLong(m_hWndMain, GWL_EXSTYLE)
-    );
-    SetWindowPos(m_hWndMain, NULL, 0, 0, rc.right - rc.left + 1, rc.bottom - rc.top + 1, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-    SetWindowPos(m_hWndMain, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
-    m_bIgnoreWM_SIZE = FALSE;
-  }
+		SetRect(&rc, 0, 0, width - 1, height - 1);
+		AdjustWindowRectEx(
+			&rc,
+			GetWindowLong(m_hWndMain, GWL_STYLE),
+			GetMenu(m_hWndMain) != NULL,
+			GetWindowLong(m_hWndMain, GWL_EXSTYLE)
+		);
+		SetWindowPos(
+			m_hWndMain,
+			NULL,
+			0,
+			0,
+			rc.right - rc.left + 1,
+			rc.bottom - rc.top + 1,
+			SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE
+		);
+		SetWindowPos(m_hWndMain, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
+		m_bIgnoreWM_SIZE = FALSE;
+	}
 
-  m_currentMode.width = width;
-  m_currentMode.height = height;
-  m_currentMode.bitsPerPixel = bpp;
+	m_currentMode.width = width;
+	m_currentMode.height = height;
+	m_currentMode.bitsPerPixel = bpp;
 
-  if (!DDCreateSurfaces())
-  {
-    return FALSE;
-  }
+	if (!DDCreateSurfaces()) {
+		return FALSE;
+	}
 
-  DDSURFACEDESC ddsd;
+	DDSURFACEDESC ddsd;
 
-  FUN_1009E020();
+	FUN_1009E020();
 
-  if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer))
-  {
-    return FALSE;
-  }
+	if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
+		return FALSE;
+	}
 
-  if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8)
-  {
-    m_bPrimaryPalettized = TRUE;
-  }
-  else
-  {
-    m_bPrimaryPalettized = FALSE;
-  }
+	if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8) {
+		m_bPrimaryPalettized = TRUE;
+	}
+	else {
+		m_bPrimaryPalettized = FALSE;
+	}
 
-  if (m_bPrimaryPalettized)
-  {
-    result = m_pDirectDraw->CreatePalette(
-      DDPCAPS_8BIT | DDPCAPS_ALLOW256 | DDPCAPS_INITIALIZE, //0x4c
-      m_paletteEntries,
-      &m_pPalette,
-      NULL);
-    if (result != DD_OK)
-    {
-      Error("CreatePalette failed", result);
-      return 0;
-    }
-    result = m_pBackBuffer->SetPalette(m_pPalette); // TODO: add FIX_BUGS define and fix this
-    result = m_pFrontBuffer->SetPalette(m_pPalette);
-    if (result != DD_OK)
-    {
-      Error("SetPalette failed", result);
-      return FALSE;
-    }
-  }
+	if (m_bPrimaryPalettized) {
+		result = m_pDirectDraw->CreatePalette(
+			DDPCAPS_8BIT | DDPCAPS_ALLOW256 | DDPCAPS_INITIALIZE, // 0x4c
+			m_paletteEntries,
+			&m_pPalette,
+			NULL
+		);
+		if (result != DD_OK) {
+			Error("CreatePalette failed", result);
+			return 0;
+		}
+		result = m_pBackBuffer->SetPalette(m_pPalette); // TODO: add FIX_BUGS define and fix this
+		result = m_pFrontBuffer->SetPalette(m_pPalette);
+		if (result != DD_OK) {
+			Error("SetPalette failed", result);
+			return FALSE;
+		}
+	}
 
-  // create debug text only in windowed mode?
-  return m_bFullScreen || CreateTextSurfaces();
+	// create debug text only in windowed mode?
+	return m_bFullScreen || CreateTextSurfaces();
 }
 
 // OFFSET: LEGO1 0x1009E830
 void MxDirectDraw::Error(const char* message, int error)
 {
-  // OFFSET: LEGO1 0x10100C70
-  static BOOL isInsideError = FALSE;
-  if (!isInsideError)
-  {
-    isInsideError = TRUE;
-    Destroy();
-    if (m_pErrorHandler)
-    {
-      m_pErrorHandler(message, error, m_pErrorHandlerArg);
-    }
-    isInsideError = FALSE;
-  }
+	// OFFSET: LEGO1 0x10100C70
+	static BOOL isInsideError = FALSE;
+	if (!isInsideError) {
+		isInsideError = TRUE;
+		Destroy();
+		if (m_pErrorHandler) {
+			m_pErrorHandler(message, error, m_pErrorHandlerArg);
+		}
+		isInsideError = FALSE;
+	}
 }
 
 // OFFSET: LEGO1 0x1009DDA0
 BOOL MxDirectDraw::GetDDSurfaceDesc(LPDDSURFACEDESC lpDDSurfDesc, LPDIRECTDRAWSURFACE lpDDSurf)
 {
-  HRESULT result;
+	HRESULT result;
 
-  memset(lpDDSurfDesc, 0, sizeof(*lpDDSurfDesc));
-  lpDDSurfDesc->dwSize = sizeof(*lpDDSurfDesc);
-  result = lpDDSurf->GetSurfaceDesc(lpDDSurfDesc);
-  if (result != DD_OK)
-  {
-    Error("Error getting a surface description", result);
-  }
+	memset(lpDDSurfDesc, 0, sizeof(*lpDDSurfDesc));
+	lpDDSurfDesc->dwSize = sizeof(*lpDDSurfDesc);
+	result = lpDDSurf->GetSurfaceDesc(lpDDSurfDesc);
+	if (result != DD_OK) {
+		Error("Error getting a surface description", result);
+	}
 
-  return (result == DD_OK);
+	return (result == DD_OK);
 }
 
 // OFFSET: LEGO1 0x1009D9D0
 BOOL MxDirectDraw::IsSupportedMode(int width, int height, int bpp)
 {
-  Mode mode = { width, height, bpp };
+	Mode mode = {width, height, bpp};
 
-  for (int i = 0; i < m_pCurrentDeviceModesList->count; i++)
-  {
-    if (m_pCurrentDeviceModesList->m_mode_ARRAY[i] == mode)
-    {
-      return TRUE;
-    }
-  }
+	for (int i = 0; i < m_pCurrentDeviceModesList->count; i++) {
+		if (m_pCurrentDeviceModesList->m_mode_ARRAY[i] == mode) {
+			return TRUE;
+		}
+	}
 
-  return FALSE;
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x1009D690
 BOOL MxDirectDraw::RecreateDirectDraw(GUID** ppGUID)
 {
-  if (m_pDirectDraw)
-  {
-    m_pDirectDraw->Release();
-    m_pDirectDraw = NULL;
-  }
+	if (m_pDirectDraw) {
+		m_pDirectDraw->Release();
+		m_pDirectDraw = NULL;
+	}
 
-  return (DirectDrawCreate(*ppGUID, &m_pDirectDraw, 0) == DD_OK);
+	return (DirectDrawCreate(*ppGUID, &m_pDirectDraw, 0) == DD_OK);
 }
 
 // OFFSET: LEGO1 0x1009E7A0
 BOOL MxDirectDraw::RestoreOriginalPaletteEntries()
 {
-  HRESULT result;
+	HRESULT result;
 
-  if (m_bPrimaryPalettized)
-  {
-    if (m_pPalette)
-    {
-      result = m_pPalette->SetEntries(0, 0, 256, m_originalPaletteEntries);
-      if (result != DD_OK)
-      {
-        Error("SetEntries failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_bPrimaryPalettized) {
+		if (m_pPalette) {
+			result = m_pPalette->SetEntries(0, 0, 256, m_originalPaletteEntries);
+			if (result != DD_OK) {
+				Error("SetEntries failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009E750
 BOOL MxDirectDraw::RestorePaletteEntries()
 {
-  HRESULT result;
+	HRESULT result;
 
-  if (m_bFullScreen && m_bPrimaryPalettized)
-  {
-    if (m_pPalette)
-    {
-      result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
-      if (result != DD_OK)
-      {
-        Error("SetEntries failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_bFullScreen && m_bPrimaryPalettized) {
+		if (m_pPalette) {
+			result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
+			if (result != DD_OK) {
+				Error("SetEntries failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009e7f0
 int MxDirectDraw::FlipToGDISurface()
 {
-  HRESULT ret;
+	HRESULT ret;
 
-  if (m_pDirectDraw)
-  {
-    ret = m_pDirectDraw->FlipToGDISurface();
-    if (ret != DD_OK)
-    {
-      Error("FlipToGDISurface failed", ret);
-    }
-    return !ret;
-  }
+	if (m_pDirectDraw) {
+		ret = m_pDirectDraw->FlipToGDISurface();
+		if (ret != DD_OK) {
+			Error("FlipToGDISurface failed", ret);
+		}
+		return !ret;
+	}
 
-  return 1;
+	return 1;
 }
 
 // OFFSET: LEGO1 0x1009E4D0
 BOOL MxDirectDraw::RestoreSurfaces()
 {
-  HRESULT result;
+	HRESULT result;
 
-  if (m_pFrontBuffer != NULL)
-  {
-    if (m_pFrontBuffer->IsLost() == DDERR_SURFACELOST)
-    {
-      result = m_pFrontBuffer->Restore();
-      if (result != DD_OK)
-      {
-        Error("Restore of front buffer failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_pFrontBuffer != NULL) {
+		if (m_pFrontBuffer->IsLost() == DDERR_SURFACELOST) {
+			result = m_pFrontBuffer->Restore();
+			if (result != DD_OK) {
+				Error("Restore of front buffer failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  if (m_pBackBuffer != NULL)
-  {
-    if (m_pBackBuffer->IsLost() == DDERR_SURFACELOST)
-    {
-      result = m_pBackBuffer->Restore();
-      if (result != DD_OK)
-      {
-        Error("Restore of back buffer failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_pBackBuffer != NULL) {
+		if (m_pBackBuffer->IsLost() == DDERR_SURFACELOST) {
+			result = m_pBackBuffer->Restore();
+			if (result != DD_OK) {
+				Error("Restore of back buffer failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  if (m_pZBuffer != NULL)
-  {
-    if (m_pZBuffer->IsLost() == DDERR_SURFACELOST)
-    {
-      result = m_pZBuffer->Restore();
-      if (result != DD_OK)
-      {
-        Error("Restore of Z-buffer failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_pZBuffer != NULL) {
+		if (m_pZBuffer->IsLost() == DDERR_SURFACELOST) {
+			result = m_pZBuffer->Restore();
+			if (result != DD_OK) {
+				Error("Restore of Z-buffer failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  if (m_pText1Surface != NULL)
-  {
-    if (m_pText1Surface->IsLost() == DDERR_SURFACELOST)
-    {
-      result = m_pText1Surface->Restore();
-      if (result != DD_OK)
-      {
-        Error("Restore of text surface 1 failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_pText1Surface != NULL) {
+		if (m_pText1Surface->IsLost() == DDERR_SURFACELOST) {
+			result = m_pText1Surface->Restore();
+			if (result != DD_OK) {
+				Error("Restore of text surface 1 failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  if (m_pText2Surface != NULL)
-  {
-    if (m_pText2Surface->IsLost() == DDERR_SURFACELOST)
-    {
-      result = m_pText2Surface->Restore();
-      if (result != DD_OK)
-      {
-        Error("Restore of text surface 2 failed", result);
-        return FALSE;
-      }
-    }
-  }
+	if (m_pText2Surface != NULL) {
+		if (m_pText2Surface->IsLost() == DDERR_SURFACELOST) {
+			result = m_pText2Surface->Restore();
+			if (result != DD_OK) {
+				Error("Restore of text surface 2 failed", result);
+				return FALSE;
+			}
+		}
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009D700
-BOOL MxDirectDraw::SetPaletteEntries(
-  const PALETTEENTRY* pPaletteEntries,
-  int paletteEntryCount,
-  BOOL fullscreen)
+BOOL MxDirectDraw::SetPaletteEntries(const PALETTEENTRY* pPaletteEntries, int paletteEntryCount, BOOL fullscreen)
 {
-  int reservedLowEntryCount = 10;
-  int reservedHighEntryCount = 10;
-  int arraySize = _countof(m_paletteEntries);
-  HDC hdc;
-  int i;
+	int reservedLowEntryCount = 10;
+	int reservedHighEntryCount = 10;
+	int arraySize = _countof(m_paletteEntries);
+	HDC hdc;
+	int i;
 
-  if (g_is_PALETTEINDEXED8)
-  {
-    hdc = GetDC(NULL);
-    GetSystemPaletteEntries(hdc, 0, arraySize, m_paletteEntries);
-    ReleaseDC(NULL, hdc);
-  }
+	if (g_is_PALETTEINDEXED8) {
+		hdc = GetDC(NULL);
+		GetSystemPaletteEntries(hdc, 0, arraySize, m_paletteEntries);
+		ReleaseDC(NULL, hdc);
+	}
 
-  for (i = 0; i < reservedLowEntryCount; i++)
-  {
-    m_paletteEntries[i].peFlags = 0x80;
-  }
+	for (i = 0; i < reservedLowEntryCount; i++) {
+		m_paletteEntries[i].peFlags = 0x80;
+	}
 
-  for (i = reservedLowEntryCount; i < 142; i++)
-  {
-    m_paletteEntries[i].peFlags = 0x44;
-  }
+	for (i = reservedLowEntryCount; i < 142; i++) {
+		m_paletteEntries[i].peFlags = 0x44;
+	}
 
-  for (i = 142; i < arraySize - reservedHighEntryCount; i++)
-  {
-    m_paletteEntries[i].peFlags = 0x84;
-  }
+	for (i = 142; i < arraySize - reservedHighEntryCount; i++) {
+		m_paletteEntries[i].peFlags = 0x84;
+	}
 
-  for (i = arraySize - reservedHighEntryCount; i < arraySize; i++)
-  {
-    m_paletteEntries[i].peFlags = 0x80;
-  }
+	for (i = arraySize - reservedHighEntryCount; i < arraySize; i++) {
+		m_paletteEntries[i].peFlags = 0x80;
+	}
 
-  if (paletteEntryCount != 0)
-  {
-    for (i = reservedLowEntryCount; 
-	(i < paletteEntryCount) && (i < arraySize - reservedHighEntryCount); 
-	i++)
-    {
-      m_paletteEntries[i].peRed   = pPaletteEntries[i].peRed;
-      m_paletteEntries[i].peGreen = pPaletteEntries[i].peGreen;
-      m_paletteEntries[i].peBlue  = pPaletteEntries[i].peBlue;
-    }
-  }
-  
-  if (m_pPalette != NULL)
-  {
-	  HRESULT result;
-    result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
-    if (result != DD_OK)
-    {
-      Error("SetEntries failed", result);
-      return FALSE;
-    }
-  }
+	if (paletteEntryCount != 0) {
+		for (i = reservedLowEntryCount; (i < paletteEntryCount) && (i < arraySize - reservedHighEntryCount); i++) {
+			m_paletteEntries[i].peRed = pPaletteEntries[i].peRed;
+			m_paletteEntries[i].peGreen = pPaletteEntries[i].peGreen;
+			m_paletteEntries[i].peBlue = pPaletteEntries[i].peBlue;
+		}
+	}
 
-  return TRUE;
+	if (m_pPalette != NULL) {
+		HRESULT result;
+		result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
+		if (result != DD_OK) {
+			Error("SetEntries failed", result);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009E110
-BOOL MxDirectDraw::TextToTextSurface(
-  const char* text,
-  IDirectDrawSurface* pSurface,
-  SIZE& textSizeOnSurface)
+BOOL MxDirectDraw::TextToTextSurface(const char* text, IDirectDrawSurface* pSurface, SIZE& textSizeOnSurface)
 {
-  HRESULT result;
-  HDC hdc;
-  RECT rc;
-  size_t  textLength;
+	HRESULT result;
+	HDC hdc;
+	RECT rc;
+	size_t textLength;
 
-  if (pSurface == NULL)
-  {
-    return FALSE;
-  }
+	if (pSurface == NULL) {
+		return FALSE;
+	}
 
-  result = pSurface->GetDC(&hdc);
-  if (result != DD_OK)
-  {
-    Error("GetDC for text surface failed", result);
-    return FALSE;
-  }
+	result = pSurface->GetDC(&hdc);
+	if (result != DD_OK) {
+		Error("GetDC for text surface failed", result);
+		return FALSE;
+	}
 
-  textLength = strlen(text);
-  
-  SelectObject(hdc, m_hFont);
-  SetTextColor(hdc, RGB(255, 255, 0));
-  SetBkColor(hdc, RGB(0, 0, 0));
-  SetBkMode(hdc, OPAQUE);
-  GetTextExtentPoint32(hdc, text, textLength, &textSizeOnSurface);
-  SetRect(&rc, 0, 0, textSizeOnSurface.cx, textSizeOnSurface.cy);
-  ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, text, textLength, NULL);
-  pSurface->ReleaseDC(hdc);
+	textLength = strlen(text);
 
-  return TRUE;
+	SelectObject(hdc, m_hFont);
+	SetTextColor(hdc, RGB(255, 255, 0));
+	SetBkColor(hdc, RGB(0, 0, 0));
+	SetBkMode(hdc, OPAQUE);
+	GetTextExtentPoint32(hdc, text, textLength, &textSizeOnSurface);
+	SetRect(&rc, 0, 0, textSizeOnSurface.cx, textSizeOnSurface.cy);
+	ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, text, textLength, NULL);
+	pSurface->ReleaseDC(hdc);
+
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x1009E210
 BOOL MxDirectDraw::TextToTextSurface1(const char* text)
 {
-  return TextToTextSurface(
-    text,
-    m_pText1Surface,
-    m_text1SizeOnSurface);
+	return TextToTextSurface(text, m_pText1Surface, m_text1SizeOnSurface);
 }
 
 // OFFSET: LEGO1 0x1009E230
 BOOL MxDirectDraw::TextToTextSurface2(const char* text)
 {
-  return TextToTextSurface(
-    text,
-    m_pText2Surface,
-    m_text2SizeOnSurface);
+	return TextToTextSurface(text, m_pText2Surface, m_text2SizeOnSurface);
 }
 
 // OFFSET: LEGO1 0x1009E020
 void MxDirectDraw::FUN_1009E020()
 {
-  HRESULT result;
-  byte* line;
-  DDSURFACEDESC ddsd;
-  int j;
-  int count = m_bFlipSurfaces ? 2 : 1;
+	HRESULT result;
+	byte* line;
+	DDSURFACEDESC ddsd;
+	int j;
+	int count = m_bFlipSurfaces ? 2 : 1;
 
-  for (int i = 0; i < count; i++)
-  {
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
+	for (int i = 0; i < count; i++) {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
 
-    result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
-    if (result == DDERR_SURFACELOST)
-    {
-      m_pBackBuffer->Restore();
-      result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
-    }
+		result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
+		if (result == DDERR_SURFACELOST) {
+			m_pBackBuffer->Restore();
+			result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
+		}
 
-    if (result != DD_OK)
-    {
-      // lock failed
-      return;
-    }
+		if (result != DD_OK) {
+			// lock failed
+			return;
+		}
 
-    // clear backBuffer
-    line = (byte*)ddsd.lpSurface;
-    for (j = ddsd.dwHeight; j-- ;)
-    {
-      memset(line, 0, ddsd.dwWidth);
-      line += ddsd.lPitch;
-    }
+		// clear backBuffer
+		line = (byte*) ddsd.lpSurface;
+		for (j = ddsd.dwHeight; j--;) {
+			memset(line, 0, ddsd.dwWidth);
+			line += ddsd.lPitch;
+		}
 
-    m_pBackBuffer->Unlock(ddsd.lpSurface);
+		m_pBackBuffer->Unlock(ddsd.lpSurface);
 
-    if (m_bFlipSurfaces)
-    {
-      m_pFrontBuffer->Flip(NULL, DDFLIP_WAIT);
-    }
-  }
+		if (m_bFlipSurfaces) {
+			m_pFrontBuffer->Flip(NULL, DDFLIP_WAIT);
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x1009D920
 void MxDirectDraw::FUN_1009D920()
 {
-  RestoreOriginalPaletteEntries();
-  if (m_pDirectDraw != NULL)
-  {
-    m_bIgnoreWM_SIZE = TRUE;
-    m_pDirectDraw->RestoreDisplayMode();
-    m_pDirectDraw->SetCooperativeLevel(NULL, DDSCL_NORMAL);
-    m_bIgnoreWM_SIZE = FALSE;
-  }
+	RestoreOriginalPaletteEntries();
+	if (m_pDirectDraw != NULL) {
+		m_bIgnoreWM_SIZE = TRUE;
+		m_pDirectDraw->RestoreDisplayMode();
+		m_pDirectDraw->SetCooperativeLevel(NULL, DDSCL_NORMAL);
+		m_bIgnoreWM_SIZE = FALSE;
+	}
 }
-

--- a/LEGO1/mxdirectdraw.h
+++ b/LEGO1/mxdirectdraw.h
@@ -8,124 +8,110 @@ extern BOOL g_is_PALETTEINDEXED8;
 
 // VTABLE 0x100db818
 // SIZE 0x880
-class MxDirectDraw
-{
+class MxDirectDraw {
 public:
-  typedef void (*ErrorHandler)(const char*, HRESULT, void*);
+	typedef void (*ErrorHandler)(const char*, HRESULT, void*);
 
-  //size 0x0c
-  struct Mode
-  {
-    int width;
-    int height;
-    int bitsPerPixel;
+	// size 0x0c
+	struct Mode {
+		int width;
+		int height;
+		int bitsPerPixel;
 
-    int operator==(const Mode& rMode) const
-    {
-      return ((width == rMode.width) &&
-        (height == rMode.height) &&
-        (bitsPerPixel == rMode.bitsPerPixel));
-    }
-  };
+		int operator==(const Mode& rMode) const
+		{
+			return ((width == rMode.width) && (height == rMode.height) && (bitsPerPixel == rMode.bitsPerPixel));
+		}
+	};
 
-  //size 0x17c
-  struct DeviceModesInfo
-  {
-    GUID* p_guid;
-    Mode* m_mode_ARRAY;
-    int count;
-    DDCAPS m_ddcaps;
-    void* a_178;
+	// size 0x17c
+	struct DeviceModesInfo {
+		GUID* p_guid;
+		Mode* m_mode_ARRAY;
+		int count;
+		DDCAPS m_ddcaps;
+		void* a_178;
 
-    DeviceModesInfo();
-    ~DeviceModesInfo();
-  };
-
+		DeviceModesInfo();
+		~DeviceModesInfo();
+	};
 
 protected:
-  BOOL m_bOnlySoftRender;
-  BOOL m_bFlipSurfaces;
-  IDirectDraw* m_pDirectDraw;
-  IDirectDrawSurface* m_pFrontBuffer;
-  IDirectDrawSurface* m_pBackBuffer;
-  IDirectDrawSurface* m_pZBuffer;
-  IDirectDrawSurface* m_pText1Surface;
-  IDirectDrawSurface* m_pText2Surface;
-  IDirectDrawClipper* m_pClipper;
-  IDirectDrawPalette* m_pPalette;
-  PALETTEENTRY m_paletteEntries[256];
-  PALETTEENTRY m_originalPaletteEntries[256];
-  SIZE m_text1SizeOnSurface;
-  SIZE m_text2SizeOnSurface;
-  HWND m_hWndMain;
-  HFONT m_hFont;
-  BOOL m_bIgnoreWM_SIZE;
-  BOOL m_bPrimaryPalettized;
-  BOOL m_bFullScreen;
-  void* a_850;
-  BOOL m_bOnlySystemMemory;
-  BOOL m_bIsOnPrimaryDevice;
-  ErrorHandler m_pErrorHandler;
-  ErrorHandler m_pFatalErrorHandler;
-  void* m_pErrorHandlerArg;
-  void* m_pFatalErrorHandlerArg;
-  int m_pauseCount;
-  DeviceModesInfo* m_pCurrentDeviceModesList;
-  Mode m_currentMode;
+	BOOL m_bOnlySoftRender;
+	BOOL m_bFlipSurfaces;
+	IDirectDraw* m_pDirectDraw;
+	IDirectDrawSurface* m_pFrontBuffer;
+	IDirectDrawSurface* m_pBackBuffer;
+	IDirectDrawSurface* m_pZBuffer;
+	IDirectDrawSurface* m_pText1Surface;
+	IDirectDrawSurface* m_pText2Surface;
+	IDirectDrawClipper* m_pClipper;
+	IDirectDrawPalette* m_pPalette;
+	PALETTEENTRY m_paletteEntries[256];
+	PALETTEENTRY m_originalPaletteEntries[256];
+	SIZE m_text1SizeOnSurface;
+	SIZE m_text2SizeOnSurface;
+	HWND m_hWndMain;
+	HFONT m_hFont;
+	BOOL m_bIgnoreWM_SIZE;
+	BOOL m_bPrimaryPalettized;
+	BOOL m_bFullScreen;
+	void* a_850;
+	BOOL m_bOnlySystemMemory;
+	BOOL m_bIsOnPrimaryDevice;
+	ErrorHandler m_pErrorHandler;
+	ErrorHandler m_pFatalErrorHandler;
+	void* m_pErrorHandlerArg;
+	void* m_pFatalErrorHandlerArg;
+	int m_pauseCount;
+	DeviceModesInfo* m_pCurrentDeviceModesList;
+	Mode m_currentMode;
 
 public:
-  __declspec(dllexport) int FlipToGDISurface();
-  __declspec(dllexport) static int GetPrimaryBitDepth();
-  __declspec(dllexport) int Pause(int);
+	__declspec(dllexport) int FlipToGDISurface();
+	__declspec(dllexport) static int GetPrimaryBitDepth();
+	__declspec(dllexport) int Pause(int);
 
-  MxDirectDraw();
+	MxDirectDraw();
 
-  virtual ~MxDirectDraw();
-  virtual BOOL Create(
-    HWND hWnd,
-    BOOL fullscreen_1,
-    BOOL surface_fullscreen,
-    BOOL onlySystemMemory,
-    int width,
-    int height,
-    int bpp,
-    const PALETTEENTRY* pPaletteEntries,
-    int paletteEntryCount);
-  virtual void Destroy();
-  virtual void DestroyButNotDirectDraw();
-  virtual const char* ErrorToString(HRESULT error);
+	virtual ~MxDirectDraw();
+	virtual BOOL Create(
+		HWND hWnd,
+		BOOL fullscreen_1,
+		BOOL surface_fullscreen,
+		BOOL onlySystemMemory,
+		int width,
+		int height,
+		int bpp,
+		const PALETTEENTRY* pPaletteEntries,
+		int paletteEntryCount
+	);
+	virtual void Destroy();
+	virtual void DestroyButNotDirectDraw();
+	virtual const char* ErrorToString(HRESULT error);
 
 protected:
-  BOOL CacheOriginalPaletteEntries();
-  HRESULT CreateDDSurface(
-    LPDDSURFACEDESC a2,
-    LPDIRECTDRAWSURFACE* a3,
-    IUnknown* a4);
-  BOOL CreateTextSurfaces();
-  BOOL CreateZBuffer(DWORD memorytype, DWORD depth);
-  BOOL DDCreateSurfaces();
-  BOOL DDInit(BOOL fullscreen);
-  BOOL DDSetMode(int width, int height, int bpp);
-  void Error(const char* message, int error);
+	BOOL CacheOriginalPaletteEntries();
+	HRESULT CreateDDSurface(LPDDSURFACEDESC a2, LPDIRECTDRAWSURFACE* a3, IUnknown* a4);
+	BOOL CreateTextSurfaces();
+	BOOL CreateZBuffer(DWORD memorytype, DWORD depth);
+	BOOL DDCreateSurfaces();
+	BOOL DDInit(BOOL fullscreen);
+	BOOL DDSetMode(int width, int height, int bpp);
+	void Error(const char* message, int error);
 
-  BOOL GetDDSurfaceDesc(LPDDSURFACEDESC lpDDSurfDesc, LPDIRECTDRAWSURFACE lpDDSurf);
-  BOOL IsSupportedMode(int width, int height, int bpp);
-  BOOL RecreateDirectDraw(GUID** a2);
-  BOOL RestoreOriginalPaletteEntries();
-  BOOL RestorePaletteEntries();
-  BOOL RestoreSurfaces();
-  BOOL SetPaletteEntries(
-    const PALETTEENTRY* pPaletteEntries,
-    int paletteEntryCount,
-    BOOL fullscreen);
-  BOOL TextToTextSurface(
-    const char* text,
-    IDirectDrawSurface* pSurface,
-    SIZE& textSizeOnSurface);
-  BOOL TextToTextSurface1(const char* text);
-  BOOL TextToTextSurface2(const char* lpString);
-  void FUN_1009E020();
-  void FUN_1009D920();
+	BOOL GetDDSurfaceDesc(LPDDSURFACEDESC lpDDSurfDesc, LPDIRECTDRAWSURFACE lpDDSurf);
+	BOOL IsSupportedMode(int width, int height, int bpp);
+	BOOL RecreateDirectDraw(GUID** a2);
+	BOOL RestoreOriginalPaletteEntries();
+	BOOL RestorePaletteEntries();
+	BOOL RestoreSurfaces();
+	BOOL SetPaletteEntries(const PALETTEENTRY* pPaletteEntries, int paletteEntryCount, BOOL fullscreen);
+	BOOL TextToTextSurface(const char* text, IDirectDrawSurface* pSurface, SIZE& textSizeOnSurface);
+	BOOL TextToTextSurface1(const char* text);
+	BOOL TextToTextSurface2(const char* lpString);
+	void FUN_1009E020();
+	void FUN_1009D920();
 };
 
 #endif // MXDIRECTDRAW_H

--- a/LEGO1/mxdiskstreamcontroller.cpp
+++ b/LEGO1/mxdiskstreamcontroller.cpp
@@ -3,65 +3,65 @@
 // OFFSET: LEGO1 0x100c7120 STUB
 MxDiskStreamController::MxDiskStreamController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c7530 STUB
 MxDiskStreamController::~MxDiskStreamController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c8640 STUB
 MxResult MxDiskStreamController::Tickle()
 {
-  // TODO
-  return SUCCESS;
+	// TODO
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100c7790 STUB
-MxResult MxDiskStreamController::Open(const char *p_filename)
+MxResult MxDiskStreamController::Open(const char* p_filename)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c7880
 MxResult MxDiskStreamController::vtable0x18(undefined4 p_unknown, undefined4 p_unknown2)
 {
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100c7ff0 STUB
 MxResult MxDiskStreamController::vtable0x20(MxDSAction* p_action)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c8160 STUB
 MxResult MxDiskStreamController::vtable0x24(undefined4 p_unknown)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c7ac0 STUB
 MxResult MxDiskStreamController::vtable0x28()
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c7c00 STUB
 MxResult MxDiskStreamController::vtable0x30(undefined4 p_unknown)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c7960
 MxResult MxDiskStreamController::vtable0x34(undefined4 p_unknown)
 {
-  return FAILURE;
+	return FAILURE;
 }

--- a/LEGO1/mxdiskstreamcontroller.h
+++ b/LEGO1/mxdiskstreamcontroller.h
@@ -1,41 +1,39 @@
 #ifndef MXDISKSTREAMCONTROLLER_H
 #define MXDISKSTREAMCONTROLLER_H
 
-#include <string.h>
-
 #include "mxstreamcontroller.h"
 #include "mxtypes.h"
 
+#include <string.h>
+
 // VTABLE 0x100dccb8
 // SIZE 0xc8
-class MxDiskStreamController : public MxStreamController
-{
+class MxDiskStreamController : public MxStreamController {
 public:
-  MxDiskStreamController();
-  virtual ~MxDiskStreamController() override;
+	MxDiskStreamController();
+	virtual ~MxDiskStreamController() override;
 
-  virtual MxResult Tickle() override; // vtable+0x8
-  virtual MxResult Open(const char *p_filename) override; // vtable+0x14
-  virtual MxResult vtable0x18(undefined4 p_unknown, undefined4 p_unknown2) override; //vtable+0x18
-  virtual MxResult vtable0x20(MxDSAction* p_action) override; //vtable+0x20
-  virtual MxResult vtable0x24(undefined4 p_unknown) override; //vtable+0x24
-  virtual MxResult vtable0x28() override; //vtable+0x28
-  virtual MxResult vtable0x30(undefined4 p_unknown) override; //vtable+0x30
-  virtual MxResult vtable0x34(undefined4 p_unknown); //vtable+0x34
+	virtual MxResult Tickle() override;                                                // vtable+0x8
+	virtual MxResult Open(const char* p_filename) override;                            // vtable+0x14
+	virtual MxResult vtable0x18(undefined4 p_unknown, undefined4 p_unknown2) override; // vtable+0x18
+	virtual MxResult vtable0x20(MxDSAction* p_action) override;                        // vtable+0x20
+	virtual MxResult vtable0x24(undefined4 p_unknown) override;                        // vtable+0x24
+	virtual MxResult vtable0x28() override;                                            // vtable+0x28
+	virtual MxResult vtable0x30(undefined4 p_unknown) override;                        // vtable+0x30
+	virtual MxResult vtable0x34(undefined4 p_unknown);                                 // vtable+0x34
 
-  // OFFSET: LEGO1 0x100c7360
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10102144
-    return "MxDiskStreamController";
-  }
+	// OFFSET: LEGO1 0x100c7360
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10102144
+		return "MxDiskStreamController";
+	}
 
-  // OFFSET: LEGO1 0x100c7370
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDiskStreamController::ClassName()) || MxStreamController::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x100c7370
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDiskStreamController::ClassName()) || MxStreamController::IsA(name);
+	}
 };
 
 #endif // MXDISKSTREAMCONTROLLER_H

--- a/LEGO1/mxdiskstreamprovider.cpp
+++ b/LEGO1/mxdiskstreamprovider.cpp
@@ -7,79 +7,78 @@ DECOMP_SIZE_ASSERT(MxDiskStreamProvider, 0x60);
 // OFFSET: LEGO1 0x100d0f30
 MxResult MxDiskStreamProviderThread::Run()
 {
-  if (m_target != NULL)
-    m_target->WaitForWorkToComplete();
-  MxThread::Run();
-  // They should probably have writen "return MxThread::Run()" but they didn't.
-  return SUCCESS;
+	if (m_target != NULL)
+		m_target->WaitForWorkToComplete();
+	MxThread::Run();
+	// They should probably have writen "return MxThread::Run()" but they didn't.
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100d0f70
 MxDiskStreamProvider::MxDiskStreamProvider()
 {
-  this->m_pFile = NULL;
-  this->m_remainingWork = 0;
-  this->m_unk35 = 0;
+	this->m_pFile = NULL;
+	this->m_remainingWork = 0;
+	this->m_unk35 = 0;
 }
 
 // OFFSET: LEGO1 0x100d1240
 MxDiskStreamProvider::~MxDiskStreamProvider()
 {
-  // TODO
+	// TODO
 }
 
 // Matching but with esi / edi swapped
 // OFFSET: LEGO1 0x100d1750
 MxResult MxDiskStreamProvider::WaitForWorkToComplete()
 {
-  while (m_remainingWork != 0)
-  {
-    m_busySemaphore.Wait(INFINITE);
-    if (m_unk35 != 0)
-      PerformWork();
-  }
-  return SUCCESS;
+	while (m_remainingWork != 0) {
+		m_busySemaphore.Wait(INFINITE);
+		if (m_unk35 != 0)
+			PerformWork();
+	}
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100d1760 STUB
 void MxDiskStreamProvider::PerformWork()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100d13d0 STUB
 MxResult MxDiskStreamProvider::SetResourceToGet(void* p_resource)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100d1e90
 MxU32 MxDiskStreamProvider::GetFileSize()
 {
-  return m_pFile->GetBufferSize();
+	return m_pFile->GetBufferSize();
 }
 
 // OFFSET: LEGO1 0x100d1ea0
 MxU32 MxDiskStreamProvider::GetStreamBuffersNum()
 {
-  return m_pFile->GetStreamBuffersNum();
+	return m_pFile->GetStreamBuffersNum();
 }
 
 // OFFSET: LEGO1 0x100d15e0 STUB
 void MxDiskStreamProvider::vtable0x20(undefined4 p_unknown1)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100d1eb0
 MxU32 MxDiskStreamProvider::GetLengthInDWords()
 {
-  return m_pFile->GetLengthInDWords();
+	return m_pFile->GetLengthInDWords();
 }
 
 // OFFSET: LEGO1 0x100d1ec0
 MxU32* MxDiskStreamProvider::GetBufferForDWords()
 {
-  return m_pFile->GetBuffer();
+	return m_pFile->GetBuffer();
 }

--- a/LEGO1/mxdiskstreamprovider.h
+++ b/LEGO1/mxdiskstreamprovider.h
@@ -2,67 +2,63 @@
 #define MXDISKSTREAMPROVIDER_H
 
 #include "decomp.h"
+#include "mxcriticalsection.h"
 #include "mxstreamprovider.h"
 #include "mxthread.h"
-#include "mxcriticalsection.h"
 #include "mxunklist.h"
 
 class MxDiskStreamProvider;
 
 // VTABLE 0x100dd130
-class MxDiskStreamProviderThread : public MxThread
-{
+class MxDiskStreamProviderThread : public MxThread {
 public:
-  // Only inlined, no offset
-  inline MxDiskStreamProviderThread()
-    : MxThread()
-    , m_target(NULL) {}
+	// Only inlined, no offset
+	inline MxDiskStreamProviderThread() : MxThread(), m_target(NULL) {}
 
-  MxResult Run() override;
+	MxResult Run() override;
 
 private:
-  MxDiskStreamProvider *m_target;
+	MxDiskStreamProvider* m_target;
 };
 
 // VTABLE 0x100dd138
-class MxDiskStreamProvider : public MxStreamProvider
-{
+class MxDiskStreamProvider : public MxStreamProvider {
 public:
-  MxDiskStreamProvider();
+	MxDiskStreamProvider();
 
-  virtual ~MxDiskStreamProvider() override;
+	virtual ~MxDiskStreamProvider() override;
 
-  // OFFSET: LEGO1 0x100d1160
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x1010287c
-    return "MxDiskStreamProvider";
-  }
+	// OFFSET: LEGO1 0x100d1160
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x1010287c
+		return "MxDiskStreamProvider";
+	}
 
-  // OFFSET: LEGO1 0x100d1170
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDiskStreamProvider::ClassName()) || MxStreamProvider::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100d1170
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDiskStreamProvider::ClassName()) || MxStreamProvider::IsA(name);
+	}
 
-  MxResult WaitForWorkToComplete();
+	MxResult WaitForWorkToComplete();
 
-  void PerformWork();
+	void PerformWork();
 
-  virtual MxResult SetResourceToGet(void* p_resource) override; //vtable+0x14
-  virtual MxU32 GetFileSize() override; //vtable+0x18
-  virtual MxU32 GetStreamBuffersNum() override; //vtable+0x1c
-  virtual void vtable0x20(undefined4 p_unknown1) override; //vtable+0x20
-  virtual MxU32 GetLengthInDWords() override; //vtable+0x24
-  virtual MxU32* GetBufferForDWords() override; //vtable+0x28
+	virtual MxResult SetResourceToGet(void* p_resource) override; // vtable+0x14
+	virtual MxU32 GetFileSize() override;                         // vtable+0x18
+	virtual MxU32 GetStreamBuffersNum() override;                 // vtable+0x1c
+	virtual void vtable0x20(undefined4 p_unknown1) override;      // vtable+0x20
+	virtual MxU32 GetLengthInDWords() override;                   // vtable+0x24
+	virtual MxU32* GetBufferForDWords() override;                 // vtable+0x28
 
 private:
-  MxDiskStreamProviderThread m_thread; // 0x10
-  MxSemaphore m_busySemaphore; // 0x2c
-  undefined m_remainingWork; // 0x34
-  undefined m_unk35; // 0x35
-  MxCriticalSection m_criticalSection; // 0x38
-  MxUnkList m_list;
+	MxDiskStreamProviderThread m_thread; // 0x10
+	MxSemaphore m_busySemaphore;         // 0x2c
+	undefined m_remainingWork;           // 0x34
+	undefined m_unk35;                   // 0x35
+	MxCriticalSection m_criticalSection; // 0x38
+	MxUnkList m_list;
 };
 
 #endif // MXDISKSTREAMPROVIDER_H

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -8,233 +8,253 @@ DECOMP_SIZE_ASSERT(MxDisplaySurface, 0xac);
 // OFFSET: LEGO1 0x100ba500
 MxDisplaySurface::MxDisplaySurface()
 {
-  this->Reset();
+	this->Reset();
 }
 
 // OFFSET: LEGO1 0x100ba5a0
 MxDisplaySurface::~MxDisplaySurface()
 {
-  this->Clear();
+	this->Clear();
 }
 
 // OFFSET: LEGO1 0x100ba610
 void MxDisplaySurface::Reset()
 {
-  this->m_ddSurface1 = NULL;
-  this->m_ddSurface2 = NULL;
-  this->m_ddClipper = NULL;
-  this->m_16bitPal = NULL;
-  this->m_initialized = FALSE;
-  memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
+	this->m_ddSurface1 = NULL;
+	this->m_ddSurface2 = NULL;
+	this->m_ddClipper = NULL;
+	this->m_16bitPal = NULL;
+	this->m_initialized = FALSE;
+	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
 }
 
 // OFFSET: LEGO1 0x100ba790
-MxResult MxDisplaySurface::Init(MxVideoParam &p_videoParam, LPDIRECTDRAWSURFACE p_ddSurface1, LPDIRECTDRAWSURFACE p_ddSurface2, LPDIRECTDRAWCLIPPER p_ddClipper)
+MxResult MxDisplaySurface::Init(
+	MxVideoParam& p_videoParam,
+	LPDIRECTDRAWSURFACE p_ddSurface1,
+	LPDIRECTDRAWSURFACE p_ddSurface2,
+	LPDIRECTDRAWCLIPPER p_ddClipper
+)
 {
-  MxResult result = SUCCESS;
+	MxResult result = SUCCESS;
 
-  this->m_videoParam = p_videoParam;
-  this->m_ddSurface1 = p_ddSurface1;
-  this->m_ddSurface2 = p_ddSurface2;
-  this->m_ddClipper = p_ddClipper;
-  this->m_initialized = FALSE;
+	this->m_videoParam = p_videoParam;
+	this->m_ddSurface1 = p_ddSurface1;
+	this->m_ddSurface2 = p_ddSurface2;
+	this->m_ddClipper = p_ddClipper;
+	this->m_initialized = FALSE;
 
-  memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
-  this->m_surfaceDesc.dwSize = sizeof(this->m_surfaceDesc);
+	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
+	this->m_surfaceDesc.dwSize = sizeof(this->m_surfaceDesc);
 
-  if (this->m_ddSurface2->GetSurfaceDesc(&this->m_surfaceDesc))
-    result = FAILURE;
+	if (this->m_ddSurface2->GetSurfaceDesc(&this->m_surfaceDesc))
+		result = FAILURE;
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100ba7f0
-MxResult MxDisplaySurface::Create(MxVideoParam &p_videoParam)
+MxResult MxDisplaySurface::Create(MxVideoParam& p_videoParam)
 {
-  DDSURFACEDESC ddsd;
-  MxResult result = FAILURE;
-  LPDIRECTDRAW lpDirectDraw = MVideoManager()->GetDirectDraw();
-  HWND hWnd = MxOmni::GetInstance()->GetWindowHandle();
+	DDSURFACEDESC ddsd;
+	MxResult result = FAILURE;
+	LPDIRECTDRAW lpDirectDraw = MVideoManager()->GetDirectDraw();
+	HWND hWnd = MxOmni::GetInstance()->GetWindowHandle();
 
-  this->m_initialized = TRUE;
-  this->m_videoParam = p_videoParam;
+	this->m_initialized = TRUE;
+	this->m_videoParam = p_videoParam;
 
-  if (!this->m_videoParam.flags().GetFullScreen())
-    this->m_videoParam.flags().SetFlipSurfaces(FALSE);
+	if (!this->m_videoParam.flags().GetFullScreen())
+		this->m_videoParam.flags().SetFlipSurfaces(FALSE);
 
-  if (!this->m_videoParam.flags().GetFlipSurfaces()) {
-    this->m_videoParam.SetBackBuffers(1);
-  }
-  else {
-    MxU32 backBuffers = this->m_videoParam.GetBackBuffers();
+	if (!this->m_videoParam.flags().GetFlipSurfaces()) {
+		this->m_videoParam.SetBackBuffers(1);
+	}
+	else {
+		MxU32 backBuffers = this->m_videoParam.GetBackBuffers();
 
-    if (backBuffers < 1)
-      this->m_videoParam.SetBackBuffers(1);
-    else if (backBuffers > 2)
-      this->m_videoParam.SetBackBuffers(2);
+		if (backBuffers < 1)
+			this->m_videoParam.SetBackBuffers(1);
+		else if (backBuffers > 2)
+			this->m_videoParam.SetBackBuffers(2);
 
-    this->m_videoParam.flags().SetBackBuffers(TRUE);
-  }
+		this->m_videoParam.flags().SetBackBuffers(TRUE);
+	}
 
-  if (this->m_videoParam.flags().GetFullScreen()) {
-    MxS32 width = this->m_videoParam.GetRect().m_right - this->m_videoParam.GetRect().m_left + 1;
-    MxS32 height = this->m_videoParam.GetRect().m_bottom - this->m_videoParam.GetRect().m_top + 1;
+	if (this->m_videoParam.flags().GetFullScreen()) {
+		MxS32 width = this->m_videoParam.GetRect().m_right - this->m_videoParam.GetRect().m_left + 1;
+		MxS32 height = this->m_videoParam.GetRect().m_bottom - this->m_videoParam.GetRect().m_top + 1;
 
-    if (lpDirectDraw->SetCooperativeLevel(hWnd, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN))
-      goto done;
+		if (lpDirectDraw->SetCooperativeLevel(hWnd, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN))
+			goto done;
 
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
 
-    if (lpDirectDraw->GetDisplayMode(&ddsd))
-      goto done;
+		if (lpDirectDraw->GetDisplayMode(&ddsd))
+			goto done;
 
-    MxS32 bitdepth = !this->m_videoParam.flags().Get16Bit() ? 8 : 16;
+		MxS32 bitdepth = !this->m_videoParam.flags().Get16Bit() ? 8 : 16;
 
-    if (ddsd.dwWidth != width || ddsd.dwHeight != height || ddsd.ddpfPixelFormat.dwRGBBitCount != bitdepth) {
-      if (lpDirectDraw->SetDisplayMode(width, height, bitdepth))
-        goto done;
-    }
-  }
+		if (ddsd.dwWidth != width || ddsd.dwHeight != height || ddsd.ddpfPixelFormat.dwRGBBitCount != bitdepth) {
+			if (lpDirectDraw->SetDisplayMode(width, height, bitdepth))
+				goto done;
+		}
+	}
 
-  if (this->m_videoParam.flags().GetFlipSurfaces()) {
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
-    ddsd.dwBackBufferCount = this->m_videoParam.GetBackBuffers();
-    ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
-    ddsd.ddsCaps.dwCaps = DDSCAPS_3DDEVICE | DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_COMPLEX;
+	if (this->m_videoParam.flags().GetFlipSurfaces()) {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwBackBufferCount = this->m_videoParam.GetBackBuffers();
+		ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_3DDEVICE | DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_COMPLEX;
 
-    if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface1, NULL))
-      goto done;
+		if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface1, NULL))
+			goto done;
 
-    ddsd.ddsCaps.dwCaps = DDSCAPS_BACKBUFFER;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_BACKBUFFER;
 
-    if (this->m_ddSurface1->GetAttachedSurface(&ddsd.ddsCaps, &this->m_ddSurface2))
-      goto done;
-  }
-  else {
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
-    ddsd.dwFlags = DDSD_CAPS;
-    ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
+		if (this->m_ddSurface1->GetAttachedSurface(&ddsd.ddsCaps, &this->m_ddSurface2))
+			goto done;
+	}
+	else {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwFlags = DDSD_CAPS;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
 
-    if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface1, NULL))
-      goto done;
+		if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface1, NULL))
+			goto done;
 
-    memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = sizeof(ddsd);
-    ddsd.dwFlags = DDSD_HEIGHT | DDSD_WIDTH | DDSD_CAPS;
-    ddsd.dwWidth = this->m_videoParam.GetRect().m_right - this->m_videoParam.GetRect().m_left + 1;
-    ddsd.dwHeight = this->m_videoParam.GetRect().m_bottom - this->m_videoParam.GetRect().m_top + 1;
-    ddsd.ddsCaps.dwCaps = DDSCAPS_VIDEOMEMORY | DDSCAPS_3DDEVICE | DDSCAPS_OFFSCREENPLAIN;
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwFlags = DDSD_HEIGHT | DDSD_WIDTH | DDSD_CAPS;
+		ddsd.dwWidth = this->m_videoParam.GetRect().m_right - this->m_videoParam.GetRect().m_left + 1;
+		ddsd.dwHeight = this->m_videoParam.GetRect().m_bottom - this->m_videoParam.GetRect().m_top + 1;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_VIDEOMEMORY | DDSCAPS_3DDEVICE | DDSCAPS_OFFSCREENPLAIN;
 
-    if (!this->m_videoParam.flags().GetBackBuffers())
-      ddsd.ddsCaps.dwCaps = DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
+		if (!this->m_videoParam.flags().GetBackBuffers())
+			ddsd.ddsCaps.dwCaps = DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
 
-    if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface2, NULL))
-      goto done;
-  }
+		if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface2, NULL))
+			goto done;
+	}
 
-  memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
-  this->m_surfaceDesc.dwSize = sizeof(this->m_surfaceDesc);
+	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
+	this->m_surfaceDesc.dwSize = sizeof(this->m_surfaceDesc);
 
-  if (!this->m_ddSurface2->GetSurfaceDesc(&this->m_surfaceDesc)) {
-    if (!lpDirectDraw->CreateClipper(0, &this->m_ddClipper, NULL) &&
-        !this->m_ddClipper->SetHWnd(0, hWnd) &&
-        !this->m_ddSurface1->SetClipper(this->m_ddClipper))
-      result = SUCCESS;
-  }
+	if (!this->m_ddSurface2->GetSurfaceDesc(&this->m_surfaceDesc)) {
+		if (!lpDirectDraw->CreateClipper(0, &this->m_ddClipper, NULL) && !this->m_ddClipper->SetHWnd(0, hWnd) &&
+			!this->m_ddSurface1->SetClipper(this->m_ddClipper))
+			result = SUCCESS;
+	}
 
 done:
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100baa90
 void MxDisplaySurface::Clear()
 {
-  if (this->m_initialized) {
-    if (this->m_ddSurface2)
-      this->m_ddSurface2->Release();
+	if (this->m_initialized) {
+		if (this->m_ddSurface2)
+			this->m_ddSurface2->Release();
 
-    if (this->m_ddSurface1)
-      this->m_ddSurface1->Release();
+		if (this->m_ddSurface1)
+			this->m_ddSurface1->Release();
 
-    if (this->m_ddClipper)
-      this->m_ddClipper->Release();
-  }
+		if (this->m_ddClipper)
+			this->m_ddClipper->Release();
+	}
 
-  if (this->m_16bitPal)
-    delete this->m_16bitPal;
+	if (this->m_16bitPal)
+		delete this->m_16bitPal;
 
-  this->Reset();
+	this->Reset();
 }
 
 // OFFSET: LEGO1 0x100baae0 STUB
-void MxDisplaySurface::SetPalette(MxPalette *p_palette)
+void MxDisplaySurface::SetPalette(MxPalette* p_palette)
 {
-
 }
 
 // OFFSET: LEGO1 0x100bc200 STUB
-void MxDisplaySurface::vtable24(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
+void MxDisplaySurface::vtable24(
+	LPDDSURFACEDESC,
+	MxBitmap*,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4
+)
 {
-
 }
 
 // OFFSET: LEGO1 0x100bacc0 STUB
 MxBool MxDisplaySurface::vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100bc630 STUB
-MxBool MxDisplaySurface::vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
+MxBool MxDisplaySurface::
+	vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100bb1d0 STUB
-MxBool MxDisplaySurface::vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
+MxBool MxDisplaySurface::vtable30(
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	MxBool
+)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100bb850 STUB
 undefined4 MxDisplaySurface::vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100bba50 STUB
 void MxDisplaySurface::Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
 {
-
 }
 
 // OFFSET: LEGO1 0x100bbc10
-void MxDisplaySurface::GetDC(HDC *p_hdc)
+void MxDisplaySurface::GetDC(HDC* p_hdc)
 {
-  if (this->m_ddSurface2 && !this->m_ddSurface2->GetDC(p_hdc))
-    return;
- 
-  *p_hdc = NULL;
+	if (this->m_ddSurface2 && !this->m_ddSurface2->GetDC(p_hdc))
+		return;
+
+	*p_hdc = NULL;
 }
 
 // OFFSET: LEGO1 0x100bbc40
 void MxDisplaySurface::ReleaseDC(HDC p_hdc)
 {
-  if (this->m_ddSurface2 && p_hdc)
-    this->m_ddSurface2->ReleaseDC(p_hdc);
+	if (this->m_ddSurface2 && p_hdc)
+		this->m_ddSurface2->ReleaseDC(p_hdc);
 }
 
 // OFFSET: LEGO1 0x100bbc60 STUB
 undefined4 MxDisplaySurface::vtable44(undefined4, undefined4*, undefined4, undefined4)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100ba640 STUB
 void MxDisplaySurface::FUN_100ba640()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -1,52 +1,74 @@
 #ifndef MXDISPLAYSURFACE_H
 #define MXDISPLAYSURFACE_H
 
-#include <ddraw.h>
-
+#include "decomp.h"
 #include "mxbitmap.h"
 #include "mxcore.h"
 #include "mxpalette.h"
 #include "mxvideoparam.h"
 
-#include "decomp.h"
+#include <ddraw.h>
 
 // VTABLE 0x100dc768
 // SIZE 0xac
-class MxDisplaySurface : public MxCore
-{
+class MxDisplaySurface : public MxCore {
 public:
-  MxDisplaySurface();
-  virtual ~MxDisplaySurface() override;
+	MxDisplaySurface();
+	virtual ~MxDisplaySurface() override;
 
-  void Reset();
+	void Reset();
 
-  void FUN_100ba640();
+	void FUN_100ba640();
 
-  virtual MxResult Init(MxVideoParam &p_videoParam, LPDIRECTDRAWSURFACE p_ddSurface1, LPDIRECTDRAWSURFACE p_ddSurface2, LPDIRECTDRAWCLIPPER p_ddClipper);
-  virtual MxResult Create(MxVideoParam &p_videoParam);
-  virtual void Clear();
-  virtual void SetPalette(MxPalette *p_palette);
-  virtual void vtable24(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual MxBool vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
-  virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
-  virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
-  virtual void GetDC(HDC *p_hdc);
-  virtual void ReleaseDC(HDC p_hdc);
-  virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);
+	virtual MxResult Init(
+		MxVideoParam& p_videoParam,
+		LPDIRECTDRAWSURFACE p_ddSurface1,
+		LPDIRECTDRAWSURFACE p_ddSurface2,
+		LPDIRECTDRAWCLIPPER p_ddClipper
+	);
+	virtual MxResult Create(MxVideoParam& p_videoParam);
+	virtual void Clear();
+	virtual void SetPalette(MxPalette* p_palette);
+	virtual void vtable24(
+		LPDDSURFACEDESC,
+		MxBitmap*,
+		undefined4,
+		undefined4,
+		undefined4,
+		undefined4,
+		undefined4,
+		undefined4
+	);
+	virtual MxBool vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+	virtual MxBool vtable2c(
+		LPDDSURFACEDESC,
+		MxBitmap*,
+		undefined4,
+		undefined4,
+		undefined4,
+		undefined4,
+		undefined4,
+		undefined4,
+		MxBool
+	);
+	virtual MxBool vtable30(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool);
+	virtual undefined4 vtable34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+	virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+	virtual void GetDC(HDC* p_hdc);
+	virtual void ReleaseDC(HDC p_hdc);
+	virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);
 
-  inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return this->m_ddSurface1; }
-  inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }
+	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return this->m_ddSurface1; }
+	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }
 
 private:
-  MxVideoParam m_videoParam;
-  LPDIRECTDRAWSURFACE m_ddSurface1;
-  LPDIRECTDRAWSURFACE m_ddSurface2;
-  LPDIRECTDRAWCLIPPER m_ddClipper;
-  MxBool m_initialized;
-  DDSURFACEDESC m_surfaceDesc;
-  MxU16 *m_16bitPal;
+	MxVideoParam m_videoParam;
+	LPDIRECTDRAWSURFACE m_ddSurface1;
+	LPDIRECTDRAWSURFACE m_ddSurface2;
+	LPDIRECTDRAWCLIPPER m_ddClipper;
+	MxBool m_initialized;
+	DDSURFACEDESC m_surfaceDesc;
+	MxU16* m_16bitPal;
 };
 
 #endif // MXDISPLAYSURFACE_H

--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -1,8 +1,8 @@
 #include "mxdsaction.h"
 
+#include "legoutil.h"
 #include "mxomni.h"
 #include "mxtimer.h"
-#include "legoutil.h"
 
 #include <float.h>
 #include <limits.h>
@@ -15,185 +15,185 @@ MxU16 g_unkSep = TWOCC(',', ' ');
 // OFFSET: LEGO1 0x100ad810
 MxDSAction::MxDSAction()
 {
-  this->m_flags = MxDSAction::Flag_Enabled;
-  this->m_startTime = INT_MIN;
-  this->m_extraData = NULL;
-  this->m_extraLength = 0;
-  this->m_duration = INT_MIN;
-  this->m_loopCount = -1;
+	this->m_flags = MxDSAction::Flag_Enabled;
+	this->m_startTime = INT_MIN;
+	this->m_extraData = NULL;
+	this->m_extraLength = 0;
+	this->m_duration = INT_MIN;
+	this->m_loopCount = -1;
 
-  this->SetType(MxDSType_Action);
-  this->m_location.Fill(FLT_MAX);
-  this->m_direction.Fill(FLT_MAX);
-  this->m_up.Fill(FLT_MAX);
-  this->m_unk84 = NULL;
-  this->m_unk88 = 0;
-  this->m_omni = NULL;
-  this->m_unkTimingField = INT_MIN;
+	this->SetType(MxDSType_Action);
+	this->m_location.Fill(FLT_MAX);
+	this->m_direction.Fill(FLT_MAX);
+	this->m_up.Fill(FLT_MAX);
+	this->m_unk84 = NULL;
+	this->m_unk88 = 0;
+	this->m_omni = NULL;
+	this->m_unkTimingField = INT_MIN;
 }
 
 // OFFSET: LEGO1 0x100ada80
 MxDSAction::~MxDSAction()
 {
-  delete[] this->m_extraData;
+	delete[] this->m_extraData;
 }
 
 // OFFSET: LEGO1 0x100adaf0
-void MxDSAction::CopyFrom(MxDSAction &p_dsAction)
+void MxDSAction::CopyFrom(MxDSAction& p_dsAction)
 {
-  this->SetObjectId(p_dsAction.GetObjectId());
-  this->m_flags = p_dsAction.m_flags;
-  this->m_startTime = p_dsAction.m_startTime;
-  this->m_duration = p_dsAction.m_duration;
-  this->m_loopCount = p_dsAction.m_loopCount;
+	this->SetObjectId(p_dsAction.GetObjectId());
+	this->m_flags = p_dsAction.m_flags;
+	this->m_startTime = p_dsAction.m_startTime;
+	this->m_duration = p_dsAction.m_duration;
+	this->m_loopCount = p_dsAction.m_loopCount;
 
-  this->m_location.CopyFrom(p_dsAction.m_location);
-  this->m_direction.CopyFrom(p_dsAction.m_direction);
-  this->m_up.CopyFrom(p_dsAction.m_up);
+	this->m_location.CopyFrom(p_dsAction.m_location);
+	this->m_direction.CopyFrom(p_dsAction.m_direction);
+	this->m_up.CopyFrom(p_dsAction.m_up);
 
-  AppendData(p_dsAction.m_extraLength, p_dsAction.m_extraData);
-  this->m_unk84 = p_dsAction.m_unk84;
-  this->m_unk88 = p_dsAction.m_unk88;
-  this->m_omni = p_dsAction.m_omni;
-  this->m_unkTimingField = p_dsAction.m_unkTimingField;
+	AppendData(p_dsAction.m_extraLength, p_dsAction.m_extraData);
+	this->m_unk84 = p_dsAction.m_unk84;
+	this->m_unk88 = p_dsAction.m_unk88;
+	this->m_omni = p_dsAction.m_omni;
+	this->m_unkTimingField = p_dsAction.m_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100adc10
-MxDSAction &MxDSAction::operator=(MxDSAction &p_dsAction)
+MxDSAction& MxDSAction::operator=(MxDSAction& p_dsAction)
 {
-  if (this == &p_dsAction)
-    return *this;
+	if (this == &p_dsAction)
+		return *this;
 
-  MxDSObject::operator=(p_dsAction);
-  this->CopyFrom(p_dsAction);
-  return *this;
+	MxDSObject::operator=(p_dsAction);
+	this->CopyFrom(p_dsAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100adbe0
 MxU32 MxDSAction::GetSizeOnDisk()
 {
-  MxU32 totalSizeOnDisk;
+	MxU32 totalSizeOnDisk;
 
-  totalSizeOnDisk = MxDSObject::GetSizeOnDisk() + 90 + this->m_extraLength;
-  this->m_sizeOnDisk = totalSizeOnDisk - MxDSObject::GetSizeOnDisk();
+	totalSizeOnDisk = MxDSObject::GetSizeOnDisk() + 90 + this->m_extraLength;
+	this->m_sizeOnDisk = totalSizeOnDisk - MxDSObject::GetSizeOnDisk();
 
-  return totalSizeOnDisk;
+	return totalSizeOnDisk;
 }
 
 // OFFSET: LEGO1 0x100adf70
-void MxDSAction::Deserialize(char **p_source, MxS16 p_unk24)
+void MxDSAction::Deserialize(char** p_source, MxS16 p_unk24)
 {
-  MxDSObject::Deserialize(p_source, p_unk24);
+	MxDSObject::Deserialize(p_source, p_unk24);
 
-  GetScalar(p_source, this->m_flags);
-  GetScalar(p_source, this->m_startTime);
-  GetScalar(p_source, this->m_duration);
-  GetScalar(p_source, this->m_loopCount);
-  GetDouble(p_source, this->m_location[0]);
-  GetDouble(p_source, this->m_location[1]);
-  GetDouble(p_source, this->m_location[2]);
-  GetDouble(p_source, this->m_direction[0]);
-  GetDouble(p_source, this->m_direction[1]);
-  GetDouble(p_source, this->m_direction[2]);
-  GetDouble(p_source, this->m_up[0]);
-  GetDouble(p_source, this->m_up[1]);
-  GetDouble(p_source, this->m_up[2]);
+	GetScalar(p_source, this->m_flags);
+	GetScalar(p_source, this->m_startTime);
+	GetScalar(p_source, this->m_duration);
+	GetScalar(p_source, this->m_loopCount);
+	GetDouble(p_source, this->m_location[0]);
+	GetDouble(p_source, this->m_location[1]);
+	GetDouble(p_source, this->m_location[2]);
+	GetDouble(p_source, this->m_direction[0]);
+	GetDouble(p_source, this->m_direction[1]);
+	GetDouble(p_source, this->m_direction[2]);
+	GetDouble(p_source, this->m_up[0]);
+	GetDouble(p_source, this->m_up[1]);
+	GetDouble(p_source, this->m_up[2]);
 
-  MxU16 extraLength = GetScalar((MxU16**) p_source);
-  if (extraLength) {
-    AppendData(extraLength, *p_source);
-    *p_source += extraLength;
-  }
+	MxU16 extraLength = GetScalar((MxU16**) p_source);
+	if (extraLength) {
+		AppendData(extraLength, *p_source);
+		*p_source += extraLength;
+	}
 }
 
 // OFFSET: LEGO1 0x100ad940
 MxLong MxDSAction::GetDuration()
 {
-  return this->m_duration;
+	return this->m_duration;
 }
 
 // OFFSET: LEGO1 0x100ad950
 void MxDSAction::SetDuration(MxLong p_duration)
 {
-  this->m_duration = p_duration;
+	this->m_duration = p_duration;
 }
 
 // OFFSET: LEGO1 0x100adc40
-MxDSAction *MxDSAction::Clone()
+MxDSAction* MxDSAction::Clone()
 {
-  MxDSAction *clone = new MxDSAction();
+	MxDSAction* clone = new MxDSAction();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }
 
 // OFFSET: LEGO1 0x100add00
-void MxDSAction::MergeFrom(MxDSAction &p_dsAction)
+void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 {
-  if (p_dsAction.m_startTime != INT_MIN)
-    this->m_startTime = p_dsAction.m_startTime;
+	if (p_dsAction.m_startTime != INT_MIN)
+		this->m_startTime = p_dsAction.m_startTime;
 
-  if (p_dsAction.GetDuration() != INT_MIN)
-    this->m_duration = p_dsAction.GetDuration();
+	if (p_dsAction.GetDuration() != INT_MIN)
+		this->m_duration = p_dsAction.GetDuration();
 
-  if (p_dsAction.m_loopCount != -1)
-    this->m_loopCount = p_dsAction.m_loopCount;
+	if (p_dsAction.m_loopCount != -1)
+		this->m_loopCount = p_dsAction.m_loopCount;
 
-  if (p_dsAction.m_location[0] != FLT_MAX)
-    this->m_location[0] = p_dsAction.m_location[0];
-  if (p_dsAction.m_location[1] != FLT_MAX)
-    this->m_location[1] = p_dsAction.m_location[1];
-  if (p_dsAction.m_location[2] != FLT_MAX)
-    this->m_location[2] = p_dsAction.m_location[2];
+	if (p_dsAction.m_location[0] != FLT_MAX)
+		this->m_location[0] = p_dsAction.m_location[0];
+	if (p_dsAction.m_location[1] != FLT_MAX)
+		this->m_location[1] = p_dsAction.m_location[1];
+	if (p_dsAction.m_location[2] != FLT_MAX)
+		this->m_location[2] = p_dsAction.m_location[2];
 
-  if (p_dsAction.m_direction[0] != FLT_MAX)
-    this->m_direction[0] = p_dsAction.m_direction[0];
-  if (p_dsAction.m_direction[1] != FLT_MAX)
-    this->m_direction[1] = p_dsAction.m_direction[1];
-  if (p_dsAction.m_direction[2] != FLT_MAX)
-    this->m_direction[2] = p_dsAction.m_up[2]; // This is correct
+	if (p_dsAction.m_direction[0] != FLT_MAX)
+		this->m_direction[0] = p_dsAction.m_direction[0];
+	if (p_dsAction.m_direction[1] != FLT_MAX)
+		this->m_direction[1] = p_dsAction.m_direction[1];
+	if (p_dsAction.m_direction[2] != FLT_MAX)
+		this->m_direction[2] = p_dsAction.m_up[2]; // This is correct
 
-  if (p_dsAction.m_up[0] != FLT_MAX)
-    this->m_up[0] = p_dsAction.m_up[0];
-  if (p_dsAction.m_up[1] != FLT_MAX)
-    this->m_up[1] = p_dsAction.m_up[1];
-  if (p_dsAction.m_up[2] != FLT_MAX)
-    this->m_up[2] = p_dsAction.m_up[2];
+	if (p_dsAction.m_up[0] != FLT_MAX)
+		this->m_up[0] = p_dsAction.m_up[0];
+	if (p_dsAction.m_up[1] != FLT_MAX)
+		this->m_up[1] = p_dsAction.m_up[1];
+	if (p_dsAction.m_up[2] != FLT_MAX)
+		this->m_up[2] = p_dsAction.m_up[2];
 
-  MxU16 extraLength = p_dsAction.m_extraLength;
-  char *extraData = p_dsAction.m_extraData;
+	MxU16 extraLength = p_dsAction.m_extraLength;
+	char* extraData = p_dsAction.m_extraData;
 
-  // Taking those references forces the compiler to move the values onto the stack.
-  // The original code most likely looked different, but this yields a 100% match.
-  MxU16 &_extraLength = extraLength;
-  char *&_extraData = extraData;
-  if (extraLength && extraData) {
-    if (!this->m_extraData || !strncmp("XXX", this->m_extraData, 3)) {
-      delete[] this->m_extraData;
-      this->m_extraLength = 0;
-      AppendData(extraLength, extraData);
-    }
-  }
+	// Taking those references forces the compiler to move the values onto the stack.
+	// The original code most likely looked different, but this yields a 100% match.
+	MxU16& _extraLength = extraLength;
+	char*& _extraData = extraData;
+	if (extraLength && extraData) {
+		if (!this->m_extraData || !strncmp("XXX", this->m_extraData, 3)) {
+			delete[] this->m_extraData;
+			this->m_extraLength = 0;
+			AppendData(extraLength, extraData);
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100ad960
 MxBool MxDSAction::HasId(MxU32 p_objectId)
 {
-  return this->GetObjectId() == p_objectId;
+	return this->GetObjectId() == p_objectId;
 }
 
 // OFFSET: LEGO1 0x100ada40
 void MxDSAction::SetUnkTimingField(MxLong p_unkTimingField)
 {
-  this->m_unkTimingField = p_unkTimingField;
+	this->m_unkTimingField = p_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100ada50
 MxLong MxDSAction::GetUnkTimingField()
 {
-  return this->m_unkTimingField;
+	return this->m_unkTimingField;
 }
 
 // Win32 defines GetCurrentTime to GetTickCount
@@ -202,33 +202,33 @@ MxLong MxDSAction::GetUnkTimingField()
 // OFFSET: LEGO1 0x100adcd0
 MxLong MxDSAction::GetCurrentTime()
 {
-  return Timer()->GetTime() - this->m_unkTimingField;
+	return Timer()->GetTime() - this->m_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100ade60
-void MxDSAction::AppendData(MxU16 p_extraLength, const char *p_extraData)
+void MxDSAction::AppendData(MxU16 p_extraLength, const char* p_extraData)
 {
-  if (this->m_extraData == p_extraData || !p_extraData)
-    return;
+	if (this->m_extraData == p_extraData || !p_extraData)
+		return;
 
-  if (this->m_extraLength) {
-    char *concat = new char[p_extraLength + this->m_extraLength + sizeof(g_unkSep)];
-    memcpy(concat, this->m_extraData, this->m_extraLength);
+	if (this->m_extraLength) {
+		char* concat = new char[p_extraLength + this->m_extraLength + sizeof(g_unkSep)];
+		memcpy(concat, this->m_extraData, this->m_extraLength);
 
-    *(MxU16*) &concat[this->m_extraLength] = g_unkSep;
-    memcpy(&concat[this->m_extraLength + sizeof(g_unkSep)], p_extraData, p_extraLength);
+		*(MxU16*) &concat[this->m_extraLength] = g_unkSep;
+		memcpy(&concat[this->m_extraLength + sizeof(g_unkSep)], p_extraData, p_extraLength);
 
-    this->m_extraLength += p_extraLength + sizeof(g_unkSep);
-    delete[] this->m_extraData;
-    this->m_extraData = concat;
-  }
-  else {
-    char *copy = new char[p_extraLength];
-    this->m_extraData = copy;
+		this->m_extraLength += p_extraLength + sizeof(g_unkSep);
+		delete[] this->m_extraData;
+		this->m_extraData = concat;
+	}
+	else {
+		char* copy = new char[p_extraLength];
+		this->m_extraData = copy;
 
-    if (copy) {
-      this->m_extraLength = p_extraLength;
-      memcpy(copy, p_extraData, p_extraLength);
-    }
-  }
+		if (copy) {
+			this->m_extraLength = p_extraLength;
+			memcpy(copy, p_extraData, p_extraLength);
+		}
+	}
 }

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -9,86 +9,84 @@ class MxOmni;
 
 // VTABLE 0x100dc098
 // SIZE 0x94
-class MxDSAction : public MxDSObject
-{
+class MxDSAction : public MxDSObject {
 public:
-  enum
-  {
-    Flag_Looping = 0x01,
-    Flag_Bit3 = 0x04,
-    Flag_Bit5 = 0x10,
-    Flag_Enabled = 0x20,
-    Flag_Parsed = 0x80,
-    Flag_Bit9 = 0x200,
-  };
+	enum {
+		Flag_Looping = 0x01,
+		Flag_Bit3 = 0x04,
+		Flag_Bit5 = 0x10,
+		Flag_Enabled = 0x20,
+		Flag_Parsed = 0x80,
+		Flag_Bit9 = 0x200,
+	};
 
-  __declspec(dllexport) MxDSAction();
-  __declspec(dllexport) virtual ~MxDSAction();
+	__declspec(dllexport) MxDSAction();
+	__declspec(dllexport) virtual ~MxDSAction();
 
-  void CopyFrom(MxDSAction &p_dsAction);
-  MxDSAction &operator=(MxDSAction &p_dsAction);
+	void CopyFrom(MxDSAction& p_dsAction);
+	MxDSAction& operator=(MxDSAction& p_dsAction);
 
-  // OFFSET: LEGO1 0x100ad980
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101013f4
-    return "MxDSAction";
-  }
+	// OFFSET: LEGO1 0x100ad980
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101013f4
+		return "MxDSAction";
+	}
 
-  // OFFSET: LEGO1 0x100ad990
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSAction::ClassName()) || MxDSObject::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100ad990
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSAction::ClassName()) || MxDSObject::IsA(name);
+	}
 
-  virtual MxU32 GetSizeOnDisk() override; // vtable+18;
-  virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
-  virtual MxLong GetDuration(); // vtable+24;
-  virtual void SetDuration(MxLong p_duration); // vtable+28;
-  virtual MxDSAction *Clone(); // vtable+2c;
-  virtual void MergeFrom(MxDSAction &p_dsAction); // vtable+30;
-  virtual MxBool HasId(MxU32 p_objectId); // vtable+34;
-  virtual void SetUnkTimingField(MxLong p_unkTimingField); // vtable+38;
-  virtual MxLong GetUnkTimingField(); // vtable+3c;
-  virtual MxLong GetCurrentTime(); // vtable+40;
+	virtual MxU32 GetSizeOnDisk() override;                            // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24) override; // vtable+1c;
+	virtual MxLong GetDuration();                                      // vtable+24;
+	virtual void SetDuration(MxLong p_duration);                       // vtable+28;
+	virtual MxDSAction* Clone();                                       // vtable+2c;
+	virtual void MergeFrom(MxDSAction& p_dsAction);                    // vtable+30;
+	virtual MxBool HasId(MxU32 p_objectId);                            // vtable+34;
+	virtual void SetUnkTimingField(MxLong p_unkTimingField);           // vtable+38;
+	virtual MxLong GetUnkTimingField();                                // vtable+3c;
+	virtual MxLong GetCurrentTime();                                   // vtable+40;
 
-  void AppendData(MxU16 p_extraLength, const char *p_extraData);
+	void AppendData(MxU16 p_extraLength, const char* p_extraData);
 
-  inline MxU32 GetFlags() { return m_flags; } 
-  inline void SetFlags(MxU32 p_flags) { m_flags = p_flags; }
-  inline char *GetExtraData() { return m_extraData; }
-  inline MxU16 GetExtraLength() const { return m_extraLength; }
-  inline MxLong GetStartTime() const { return m_startTime; }
-  inline MxS32 GetLoopCount() { return m_loopCount; }
-  inline void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
-  inline const MxVector3Data &GetLocation() const { return m_location; }
-  inline void SetUnknown84(MxCore *p_unk84) { m_unk84 = p_unk84; }
-  inline void SetOmni(MxOmni *p_omni) { m_omni = p_omni; }
+	inline MxU32 GetFlags() { return m_flags; }
+	inline void SetFlags(MxU32 p_flags) { m_flags = p_flags; }
+	inline char* GetExtraData() { return m_extraData; }
+	inline MxU16 GetExtraLength() const { return m_extraLength; }
+	inline MxLong GetStartTime() const { return m_startTime; }
+	inline MxS32 GetLoopCount() { return m_loopCount; }
+	inline void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
+	inline const MxVector3Data& GetLocation() const { return m_location; }
+	inline void SetUnknown84(MxCore* p_unk84) { m_unk84 = p_unk84; }
+	inline void SetOmni(MxOmni* p_omni) { m_omni = p_omni; }
 
-  inline MxBool IsLooping() const { return m_flags & Flag_Looping; }
-  inline MxBool IsBit3() const { return m_flags & Flag_Bit3; }
-
-private:
-  MxU32 m_sizeOnDisk;
-  MxU32 m_flags;
-  MxLong m_startTime;
-
-protected:
-  MxLong m_duration;
-  MxS32 m_loopCount;
+	inline MxBool IsLooping() const { return m_flags & Flag_Looping; }
+	inline MxBool IsBit3() const { return m_flags & Flag_Bit3; }
 
 private:
-  MxVector3Data m_location;
-  MxVector3Data m_direction;
-  MxVector3Data m_up;
-  char *m_extraData;
-  MxU16 m_extraLength;
-  MxCore *m_unk84;
-  undefined4 m_unk88;
-  MxOmni *m_omni; // 0x8c
+	MxU32 m_sizeOnDisk;
+	MxU32 m_flags;
+	MxLong m_startTime;
 
 protected:
-  MxLong m_unkTimingField; // 0x90
+	MxLong m_duration;
+	MxS32 m_loopCount;
+
+private:
+	MxVector3Data m_location;
+	MxVector3Data m_direction;
+	MxVector3Data m_up;
+	char* m_extraData;
+	MxU16 m_extraLength;
+	MxCore* m_unk84;
+	undefined4 m_unk88;
+	MxOmni* m_omni; // 0x8c
+
+protected:
+	MxLong m_unkTimingField; // 0x90
 };
 
 #endif // MXDSACTION_H

--- a/LEGO1/mxdsactionlist.cpp
+++ b/LEGO1/mxdsactionlist.cpp
@@ -1,22 +1,23 @@
 #include "mxdsactionlist.h"
+
 #include "mxdsaction.h"
 
 DECOMP_SIZE_ASSERT(MxDSActionList, 0x1c);
 DECOMP_SIZE_ASSERT(MxDSActionListCursor, 0x10);
 
 // OFFSET: LEGO1 0x100c9c90
-MxS8 MxDSActionList::Compare(MxDSAction *p_var0, MxDSAction *p_var1)
+MxS8 MxDSActionList::Compare(MxDSAction* p_var0, MxDSAction* p_var1)
 {
-  if (p_var1 == p_var0)
-    return 0;
-  if (p_var1 <= p_var0)
-    return 1;
-  return -1;
+	if (p_var1 == p_var0)
+		return 0;
+	if (p_var1 <= p_var0)
+		return 1;
+	return -1;
 }
 
 // OFFSET: LEGO1 0x100c9cb0
-void MxDSActionList::Destroy(MxDSAction *p_action)
+void MxDSActionList::Destroy(MxDSAction* p_action)
 {
-  if (p_action)
-    delete p_action;
+	if (p_action)
+		delete p_action;
 }

--- a/LEGO1/mxdsactionlist.h
+++ b/LEGO1/mxdsactionlist.h
@@ -8,19 +8,16 @@ class MxDSAction;
 
 // VTABLE 0x100dced8
 // SIZE 0x1c
-class MxDSActionList : public MxList<MxDSAction*>
-{
+class MxDSActionList : public MxList<MxDSAction*> {
 public:
-  MxDSActionList() {
-    this->m_unk18 = 0;
-  }
+	MxDSActionList() { this->m_unk18 = 0; }
 
-  virtual MxS8 Compare(MxDSAction *, MxDSAction *); // +0x14
+	virtual MxS8 Compare(MxDSAction*, MxDSAction*); // +0x14
 
-  static void Destroy(MxDSAction *p_action);
+	static void Destroy(MxDSAction* p_action);
 
 private:
-  undefined m_unk18;
+	undefined m_unk18;
 };
 
 typedef MxListCursorChild<MxDSAction*> MxDSActionListCursor;

--- a/LEGO1/mxdsanim.cpp
+++ b/LEGO1/mxdsanim.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(MxDSAnim, 0xb8)
 // OFFSET: LEGO1 0x100c8ff0
 MxDSAnim::MxDSAnim()
 {
-  this->SetType(MxDSType_Anim);
+	this->SetType(MxDSType_Anim);
 }
 
 // OFFSET: LEGO1 0x100c91a0
@@ -14,28 +14,28 @@ MxDSAnim::~MxDSAnim()
 }
 
 // OFFSET: LEGO1 0x100c91f0
-void MxDSAnim::CopyFrom(MxDSAnim &p_dsAnim)
+void MxDSAnim::CopyFrom(MxDSAnim& p_dsAnim)
 {
 }
 
 // OFFSET: LEGO1 0x100c9200
-MxDSAnim &MxDSAnim::operator=(MxDSAnim &p_dsAnim)
+MxDSAnim& MxDSAnim::operator=(MxDSAnim& p_dsAnim)
 {
-  if (this == &p_dsAnim)
-    return *this;
+	if (this == &p_dsAnim)
+		return *this;
 
-  MxDSMediaAction::operator=(p_dsAnim);
-  this->CopyFrom(p_dsAnim);
-  return *this;
+	MxDSMediaAction::operator=(p_dsAnim);
+	this->CopyFrom(p_dsAnim);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100c9230
-MxDSAction *MxDSAnim::Clone()
+MxDSAction* MxDSAnim::Clone()
 {
-  MxDSAnim *clone = new MxDSAnim();
+	MxDSAnim* clone = new MxDSAnim();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }

--- a/LEGO1/mxdsanim.h
+++ b/LEGO1/mxdsanim.h
@@ -5,29 +5,28 @@
 
 // VTABLE 0x100dcd88
 // SIZE 0xb8
-class MxDSAnim : public MxDSMediaAction
-{
+class MxDSAnim : public MxDSMediaAction {
 public:
-  MxDSAnim();
-  virtual ~MxDSAnim() override;
+	MxDSAnim();
+	virtual ~MxDSAnim() override;
 
-  void CopyFrom(MxDSAnim &p_dsAnim);
-  MxDSAnim &operator=(MxDSAnim &p_dsAnim);
+	void CopyFrom(MxDSAnim& p_dsAnim);
+	MxDSAnim& operator=(MxDSAnim& p_dsAnim);
 
-  // OFFSET: LEGO1 0x100c9060
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101025d8
-    return "MxDSAnim";
-  }
+	// OFFSET: LEGO1 0x100c9060
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101025d8
+		return "MxDSAnim";
+	}
 
-  // OFFSET: LEGO1 0x100c9070
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSAnim::ClassName()) || MxDSMediaAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c9070
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSAnim::ClassName()) || MxDSMediaAction::IsA(name);
+	}
 
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxDSAction* Clone() override; // vtable+2c;
 };
 
 #endif // MXDSANIM_H

--- a/LEGO1/mxdsbuffer.cpp
+++ b/LEGO1/mxdsbuffer.cpp
@@ -5,33 +5,33 @@ DECOMP_SIZE_ASSERT(MxDSBuffer, 0x34);
 // OFFSET: LEGO1 0x100c6470
 MxDSBuffer::MxDSBuffer()
 {
-  m_unk20 = 0;
-  m_pBuffer = NULL;
-  m_pIntoBuffer = NULL;
-  m_pIntoBuffer2 = NULL;
-  m_unk14 = 0;
-  m_unk18 = 0;
-  m_unk1c = 0;
-  m_writeOffset = 0;
-  m_bytesRemaining = 0;
-  m_mode = 2;
-  m_unk30 = 0;
+	m_unk20 = 0;
+	m_pBuffer = NULL;
+	m_pIntoBuffer = NULL;
+	m_pIntoBuffer2 = NULL;
+	m_unk14 = 0;
+	m_unk18 = 0;
+	m_unk1c = 0;
+	m_writeOffset = 0;
+	m_bytesRemaining = 0;
+	m_mode = 2;
+	m_unk30 = 0;
 }
 
 // OFFSET: LEGO1 0x100c6530
 MxDSBuffer::~MxDSBuffer()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c6780
 MxResult MxDSBuffer::FUN_100c6780(void* p_buffer, MxU32 p_size)
 {
-  m_pBuffer = p_buffer;
-  m_pIntoBuffer = p_buffer;
-  m_pIntoBuffer2 = p_buffer;
-  m_bytesRemaining = p_size;
-  m_writeOffset = p_size;
-  m_mode = 2;
-  return SUCCESS;
+	m_pBuffer = p_buffer;
+	m_pIntoBuffer = p_buffer;
+	m_pIntoBuffer2 = p_buffer;
+	m_bytesRemaining = p_size;
+	m_writeOffset = p_size;
+	m_mode = 2;
+	return SUCCESS;
 }

--- a/LEGO1/mxdsbuffer.h
+++ b/LEGO1/mxdsbuffer.h
@@ -6,36 +6,35 @@
 
 // VTABLE 0x100dcca0
 // SIZE 0x34
-class MxDSBuffer : public MxCore
-{
+class MxDSBuffer : public MxCore {
 public:
-  MxDSBuffer();
-  virtual ~MxDSBuffer() override;
+	MxDSBuffer();
+	virtual ~MxDSBuffer() override;
 
-  // OFFSET: LEGO1 0x100c6500
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0568
-    return "MxDSBuffer";
-  }
+	// OFFSET: LEGO1 0x100c6500
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0568
+		return "MxDSBuffer";
+	}
 
-  MxResult FUN_100c6780(void* p_buffer, MxU32 p_size);
+	MxResult FUN_100c6780(void* p_buffer, MxU32 p_size);
 
-  inline void* GetBuffer() { return m_pBuffer;}
-  inline MxU32 GetWriteOffset() { return m_writeOffset;}
+	inline void* GetBuffer() { return m_pBuffer; }
+	inline MxU32 GetWriteOffset() { return m_writeOffset; }
 
 private:
-  void* m_pBuffer;
-  void* m_pIntoBuffer;
-  void* m_pIntoBuffer2;
-  undefined4 m_unk14;
-  undefined4 m_unk18;
-  undefined4 m_unk1c;
-  undefined2 m_unk20;
-  undefined4 m_mode;
-  MxU32 m_writeOffset;
-  MxU32 m_bytesRemaining;
-  undefined4 m_unk30;
+	void* m_pBuffer;
+	void* m_pIntoBuffer;
+	void* m_pIntoBuffer2;
+	undefined4 m_unk14;
+	undefined4 m_unk18;
+	undefined4 m_unk1c;
+	undefined2 m_unk20;
+	undefined4 m_mode;
+	MxU32 m_writeOffset;
+	MxU32 m_bytesRemaining;
+	undefined4 m_unk30;
 };
 
 #endif // MXDSBUFFER_H

--- a/LEGO1/mxdschunk.cpp
+++ b/LEGO1/mxdschunk.cpp
@@ -3,17 +3,17 @@
 // OFFSET: LEGO1 0x100be050
 MxDSChunk::MxDSChunk()
 {
-  this->m_length = 0;
-  this->m_unk18 = NULL;
-  this->m_buffer = -1;
-  this->m_unk10 = 0;
-  this->m_unk14 = 0;
+	this->m_length = 0;
+	this->m_unk18 = NULL;
+	this->m_buffer = -1;
+	this->m_unk10 = 0;
+	this->m_unk14 = 0;
 }
 
 // OFFSET: LEGO1 0x100be170
 MxDSChunk::~MxDSChunk()
 {
-  if ((this->m_length & 1) != 0) {
-    delete this->m_unk18;
-  }
+	if ((this->m_length & 1) != 0) {
+		delete this->m_unk18;
+	}
 }

--- a/LEGO1/mxdschunk.h
+++ b/LEGO1/mxdschunk.h
@@ -5,31 +5,31 @@
 #include "mxtypes.h"
 
 // VTABLE 0x100dc7f8
-class MxDSChunk : public MxCore
-{
+class MxDSChunk : public MxCore {
 public:
-  MxDSChunk();
-  virtual ~MxDSChunk() override;
+	MxDSChunk();
+	virtual ~MxDSChunk() override;
 
-  // OFFSET: LEGO1 0x100be0c0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10101e6c
-    return "MxDSChunk";
-  }
+	// OFFSET: LEGO1 0x100be0c0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10101e6c
+		return "MxDSChunk";
+	}
 
-  // OFFSET: LEGO1 0x100be0d0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSChunk::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100be0d0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSChunk::ClassName()) || MxCore::IsA(name);
+	}
+
 private:
-  MxS16 m_length; // 0x8
-  MxLong m_buffer; // 0xc
-  MxLong m_unk10; // 0x10
-  MxLong m_unk14; // 0x14
-  void* m_unk18; // 0x18
-  void* m_unk1c; // 0x1c
+	MxS16 m_length;  // 0x8
+	MxLong m_buffer; // 0xc
+	MxLong m_unk10;  // 0x10
+	MxLong m_unk14;  // 0x14
+	void* m_unk18;   // 0x18
+	void* m_unk1c;   // 0x1c
 };
 
 #endif // MXDSCHUNK_H

--- a/LEGO1/mxdsevent.cpp
+++ b/LEGO1/mxdsevent.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(MxDSEvent, 0xb8)
 // OFFSET: LEGO1 0x100c95f0
 MxDSEvent::MxDSEvent()
 {
-  this->SetType(MxDSType_Event);
+	this->SetType(MxDSType_Event);
 }
 
 // OFFSET: LEGO1 0x100c97a0
@@ -14,28 +14,28 @@ MxDSEvent::~MxDSEvent()
 }
 
 // OFFSET: LEGO1 0x100c97f0
-void MxDSEvent::CopyFrom(MxDSEvent &p_dsEvent)
+void MxDSEvent::CopyFrom(MxDSEvent& p_dsEvent)
 {
 }
 
 // OFFSET: LEGO1 0x100c9800
-MxDSEvent &MxDSEvent::operator=(MxDSEvent &p_dsEvent)
+MxDSEvent& MxDSEvent::operator=(MxDSEvent& p_dsEvent)
 {
-  if (this == &p_dsEvent)
-    return *this;
+	if (this == &p_dsEvent)
+		return *this;
 
-  MxDSMediaAction::operator=(p_dsEvent);
-  this->CopyFrom(p_dsEvent);
-  return *this;
+	MxDSMediaAction::operator=(p_dsEvent);
+	this->CopyFrom(p_dsEvent);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100c9830
-MxDSAction *MxDSEvent::Clone()
+MxDSAction* MxDSEvent::Clone()
 {
-  MxDSEvent *clone = new MxDSEvent();
+	MxDSEvent* clone = new MxDSEvent();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }

--- a/LEGO1/mxdsevent.h
+++ b/LEGO1/mxdsevent.h
@@ -3,29 +3,28 @@
 
 #include "mxdsmediaaction.h"
 
-class MxDSEvent : public MxDSMediaAction
-{
+class MxDSEvent : public MxDSMediaAction {
 public:
-  MxDSEvent();
-  virtual ~MxDSEvent() override;
+	MxDSEvent();
+	virtual ~MxDSEvent() override;
 
-  void CopyFrom(MxDSEvent &p_dsEvent);
-  MxDSEvent &operator=(MxDSEvent &p_dsEvent);
+	void CopyFrom(MxDSEvent& p_dsEvent);
+	MxDSEvent& operator=(MxDSEvent& p_dsEvent);
 
-  // OFFSET: LEGO1 0x100c9660
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101025f0
-    return "MxDSEvent";
-  }
+	// OFFSET: LEGO1 0x100c9660
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101025f0
+		return "MxDSEvent";
+	}
 
-  // OFFSET: LEGO1 0x100c9670
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSEvent::ClassName()) || MxDSMediaAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c9670
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSEvent::ClassName()) || MxDSMediaAction::IsA(name);
+	}
 
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxDSAction* Clone() override; // vtable+2c;
 };
 
 #endif // MXDSEVENT_H

--- a/LEGO1/mxdsfile.cpp
+++ b/LEGO1/mxdsfile.cpp
@@ -6,122 +6,119 @@
 #define SI_MINOR_VERSION 2
 
 // OFFSET: LEGO1 0x100cc4b0
-MxDSFile::MxDSFile(const char *filename, MxULong skipReadingChunks)
+MxDSFile::MxDSFile(const char* filename, MxULong skipReadingChunks)
 {
-  m_filename = filename;
-  m_skipReadingChunks = skipReadingChunks;
+	m_filename = filename;
+	m_skipReadingChunks = skipReadingChunks;
 }
 
 // OFFSET: LEGO1 0x100bfed0
 MxDSFile::~MxDSFile()
 {
-  Close();
+	Close();
 }
 
 // OFFSET: LEGO1 0x100cc590
 MxLong MxDSFile::Open(MxULong uStyle)
 {
-  MXIOINFO& io = m_io;
-  MxLong longResult = 1;
-  memset(&io, 0, sizeof(MXIOINFO));
+	MXIOINFO& io = m_io;
+	MxLong longResult = 1;
+	memset(&io, 0, sizeof(MXIOINFO));
 
-  if (io.Open(m_filename.GetData(), uStyle) != 0) {
-    return -1;
-  }
+	if (io.Open(m_filename.GetData(), uStyle) != 0) {
+		return -1;
+	}
 
-  io.SetBuffer(NULL, 0, 0);
-  m_position = 0;
+	io.SetBuffer(NULL, 0, 0);
+	m_position = 0;
 
-  if (m_skipReadingChunks == 0) {
-    longResult = ReadChunks();
-  }
+	if (m_skipReadingChunks == 0) {
+		longResult = ReadChunks();
+	}
 
-  if (longResult != 0) {
-    Close(); // vtable + 0x18
-  }
-  else {
-    Seek(0, 0); // vtable + 0x24
-  }
+	if (longResult != 0) {
+		Close(); // vtable + 0x18
+	}
+	else {
+		Seek(0, 0); // vtable + 0x24
+	}
 
-  return longResult;
+	return longResult;
 }
 
 // OFFSET: LEGO1 0x100cc780
-MxResult MxDSFile::Read(unsigned char *p_buf, MxULong p_nbytes)
+MxResult MxDSFile::Read(unsigned char* p_buf, MxULong p_nbytes)
 {
-  if (m_io.Read(p_buf, p_nbytes) != p_nbytes)
-    return FAILURE;
+	if (m_io.Read(p_buf, p_nbytes) != p_nbytes)
+		return FAILURE;
 
-  m_position += p_nbytes;
-  return SUCCESS;
+	m_position += p_nbytes;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100cc620
 MxLong MxDSFile::ReadChunks()
 {
-  _MMCKINFO topChunk;
-  _MMCKINFO childChunk;
-  char tempBuffer[80];
-  
-  topChunk.fccType = FOURCC('O', 'M', 'N', 'I');
-  if (m_io.Descend(&topChunk, NULL, MMIO_FINDRIFF) != 0) {
-    return -1;
-  }
-  childChunk.ckid = FOURCC('M', 'x', 'H', 'd');
-  if (m_io.Descend(&childChunk, &topChunk, 0) != 0) {
-    return -1;
-  }
+	_MMCKINFO topChunk;
+	_MMCKINFO childChunk;
+	char tempBuffer[80];
 
-  m_io.Read(&m_header, 0xc);
-  if ((m_header.majorVersion == SI_MAJOR_VERSION) && (m_header.minorVersion == SI_MINOR_VERSION))
-  {
-    childChunk.ckid = FOURCC('M', 'x', 'O', 'f');
-    if (m_io.Descend(&childChunk, &topChunk, 0) != 0) {
-      return -1;
-    }
-    MxULong* pLengthInDWords = &m_lengthInDWords;
-    m_io.Read(pLengthInDWords, 4);
-    m_pBuffer = new MxU32[*pLengthInDWords];
-    m_io.Read(m_pBuffer, *pLengthInDWords * 4);
-    return 0;
-  }
-  else
-  {
-    sprintf(tempBuffer, "Wrong SI file version. %d.%d expected.", SI_MAJOR_VERSION, SI_MINOR_VERSION);
-    MessageBoxA(NULL, tempBuffer, NULL, MB_ICONERROR);
-    return -1;
-  }
+	topChunk.fccType = FOURCC('O', 'M', 'N', 'I');
+	if (m_io.Descend(&topChunk, NULL, MMIO_FINDRIFF) != 0) {
+		return -1;
+	}
+	childChunk.ckid = FOURCC('M', 'x', 'H', 'd');
+	if (m_io.Descend(&childChunk, &topChunk, 0) != 0) {
+		return -1;
+	}
+
+	m_io.Read(&m_header, 0xc);
+	if ((m_header.majorVersion == SI_MAJOR_VERSION) && (m_header.minorVersion == SI_MINOR_VERSION)) {
+		childChunk.ckid = FOURCC('M', 'x', 'O', 'f');
+		if (m_io.Descend(&childChunk, &topChunk, 0) != 0) {
+			return -1;
+		}
+		MxULong* pLengthInDWords = &m_lengthInDWords;
+		m_io.Read(pLengthInDWords, 4);
+		m_pBuffer = new MxU32[*pLengthInDWords];
+		m_io.Read(m_pBuffer, *pLengthInDWords * 4);
+		return 0;
+	}
+	else {
+		sprintf(tempBuffer, "Wrong SI file version. %d.%d expected.", SI_MAJOR_VERSION, SI_MINOR_VERSION);
+		MessageBoxA(NULL, tempBuffer, NULL, MB_ICONERROR);
+		return -1;
+	}
 }
 
 // OFFSET: LEGO1 0x100cc7b0
 MxLong MxDSFile::Seek(MxLong lOffset, int iOrigin)
 {
-  return (m_position = m_io.Seek(lOffset, iOrigin)) == -1 ? -1 : 0;
+	return (m_position = m_io.Seek(lOffset, iOrigin)) == -1 ? -1 : 0;
 }
 
 // OFFSET: LEGO1 0x100cc7e0
 MxULong MxDSFile::GetBufferSize()
 {
-  return m_header.bufferSize;
+	return m_header.bufferSize;
 }
 
 // OFFSET: LEGO1 0x100cc7f0
 MxULong MxDSFile::GetStreamBuffersNum()
 {
-  return m_header.streamBuffersNum;
+	return m_header.streamBuffersNum;
 }
 
 // OFFSET: LEGO1 0x100cc740
 MxLong MxDSFile::Close()
 {
-  m_io.Close(0);
-  m_position = -1;
-  memset(&m_header, 0, sizeof(m_header));
-  if (m_lengthInDWords != 0)
-  {
-    m_lengthInDWords = 0;
-    delete[] m_pBuffer;
-    m_pBuffer = NULL;
-  }
-  return 0;
+	m_io.Close(0);
+	m_position = -1;
+	memset(&m_header, 0, sizeof(m_header));
+	if (m_lengthInDWords != 0) {
+		m_lengthInDWords = 0;
+		delete[] m_pBuffer;
+		m_pBuffer = NULL;
+	}
+	return 0;
 }

--- a/LEGO1/mxdsfile.h
+++ b/LEGO1/mxdsfile.h
@@ -7,55 +7,49 @@
 #include "mxtypes.h"
 
 // VTABLE 0x100dc890
-class MxDSFile : public MxDSSource
-{
+class MxDSFile : public MxDSSource {
 public:
-  __declspec(dllexport) MxDSFile(const char *filename, MxULong skipReadingChunks);
-  __declspec(dllexport) virtual ~MxDSFile(); // vtable+0x0
+	__declspec(dllexport) MxDSFile(const char* filename, MxULong skipReadingChunks);
+	__declspec(dllexport) virtual ~MxDSFile(); // vtable+0x0
 
-  // OFFSET: LEGO1 0x100c0120
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10102594
-    return "MxDSFile";
-  }
+	// OFFSET: LEGO1 0x100c0120
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10102594
+		return "MxDSFile";
+	}
 
-  // OFFSET: LEGO1 0x100c0130
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSFile::ClassName()) || MxDSSource::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c0130
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSFile::ClassName()) || MxDSSource::IsA(name);
+	}
 
-  __declspec(dllexport) virtual MxLong Open(MxULong); // vtable+0x14
-  __declspec(dllexport) virtual MxLong Close(); // vtable+0x18
-  __declspec(dllexport) virtual MxResult Read(unsigned char *,MxULong); // vtable+0x20
-  __declspec(dllexport) virtual MxLong Seek(MxLong,int); // vtable+0x24
-  __declspec(dllexport) virtual MxULong GetBufferSize(); // vtable+0x28
-  __declspec(dllexport) virtual MxULong GetStreamBuffersNum();  // vtable+0x2c
+	__declspec(dllexport) virtual MxLong Open(MxULong);                   // vtable+0x14
+	__declspec(dllexport) virtual MxLong Close();                         // vtable+0x18
+	__declspec(dllexport) virtual MxResult Read(unsigned char*, MxULong); // vtable+0x20
+	__declspec(dllexport) virtual MxLong Seek(MxLong, int);               // vtable+0x24
+	__declspec(dllexport) virtual MxULong GetBufferSize();                // vtable+0x28
+	__declspec(dllexport) virtual MxULong GetStreamBuffersNum();          // vtable+0x2c
 private:
-  MxLong ReadChunks();
-  struct ChunkHeader {
-    ChunkHeader()
-      : majorVersion(0)
-      , minorVersion(0)
-      , bufferSize(0)
-      , streamBuffersNum(0)
-    {}
+	MxLong ReadChunks();
+	struct ChunkHeader {
+		ChunkHeader() : majorVersion(0), minorVersion(0), bufferSize(0), streamBuffersNum(0) {}
 
-    MxU16 majorVersion;
-    MxU16 minorVersion;
-    MxULong bufferSize;
-    MxS16 streamBuffersNum;
-    MxS16 reserved;
-  };
+		MxU16 majorVersion;
+		MxU16 minorVersion;
+		MxULong bufferSize;
+		MxS16 streamBuffersNum;
+		MxS16 reserved;
+	};
 
-  MxString m_filename;
-  MXIOINFO m_io;
-  ChunkHeader m_header;
+	MxString m_filename;
+	MXIOINFO m_io;
+	ChunkHeader m_header;
 
-  // If false, read chunks immediately on open, otherwise
-  // skip reading chunks until ReadChunks is explicitly called.
-  MxULong m_skipReadingChunks;
+	// If false, read chunks immediately on open, otherwise
+	// skip reading chunks until ReadChunks is explicitly called.
+	MxULong m_skipReadingChunks;
 };
 
 #endif // MXDSFILE_H

--- a/LEGO1/mxdsmediaaction.cpp
+++ b/LEGO1/mxdsmediaaction.cpp
@@ -7,88 +7,88 @@ DECOMP_SIZE_ASSERT(MxDSMediaAction, 0xb8)
 // OFFSET: LEGO1 0x100c8b40
 MxDSMediaAction::MxDSMediaAction()
 {
-  this->m_mediaSrcPath = NULL;
-  this->m_unk9c.m_unk00 = 0;
-  this->m_unk9c.m_unk04 = 0;
-  this->m_framesPerSecond = 0;
-  this->m_mediaFormat = 0;
-  this->m_paletteManagement = 1;
-  this->m_unkb4 = -1;
-  this->m_sustainTime = 0;
-  this->SetType(MxDSType_MediaAction);
+	this->m_mediaSrcPath = NULL;
+	this->m_unk9c.m_unk00 = 0;
+	this->m_unk9c.m_unk04 = 0;
+	this->m_framesPerSecond = 0;
+	this->m_mediaFormat = 0;
+	this->m_paletteManagement = 1;
+	this->m_unkb4 = -1;
+	this->m_sustainTime = 0;
+	this->SetType(MxDSType_MediaAction);
 }
 
 // OFFSET: LEGO1 0x100c8cf0
 MxDSMediaAction::~MxDSMediaAction()
 {
-  delete[] this->m_mediaSrcPath;
+	delete[] this->m_mediaSrcPath;
 }
 
 // OFFSET: LEGO1 0x100c8d60
-void MxDSMediaAction::CopyFrom(MxDSMediaAction &p_dsMediaAction)
+void MxDSMediaAction::CopyFrom(MxDSMediaAction& p_dsMediaAction)
 {
-  CopyMediaSrcPath(p_dsMediaAction.m_mediaSrcPath);
+	CopyMediaSrcPath(p_dsMediaAction.m_mediaSrcPath);
 
-  this->m_unk9c = p_dsMediaAction.m_unk9c;
-  this->m_framesPerSecond = p_dsMediaAction.m_framesPerSecond;
-  this->m_mediaFormat = p_dsMediaAction.m_mediaFormat;
-  this->m_paletteManagement = p_dsMediaAction.m_paletteManagement;
-  this->m_sustainTime = p_dsMediaAction.m_sustainTime;
+	this->m_unk9c = p_dsMediaAction.m_unk9c;
+	this->m_framesPerSecond = p_dsMediaAction.m_framesPerSecond;
+	this->m_mediaFormat = p_dsMediaAction.m_mediaFormat;
+	this->m_paletteManagement = p_dsMediaAction.m_paletteManagement;
+	this->m_sustainTime = p_dsMediaAction.m_sustainTime;
 }
 
 // OFFSET: LEGO1 0x100c8dc0
-MxDSMediaAction &MxDSMediaAction::operator=(MxDSMediaAction &p_dsMediaAction)
+MxDSMediaAction& MxDSMediaAction::operator=(MxDSMediaAction& p_dsMediaAction)
 {
-  if (this == &p_dsMediaAction)
-    return *this;
+	if (this == &p_dsMediaAction)
+		return *this;
 
-  MxDSAction::operator=(p_dsMediaAction);
-  this->CopyFrom(p_dsMediaAction);
-  return *this;
+	MxDSAction::operator=(p_dsMediaAction);
+	this->CopyFrom(p_dsMediaAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100c8f10
 MxU32 MxDSMediaAction::GetSizeOnDisk()
 {
-  MxU32 totalSizeOnDisk = MxDSAction::GetSizeOnDisk();
+	MxU32 totalSizeOnDisk = MxDSAction::GetSizeOnDisk();
 
-  if (this->m_mediaSrcPath)
-    totalSizeOnDisk += strlen(this->m_mediaSrcPath) + 1;
-  else
-    totalSizeOnDisk++;
+	if (this->m_mediaSrcPath)
+		totalSizeOnDisk += strlen(this->m_mediaSrcPath) + 1;
+	else
+		totalSizeOnDisk++;
 
-  totalSizeOnDisk += 24;
-  this->m_sizeOnDisk = totalSizeOnDisk - MxDSAction::GetSizeOnDisk();
-  return totalSizeOnDisk;
+	totalSizeOnDisk += 24;
+	this->m_sizeOnDisk = totalSizeOnDisk - MxDSAction::GetSizeOnDisk();
+	return totalSizeOnDisk;
 }
 
 // OFFSET: LEGO1 0x100c8f60
-void MxDSMediaAction::Deserialize(char **p_source, MxS16 p_unk24)
+void MxDSMediaAction::Deserialize(char** p_source, MxS16 p_unk24)
 {
-  MxDSAction::Deserialize(p_source, p_unk24);
+	MxDSAction::Deserialize(p_source, p_unk24);
 
-  GetString(p_source, this->m_mediaSrcPath, this, &MxDSMediaAction::CopyMediaSrcPath);
-  GetScalar(p_source, this->m_unk9c.m_unk00);
-  GetScalar(p_source, this->m_unk9c.m_unk04);
-  GetScalar(p_source, this->m_framesPerSecond);
-  GetScalar(p_source, this->m_mediaFormat);
-  GetScalar(p_source, this->m_paletteManagement);
-  GetScalar(p_source, this->m_sustainTime);
+	GetString(p_source, this->m_mediaSrcPath, this, &MxDSMediaAction::CopyMediaSrcPath);
+	GetScalar(p_source, this->m_unk9c.m_unk00);
+	GetScalar(p_source, this->m_unk9c.m_unk04);
+	GetScalar(p_source, this->m_framesPerSecond);
+	GetScalar(p_source, this->m_mediaFormat);
+	GetScalar(p_source, this->m_paletteManagement);
+	GetScalar(p_source, this->m_sustainTime);
 }
 
 // OFFSET: LEGO1 0x100c8e80
-void MxDSMediaAction::CopyMediaSrcPath(const char *p_mediaSrcPath)
+void MxDSMediaAction::CopyMediaSrcPath(const char* p_mediaSrcPath)
 {
-  if (this->m_mediaSrcPath == p_mediaSrcPath)
-    return;
+	if (this->m_mediaSrcPath == p_mediaSrcPath)
+		return;
 
-  delete[] this->m_mediaSrcPath;
+	delete[] this->m_mediaSrcPath;
 
-  if (p_mediaSrcPath) {
-    this->m_mediaSrcPath = new char[strlen(p_mediaSrcPath) + 1];
-    if (this->m_mediaSrcPath)
-      strcpy(this->m_mediaSrcPath, p_mediaSrcPath);
-  }
-  else
-    this->m_mediaSrcPath = NULL;
+	if (p_mediaSrcPath) {
+		this->m_mediaSrcPath = new char[strlen(p_mediaSrcPath) + 1];
+		if (this->m_mediaSrcPath)
+			strcpy(this->m_mediaSrcPath, p_mediaSrcPath);
+	}
+	else
+		this->m_mediaSrcPath = NULL;
 }

--- a/LEGO1/mxdsmediaaction.h
+++ b/LEGO1/mxdsmediaaction.h
@@ -7,47 +7,47 @@
 
 // VTABLE 0x100dcd40
 // SIZE 0xb8
-class MxDSMediaAction : public MxDSAction
-{
+class MxDSMediaAction : public MxDSAction {
 public:
-  MxDSMediaAction();
-  virtual ~MxDSMediaAction() override;
+	MxDSMediaAction();
+	virtual ~MxDSMediaAction() override;
 
-  void CopyFrom(MxDSMediaAction &p_dsMediaAction);
-  MxDSMediaAction &operator=(MxDSMediaAction &p_dsMediaAction);
+	void CopyFrom(MxDSMediaAction& p_dsMediaAction);
+	MxDSMediaAction& operator=(MxDSMediaAction& p_dsMediaAction);
 
-  // OFFSET: LEGO1 0x100c8be0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f7624
-    return "MxDSMediaAction";
-  }
+	// OFFSET: LEGO1 0x100c8be0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f7624
+		return "MxDSMediaAction";
+	}
 
-  // OFFSET: LEGO1 0x100c8bf0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSMediaAction::ClassName()) || MxDSAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c8bf0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSMediaAction::ClassName()) || MxDSAction::IsA(name);
+	}
 
-  virtual MxU32 GetSizeOnDisk() override; // vtable+18;
-  virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
+	virtual MxU32 GetSizeOnDisk() override;                            // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24) override; // vtable+1c;
 
-  void CopyMediaSrcPath(const char *p_mediaSrcPath);
+	void CopyMediaSrcPath(const char* p_mediaSrcPath);
 
-  inline MxS32 GetMediaFormat() const { return this->m_mediaFormat; }
-  inline MxLong GetSustainTime() const { return this->m_sustainTime; }
+	inline MxS32 GetMediaFormat() const { return this->m_mediaFormat; }
+	inline MxLong GetSustainTime() const { return this->m_sustainTime; }
+
 private:
-  MxU32 m_sizeOnDisk;
-  char *m_mediaSrcPath;
-  struct {
-    undefined4 m_unk00;
-    undefined4 m_unk04;
-  } m_unk9c;
-  MxS32 m_framesPerSecond;
-  MxS32 m_mediaFormat;
-  MxS32 m_paletteManagement;
-  MxLong m_sustainTime;
-  undefined4 m_unkb4;
+	MxU32 m_sizeOnDisk;
+	char* m_mediaSrcPath;
+	struct {
+		undefined4 m_unk00;
+		undefined4 m_unk04;
+	} m_unk9c;
+	MxS32 m_framesPerSecond;
+	MxS32 m_mediaFormat;
+	MxS32 m_paletteManagement;
+	MxLong m_sustainTime;
+	undefined4 m_unkb4;
 };
 
 #endif // MXDSMEDIAACTION_H

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -5,150 +5,150 @@ DECOMP_SIZE_ASSERT(MxDSMultiAction, 0x9c)
 // OFFSET: LEGO1 0x100c9b90
 MxDSMultiAction::MxDSMultiAction()
 {
-  this->SetType(MxDSType_MultiAction);
-  this->m_actions = new MxDSActionList;
-  this->m_actions->SetDestroy(MxDSActionList::Destroy);
+	this->SetType(MxDSType_MultiAction);
+	this->m_actions = new MxDSActionList;
+	this->m_actions->SetDestroy(MxDSActionList::Destroy);
 }
 
 // OFFSET: LEGO1 0x100ca060
 MxDSMultiAction::~MxDSMultiAction()
 {
-  if (this->m_actions)
-    delete this->m_actions;
+	if (this->m_actions)
+		delete this->m_actions;
 }
 
 // OFFSET: LEGO1 0x100ca0d0
-void MxDSMultiAction::CopyFrom(MxDSMultiAction &p_dsMultiAction)
+void MxDSMultiAction::CopyFrom(MxDSMultiAction& p_dsMultiAction)
 {
-  this->m_actions->DeleteAll();
+	this->m_actions->DeleteAll();
 
-  MxDSActionListCursor cursor(p_dsMultiAction.m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action))
-    this->m_actions->Append(action->Clone());
+	MxDSActionListCursor cursor(p_dsMultiAction.m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action))
+		this->m_actions->Append(action->Clone());
 }
 
 // OFFSET: LEGO1 0x100ca260
-MxDSMultiAction &MxDSMultiAction::operator=(MxDSMultiAction &p_dsMultiAction)
+MxDSMultiAction& MxDSMultiAction::operator=(MxDSMultiAction& p_dsMultiAction)
 {
-  if (this == &p_dsMultiAction)
-    return *this;
+	if (this == &p_dsMultiAction)
+		return *this;
 
-  MxDSAction::operator=(p_dsMultiAction);
-  this->CopyFrom(p_dsMultiAction);
-  return *this;
+	MxDSAction::operator=(p_dsMultiAction);
+	this->CopyFrom(p_dsMultiAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100ca290
 void MxDSMultiAction::SetUnkTimingField(MxLong p_unkTimingField)
 {
-  this->m_unkTimingField = p_unkTimingField;
+	this->m_unkTimingField = p_unkTimingField;
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action))
-    action->SetUnkTimingField(p_unkTimingField);
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action))
+		action->SetUnkTimingField(p_unkTimingField);
 }
 
 // OFFSET: LEGO1 0x100ca370
-void MxDSMultiAction::MergeFrom(MxDSAction &p_dsMultiAction)
+void MxDSMultiAction::MergeFrom(MxDSAction& p_dsMultiAction)
 {
-  MxDSAction::MergeFrom(p_dsMultiAction);
+	MxDSAction::MergeFrom(p_dsMultiAction);
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action))
-    action->MergeFrom(p_dsMultiAction);
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action))
+		action->MergeFrom(p_dsMultiAction);
 }
 
 // OFFSET: LEGO1 0x100ca450
 MxBool MxDSMultiAction::HasId(MxU32 p_objectId)
 {
-  if (this->GetObjectId() == p_objectId)
-    return TRUE;
+	if (this->GetObjectId() == p_objectId)
+		return TRUE;
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action)) {
-    if (action->HasId(p_objectId))
-      return TRUE;
-  }
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action)) {
+		if (action->HasId(p_objectId))
+			return TRUE;
+	}
 
-  return FALSE;
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x100ca550
-MxDSAction *MxDSMultiAction::Clone()
+MxDSAction* MxDSMultiAction::Clone()
 {
-  MxDSMultiAction *clone = new MxDSMultiAction();
+	MxDSMultiAction* clone = new MxDSMultiAction();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }
 
 // OFFSET: LEGO1 0x100ca5e0
 undefined4 MxDSMultiAction::unk14()
 {
-  undefined4 result = MxDSAction::unk14();
+	undefined4 result = MxDSAction::unk14();
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action))
-    result += action->unk14();
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action))
+		result += action->unk14();
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100ca6c0
 MxU32 MxDSMultiAction::GetSizeOnDisk()
 {
-  MxU32 totalSizeOnDisk = MxDSAction::GetSizeOnDisk() + 16;
+	MxU32 totalSizeOnDisk = MxDSAction::GetSizeOnDisk() + 16;
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action))
-    totalSizeOnDisk += action->GetSizeOnDisk();
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action))
+		totalSizeOnDisk += action->GetSizeOnDisk();
 
-  this->m_sizeOnDisk = totalSizeOnDisk - MxDSAction::GetSizeOnDisk();
+	this->m_sizeOnDisk = totalSizeOnDisk - MxDSAction::GetSizeOnDisk();
 
-  return totalSizeOnDisk;
+	return totalSizeOnDisk;
 }
 
 // OFFSET: LEGO1 0x100ca7b0
-void MxDSMultiAction::Deserialize(char **p_source, MxS16 p_unk24)
+void MxDSMultiAction::Deserialize(char** p_source, MxS16 p_unk24)
 {
-  MxDSAction::Deserialize(p_source, p_unk24);
+	MxDSAction::Deserialize(p_source, p_unk24);
 
-  MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
-  *p_source += 12;
+	MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
+	*p_source += 12;
 
-  MxU32 count = *(MxU32*) *p_source;
-  *p_source += sizeof(count);
+	MxU32 count = *(MxU32*) *p_source;
+	*p_source += sizeof(count);
 
-  if (count) {
-    while (count--) {
-      MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
-      *p_source += 8;
+	if (count) {
+		while (count--) {
+			MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
+			*p_source += 8;
 
-      MxDSAction *action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk24);
-      *p_source += extraFlag;
+			MxDSAction* action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk24);
+			*p_source += extraFlag;
 
-      this->m_actions->Append(action);
-    }
-  }
+			this->m_actions->Append(action);
+		}
+	}
 
-  *p_source += extraFlag;
+	*p_source += extraFlag;
 }
 
 // OFFSET: LEGO1 0x100ca8c0
 void MxDSMultiAction::SetAtomId(MxAtomId p_atomId)
 {
-  MxDSAction::SetAtomId(p_atomId);
+	MxDSAction::SetAtomId(p_atomId);
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
-  while (cursor.Next(action))
-    action->SetAtomId(p_atomId);
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
+	while (cursor.Next(action))
+		action->SetAtomId(p_atomId);
 }

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -6,40 +6,39 @@
 
 // VTABLE 0x100dcef0
 // SIZE 0x9c
-class MxDSMultiAction : public MxDSAction
-{
+class MxDSMultiAction : public MxDSAction {
 public:
-  MxDSMultiAction();
-  virtual ~MxDSMultiAction() override;
+	MxDSMultiAction();
+	virtual ~MxDSMultiAction() override;
 
-  void CopyFrom(MxDSMultiAction &p_dsMultiAction);
-  MxDSMultiAction &operator=(MxDSMultiAction &p_dsMultiAction);
+	void CopyFrom(MxDSMultiAction& p_dsMultiAction);
+	MxDSMultiAction& operator=(MxDSMultiAction& p_dsMultiAction);
 
-  // OFFSET: LEGO1 0x100c9f50
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10101dbc
-    return "MxDSMultiAction";
-  }
+	// OFFSET: LEGO1 0x100c9f50
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10101dbc
+		return "MxDSMultiAction";
+	}
 
-  // OFFSET: LEGO1 0x100c9f60
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSMultiAction::ClassName()) || MxDSAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c9f60
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSMultiAction::ClassName()) || MxDSAction::IsA(name);
+	}
 
-  virtual undefined4 unk14() override; // vtable+14;
-  virtual MxU32 GetSizeOnDisk() override; // vtable+18;
-  virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
-  virtual void SetAtomId(MxAtomId p_atomId) override; // vtable+20;
-  virtual MxDSAction *Clone() override; // vtable+2c;
-  virtual void MergeFrom(MxDSAction &p_dsAction) override; // vtable+30;
-  virtual MxBool HasId(MxU32 p_objectId) override; // vtable+34;
-  virtual void SetUnkTimingField(MxLong p_unkTimingField) override; // vtable+38;
+	virtual undefined4 unk14() override;                               // vtable+14;
+	virtual MxU32 GetSizeOnDisk() override;                            // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24) override; // vtable+1c;
+	virtual void SetAtomId(MxAtomId p_atomId) override;                // vtable+20;
+	virtual MxDSAction* Clone() override;                              // vtable+2c;
+	virtual void MergeFrom(MxDSAction& p_dsAction) override;           // vtable+30;
+	virtual MxBool HasId(MxU32 p_objectId) override;                   // vtable+34;
+	virtual void SetUnkTimingField(MxLong p_unkTimingField) override;  // vtable+38;
 
 protected:
-  MxU32 m_sizeOnDisk;
-  MxDSActionList *m_actions;
+	MxU32 m_sizeOnDisk;
+	MxDSActionList* m_actions;
 };
 
 #endif // MXDSMULTIACTION_H

--- a/LEGO1/mxdsobject.cpp
+++ b/LEGO1/mxdsobject.cpp
@@ -1,194 +1,194 @@
 #include "mxdsobject.h"
 
-#include <string.h>
-#include <stdlib.h>
-
-#include "mxdstypes.h"
-#include "mxdsaction.h"
-#include "mxdsmediaaction.h"
-#include "mxdsanim.h"
-#include "mxdssound.h"
-#include "mxdsmultiaction.h"
-#include "mxdsserialaction.h"
-#include "mxdsparallelaction.h"
-#include "mxdsevent.h"
-#include "mxdsselectaction.h"
-#include "mxdsstill.h"
-#include "mxdsobjectaction.h"
 #include "legoutil.h"
+#include "mxdsaction.h"
+#include "mxdsanim.h"
+#include "mxdsevent.h"
+#include "mxdsmediaaction.h"
+#include "mxdsmultiaction.h"
+#include "mxdsobjectaction.h"
+#include "mxdsparallelaction.h"
+#include "mxdsselectaction.h"
+#include "mxdsserialaction.h"
+#include "mxdssound.h"
+#include "mxdsstill.h"
+#include "mxdstypes.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 DECOMP_SIZE_ASSERT(MxDSObject, 0x2c);
 
 // OFFSET: LEGO1 0x100bf6a0
 MxDSObject::MxDSObject()
 {
-  this->SetType(MxDSType_Object);
-  this->m_sourceName = NULL;
-  this->m_unk14 = 0;
-  this->m_objectName = NULL;
-  this->m_unk24 = -1;
-  this->m_objectId = -1;
-  this->m_unk28 = 0;
+	this->SetType(MxDSType_Object);
+	this->m_sourceName = NULL;
+	this->m_unk14 = 0;
+	this->m_objectName = NULL;
+	this->m_unk24 = -1;
+	this->m_objectId = -1;
+	this->m_unk28 = 0;
 }
 
 // OFFSET: LEGO1 0x100bf7e0
 MxDSObject::~MxDSObject()
 {
-  delete[] m_objectName;
-  delete[] m_sourceName;
+	delete[] m_objectName;
+	delete[] m_sourceName;
 }
 
 // OFFSET: LEGO1 0x100bf870
-void MxDSObject::CopyFrom(MxDSObject &p_dsObject)
+void MxDSObject::CopyFrom(MxDSObject& p_dsObject)
 {
-  this->SetSourceName(p_dsObject.m_sourceName);
-  this->m_unk14 = p_dsObject.m_unk14;
-  this->SetObjectName(p_dsObject.m_objectName);
-  this->m_objectId = p_dsObject.m_objectId;
-  this->m_unk24 = p_dsObject.m_unk24;
-  this->m_atomId = p_dsObject.m_atomId;
-  this->m_unk28 = p_dsObject.m_unk28;
+	this->SetSourceName(p_dsObject.m_sourceName);
+	this->m_unk14 = p_dsObject.m_unk14;
+	this->SetObjectName(p_dsObject.m_objectName);
+	this->m_objectId = p_dsObject.m_objectId;
+	this->m_unk24 = p_dsObject.m_unk24;
+	this->m_atomId = p_dsObject.m_atomId;
+	this->m_unk28 = p_dsObject.m_unk28;
 }
 
 // OFFSET: LEGO1 0x100bf8c0
-MxDSObject &MxDSObject::operator=(MxDSObject &p_dsObject)
+MxDSObject& MxDSObject::operator=(MxDSObject& p_dsObject)
 {
-  if (this == &p_dsObject)
-    return *this;
+	if (this == &p_dsObject)
+		return *this;
 
-  this->CopyFrom(p_dsObject);
-  return *this;
+	this->CopyFrom(p_dsObject);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100bf8e0
-void MxDSObject::SetObjectName(const char *p_objectName)
+void MxDSObject::SetObjectName(const char* p_objectName)
 {
-  if (p_objectName != this->m_objectName) {
-    delete[] this->m_objectName;
+	if (p_objectName != this->m_objectName) {
+		delete[] this->m_objectName;
 
-    if (p_objectName) {
-      this->m_objectName = new char[strlen(p_objectName) + 1];
+		if (p_objectName) {
+			this->m_objectName = new char[strlen(p_objectName) + 1];
 
-      if (this->m_objectName) {
-        strcpy(this->m_objectName, p_objectName);
-      }
-    }
-    else {
-      this->m_objectName = NULL;
-    }
-  }
+			if (this->m_objectName) {
+				strcpy(this->m_objectName, p_objectName);
+			}
+		}
+		else {
+			this->m_objectName = NULL;
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100bf950
-void MxDSObject::SetSourceName(const char *p_sourceName)
+void MxDSObject::SetSourceName(const char* p_sourceName)
 {
-  if (p_sourceName != this->m_sourceName) {
-    delete[] this->m_sourceName;
+	if (p_sourceName != this->m_sourceName) {
+		delete[] this->m_sourceName;
 
-    if (p_sourceName) {
-      this->m_sourceName = new char[strlen(p_sourceName) + 1];
+		if (p_sourceName) {
+			this->m_sourceName = new char[strlen(p_sourceName) + 1];
 
-      if (this->m_sourceName) {
-        strcpy(this->m_sourceName, p_sourceName);
-      }
-    }
-    else {
-      this->m_sourceName = NULL;
-    }
-  }
+			if (this->m_sourceName) {
+				strcpy(this->m_sourceName, p_sourceName);
+			}
+		}
+		else {
+			this->m_sourceName = NULL;
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100bf9c0
 undefined4 MxDSObject::unk14()
 {
-  return 10;
+	return 10;
 }
 
 // OFFSET: LEGO1 0x100bf9d0
 MxU32 MxDSObject::GetSizeOnDisk()
 {
-  MxU32 sizeOnDisk;
+	MxU32 sizeOnDisk;
 
-  if (this->m_sourceName)
-    sizeOnDisk = strlen(this->m_sourceName) + 3;
-  else
-    sizeOnDisk = 3;
+	if (this->m_sourceName)
+		sizeOnDisk = strlen(this->m_sourceName) + 3;
+	else
+		sizeOnDisk = 3;
 
-  sizeOnDisk += 4;
+	sizeOnDisk += 4;
 
-  if (this->m_objectName)
-    sizeOnDisk += strlen(this->m_objectName) + 1;
-  else
-    sizeOnDisk++;
+	if (this->m_objectName)
+		sizeOnDisk += strlen(this->m_objectName) + 1;
+	else
+		sizeOnDisk++;
 
-  sizeOnDisk += 4;
-  this->m_sizeOnDisk = sizeOnDisk;
-  return sizeOnDisk;
+	sizeOnDisk += 4;
+	this->m_sizeOnDisk = sizeOnDisk;
+	return sizeOnDisk;
 }
 
 // OFFSET: LEGO1 0x100bfa20
-void MxDSObject::Deserialize(char **p_source, MxS16 p_unk24)
+void MxDSObject::Deserialize(char** p_source, MxS16 p_unk24)
 {
-  GetString(p_source, this->m_sourceName, this, &MxDSObject::SetSourceName);
-  GetScalar(p_source, this->m_unk14);
-  GetString(p_source, this->m_objectName, this, &MxDSObject::SetObjectName);
-  GetScalar(p_source, this->m_objectId);
+	GetString(p_source, this->m_sourceName, this, &MxDSObject::SetSourceName);
+	GetScalar(p_source, this->m_unk14);
+	GetString(p_source, this->m_objectName, this, &MxDSObject::SetObjectName);
+	GetScalar(p_source, this->m_objectId);
 
-  this->m_unk24 = p_unk24;
+	this->m_unk24 = p_unk24;
 }
 
 // OFFSET: LEGO1 0x100bfb30
-MxDSObject *DeserializeDSObjectDispatch(char **p_source, MxS16 p_flags)
+MxDSObject* DeserializeDSObjectDispatch(char** p_source, MxS16 p_flags)
 {
-  MxU16 type = *(MxU16*) *p_source;
-  *p_source += 2;
+	MxU16 type = *(MxU16*) *p_source;
+	*p_source += 2;
 
-  MxDSObject *obj = NULL;
+	MxDSObject* obj = NULL;
 
-  switch (type) {
-    default:
-      return NULL;
-    case MxDSType_Object:
-      obj = new MxDSObject();
-      break;
-    case MxDSType_Action:
-      obj = new MxDSAction();
-      break;
-    case MxDSType_MediaAction:
-      obj = new MxDSMediaAction();
-      break;
-    case MxDSType_Anim:
-      obj = new MxDSAnim();
-      break;
-    case MxDSType_Sound:
-      obj = new MxDSSound();
-      break;
-    case MxDSType_MultiAction:
-      obj = new MxDSMultiAction();
-      break;
-    case MxDSType_SerialAction:
-      obj = new MxDSSerialAction();
-      break;
-    case MxDSType_ParallelAction:
-      obj = new MxDSParallelAction();
-      break;
-    case MxDSType_Event:
-      obj = new MxDSEvent();
-      break;
-    case MxDSType_SelectAction:
-      obj = new MxDSSelectAction();
-      break;
-    case MxDSType_Still:
-      obj = new MxDSStill();
-      break;
-    case MxDSType_ObjectAction:
-      obj = new MxDSObjectAction();
-      break;
-  }
+	switch (type) {
+	default:
+		return NULL;
+	case MxDSType_Object:
+		obj = new MxDSObject();
+		break;
+	case MxDSType_Action:
+		obj = new MxDSAction();
+		break;
+	case MxDSType_MediaAction:
+		obj = new MxDSMediaAction();
+		break;
+	case MxDSType_Anim:
+		obj = new MxDSAnim();
+		break;
+	case MxDSType_Sound:
+		obj = new MxDSSound();
+		break;
+	case MxDSType_MultiAction:
+		obj = new MxDSMultiAction();
+		break;
+	case MxDSType_SerialAction:
+		obj = new MxDSSerialAction();
+		break;
+	case MxDSType_ParallelAction:
+		obj = new MxDSParallelAction();
+		break;
+	case MxDSType_Event:
+		obj = new MxDSEvent();
+		break;
+	case MxDSType_SelectAction:
+		obj = new MxDSSelectAction();
+		break;
+	case MxDSType_Still:
+		obj = new MxDSStill();
+		break;
+	case MxDSType_ObjectAction:
+		obj = new MxDSObjectAction();
+		break;
+	}
 
-  if (obj) {
-    obj->Deserialize(p_source, p_flags);
-  }
+	if (obj) {
+		obj->Deserialize(p_source, p_flags);
+	}
 
-  return obj;
+	return obj;
 }

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -2,62 +2,63 @@
 #define MXDSOBJECT_H
 
 #include "decomp.h"
-
-#include "mxcore.h"
 #include "mxatomid.h"
+#include "mxcore.h"
 #include "mxdstypes.h"
 
 // VTABLE 0x100dc868
 // SIZE 0x2c
-class MxDSObject : public MxCore
-{
+class MxDSObject : public MxCore {
 public:
-  MxDSObject();
-  virtual ~MxDSObject() override;
+	MxDSObject();
+	virtual ~MxDSObject() override;
 
-  void CopyFrom(MxDSObject &p_dsObject);
-  MxDSObject &operator=(MxDSObject &p_dsObject);
+	void CopyFrom(MxDSObject& p_dsObject);
+	MxDSObject& operator=(MxDSObject& p_dsObject);
 
-  __declspec(dllexport) void SetObjectName(const char *p_objectName);
-  void SetSourceName(const char *p_sourceName);
+	__declspec(dllexport) void SetObjectName(const char* p_objectName);
+	void SetSourceName(const char* p_sourceName);
 
-  // OFFSET: LEGO1 0x100bf730
-  inline virtual const char *ClassName() const override { return "MxDSObject"; }; // vtable+0c
+	// OFFSET: LEGO1 0x100bf730
+	inline virtual const char* ClassName() const override { return "MxDSObject"; }; // vtable+0c
 
-  // OFFSET: LEGO1 0x100bf740
-  inline virtual MxBool IsA(const char *name) const override { return !strcmp(name, MxDSObject::ClassName()) || MxCore::IsA(name); }; // vtable+10;
+	// OFFSET: LEGO1 0x100bf740
+	inline virtual MxBool IsA(const char* name) const override
+	{
+		return !strcmp(name, MxDSObject::ClassName()) || MxCore::IsA(name);
+	}; // vtable+10;
 
-  virtual undefined4 unk14(); // vtable+14;
-  virtual MxU32 GetSizeOnDisk(); // vtable+18;
-  virtual void Deserialize(char **p_source, MxS16 p_unk24); // vtable+1c;
-  // OFFSET: ISLE 0x401c40
-  // OFFSET: LEGO1 0x10005530
-  inline virtual void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; } // vtable+20;
+	virtual undefined4 unk14();                               // vtable+14;
+	virtual MxU32 GetSizeOnDisk();                            // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24); // vtable+1c;
+	// OFFSET: ISLE 0x401c40
+	// OFFSET: LEGO1 0x10005530
+	inline virtual void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; } // vtable+20;
 
-  inline const MxAtomId& GetAtomId() { return this->m_atomId; }
-  inline MxU32 GetObjectId() { return this->m_objectId; }
-  inline MxS16 GetUnknown24() { return this->m_unk24; }
+	inline const MxAtomId& GetAtomId() { return this->m_atomId; }
+	inline MxU32 GetObjectId() { return this->m_objectId; }
+	inline MxS16 GetUnknown24() { return this->m_unk24; }
 
-  inline void SetObjectId(MxU32 p_objectId) { this->m_objectId = p_objectId; }
-  inline void SetUnknown24(MxS16 p_unk24) { this->m_unk24 = p_unk24; }
+	inline void SetObjectId(MxU32 p_objectId) { this->m_objectId = p_objectId; }
+	inline void SetUnknown24(MxS16 p_unk24) { this->m_unk24 = p_unk24; }
 
-  inline const char *GetSourceName() const { return this->m_sourceName; }
+	inline const char* GetSourceName() const { return this->m_sourceName; }
 
-  inline void SetType(MxDSType p_type) { this->m_type = p_type; }
-  inline MxDSType GetType() const { return (MxDSType) this->m_type; }
+	inline void SetType(MxDSType p_type) { this->m_type = p_type; }
+	inline MxDSType GetType() const { return (MxDSType) this->m_type; }
 
 private:
-  MxU32 m_sizeOnDisk; // 0x8
-  MxU16 m_type; // 0xc
-  char* m_sourceName; // 0x10
-  undefined4 m_unk14; // 0x14
-  char *m_objectName; // 0x18
-  MxU32 m_objectId; // 0x1c
-  MxAtomId m_atomId; // 0x20
-  MxS16 m_unk24; // 0x24
-  undefined4 m_unk28; // 0x28
+	MxU32 m_sizeOnDisk; // 0x8
+	MxU16 m_type;       // 0xc
+	char* m_sourceName; // 0x10
+	undefined4 m_unk14; // 0x14
+	char* m_objectName; // 0x18
+	MxU32 m_objectId;   // 0x1c
+	MxAtomId m_atomId;  // 0x20
+	MxS16 m_unk24;      // 0x24
+	undefined4 m_unk28; // 0x28
 };
 
-MxDSObject *DeserializeDSObjectDispatch(char **, MxS16);
+MxDSObject* DeserializeDSObjectDispatch(char**, MxS16);
 
 #endif // MXDSOBJECT_H

--- a/LEGO1/mxdsobjectaction.cpp
+++ b/LEGO1/mxdsobjectaction.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(MxDSObjectAction, 0xb8)
 // OFFSET: LEGO1 0x100c8870
 MxDSObjectAction::MxDSObjectAction()
 {
-  this->SetType(MxDSType_ObjectAction);
+	this->SetType(MxDSType_ObjectAction);
 }
 
 // OFFSET: LEGO1 0x100c8a20
@@ -14,28 +14,28 @@ MxDSObjectAction::~MxDSObjectAction()
 }
 
 // OFFSET: LEGO1 0x100c8a70
-void MxDSObjectAction::CopyFrom(MxDSObjectAction &p_dsObjectAction)
+void MxDSObjectAction::CopyFrom(MxDSObjectAction& p_dsObjectAction)
 {
 }
 
 // OFFSET: LEGO1 0x100c8a80
-MxDSObjectAction &MxDSObjectAction::operator=(MxDSObjectAction &p_dsObjectAction)
+MxDSObjectAction& MxDSObjectAction::operator=(MxDSObjectAction& p_dsObjectAction)
 {
-  if (this == &p_dsObjectAction)
-    return *this;
+	if (this == &p_dsObjectAction)
+		return *this;
 
-  MxDSMediaAction::operator=(p_dsObjectAction);
-  this->CopyFrom(p_dsObjectAction);
-  return *this;
+	MxDSMediaAction::operator=(p_dsObjectAction);
+	this->CopyFrom(p_dsObjectAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100c8ab0
-MxDSAction *MxDSObjectAction::Clone()
+MxDSAction* MxDSObjectAction::Clone()
 {
-  MxDSObjectAction *clone = new MxDSObjectAction();
+	MxDSObjectAction* clone = new MxDSObjectAction();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }

--- a/LEGO1/mxdsobjectaction.h
+++ b/LEGO1/mxdsobjectaction.h
@@ -5,29 +5,28 @@
 
 // VTABLE 0x100dccf8
 // SIZE 0xb8
-class MxDSObjectAction : public MxDSMediaAction
-{
+class MxDSObjectAction : public MxDSMediaAction {
 public:
-  MxDSObjectAction();
-  virtual ~MxDSObjectAction() override;
+	MxDSObjectAction();
+	virtual ~MxDSObjectAction() override;
 
-  MxDSObjectAction &operator=(MxDSObjectAction &p_dsObjectAction);
+	MxDSObjectAction& operator=(MxDSObjectAction& p_dsObjectAction);
 
-  // OFFSET: LEGO1 0x100c88e0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101025c4
-    return "MxDSObjectAction";
-  }
+	// OFFSET: LEGO1 0x100c88e0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101025c4
+		return "MxDSObjectAction";
+	}
 
-  // OFFSET: LEGO1 0x100c88f0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSObjectAction::ClassName()) || MxDSMediaAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c88f0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSObjectAction::ClassName()) || MxDSMediaAction::IsA(name);
+	}
 
-  virtual MxDSAction *Clone() override; // vtable+2c;
-  virtual void CopyFrom(MxDSObjectAction &p_dsObjectAction); // vtable+44;
+	virtual MxDSAction* Clone() override;                      // vtable+2c;
+	virtual void CopyFrom(MxDSObjectAction& p_dsObjectAction); // vtable+44;
 };
 
 #endif // MXDSOBJECTACTION_H

--- a/LEGO1/mxdsparallelaction.cpp
+++ b/LEGO1/mxdsparallelaction.cpp
@@ -1,4 +1,5 @@
 #include "mxdsparallelaction.h"
+
 #include "mxdsmediaaction.h"
 
 DECOMP_SIZE_ASSERT(MxDSParallelAction, 0x9c)
@@ -6,7 +7,7 @@ DECOMP_SIZE_ASSERT(MxDSParallelAction, 0x9c)
 // OFFSET: LEGO1 0x100cae80
 MxDSParallelAction::MxDSParallelAction()
 {
-  this->SetType(MxDSType_ParallelAction);
+	this->SetType(MxDSType_ParallelAction);
 }
 
 // OFFSET: LEGO1 0x100cb040
@@ -15,72 +16,72 @@ MxDSParallelAction::~MxDSParallelAction()
 }
 
 // OFFSET: LEGO1 0x100cb090
-void MxDSParallelAction::CopyFrom(MxDSParallelAction &p_dsParallelAction)
+void MxDSParallelAction::CopyFrom(MxDSParallelAction& p_dsParallelAction)
 {
 }
 
 // OFFSET: LEGO1 0x100cb0a0
-MxDSParallelAction &MxDSParallelAction::operator=(MxDSParallelAction &p_dsParallelAction)
+MxDSParallelAction& MxDSParallelAction::operator=(MxDSParallelAction& p_dsParallelAction)
 {
-  if (this == &p_dsParallelAction)
-    return *this;
+	if (this == &p_dsParallelAction)
+		return *this;
 
-  MxDSMultiAction::operator=(p_dsParallelAction);
-  this->CopyFrom(p_dsParallelAction);
-  return *this;
+	MxDSMultiAction::operator=(p_dsParallelAction);
+	this->CopyFrom(p_dsParallelAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100cb0d0
-MxDSAction *MxDSParallelAction::Clone()
+MxDSAction* MxDSParallelAction::Clone()
 {
-  MxDSParallelAction *clone = new MxDSParallelAction();
+	MxDSParallelAction* clone = new MxDSParallelAction();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }
 
 // OFFSET: LEGO1 0x100cb160
 MxLong MxDSParallelAction::GetDuration()
 {
-  if (this->m_duration)
-    return this->m_duration;
+	if (this->m_duration)
+		return this->m_duration;
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
 
-  while (cursor.Next(action)) {
-    if (!action)
-      continue;
+	while (cursor.Next(action)) {
+		if (!action)
+			continue;
 
-    MxLong duration = action->GetDuration();
-    if (duration == -1) {
-      this->m_duration = -1;
-      break;
-    }
+		MxLong duration = action->GetDuration();
+		if (duration == -1) {
+			this->m_duration = -1;
+			break;
+		}
 
-    duration += action->GetStartTime();
-    if (action->IsA("MxDSMediaAction")) {
-      MxLong sustainTime = ((MxDSMediaAction*) action)->GetSustainTime();
+		duration += action->GetStartTime();
+		if (action->IsA("MxDSMediaAction")) {
+			MxLong sustainTime = ((MxDSMediaAction*) action)->GetSustainTime();
 
-      if (sustainTime == -1)
-        duration = -1;
-      else if (sustainTime)
-        duration += sustainTime;
-    }
+			if (sustainTime == -1)
+				duration = -1;
+			else if (sustainTime)
+				duration += sustainTime;
+		}
 
-    if (duration == -1) {
-      this->m_duration = -1;
-      break;
-     }
-      
-    if (this->m_duration < duration)
-      this->m_duration = duration;
-  }
+		if (duration == -1) {
+			this->m_duration = -1;
+			break;
+		}
 
-  if (this->IsBit3())
-    this->m_duration *= this->m_loopCount;
+		if (this->m_duration < duration)
+			this->m_duration = duration;
+	}
 
-  return this->m_duration;
+	if (this->IsBit3())
+		this->m_duration *= this->m_loopCount;
+
+	return this->m_duration;
 }

--- a/LEGO1/mxdsparallelaction.h
+++ b/LEGO1/mxdsparallelaction.h
@@ -5,30 +5,29 @@
 
 // VTABLE 0x100dcf80
 // SIZE 0x9c
-class MxDSParallelAction : public MxDSMultiAction
-{
+class MxDSParallelAction : public MxDSMultiAction {
 public:
-  MxDSParallelAction();
-  virtual ~MxDSParallelAction() override;
+	MxDSParallelAction();
+	virtual ~MxDSParallelAction() override;
 
-  void CopyFrom(MxDSParallelAction &p_dsParallelAction);
-  MxDSParallelAction &operator=(MxDSParallelAction &p_dsParallelAction);
+	void CopyFrom(MxDSParallelAction& p_dsParallelAction);
+	MxDSParallelAction& operator=(MxDSParallelAction& p_dsParallelAction);
 
-  // OFFSET: LEGO1 0x100caf00
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10102608
-    return "MxDSParallelAction";
-  }
+	// OFFSET: LEGO1 0x100caf00
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10102608
+		return "MxDSParallelAction";
+	}
 
-  // OFFSET: LEGO1 0x100caf10
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSParallelAction::ClassName()) || MxDSMultiAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100caf10
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSParallelAction::ClassName()) || MxDSMultiAction::IsA(name);
+	}
 
-  virtual MxLong GetDuration() override; // vtable+24;
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxLong GetDuration() override; // vtable+24;
+	virtual MxDSAction* Clone() override;  // vtable+2c;
 };
 
 #endif // MXDSPARALLELACTION_H

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -1,131 +1,132 @@
 #include "mxdsselectaction.h"
-#include "mxvariabletable.h"
-#include "mxtimer.h"
+
 #include "mxomni.h"
+#include "mxtimer.h"
+#include "mxvariabletable.h"
 
 DECOMP_SIZE_ASSERT(MxDSSelectAction, 0xb0)
 
 // OFFSET: LEGO1 0x100cb2b0
 MxDSSelectAction::MxDSSelectAction()
 {
-  this->SetType(MxDSType_SelectAction);
-  this->m_unk0xac = new MxStringList;
+	this->SetType(MxDSType_SelectAction);
+	this->m_unk0xac = new MxStringList;
 }
 
 // OFFSET: LEGO1 0x100cb8d0
 MxDSSelectAction::~MxDSSelectAction()
 {
-  if (this->m_unk0xac)
-    delete this->m_unk0xac;
+	if (this->m_unk0xac)
+		delete this->m_unk0xac;
 }
 
 // OFFSET: LEGO1 0x100cb950
-void MxDSSelectAction::CopyFrom(MxDSSelectAction &p_dsSelectAction)
+void MxDSSelectAction::CopyFrom(MxDSSelectAction& p_dsSelectAction)
 {
-  this->m_unk0x9c = p_dsSelectAction.m_unk0x9c;
+	this->m_unk0x9c = p_dsSelectAction.m_unk0x9c;
 
-  this->m_unk0xac->DeleteAll();
+	this->m_unk0xac->DeleteAll();
 
-  MxStringListCursor cursor(p_dsSelectAction.m_unk0xac);
-  MxString string;
-  while (cursor.Next(string))
-    this->m_unk0xac->OtherAppend(string);
+	MxStringListCursor cursor(p_dsSelectAction.m_unk0xac);
+	MxString string;
+	while (cursor.Next(string))
+		this->m_unk0xac->OtherAppend(string);
 }
 
 // OFFSET: LEGO1 0x100cbd50
-MxDSSelectAction &MxDSSelectAction::operator=(MxDSSelectAction &p_dsSelectAction)
+MxDSSelectAction& MxDSSelectAction::operator=(MxDSSelectAction& p_dsSelectAction)
 {
-  if (this != &p_dsSelectAction) {
-    MxDSParallelAction::operator=(p_dsSelectAction);
-    this->CopyFrom(p_dsSelectAction);
-  }
-  return *this;
+	if (this != &p_dsSelectAction) {
+		MxDSParallelAction::operator=(p_dsSelectAction);
+		this->CopyFrom(p_dsSelectAction);
+	}
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100cbd80
-MxDSAction *MxDSSelectAction::Clone()
+MxDSAction* MxDSSelectAction::Clone()
 {
-  MxDSSelectAction *clone = new MxDSSelectAction();
+	MxDSSelectAction* clone = new MxDSSelectAction();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }
 
 // OFFSET: LEGO1 0x100cbe10
 MxU32 MxDSSelectAction::GetSizeOnDisk()
 {
-  MxU32 totalSizeOnDisk = MxDSParallelAction::GetSizeOnDisk();
+	MxU32 totalSizeOnDisk = MxDSParallelAction::GetSizeOnDisk();
 
-  totalSizeOnDisk += strlen(this->m_unk0x9c.GetData()) + 1;
+	totalSizeOnDisk += strlen(this->m_unk0x9c.GetData()) + 1;
 
-  MxStringListCursor cursor(this->m_unk0xac);
-  MxString string;
-  while (cursor.Next(string))
-    totalSizeOnDisk += strlen(string.GetData()) + 1;
+	MxStringListCursor cursor(this->m_unk0xac);
+	MxString string;
+	while (cursor.Next(string))
+		totalSizeOnDisk += strlen(string.GetData()) + 1;
 
-  // Note: unlike the other classes, MxDSSelectAction does not have its own
-  // sizeOnDisk member. Instead, it overrides the one from MxDSMultiAction.
-  this->m_sizeOnDisk = totalSizeOnDisk;
+	// Note: unlike the other classes, MxDSSelectAction does not have its own
+	// sizeOnDisk member. Instead, it overrides the one from MxDSMultiAction.
+	this->m_sizeOnDisk = totalSizeOnDisk;
 
-  return totalSizeOnDisk;
+	return totalSizeOnDisk;
 }
 
 // OFFSET: LEGO1 0x100cbf60
-void MxDSSelectAction::Deserialize(char **p_source, MxS16 p_unk24)
+void MxDSSelectAction::Deserialize(char** p_source, MxS16 p_unk24)
 {
-  MxString string;
-  MxDSAction::Deserialize(p_source, p_unk24);
+	MxString string;
+	MxDSAction::Deserialize(p_source, p_unk24);
 
-  MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
-  *p_source += 12;
+	MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
+	*p_source += 12;
 
-  this->m_unk0x9c = *p_source;
+	this->m_unk0x9c = *p_source;
 
-  if (!strnicmp(this->m_unk0x9c.GetData(), "RANDOM_", strlen("RANDOM_"))) {
-    char buffer[10];
-    MxS16 value = atoi(&this->m_unk0x9c.GetData()[strlen("RANDOM_")]);
+	if (!strnicmp(this->m_unk0x9c.GetData(), "RANDOM_", strlen("RANDOM_"))) {
+		char buffer[10];
+		MxS16 value = atoi(&this->m_unk0x9c.GetData()[strlen("RANDOM_")]);
 
-    srand(Timer()->GetTime());
-    MxS32 random = rand() % value;
-    string = itoa((MxS16) random, buffer, 10);
-  }
-  else
-    string = VariableTable()->GetVariable(*p_source);
+		srand(Timer()->GetTime());
+		MxS32 random = rand() % value;
+		string = itoa((MxS16) random, buffer, 10);
+	}
+	else
+		string = VariableTable()->GetVariable(*p_source);
 
-  *p_source += strlen(*p_source) + 1;
+	*p_source += strlen(*p_source) + 1;
 
-  MxU32 count = *(MxU32*) *p_source;
-  *p_source += sizeof(MxU32);
+	MxU32 count = *(MxU32*) *p_source;
+	*p_source += sizeof(MxU32);
 
-  if (count) {
-    MxS32 index = -1;
-    this->m_unk0xac->DeleteAll();
+	if (count) {
+		MxS32 index = -1;
+		this->m_unk0xac->DeleteAll();
 
-    MxU32 i;
-    for (i = 0; i < count; i++) {
-      if (!strcmp(string.GetData(), *p_source))
-        index = i;
+		MxU32 i;
+		for (i = 0; i < count; i++) {
+			if (!strcmp(string.GetData(), *p_source))
+				index = i;
 
-      this->m_unk0xac->OtherAppend(*p_source);
-      *p_source += strlen(*p_source) + 1;
-    }
+			this->m_unk0xac->OtherAppend(*p_source);
+			*p_source += strlen(*p_source) + 1;
+		}
 
-    for (i = 0; i < count; i++) {
-      MxU32 extraFlag = *(MxU32*)(*p_source + 4) & 1;
-      *p_source += 8;
+		for (i = 0; i < count; i++) {
+			MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
+			*p_source += 8;
 
-      MxDSAction *action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk24);
+			MxDSAction* action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk24);
 
-      if (index == i)
-        this->m_actions->Append(action);
-      else
-        delete action;
+			if (index == i)
+				this->m_actions->Append(action);
+			else
+				delete action;
 
-      *p_source += extraFlag;
-    }
-  }
+			*p_source += extraFlag;
+		}
+	}
 
-  *p_source += extraFlag;
+	*p_source += extraFlag;
 }

--- a/LEGO1/mxdsselectaction.h
+++ b/LEGO1/mxdsselectaction.h
@@ -1,41 +1,40 @@
 #ifndef MXDSSELECTACTION_H
 #define MXDSSELECTACTION_H
 
+#include "decomp.h"
 #include "mxdsparallelaction.h"
 #include "mxstringlist.h"
-#include "decomp.h"
 
 // VTABLE 0x100dcfc8
 // SIZE 0xb0
-class MxDSSelectAction : public MxDSParallelAction
-{
+class MxDSSelectAction : public MxDSParallelAction {
 public:
-  MxDSSelectAction();
-  virtual ~MxDSSelectAction() override;
+	MxDSSelectAction();
+	virtual ~MxDSSelectAction() override;
 
-  void CopyFrom(MxDSSelectAction &p_dsSelectAction);
-  MxDSSelectAction &operator=(MxDSSelectAction &p_dsSelectAction);
+	void CopyFrom(MxDSSelectAction& p_dsSelectAction);
+	MxDSSelectAction& operator=(MxDSSelectAction& p_dsSelectAction);
 
-  // OFFSET: LEGO1 0x100cb6f0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x1010261c
-    return "MxDSSelectAction";
-  }
+	// OFFSET: LEGO1 0x100cb6f0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x1010261c
+		return "MxDSSelectAction";
+	}
 
-  // OFFSET: LEGO1 0x100cb700
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100cb700
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(name);
+	}
 
-  virtual MxU32 GetSizeOnDisk() override; // vtable+18;
-  virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxU32 GetSizeOnDisk() override;                            // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24) override; // vtable+1c;
+	virtual MxDSAction* Clone() override;                              // vtable+2c;
 
 private:
-  MxString m_unk0x9c;
-  MxStringList *m_unk0xac;
+	MxString m_unk0x9c;
+	MxStringList* m_unk0xac;
 };
 
 #endif // MXDSSELECTACTION_H

--- a/LEGO1/mxdsserialaction.cpp
+++ b/LEGO1/mxdsserialaction.cpp
@@ -1,4 +1,5 @@
 #include "mxdsserialaction.h"
+
 #include "mxdsmediaaction.h"
 
 DECOMP_SIZE_ASSERT(MxDSSerialAction, 0xa8)
@@ -6,75 +7,75 @@ DECOMP_SIZE_ASSERT(MxDSSerialAction, 0xa8)
 // OFFSET: LEGO1 0x100ca9d0
 MxDSSerialAction::MxDSSerialAction()
 {
-  this->SetType(MxDSType_SerialAction);
-  this->m_cursor = new MxDSActionListCursor(this->m_actions);
-  this->m_unk0xa0 = 0;
+	this->SetType(MxDSType_SerialAction);
+	this->m_cursor = new MxDSActionListCursor(this->m_actions);
+	this->m_unk0xa0 = 0;
 }
 
 // OFFSET: LEGO1 0x100caac0
 void MxDSSerialAction::SetDuration(MxLong p_duration)
 {
-  this->m_duration = p_duration;
+	this->m_duration = p_duration;
 }
 
 // OFFSET: LEGO1 0x100cac10
 MxDSSerialAction::~MxDSSerialAction()
 {
-  if (this->m_cursor)
-    delete this->m_cursor;
+	if (this->m_cursor)
+		delete this->m_cursor;
 
-  this->m_cursor = NULL;
+	this->m_cursor = NULL;
 }
 
 // OFFSET: LEGO1 0x100cac90
-void MxDSSerialAction::CopyFrom(MxDSSerialAction &p_dsSerialAction)
+void MxDSSerialAction::CopyFrom(MxDSSerialAction& p_dsSerialAction)
 {
 }
 
 // OFFSET: LEGO1 0x100caca0
-MxDSSerialAction &MxDSSerialAction::operator=(MxDSSerialAction &p_dsSerialAction)
+MxDSSerialAction& MxDSSerialAction::operator=(MxDSSerialAction& p_dsSerialAction)
 {
-  if (this == &p_dsSerialAction)
-    return *this;
+	if (this == &p_dsSerialAction)
+		return *this;
 
-  MxDSMultiAction::operator=(p_dsSerialAction);
-  this->CopyFrom(p_dsSerialAction);
-  return *this;
+	MxDSMultiAction::operator=(p_dsSerialAction);
+	this->CopyFrom(p_dsSerialAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100cacd0
-MxDSAction *MxDSSerialAction::Clone()
+MxDSAction* MxDSSerialAction::Clone()
 {
-  MxDSSerialAction *clone = new MxDSSerialAction();
+	MxDSSerialAction* clone = new MxDSSerialAction();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }
 
 // OFFSET: LEGO1 0x100cad60
 MxLong MxDSSerialAction::GetDuration()
 {
-  if (this->m_duration)
-    return this->m_duration;
+	if (this->m_duration)
+		return this->m_duration;
 
-  MxDSActionListCursor cursor(this->m_actions);
-  MxDSAction *action;
+	MxDSActionListCursor cursor(this->m_actions);
+	MxDSAction* action;
 
-  while (cursor.Next(action)) {
-    if (!action)
-      continue;
+	while (cursor.Next(action)) {
+		if (!action)
+			continue;
 
-    this->m_duration += action->GetDuration() + action->GetStartTime();
+		this->m_duration += action->GetDuration() + action->GetStartTime();
 
-    if (action->IsA("MxDSMediaAction")) {
-      MxLong sustainTime = ((MxDSMediaAction*) action)->GetSustainTime();
+		if (action->IsA("MxDSMediaAction")) {
+			MxLong sustainTime = ((MxDSMediaAction*) action)->GetSustainTime();
 
-      if (sustainTime && sustainTime != -1)
-        this->m_duration += sustainTime;
-    }
-  }
+			if (sustainTime && sustainTime != -1)
+				this->m_duration += sustainTime;
+		}
+	}
 
-  return this->m_duration;
+	return this->m_duration;
 }

--- a/LEGO1/mxdsserialaction.h
+++ b/LEGO1/mxdsserialaction.h
@@ -1,41 +1,40 @@
 #ifndef MXDSSERIALACTION_H
 #define MXDSSERIALACTION_H
 
-#include "mxdsmultiaction.h"
 #include "decomp.h"
+#include "mxdsmultiaction.h"
 
 // VTABLE 0x100dcf38
 // SIZE 0xa8
-class MxDSSerialAction : public MxDSMultiAction
-{
+class MxDSSerialAction : public MxDSMultiAction {
 public:
-  MxDSSerialAction();
-  virtual ~MxDSSerialAction() override;
+	MxDSSerialAction();
+	virtual ~MxDSSerialAction() override;
 
-  void CopyFrom(MxDSSerialAction &p_dsSerialAction);
-  MxDSSerialAction &operator=(MxDSSerialAction &p_dsSerialAction);
+	void CopyFrom(MxDSSerialAction& p_dsSerialAction);
+	MxDSSerialAction& operator=(MxDSSerialAction& p_dsSerialAction);
 
-  // OFFSET: LEGO1 0x100caad0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f75dc
-    return "MxDSSerialAction";
-  }
+	// OFFSET: LEGO1 0x100caad0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f75dc
+		return "MxDSSerialAction";
+	}
 
-  // OFFSET: LEGO1 0x100caae0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSSerialAction::ClassName()) || MxDSMultiAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100caae0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSSerialAction::ClassName()) || MxDSMultiAction::IsA(name);
+	}
 
-  virtual MxLong GetDuration() override; // vtable+24;
-  virtual void SetDuration(MxLong p_duration) override; // vtable+28;
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxLong GetDuration() override;                // vtable+24;
+	virtual void SetDuration(MxLong p_duration) override; // vtable+28;
+	virtual MxDSAction* Clone() override;                 // vtable+2c;
 
 private:
-  MxDSActionListCursor *m_cursor;
-  undefined4 m_unk0xa0;
-  undefined4 m_unk0xa4;
+	MxDSActionListCursor* m_cursor;
+	undefined4 m_unk0xa0;
+	undefined4 m_unk0xa4;
 };
 
 #endif // MXDSSERIALACTION_H

--- a/LEGO1/mxdssound.cpp
+++ b/LEGO1/mxdssound.cpp
@@ -1,4 +1,5 @@
 #include "mxdssound.h"
+
 #include "legoutil.h"
 
 DECOMP_SIZE_ASSERT(MxDSSound, 0xc0)
@@ -6,8 +7,8 @@ DECOMP_SIZE_ASSERT(MxDSSound, 0xc0)
 // OFFSET: LEGO1 0x100c92c0
 MxDSSound::MxDSSound()
 {
-  this->m_volume = 0x4f;
-  this->SetType(MxDSType_Sound);
+	this->m_volume = 0x4f;
+	this->SetType(MxDSType_Sound);
 }
 
 // OFFSET: LEGO1 0x100c9470
@@ -16,47 +17,47 @@ MxDSSound::~MxDSSound()
 }
 
 // OFFSET: LEGO1 0x100c94c0
-void MxDSSound::CopyFrom(MxDSSound &p_dsSound)
+void MxDSSound::CopyFrom(MxDSSound& p_dsSound)
 {
-  this->SetType(p_dsSound.GetType());
-  this->m_volume = p_dsSound.m_volume;
+	this->SetType(p_dsSound.GetType());
+	this->m_volume = p_dsSound.m_volume;
 }
 
 // OFFSET: LEGO1 0x100c94e0
-MxDSSound &MxDSSound::operator=(MxDSSound &p_dsSound)
+MxDSSound& MxDSSound::operator=(MxDSSound& p_dsSound)
 {
-  if (this == &p_dsSound)
-    return *this;
+	if (this == &p_dsSound)
+		return *this;
 
-  MxDSMediaAction::operator=(p_dsSound);
-  this->CopyFrom(p_dsSound);
-  return *this;
+	MxDSMediaAction::operator=(p_dsSound);
+	this->CopyFrom(p_dsSound);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100c95d0
 MxU32 MxDSSound::GetSizeOnDisk()
 {
-  MxU32 totalSizeOnDisk = MxDSMediaAction::GetSizeOnDisk();
+	MxU32 totalSizeOnDisk = MxDSMediaAction::GetSizeOnDisk();
 
-  this->m_sizeOnDisk = sizeof(this->m_volume);
-  return totalSizeOnDisk + 4;
+	this->m_sizeOnDisk = sizeof(this->m_volume);
+	return totalSizeOnDisk + 4;
 }
 
 // OFFSET: LEGO1 0x100c95a0
-void MxDSSound::Deserialize(char **p_source, MxS16 p_unk24)
+void MxDSSound::Deserialize(char** p_source, MxS16 p_unk24)
 {
-  MxDSMediaAction::Deserialize(p_source, p_unk24);
+	MxDSMediaAction::Deserialize(p_source, p_unk24);
 
-  GetScalar(p_source, this->m_volume);
+	GetScalar(p_source, this->m_volume);
 }
 
 // OFFSET: LEGO1 0x100c9510
-MxDSAction *MxDSSound::Clone()
+MxDSAction* MxDSSound::Clone()
 {
-  MxDSSound *clone = new MxDSSound();
+	MxDSSound* clone = new MxDSSound();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }

--- a/LEGO1/mxdssound.h
+++ b/LEGO1/mxdssound.h
@@ -5,35 +5,34 @@
 
 // VTABLE 0x100dcdd0
 // SIZE 0xc0
-class MxDSSound : public MxDSMediaAction
-{
+class MxDSSound : public MxDSMediaAction {
 public:
-  MxDSSound();
-  virtual ~MxDSSound() override;
+	MxDSSound();
+	virtual ~MxDSSound() override;
 
-  void CopyFrom(MxDSSound &p_dsSound);
-  MxDSSound &operator=(MxDSSound &p_dsSound);
+	void CopyFrom(MxDSSound& p_dsSound);
+	MxDSSound& operator=(MxDSSound& p_dsSound);
 
-  // OFFSET: LEGO1 0x100c9330
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101025e4
-    return "MxDSSound";
-  }
+	// OFFSET: LEGO1 0x100c9330
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101025e4
+		return "MxDSSound";
+	}
 
-  // OFFSET: LEGO1 0x100c9340
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSSound::ClassName()) || MxDSMediaAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c9340
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSSound::ClassName()) || MxDSMediaAction::IsA(name);
+	}
 
-  virtual MxU32 GetSizeOnDisk() override; // vtable+18;
-  virtual void Deserialize(char **p_source, MxS16 p_unk24) override; // vtable+1c;
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxU32 GetSizeOnDisk() override;                            // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24) override; // vtable+1c;
+	virtual MxDSAction* Clone() override;                              // vtable+2c;
 
 private:
-  MxU32 m_sizeOnDisk;
-  MxS32 m_volume; // 0xbc
+	MxU32 m_sizeOnDisk;
+	MxS32 m_volume; // 0xbc
 };
 
 #endif // MXDSSOUND_H

--- a/LEGO1/mxdssource.cpp
+++ b/LEGO1/mxdssource.cpp
@@ -1,20 +1,21 @@
 #include "mxdssource.h"
+
 #include "mxdsbuffer.h"
 
 // OFFSET: LEGO1 0x100bffd0
 void MxDSSource::ReadToBuffer(MxDSBuffer* p_buffer)
 {
-  Read((unsigned char*)p_buffer->GetBuffer(), p_buffer->GetWriteOffset());
+	Read((unsigned char*) p_buffer->GetBuffer(), p_buffer->GetWriteOffset());
 }
 
 // OFFSET: LEGO1 0x100bfff0
 MxLong MxDSSource::GetLengthInDWords()
 {
-  return m_lengthInDWords;
+	return m_lengthInDWords;
 }
 
 // OFFSET: LEGO1 0x100c0000
-MxU32 *MxDSSource::GetBuffer()
+MxU32* MxDSSource::GetBuffer()
 {
-  return m_pBuffer;
+	return m_pBuffer;
 }

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -6,42 +6,37 @@
 class MxDSBuffer;
 
 // VTABLE 0x100dc8c8
-class MxDSSource : public MxCore
-{
+class MxDSSource : public MxCore {
 public:
-  MxDSSource()
-    : m_lengthInDWords(0)
-    , m_pBuffer(NULL)
-    , m_position(-1)
-  {}
+	MxDSSource() : m_lengthInDWords(0), m_pBuffer(NULL), m_position(-1) {}
 
-  // OFFSET: LEGO1 0x100c0010
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x10102588
-    return "MxDSSource";
-  }
+	// OFFSET: LEGO1 0x100c0010
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x10102588
+		return "MxDSSource";
+	}
 
-  // OFFSET: LEGO1 0x100c0020
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSSource::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c0020
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSSource::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxLong Open(MxULong) = 0;
-  virtual MxLong Close() = 0;
-  virtual void ReadToBuffer(MxDSBuffer* p_buffer);
-  virtual MxResult Read(unsigned char *, MxULong) = 0;
-  virtual MxLong Seek(MxLong, int) = 0;
-  virtual MxULong GetBufferSize() = 0;
-  virtual MxULong GetStreamBuffersNum() = 0;
-  virtual MxLong GetLengthInDWords();
-  virtual MxU32* GetBuffer(); // 0x34
+	virtual MxLong Open(MxULong) = 0;
+	virtual MxLong Close() = 0;
+	virtual void ReadToBuffer(MxDSBuffer* p_buffer);
+	virtual MxResult Read(unsigned char*, MxULong) = 0;
+	virtual MxLong Seek(MxLong, int) = 0;
+	virtual MxULong GetBufferSize() = 0;
+	virtual MxULong GetStreamBuffersNum() = 0;
+	virtual MxLong GetLengthInDWords();
+	virtual MxU32* GetBuffer(); // 0x34
 
 protected:
-  MxULong m_lengthInDWords;
-  MxU32* m_pBuffer;
-  MxLong m_position;
+	MxULong m_lengthInDWords;
+	MxU32* m_pBuffer;
+	MxLong m_position;
 };
 
 #endif // MXDSSOURCE_H

--- a/LEGO1/mxdsstill.cpp
+++ b/LEGO1/mxdsstill.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(MxDSStill, 0xb8)
 // OFFSET: LEGO1 0x100c98c0
 MxDSStill::MxDSStill()
 {
-  this->SetType(MxDSType_Still);
+	this->SetType(MxDSType_Still);
 }
 
 // OFFSET: LEGO1 0x100c9a70
@@ -14,28 +14,28 @@ MxDSStill::~MxDSStill()
 }
 
 // OFFSET: LEGO1 0x100c9ac0
-void MxDSStill::CopyFrom(MxDSStill &p_dsStill)
+void MxDSStill::CopyFrom(MxDSStill& p_dsStill)
 {
 }
 
 // OFFSET: LEGO1 0x100c9ad0
-MxDSStill &MxDSStill::operator=(MxDSStill &p_dsStill)
+MxDSStill& MxDSStill::operator=(MxDSStill& p_dsStill)
 {
-  if (this == &p_dsStill)
-    return *this;
+	if (this == &p_dsStill)
+		return *this;
 
-  MxDSMediaAction::operator=(p_dsStill);
-  this->CopyFrom(p_dsStill);
-  return *this;
+	MxDSMediaAction::operator=(p_dsStill);
+	this->CopyFrom(p_dsStill);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100c9b00
-MxDSAction *MxDSStill::Clone()
+MxDSAction* MxDSStill::Clone()
 {
-  MxDSStill *clone = new MxDSStill();
+	MxDSStill* clone = new MxDSStill();
 
-  if (clone)
-    *clone = *this;
+	if (clone)
+		*clone = *this;
 
-  return clone;
+	return clone;
 }

--- a/LEGO1/mxdsstill.h
+++ b/LEGO1/mxdsstill.h
@@ -5,29 +5,28 @@
 
 // VTABLE 0x100dce60
 // SIZE 0xb8
-class MxDSStill : public MxDSMediaAction
-{
+class MxDSStill : public MxDSMediaAction {
 public:
-  MxDSStill();
-  virtual ~MxDSStill() override;
+	MxDSStill();
+	virtual ~MxDSStill() override;
 
-  void CopyFrom(MxDSStill &p_dsStill);
-  MxDSStill &operator=(MxDSStill &p_dsStill);
+	void CopyFrom(MxDSStill& p_dsStill);
+	MxDSStill& operator=(MxDSStill& p_dsStill);
 
-  // OFFSET: LEGO1 0x100c9930
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101025fc
-    return "MxDSStill";
-  }
+	// OFFSET: LEGO1 0x100c9930
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101025fc
+		return "MxDSStill";
+	}
 
-  // OFFSET: LEGO1 0x100c9940
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSStill::ClassName()) || MxDSMediaAction::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c9940
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSStill::ClassName()) || MxDSMediaAction::IsA(name);
+	}
 
-  virtual MxDSAction *Clone() override; // vtable+2c;
+	virtual MxDSAction* Clone() override; // vtable+2c;
 };
 
 #endif // MXDSSTILL_H

--- a/LEGO1/mxdsstreamingaction.cpp
+++ b/LEGO1/mxdsstreamingaction.cpp
@@ -1,91 +1,92 @@
 #include "mxdsstreamingaction.h"
+
 #include "mxdsbuffer.h"
 
 DECOMP_SIZE_ASSERT(MxDSStreamingAction, 0xb4)
 
 // OFFSET: LEGO1 0x100cd010
-MxDSStreamingAction::MxDSStreamingAction(MxDSAction &p_dsAction, MxU32 p_offset)
+MxDSStreamingAction::MxDSStreamingAction(MxDSAction& p_dsAction, MxU32 p_offset)
 {
-  Init();
+	Init();
 
-  *this = p_dsAction;
-  this->m_unk94 = p_offset;
-  this->m_bufferOffset = p_offset;
+	*this = p_dsAction;
+	this->m_unk94 = p_offset;
+	this->m_bufferOffset = p_offset;
 }
 
 // OFFSET: LEGO1 0x100cd0d0
-MxDSStreamingAction::MxDSStreamingAction(MxDSStreamingAction &p_dsStreamingAction)
+MxDSStreamingAction::MxDSStreamingAction(MxDSStreamingAction& p_dsStreamingAction)
 {
-  Init();
-  CopyFrom(p_dsStreamingAction);
+	Init();
+	CopyFrom(p_dsStreamingAction);
 }
 
 // OFFSET: LEGO1 0x100cd150
 MxDSStreamingAction::~MxDSStreamingAction()
 {
-  if (this->m_unka0)
-    delete this->m_unka0;
-  if (this->m_unka4)
-    delete this->m_unka4;
-  if (this->m_internalAction)
-    delete this->m_internalAction;
+	if (this->m_unka0)
+		delete this->m_unka0;
+	if (this->m_unka4)
+		delete this->m_unka4;
+	if (this->m_internalAction)
+		delete this->m_internalAction;
 }
 
 // OFFSET: LEGO1 0x100cd220
-MxDSStreamingAction *MxDSStreamingAction::CopyFrom(MxDSStreamingAction &p_dsStreamingAction)
+MxDSStreamingAction* MxDSStreamingAction::CopyFrom(MxDSStreamingAction& p_dsStreamingAction)
 {
-  *this = p_dsStreamingAction;
-  this->m_unk94 = p_dsStreamingAction.m_unk94;
-  this->m_bufferOffset = p_dsStreamingAction.m_bufferOffset;
-  this->m_unk9c = p_dsStreamingAction.m_unk9c;
-  this->m_unka0 = NULL;
-  this->m_unka4 = NULL;
-  this->m_unkac = p_dsStreamingAction.m_unkac;
-  this->m_unka8 = p_dsStreamingAction.m_unka8;
-  SetInternalAction(p_dsStreamingAction.m_internalAction ? p_dsStreamingAction.m_internalAction->Clone() : NULL);
+	*this = p_dsStreamingAction;
+	this->m_unk94 = p_dsStreamingAction.m_unk94;
+	this->m_bufferOffset = p_dsStreamingAction.m_bufferOffset;
+	this->m_unk9c = p_dsStreamingAction.m_unk9c;
+	this->m_unka0 = NULL;
+	this->m_unka4 = NULL;
+	this->m_unkac = p_dsStreamingAction.m_unkac;
+	this->m_unka8 = p_dsStreamingAction.m_unka8;
+	SetInternalAction(p_dsStreamingAction.m_internalAction ? p_dsStreamingAction.m_internalAction->Clone() : NULL);
 
-  return this;
+	return this;
 }
 
 // OFFSET: LEGO1 0x100cd090
 MxBool MxDSStreamingAction::HasId(MxU32 p_objectId)
 {
-  if (this->m_internalAction)
-    return this->m_internalAction->HasId(p_objectId);
-  return FALSE;
+	if (this->m_internalAction)
+		return this->m_internalAction->HasId(p_objectId);
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x100cd1e0
 MxResult MxDSStreamingAction::Init()
 {
-  this->m_unk94 = 0;
-  this->m_bufferOffset = 0;
-  this->m_unk9c = 0;
-  this->m_unka0 = NULL;
-  this->m_unka4 = NULL;
-  this->m_unka8 = 0;
-  this->m_unkac = 2;
-  this->m_internalAction = NULL;
-  return SUCCESS;
+	this->m_unk94 = 0;
+	this->m_bufferOffset = 0;
+	this->m_unk9c = 0;
+	this->m_unka0 = NULL;
+	this->m_unka4 = NULL;
+	this->m_unka8 = 0;
+	this->m_unkac = 2;
+	this->m_internalAction = NULL;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100cd2a0
-void MxDSStreamingAction::SetInternalAction(MxDSAction *p_dsAction)
+void MxDSStreamingAction::SetInternalAction(MxDSAction* p_dsAction)
 {
-  if (this->m_internalAction)
-    delete this->m_internalAction;
-  this->m_internalAction = p_dsAction;
+	if (this->m_internalAction)
+		delete this->m_internalAction;
+	this->m_internalAction = p_dsAction;
 }
 
 // OFFSET: LEGO1 0x100cd2d0
 void MxDSStreamingAction::FUN_100CD2D0()
 {
-  if (this->m_duration == -1)
-    return;
+	if (this->m_duration == -1)
+		return;
 
-  MxLong duration = this->m_duration / this->m_loopCount;
-  this->m_loopCount--;
-    
-  this->m_duration -= duration;
-  this->m_unka8 += duration;
+	MxLong duration = this->m_duration / this->m_loopCount;
+	this->m_loopCount--;
+
+	this->m_duration -= duration;
+	this->m_unka8 += duration;
 }

--- a/LEGO1/mxdsstreamingaction.h
+++ b/LEGO1/mxdsstreamingaction.h
@@ -7,38 +7,39 @@ class MxDSBuffer;
 
 // VTABLE 0x100dd088
 // SIZE 0xb4
-class MxDSStreamingAction : public MxDSAction
-{
+class MxDSStreamingAction : public MxDSAction {
 public:
-  MxDSStreamingAction(MxDSAction &p_dsAction, MxU32 p_offset);
-  MxDSStreamingAction(MxDSStreamingAction &p_dsStreamingAction);
-  virtual ~MxDSStreamingAction();
+	MxDSStreamingAction(MxDSAction& p_dsAction, MxU32 p_offset);
+	MxDSStreamingAction(MxDSStreamingAction& p_dsStreamingAction);
+	virtual ~MxDSStreamingAction();
 
-  MxDSStreamingAction *CopyFrom(MxDSStreamingAction &p_dsStreamingAction);
-  MxDSStreamingAction &operator=(MxDSAction &p_dsAction) {
-    MxDSAction::operator=(p_dsAction);
-    return *this; 
-  }
-  MxDSStreamingAction &operator=(MxDSStreamingAction &p_dsStreamingAction) {
-    MxDSAction::operator=(p_dsStreamingAction);
-    return *this; 
-  }
+	MxDSStreamingAction* CopyFrom(MxDSStreamingAction& p_dsStreamingAction);
+	MxDSStreamingAction& operator=(MxDSAction& p_dsAction)
+	{
+		MxDSAction::operator=(p_dsAction);
+		return *this;
+	}
+	MxDSStreamingAction& operator=(MxDSStreamingAction& p_dsStreamingAction)
+	{
+		MxDSAction::operator=(p_dsStreamingAction);
+		return *this;
+	}
 
-  virtual MxBool HasId(MxU32 p_objectId) override; // vtable+34;
+	virtual MxBool HasId(MxU32 p_objectId) override; // vtable+34;
 
-  MxResult Init();
-  void SetInternalAction(MxDSAction *p_dsAction);
-  void FUN_100CD2D0();
+	MxResult Init();
+	void SetInternalAction(MxDSAction* p_dsAction);
+	void FUN_100CD2D0();
 
 private:
-  MxU32 m_unk94;
-  MxU32 m_bufferOffset;
-  MxS32 m_unk9c;
-  MxDSBuffer *m_unka0;
-  MxDSBuffer *m_unka4;
-  MxLong m_unka8;
-  undefined2 m_unkac;
-  MxDSAction *m_internalAction;
+	MxU32 m_unk94;
+	MxU32 m_bufferOffset;
+	MxS32 m_unk9c;
+	MxDSBuffer* m_unka0;
+	MxDSBuffer* m_unka4;
+	MxLong m_unka8;
+	undefined2 m_unkac;
+	MxDSAction* m_internalAction;
 };
 
 #endif // MXDSSTREAMINGACTION_H

--- a/LEGO1/mxdssubscriber.cpp
+++ b/LEGO1/mxdssubscriber.cpp
@@ -3,11 +3,11 @@
 // OFFSET: LEGO1 0x100b7bb0
 MxDSSubscriber::MxDSSubscriber()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b7e00
 MxDSSubscriber::~MxDSSubscriber()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -5,24 +5,23 @@
 
 // VTABLE 0x100dc698
 // SIZE 0x4c
-class MxDSSubscriber : public MxCore
-{
+class MxDSSubscriber : public MxCore {
 public:
-  MxDSSubscriber();
-  virtual ~MxDSSubscriber() override;
+	MxDSSubscriber();
+	virtual ~MxDSSubscriber() override;
 
-  // OFFSET: LEGO1 0x100b7d50
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x101020f8
-    return "MxDSSubscriber";
-  }
+	// OFFSET: LEGO1 0x100b7d50
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x101020f8
+		return "MxDSSubscriber";
+	}
 
-  // OFFSET: LEGO1 0x100b7d60
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxDSSubscriber::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100b7d60
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxDSSubscriber::ClassName()) || MxCore::IsA(name);
+	}
 };
 
 #endif // MXDSSUBSCRIBER_H

--- a/LEGO1/mxdstypes.h
+++ b/LEGO1/mxdstypes.h
@@ -1,20 +1,19 @@
 #ifndef MXDSTYPES_H
 #define MXDSTYPES_H
 
-enum MxDSType
-{
-  MxDSType_Object = 0,
-  MxDSType_Action = 1,
-  MxDSType_MediaAction = 2,
-  MxDSType_Anim = 3,
-  MxDSType_Sound = 4,
-  MxDSType_MultiAction = 5,
-  MxDSType_SerialAction = 6,
-  MxDSType_ParallelAction = 7,
-  MxDSType_Event = 8,
-  MxDSType_SelectAction = 9,
-  MxDSType_Still = 10,
-  MxDSType_ObjectAction = 11,
+enum MxDSType {
+	MxDSType_Object = 0,
+	MxDSType_Action = 1,
+	MxDSType_MediaAction = 2,
+	MxDSType_Anim = 3,
+	MxDSType_Sound = 4,
+	MxDSType_MultiAction = 5,
+	MxDSType_SerialAction = 6,
+	MxDSType_ParallelAction = 7,
+	MxDSType_Event = 8,
+	MxDSType_SelectAction = 9,
+	MxDSType_Still = 10,
+	MxDSType_ObjectAction = 11,
 };
 
 #endif // MXDSTYPES_H

--- a/LEGO1/mxentity.cpp
+++ b/LEGO1/mxentity.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(MxEntity, 0x10)
 // OFFSET: LEGO1 0x1001d190
 MxEntity::MxEntity()
 {
-  this->m_mxEntityId = -1;
+	this->m_mxEntityId = -1;
 }
 
 // OFFSET: LEGO1 0x1000c110
@@ -14,9 +14,9 @@ MxEntity::~MxEntity()
 }
 
 // OFFSET: LEGO1 0x10001070
-MxResult MxEntity::SetEntityId(MxS32 p_id, const MxAtomId &p_atom)
+MxResult MxEntity::SetEntityId(MxS32 p_id, const MxAtomId& p_atom)
 {
-  this->m_mxEntityId = p_id;
-  this->m_atom = p_atom;
-  return SUCCESS;
+	this->m_mxEntityId = p_id;
+	this->m_atom = p_atom;
+	return SUCCESS;
 }

--- a/LEGO1/mxentity.h
+++ b/LEGO1/mxentity.h
@@ -9,35 +9,35 @@
 
 // VTABLE 0x100d5390
 // SIZE 0x10
-class MxEntity : public MxCore
-{
+class MxEntity : public MxCore {
 public:
-  MxEntity();
-  virtual ~MxEntity() override;
+	MxEntity();
+	virtual ~MxEntity() override;
 
-  // OFFSET: LEGO1 0x1000c180
-  inline virtual const char* ClassName() const override // vtable+0xc
-  {
-    // 0x100f0070
-    return "MxEntity";
-  }
+	// OFFSET: LEGO1 0x1000c180
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0070
+		return "MxEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000c190
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxEntity::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000c190
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxEntity::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxResult SetEntityId(MxS32 p_id, const MxAtomId &p_atom); // vtable+0x14
-  inline  MxResult InitFromMxDSObject(MxDSObject &p_dsObject)
-  {
-    m_mxEntityId = p_dsObject.GetObjectId();
-    m_atom = p_dsObject.GetAtomId();
-    return SUCCESS;
-  }
+	virtual MxResult SetEntityId(MxS32 p_id, const MxAtomId& p_atom); // vtable+0x14
+	inline MxResult InitFromMxDSObject(MxDSObject& p_dsObject)
+	{
+		m_mxEntityId = p_dsObject.GetObjectId();
+		m_atom = p_dsObject.GetAtomId();
+		return SUCCESS;
+	}
+
 protected:
-  MxS32 m_mxEntityId; // 0x8
-  MxAtomId m_atom; // 0xc
+	MxS32 m_mxEntityId; // 0x8
+	MxAtomId m_atom;    // 0xc
 };
 
 #endif // MXENTITY_H

--- a/LEGO1/mxeventmanager.cpp
+++ b/LEGO1/mxeventmanager.cpp
@@ -1,75 +1,76 @@
 #include "mxeventmanager.h"
+
 #include "mxcriticalsection.h"
+#include "mxomni.h"
 #include "mxthread.h"
 #include "mxticklemanager.h"
-#include "mxomni.h"
 
 // OFFSET: LEGO1 0x100c0360
 MxEventManager::MxEventManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100c03f0
 MxEventManager::~MxEventManager()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100c0450
 void MxEventManager::Init()
 {
-  // This is intentionally left blank
+	// This is intentionally left blank
 }
 
 // OFFSET: LEGO1 0x100c0460
 void MxEventManager::Destroy(MxBool p_fromDestructor)
 {
-  if (m_thread != NULL) {
-    m_thread->Terminate();
-    delete m_thread;
-  }
-  else
-    TickleManager()->UnregisterClient(this);
+	if (m_thread != NULL) {
+		m_thread->Terminate();
+		delete m_thread;
+	}
+	else
+		TickleManager()->UnregisterClient(this);
 
-  if (!p_fromDestructor)
-    MxMediaManager::Destroy();
+	if (!p_fromDestructor)
+		MxMediaManager::Destroy();
 }
 
 // OFFSET: LEGO1 0x100c04a0
 MxResult MxEventManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  MxResult status = FAILURE;
-  MxBool locked = FALSE;
+	MxResult status = FAILURE;
+	MxBool locked = FALSE;
 
-  MxResult result = MxMediaManager::InitPresenters();
-  if (result == SUCCESS) {
-    if (p_createThread) {
-      this->m_criticalSection.Enter();
-      locked = TRUE;
-      this->m_thread = new MxTickleThread(this, p_frequencyMS);
+	MxResult result = MxMediaManager::InitPresenters();
+	if (result == SUCCESS) {
+		if (p_createThread) {
+			this->m_criticalSection.Enter();
+			locked = TRUE;
+			this->m_thread = new MxTickleThread(this, p_frequencyMS);
 
-      if (!this->m_thread || this->m_thread->Start(0, 0) != SUCCESS)
-        goto done;
-    }
-    else
-      TickleManager()->RegisterClient(this, p_frequencyMS);
+			if (!this->m_thread || this->m_thread->Start(0, 0) != SUCCESS)
+				goto done;
+		}
+		else
+			TickleManager()->RegisterClient(this, p_frequencyMS);
 
-    status = SUCCESS;
-  }
+		status = SUCCESS;
+	}
 
 done:
-  if (status != SUCCESS)
-    Destroy();
+	if (status != SUCCESS)
+		Destroy();
 
-  if (locked)
-    this->m_criticalSection.Leave();
+	if (locked)
+		this->m_criticalSection.Leave();
 
-  return status;
+	return status;
 }
 
 // OFFSET: LEGO1 0x100c0590
 void MxEventManager::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }

--- a/LEGO1/mxeventmanager.h
+++ b/LEGO1/mxeventmanager.h
@@ -1,23 +1,22 @@
 #ifndef MXEVENTMANAGER_H
 #define MXEVENTMANAGER_H
 
-#include "mxmediamanager.h"
 #include "decomp.h"
+#include "mxmediamanager.h"
 
 // VTABLE 0x100dc900
 // SIZE 0x2c
-class MxEventManager : public MxMediaManager
-{
+class MxEventManager : public MxMediaManager {
 public:
-  MxEventManager();
-  virtual ~MxEventManager() override;
+	MxEventManager();
+	virtual ~MxEventManager() override;
 
-  virtual void Destroy() override; // vtable+18
-  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+28
+	virtual void Destroy() override;                                     // vtable+18
+	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+28
 
 private:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 };
 
 #endif // MXEVENTMANAGER_H

--- a/LEGO1/mxeventpresenter.cpp
+++ b/LEGO1/mxeventpresenter.cpp
@@ -1,42 +1,42 @@
 #include "mxeventpresenter.h"
-#include "mxeventmanager.h"
-#include "mxomni.h"
 
 #include "decomp.h"
+#include "mxeventmanager.h"
+#include "mxomni.h"
 
 DECOMP_SIZE_ASSERT(MxEventPresenter, 0x54);
 
 // OFFSET: LEGO1 0x100c2b70
 MxEventPresenter::MxEventPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100c2d40
 MxEventPresenter::~MxEventPresenter()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x100c2da0
 void MxEventPresenter::Init()
 {
-  m_unk50 = NULL;
+	m_unk50 = NULL;
 }
 
 // OFFSET: LEGO1 0x100c2de0
 void MxEventPresenter::Destroy()
 {
-  MxEventManager *eventManager = EventManager();
-  if (eventManager) 
-    EventManager()->RemovePresenter(*this);
+	MxEventManager* eventManager = EventManager();
+	if (eventManager)
+		EventManager()->RemovePresenter(*this);
 
-  m_criticalSection.Enter();
+	m_criticalSection.Enter();
 
-  if (m_unk50)
-    delete m_unk50;
+	if (m_unk50)
+		delete m_unk50;
 
-  Init();
+	Init();
 
-  m_criticalSection.Leave();
+	m_criticalSection.Leave();
 }

--- a/LEGO1/mxeventpresenter.h
+++ b/LEGO1/mxeventpresenter.h
@@ -1,37 +1,35 @@
 #ifndef MXEVENTPRESENTER_H
 #define MXEVENTPRESENTER_H
 
-#include "mxmediapresenter.h"
-
 #include "decomp.h"
+#include "mxmediapresenter.h"
 
 // VTABLE 0x100dca88
 // SIZE 0x54
-class MxEventPresenter : public MxMediaPresenter
-{
+class MxEventPresenter : public MxMediaPresenter {
 public:
-  MxEventPresenter();
-  virtual ~MxEventPresenter() override;
+	MxEventPresenter();
+	virtual ~MxEventPresenter() override;
 
-  // OFFSET: LEGO1 0x100c2c30
-  inline virtual const char* ClassName() const override // vtable+0xc
-  {
-    // 0x10101dcc
-    return "MxEventPresenter";
-  }
+	// OFFSET: LEGO1 0x100c2c30
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10101dcc
+		return "MxEventPresenter";
+	}
 
-  // OFFSET: LEGO1 0x100c2c40
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxEventPresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c2c40
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxEventPresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 
-  virtual void Destroy() override; // vtable+0x38
+	virtual void Destroy() override; // vtable+0x38
 
 private:
-  void Init();
+	void Init();
 
-  undefined4 *m_unk50;
+	undefined4* m_unk50;
 };
 
 #endif // MXEVENTPRESENTER_H

--- a/LEGO1/mxflcpresenter.cpp
+++ b/LEGO1/mxflcpresenter.cpp
@@ -7,15 +7,15 @@ DECOMP_SIZE_ASSERT(MxFlcPresenter, 0x68);
 // OFFSET: LEGO1 0x100b3310
 MxFlcPresenter::MxFlcPresenter()
 {
-  this->m_unk64 = 0;
-  this->m_flags &= 0xfd;
-  this->m_flags &= 0xfb;
+	this->m_unk64 = 0;
+	this->m_flags &= 0xfd;
+	this->m_flags &= 0xfb;
 }
 
 // OFFSET: LEGO1 0x100b3420
 MxFlcPresenter::~MxFlcPresenter()
 {
-  if (this->m_unk64) {
-    delete this->m_unk64;
-  }
+	if (this->m_unk64) {
+		delete this->m_unk64;
+	}
 }

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -1,32 +1,30 @@
 #ifndef MXFLCPRESENTER_H
 #define MXFLCPRESENTER_H
 
-#include "mxvideopresenter.h"
-
 #include "decomp.h"
+#include "mxvideopresenter.h"
 
 // VTABLE 0x100dc2c0
 // SIZE 0x68
-class MxFlcPresenter : public MxVideoPresenter
-{
+class MxFlcPresenter : public MxVideoPresenter {
 public:
-  MxFlcPresenter();
-  virtual ~MxFlcPresenter() override;
+	MxFlcPresenter();
+	virtual ~MxFlcPresenter() override;
 
-  // OFFSET: LEGO1 0x100b33f0
-  inline virtual const char* ClassName() const override // vtable+0xc
-  {
-    // 0x100f43c8
-    return "MxFlcPresenter";
-  }
+	// OFFSET: LEGO1 0x100b33f0
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f43c8
+		return "MxFlcPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1004e200
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxFlcPresenter::ClassName()) || MxVideoPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1004e200
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxFlcPresenter::ClassName()) || MxVideoPresenter::IsA(name);
+	}
 
-  undefined4 *m_unk64;
+	undefined4* m_unk64;
 };
 
 #endif // MXFLCPRESENTER_H

--- a/LEGO1/mxhashtable.h
+++ b/LEGO1/mxhashtable.h
@@ -1,244 +1,241 @@
 #ifndef MXHASHTABLE_H
 #define MXHASHTABLE_H
 
-#include "mxtypes.h"
 #include "mxcore.h"
+#include "mxtypes.h"
 
-#define HASH_TABLE_INIT_SIZE              128
-#define HASH_TABLE_OPT_NO_EXPAND          0
-#define HASH_TABLE_OPT_EXPAND_ADD         1
-#define HASH_TABLE_OPT_EXPAND_MULTIPLY    2
+#define HASH_TABLE_INIT_SIZE 128
+#define HASH_TABLE_OPT_NO_EXPAND 0
+#define HASH_TABLE_OPT_EXPAND_ADD 1
+#define HASH_TABLE_OPT_EXPAND_MULTIPLY 2
 
 template <class T>
 class MxHashTableCursor;
 
 template <class T>
-class MxHashTableNode
-{
+class MxHashTableNode {
 public:
-  MxHashTableNode<T>() {}
-  MxHashTableNode<T>(T *p_obj, MxU32 p_hash)
-  {
-    m_obj = p_obj;
-    m_hash = p_hash;
-    m_prev = NULL;
-    m_next = NULL;
-  }
+	MxHashTableNode<T>() {}
+	MxHashTableNode<T>(T* p_obj, MxU32 p_hash)
+	{
+		m_obj = p_obj;
+		m_hash = p_hash;
+		m_prev = NULL;
+		m_next = NULL;
+	}
 
-//private:
-  T* m_obj;
-  MxU32 m_hash;
-  MxHashTableNode *m_prev;
-  MxHashTableNode *m_next;
+	// private:
+	T* m_obj;
+	MxU32 m_hash;
+	MxHashTableNode* m_prev;
+	MxHashTableNode* m_next;
 };
 
 // See MxOmni::Create
 // VTABLE 0x100dc1b0
 template <class T>
-class HashTableParent : public MxCore
-{
+class HashTableParent : public MxCore {
 public:
-  HashTableParent() {
-    m_numKeys = 0;
-    m_customDestructor = Destroy;
-  }
+	HashTableParent()
+	{
+		m_numKeys = 0;
+		m_customDestructor = Destroy;
+	}
 
-  // OFFSET: LEGO1 0x100afd30
-  static void Destroy(T*) {};
+	// OFFSET: LEGO1 0x100afd30
+	static void Destroy(T*){};
 
-  // OFFSET: LEGO1 0x100afcd0
-  virtual MxS8 Compare(T*, T*) = 0;
+	// OFFSET: LEGO1 0x100afcd0
+	virtual MxS8 Compare(T*, T*) = 0;
 
 protected:
-  MxU32 m_numKeys; // +0x8
-  void (*m_customDestructor)(T*); // +0xc
+	MxU32 m_numKeys;                // +0x8
+	void (*m_customDestructor)(T*); // +0xc
 };
 
 // VTABLE 0x100dc1e8
 template <class T>
-class MxHashTable : protected HashTableParent<T>
-{
+class MxHashTable : protected HashTableParent<T> {
 public:
-  MxHashTable()
-  {
-    m_numSlots = HASH_TABLE_INIT_SIZE;
-    m_slots = new MxHashTableNode<T>*[HASH_TABLE_INIT_SIZE];
-    memset(m_slots, 0, sizeof(MxHashTableNode<T> *) * m_numSlots);
-    m_resizeOption = HASH_TABLE_OPT_NO_EXPAND;
-  }
+	MxHashTable()
+	{
+		m_numSlots = HASH_TABLE_INIT_SIZE;
+		m_slots = new MxHashTableNode<T>*[HASH_TABLE_INIT_SIZE];
+		memset(m_slots, 0, sizeof(MxHashTableNode<T>*) * m_numSlots);
+		m_resizeOption = HASH_TABLE_OPT_NO_EXPAND;
+	}
 
-  virtual ~MxHashTable();
+	virtual ~MxHashTable();
 
-  void Resize();
-  void Add(T* );
+	void Resize();
+	void Add(T*);
 
-  virtual MxS8 Compare(T*, T*) = 0;
+	virtual MxS8 Compare(T*, T*) = 0;
 
-  // OFFSET: LEGO1 0x100afdc0
-  virtual MxU32 Hash(T*) = 0;
+	// OFFSET: LEGO1 0x100afdc0
+	virtual MxU32 Hash(T*) = 0;
 
-  // FIXME: use of friend here?
-  friend class MxHashTableCursor<T>;
+	// FIXME: use of friend here?
+	friend class MxHashTableCursor<T>;
 
 protected:
-  void _NodeInsert(MxHashTableNode<T> *);
+	void _NodeInsert(MxHashTableNode<T>*);
 
-  MxHashTableNode<T> **m_slots; // +0x10
-  MxU32 m_numSlots; // +0x14
-  MxU32 m_autoResizeRatio;
-  int m_resizeOption; // +0x1c
-  // FIXME: or FIXME? This qword is used as an integer or double depending
-  // on the value of m_resizeOption. Hard to say whether this is how the devs
-  // did it, but a simple cast in either direction doesn't match.
-  union {
-    MxU32 m_increaseAmount;
-    double m_increaseFactor;
-  };
+	MxHashTableNode<T>** m_slots; // +0x10
+	MxU32 m_numSlots;             // +0x14
+	MxU32 m_autoResizeRatio;
+	int m_resizeOption; // +0x1c
+	// FIXME: or FIXME? This qword is used as an integer or double depending
+	// on the value of m_resizeOption. Hard to say whether this is how the devs
+	// did it, but a simple cast in either direction doesn't match.
+	union {
+		MxU32 m_increaseAmount;
+		double m_increaseFactor;
+	};
 };
 
 template <class T>
-class MxHashTableCursor : public MxCore
-{
+class MxHashTableCursor : public MxCore {
 public:
-  MxHashTableCursor(MxHashTable<T> *p_hashTable)
-  {
-    m_table = p_hashTable;
-    m_match = NULL;
-  }
+	MxHashTableCursor(MxHashTable<T>* p_hashTable)
+	{
+		m_table = p_hashTable;
+		m_match = NULL;
+	}
 
-  MxBool Find(T *p_obj)
-  {
-    MxU32 hash = m_table->Hash(p_obj);
-    int bucket = hash % m_table->m_numSlots;
+	MxBool Find(T* p_obj)
+	{
+		MxU32 hash = m_table->Hash(p_obj);
+		int bucket = hash % m_table->m_numSlots;
 
-    MxHashTableNode<T> *t = m_table->m_slots[bucket];
+		MxHashTableNode<T>* t = m_table->m_slots[bucket];
 
-    while (t) {
-      if (t->m_hash == hash && !m_table->Compare(t->m_obj, p_obj))
-        m_match = t;
-      t = t->m_next;
-    }
+		while (t) {
+			if (t->m_hash == hash && !m_table->Compare(t->m_obj, p_obj))
+				m_match = t;
+			t = t->m_next;
+		}
 
-    return m_match != NULL;
-  }
+		return m_match != NULL;
+	}
 
-  void GetMatch(T*& p_obj)
-  {
-    if (m_match) {
-      p_obj = m_match->m_obj;
-    }
-  }
+	void GetMatch(T*& p_obj)
+	{
+		if (m_match) {
+			p_obj = m_match->m_obj;
+		}
+	}
 
-  void DeleteMatch()
-  {
-    // Cut the matching node out of the linked list
-    // by updating pointer references.
+	void DeleteMatch()
+	{
+		// Cut the matching node out of the linked list
+		// by updating pointer references.
 
-    if (m_match->m_prev) {
-      m_match->m_prev->m_next = m_match->m_next;
-    } else {
-      // No "prev" node, so move "next" to the head of the list.
-      int bucket = m_match->m_hash % m_table->m_numSlots;
-      m_table->m_slots[bucket] = m_match->m_next;
-    }
+		if (m_match->m_prev) {
+			m_match->m_prev->m_next = m_match->m_next;
+		}
+		else {
+			// No "prev" node, so move "next" to the head of the list.
+			int bucket = m_match->m_hash % m_table->m_numSlots;
+			m_table->m_slots[bucket] = m_match->m_next;
+		}
 
-    if (m_match->m_next)
-      m_match->m_next->m_prev = m_match->m_prev;
+		if (m_match->m_next)
+			m_match->m_next->m_prev = m_match->m_prev;
 
-    m_table->m_customDestructor(m_match->m_obj);
-    delete m_match;
-    m_table->m_numKeys--;
-  }
+		m_table->m_customDestructor(m_match->m_obj);
+		delete m_match;
+		m_table->m_numKeys--;
+	}
 
 private:
-  MxHashTable<T> *m_table;
-  MxHashTableNode<T> *m_match;
+	MxHashTable<T>* m_table;
+	MxHashTableNode<T>* m_match;
 };
-
 
 template <class T>
 // OFFSET: LEGO1 0x100b0bd0
 MxHashTable<T>::~MxHashTable()
 {
-  for (int i = 0; i < m_numSlots; i++) {
-    MxHashTableNode<T> *t = m_slots[i];
-    
-    while (t) {
-      MxHashTableNode<T> *next = t->m_next;
-      this->m_customDestructor(t->m_obj);
-      delete t;
-      t = next;
-    }
-  }
+	for (int i = 0; i < m_numSlots; i++) {
+		MxHashTableNode<T>* t = m_slots[i];
 
-  this->m_numKeys = 0;
-  memset(m_slots, 0, sizeof(MxHashTableNode<T> *) * m_numSlots);
+		while (t) {
+			MxHashTableNode<T>* next = t->m_next;
+			this->m_customDestructor(t->m_obj);
+			delete t;
+			t = next;
+		}
+	}
 
-  delete[] m_slots;
+	this->m_numKeys = 0;
+	memset(m_slots, 0, sizeof(MxHashTableNode<T>*) * m_numSlots);
+
+	delete[] m_slots;
 }
 
 template <class T>
 // OFFSET: LEGO1 0x100b7ab0
 inline void MxHashTable<T>::Resize()
 {
-  // Save a reference to the current table
-  // so we can walk nodes and re-insert
-  MxU32 old_size = m_numSlots;
-  MxHashTableNode<T> **old_table = m_slots;
+	// Save a reference to the current table
+	// so we can walk nodes and re-insert
+	MxU32 old_size = m_numSlots;
+	MxHashTableNode<T>** old_table = m_slots;
 
-  switch (m_resizeOption) {
-    case HASH_TABLE_OPT_EXPAND_ADD:
-      m_numSlots = old_size + m_increaseAmount;
-      break;
-    case HASH_TABLE_OPT_EXPAND_MULTIPLY:
-      m_numSlots = old_size * m_increaseFactor;
-      break;
-  }
+	switch (m_resizeOption) {
+	case HASH_TABLE_OPT_EXPAND_ADD:
+		m_numSlots = old_size + m_increaseAmount;
+		break;
+	case HASH_TABLE_OPT_EXPAND_MULTIPLY:
+		m_numSlots = old_size * m_increaseFactor;
+		break;
+	}
 
-  MxHashTableNode<T> **new_table = new MxHashTableNode<T>*[m_numSlots];
-  // FIXME: order? m_numKeys set after `rep stosd`
-  m_slots = new_table;
-  memset(m_slots, 0, sizeof(MxHashTableNode<T> *) * m_numSlots);
-  this->m_numKeys = 0;
+	MxHashTableNode<T>** new_table = new MxHashTableNode<T>*[m_numSlots];
+	// FIXME: order? m_numKeys set after `rep stosd`
+	m_slots = new_table;
+	memset(m_slots, 0, sizeof(MxHashTableNode<T>*) * m_numSlots);
+	this->m_numKeys = 0;
 
-  for (int i = 0; i != old_size; i++) {
-    MxHashTableNode<T> *t = old_table[i];
-    
-    while (t) {
-      MxHashTableNode<T> *next = t->m_next;
-      _NodeInsert(t);
-      t = next;
-    }
-  }
+	for (int i = 0; i != old_size; i++) {
+		MxHashTableNode<T>* t = old_table[i];
 
-  delete[] old_table;
+		while (t) {
+			MxHashTableNode<T>* next = t->m_next;
+			_NodeInsert(t);
+			t = next;
+		}
+	}
+
+	delete[] old_table;
 }
 
 template <class T>
 // OFFSET: LEGO1 0x100b7b80
-inline void MxHashTable<T>::_NodeInsert(MxHashTableNode<T> *p_node)
+inline void MxHashTable<T>::_NodeInsert(MxHashTableNode<T>* p_node)
 {
-  int bucket = p_node->m_hash % m_numSlots;
-  
-  p_node->m_next = m_slots[bucket];
-  
-  if (m_slots[bucket])
-    m_slots[bucket]->m_prev = p_node;
+	int bucket = p_node->m_hash % m_numSlots;
 
-  m_slots[bucket] = p_node;
-  this->m_numKeys++;
+	p_node->m_next = m_slots[bucket];
+
+	if (m_slots[bucket])
+		m_slots[bucket]->m_prev = p_node;
+
+	m_slots[bucket] = p_node;
+	this->m_numKeys++;
 }
 
 template <class T>
 inline void MxHashTable<T>::Add(T* p_newobj)
 {
-  if (m_resizeOption && ((this->m_numKeys + 1) / m_numSlots) > m_autoResizeRatio)
-    MxHashTable<T>::Resize();
+	if (m_resizeOption && ((this->m_numKeys + 1) / m_numSlots) > m_autoResizeRatio)
+		MxHashTable<T>::Resize();
 
-  MxU32 hash = Hash(p_newobj);
-  MxHashTableNode<T> *node = new MxHashTableNode<T>(p_newobj, hash);
+	MxU32 hash = Hash(p_newobj);
+	MxHashTableNode<T>* node = new MxHashTableNode<T>(p_newobj, hash);
 
-  MxHashTable<T>::_NodeInsert(node);
+	MxHashTable<T>::_NodeInsert(node);
 }
 
 #endif // MXHASHTABLE_H

--- a/LEGO1/mxioinfo.cpp
+++ b/LEGO1/mxioinfo.cpp
@@ -1,4 +1,5 @@
 #include "mxioinfo.h"
+
 #include "decomp.h"
 
 // This class should be 72 bytes in size, same as the MMIOINFO struct.
@@ -9,437 +10,462 @@ DECOMP_SIZE_ASSERT(MXIOINFO, sizeof(MMIOINFO));
 // OFFSET: LEGO1 0x100cc800
 MXIOINFO::MXIOINFO()
 {
-  memset(&m_info, 0, sizeof(m_info));
+	memset(&m_info, 0, sizeof(m_info));
 }
 
 // OFFSET: LEGO1 0x100cc820
 MXIOINFO::~MXIOINFO()
 {
-  Close(0);
+	Close(0);
 }
 
 // OFFSET: LEGO1 0x100cc830
-MxU16 MXIOINFO::Open(const char *p_filename, MxULong p_flags)
+MxU16 MXIOINFO::Open(const char* p_filename, MxULong p_flags)
 {
-  OFSTRUCT _unused;
-  MxU16 result = 0;
+	OFSTRUCT _unused;
+	MxU16 result = 0;
 
-  m_info.lBufOffset = 0;
-  m_info.lDiskOffset = 0;
+	m_info.lBufOffset = 0;
+	m_info.lDiskOffset = 0;
 
-  // Cast of p_flags to u16 forces the `movzx` instruction
-  m_info.hmmio = (HMMIO)OpenFile(p_filename, &_unused, (MxU16)p_flags);
-  
-  if ((HFILE)m_info.hmmio != HFILE_ERROR) {
-    m_info.dwFlags = p_flags;
-    if (p_flags & MMIO_ALLOCBUF) {
+	// Cast of p_flags to u16 forces the `movzx` instruction
+	m_info.hmmio = (HMMIO) OpenFile(p_filename, &_unused, (MxU16) p_flags);
 
-      // Default buffer length of 8k if none specified
-      int len = m_info.cchBuffer ? m_info.cchBuffer : 8192;
-      HPSTR buf = new char[len];
+	if ((HFILE) m_info.hmmio != HFILE_ERROR) {
+		m_info.dwFlags = p_flags;
+		if (p_flags & MMIO_ALLOCBUF) {
 
-      if (!buf) {
-        result = MMIOERR_OUTOFMEMORY;
-        m_info.cchBuffer = 0;
-        m_info.dwFlags &= ~MMIO_ALLOCBUF;
-        m_info.pchBuffer = 0;
-      } else {
-        m_info.pchBuffer = buf;
-        m_info.cchBuffer = len;
-      }
+			// Default buffer length of 8k if none specified
+			int len = m_info.cchBuffer ? m_info.cchBuffer : 8192;
+			HPSTR buf = new char[len];
 
-      m_info.pchEndRead = m_info.pchBuffer;
-      m_info.pchNext = m_info.pchBuffer;
-      m_info.pchEndWrite = m_info.pchBuffer + m_info.cchBuffer;
-    }
-  } else {
-    result = MMIOERR_CANNOTOPEN;
-  }
+			if (!buf) {
+				result = MMIOERR_OUTOFMEMORY;
+				m_info.cchBuffer = 0;
+				m_info.dwFlags &= ~MMIO_ALLOCBUF;
+				m_info.pchBuffer = 0;
+			}
+			else {
+				m_info.pchBuffer = buf;
+				m_info.cchBuffer = len;
+			}
 
-  return result;
+			m_info.pchEndRead = m_info.pchBuffer;
+			m_info.pchNext = m_info.pchBuffer;
+			m_info.pchEndWrite = m_info.pchBuffer + m_info.cchBuffer;
+		}
+	}
+	else {
+		result = MMIOERR_CANNOTOPEN;
+	}
+
+	return result;
 }
 
 // OFFSET: LEGO1 0x100cc8e0
 MxU16 MXIOINFO::Close(MxLong p_unused)
 {
-  MxU16 result = 0;
+	MxU16 result = 0;
 
-  if (m_info.hmmio) {
-    result = Flush(0);
-    _lclose((HFILE)m_info.hmmio);
-    m_info.hmmio = 0;
+	if (m_info.hmmio) {
+		result = Flush(0);
+		_lclose((HFILE) m_info.hmmio);
+		m_info.hmmio = 0;
 
-    if (m_info.dwFlags & MMIO_ALLOCBUF)
-      delete[] m_info.pchBuffer;
+		if (m_info.dwFlags & MMIO_ALLOCBUF)
+			delete[] m_info.pchBuffer;
 
-    m_info.pchEndWrite = 0;
-    m_info.pchEndRead = 0;
-    m_info.pchBuffer = 0;
-    m_info.dwFlags = 0;
-  }
+		m_info.pchEndWrite = 0;
+		m_info.pchEndRead = 0;
+		m_info.pchBuffer = 0;
+		m_info.dwFlags = 0;
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100cc930
-MxLong MXIOINFO::Read(void *p_buf, MxLong p_len)
+MxLong MXIOINFO::Read(void* p_buf, MxLong p_len)
 {
-  MxLong bytes_read = 0;
+	MxLong bytes_read = 0;
 
-  if (m_info.pchBuffer) {
+	if (m_info.pchBuffer) {
 
-    int bytes_left = m_info.pchEndRead - m_info.pchNext;
-    while (p_len > 0) {
+		int bytes_left = m_info.pchEndRead - m_info.pchNext;
+		while (p_len > 0) {
 
-      if (bytes_left > 0) {
-        if (p_len < bytes_left)
-          bytes_left = p_len;
-        
-        memcpy(p_buf, m_info.pchNext, bytes_left);
-        p_len -= bytes_left;
-        
-        m_info.pchNext += bytes_left;
-        bytes_read += bytes_left;
-      }
+			if (bytes_left > 0) {
+				if (p_len < bytes_left)
+					bytes_left = p_len;
 
-      if (p_len <= 0 || Advance(0))
-        break;
+				memcpy(p_buf, m_info.pchNext, bytes_left);
+				p_len -= bytes_left;
 
-      bytes_left = m_info.pchEndRead - m_info.pchNext;
-      if (bytes_left <= 0)
-        break;
-    }
-  } else if (m_info.hmmio && p_len > 0) {
-    bytes_read = _hread((HFILE)m_info.hmmio, p_buf, p_len);
+				m_info.pchNext += bytes_left;
+				bytes_read += bytes_left;
+			}
 
-    if (bytes_read == -1) {
-      bytes_read = 0;
-      m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-    } else {
-      m_info.lDiskOffset += bytes_read;
-    }
-  }
+			if (p_len <= 0 || Advance(0))
+				break;
 
-  return bytes_read;
+			bytes_left = m_info.pchEndRead - m_info.pchNext;
+			if (bytes_left <= 0)
+				break;
+		}
+	}
+	else if (m_info.hmmio && p_len > 0) {
+		bytes_read = _hread((HFILE) m_info.hmmio, p_buf, p_len);
+
+		if (bytes_read == -1) {
+			bytes_read = 0;
+			m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+		}
+		else {
+			m_info.lDiskOffset += bytes_read;
+		}
+	}
+
+	return bytes_read;
 }
 
 // OFFSET: LEGO1 0x100cca00
 MxLong MXIOINFO::Seek(MxLong p_offset, int p_origin)
 {
-  MxLong result = -1;
+	MxLong result = -1;
 
-  // If buffered I/O
-  if (m_info.pchBuffer) {
-    if (p_origin == SEEK_CUR) {
-      if (!p_offset) {
-        // don't seek at all and just return where we are.
-        return m_info.lBufOffset + (m_info.pchNext - m_info.pchBuffer);
-      } else {
-        // With SEEK_CUR, p_offset is a relative offset.
-        // Get the absolute position instead and use SEEK_SET.
-        p_offset += m_info.lBufOffset + (m_info.pchNext - m_info.pchBuffer);
-        p_origin = SEEK_SET;
-      }
-    } else if (p_origin == SEEK_END) {
-      // not possible with buffered I/O
-      return -1;
-    }
-    
-    // else p_origin == SEEK_SET.
+	// If buffered I/O
+	if (m_info.pchBuffer) {
+		if (p_origin == SEEK_CUR) {
+			if (!p_offset) {
+				// don't seek at all and just return where we are.
+				return m_info.lBufOffset + (m_info.pchNext - m_info.pchBuffer);
+			}
+			else {
+				// With SEEK_CUR, p_offset is a relative offset.
+				// Get the absolute position instead and use SEEK_SET.
+				p_offset += m_info.lBufOffset + (m_info.pchNext - m_info.pchBuffer);
+				p_origin = SEEK_SET;
+			}
+		}
+		else if (p_origin == SEEK_END) {
+			// not possible with buffered I/O
+			return -1;
+		}
 
-    // is p_offset between the start and end of the buffer?
-    // i.e. can we do the seek without reading more from disk?
-    if (p_offset >= m_info.lBufOffset && p_offset < m_info.lBufOffset + m_info.cchBuffer) {
-      m_info.pchNext = m_info.pchBuffer + (p_offset - m_info.lBufOffset);
-      result = p_offset;
-    } else {
-      // we have to read another chunk from disk.
-      if (m_info.hmmio && !Flush(0)) {
-        m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, p_offset, p_origin);
+		// else p_origin == SEEK_SET.
 
-        if (m_info.lDiskOffset == -1) {
-          m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-        } else {
+		// is p_offset between the start and end of the buffer?
+		// i.e. can we do the seek without reading more from disk?
+		if (p_offset >= m_info.lBufOffset && p_offset < m_info.lBufOffset + m_info.cchBuffer) {
+			m_info.pchNext = m_info.pchBuffer + (p_offset - m_info.lBufOffset);
+			result = p_offset;
+		}
+		else {
+			// we have to read another chunk from disk.
+			if (m_info.hmmio && !Flush(0)) {
+				m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, p_offset, p_origin);
 
-          // align offset to buffer size
-          int new_offset = p_offset - (p_offset % m_info.cchBuffer);
-          m_info.lBufOffset = new_offset;
+				if (m_info.lDiskOffset == -1) {
+					m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+				}
+				else {
 
-          // do we need to seek again?
-          // (i.e. are we already aligned to buffer size?)
-          if (p_offset != new_offset) {
-            m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, new_offset, SEEK_SET);
+					// align offset to buffer size
+					int new_offset = p_offset - (p_offset % m_info.cchBuffer);
+					m_info.lBufOffset = new_offset;
 
-            if (m_info.lDiskOffset == -1) {
-              m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-            }
-          }
+					// do we need to seek again?
+					// (i.e. are we already aligned to buffer size?)
+					if (p_offset != new_offset) {
+						m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, new_offset, SEEK_SET);
 
-          if (m_info.lBufOffset == m_info.lDiskOffset) {
-            // is the file open for writing only?
-            if ((m_info.dwFlags & MMIO_RWMODE) &&
-                ((m_info.dwFlags & MMIO_RWMODE) != MMIO_READWRITE)) {
+						if (m_info.lDiskOffset == -1) {
+							m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+						}
+					}
 
-              m_info.pchNext = m_info.pchBuffer - m_info.lBufOffset + p_offset;
-              
-              result = p_offset;
-            } else {
-              // We can read from the file. Fill the buffer.
-              int bytes_read = _hread((HFILE)m_info.hmmio, m_info.pchBuffer, m_info.cchBuffer);
-              
-              if (bytes_read == -1) {
-                m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-              } else {
-                m_info.lDiskOffset += bytes_read;
-                m_info.pchNext = p_offset - m_info.lBufOffset + m_info.pchBuffer;
-                m_info.pchEndRead = m_info.pchBuffer + bytes_read;
+					if (m_info.lBufOffset == m_info.lDiskOffset) {
+						// is the file open for writing only?
+						if ((m_info.dwFlags & MMIO_RWMODE) && ((m_info.dwFlags & MMIO_RWMODE) != MMIO_READWRITE)) {
 
-                if (m_info.pchNext < m_info.pchEndRead) {
-                  result = p_offset;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  } else {
-    // No buffer so just seek the file directly (if we have a valid handle)
-    if (m_info.hmmio) {
-      // i.e. if we just want to get the current file position
-      if (p_origin == SEEK_CUR && p_offset == 0) {
-        return m_info.lDiskOffset;
-      } else {
-        m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, p_offset, p_origin);
+							m_info.pchNext = m_info.pchBuffer - m_info.lBufOffset + p_offset;
 
-        result = m_info.lDiskOffset;
+							result = p_offset;
+						}
+						else {
+							// We can read from the file. Fill the buffer.
+							int bytes_read = _hread((HFILE) m_info.hmmio, m_info.pchBuffer, m_info.cchBuffer);
 
-        if (result == -1) {
-          m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-        }
-      }
-    }
-  }
+							if (bytes_read == -1) {
+								m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+							}
+							else {
+								m_info.lDiskOffset += bytes_read;
+								m_info.pchNext = p_offset - m_info.lBufOffset + m_info.pchBuffer;
+								m_info.pchEndRead = m_info.pchBuffer + bytes_read;
 
-  return result;
+								if (m_info.pchNext < m_info.pchEndRead) {
+									result = p_offset;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	else {
+		// No buffer so just seek the file directly (if we have a valid handle)
+		if (m_info.hmmio) {
+			// i.e. if we just want to get the current file position
+			if (p_origin == SEEK_CUR && p_offset == 0) {
+				return m_info.lDiskOffset;
+			}
+			else {
+				m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, p_offset, p_origin);
+
+				result = m_info.lDiskOffset;
+
+				if (result == -1) {
+					m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+				}
+			}
+		}
+	}
+
+	return result;
 }
 
 // OFFSET: LEGO1 0x100ccbc0
-MxU16 MXIOINFO::SetBuffer(char *p_buf, MxLong p_len, MxLong p_unused)
+MxU16 MXIOINFO::SetBuffer(char* p_buf, MxLong p_len, MxLong p_unused)
 {
-  MxU16 result = Flush(0);
+	MxU16 result = Flush(0);
 
-  if (m_info.dwFlags & MMIO_ALLOCBUF) {
-    m_info.dwFlags &= ~MMIO_ALLOCBUF;
-    delete[] m_info.pchBuffer;
-  }
+	if (m_info.dwFlags & MMIO_ALLOCBUF) {
+		m_info.dwFlags &= ~MMIO_ALLOCBUF;
+		delete[] m_info.pchBuffer;
+	}
 
-  m_info.pchBuffer = p_buf;
-  m_info.cchBuffer = p_len;
-  m_info.pchEndWrite = m_info.pchBuffer + m_info.cchBuffer;
-  m_info.pchEndRead = m_info.pchBuffer;
+	m_info.pchBuffer = p_buf;
+	m_info.cchBuffer = p_len;
+	m_info.pchEndWrite = m_info.pchBuffer + m_info.cchBuffer;
+	m_info.pchEndRead = m_info.pchBuffer;
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100ccc10
 MxU16 MXIOINFO::Flush(MxU16 p_unused)
 {
-  MxU16 result = 0;
+	MxU16 result = 0;
 
-  // if buffer is dirty
-  if (m_info.dwFlags & MMIO_DIRTY) {
-    // if we have allocated an IO buffer
-    if (m_info.pchBuffer) {
-      // if we have a file open for writing
-      if (m_info.hmmio && (m_info.dwFlags & MMIO_RWMODE)) {
-        // (pulling this value out into a variable forces it into EBX)
-        MxLong cchBuffer = m_info.cchBuffer;
-        if (cchBuffer > 0) {
-          if (m_info.lBufOffset != m_info.lDiskOffset) {
-            m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, m_info.lBufOffset, SEEK_SET);
-          }
+	// if buffer is dirty
+	if (m_info.dwFlags & MMIO_DIRTY) {
+		// if we have allocated an IO buffer
+		if (m_info.pchBuffer) {
+			// if we have a file open for writing
+			if (m_info.hmmio && (m_info.dwFlags & MMIO_RWMODE)) {
+				// (pulling this value out into a variable forces it into EBX)
+				MxLong cchBuffer = m_info.cchBuffer;
+				if (cchBuffer > 0) {
+					if (m_info.lBufOffset != m_info.lDiskOffset) {
+						m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, m_info.lBufOffset, SEEK_SET);
+					}
 
-          // Was the previous seek (if required) successful?
-          if (m_info.lBufOffset != m_info.lDiskOffset) {
-            result = MMIOERR_CANNOTSEEK;
-            m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-          } else {
-            MxLong bytes_written = _hwrite((HFILE)m_info.hmmio, m_info.pchBuffer, cchBuffer);
+					// Was the previous seek (if required) successful?
+					if (m_info.lBufOffset != m_info.lDiskOffset) {
+						result = MMIOERR_CANNOTSEEK;
+						m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+					}
+					else {
+						MxLong bytes_written = _hwrite((HFILE) m_info.hmmio, m_info.pchBuffer, cchBuffer);
 
-            if (bytes_written != -1 && bytes_written == cchBuffer) {
-              m_info.lDiskOffset += bytes_written;
-              m_info.pchNext = m_info.pchBuffer;
-              m_info.dwFlags &= ~MMIO_DIRTY;
-            } else {
-              result = MMIOERR_CANNOTWRITE;
-              m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-            }
-          }
-        }
-      } else {
-        result = MMIOERR_CANNOTWRITE;
-      }
-    } else {
-      result = MMIOERR_UNBUFFERED;
-    }
-  }
+						if (bytes_written != -1 && bytes_written == cchBuffer) {
+							m_info.lDiskOffset += bytes_written;
+							m_info.pchNext = m_info.pchBuffer;
+							m_info.dwFlags &= ~MMIO_DIRTY;
+						}
+						else {
+							result = MMIOERR_CANNOTWRITE;
+							m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+						}
+					}
+				}
+			}
+			else {
+				result = MMIOERR_CANNOTWRITE;
+			}
+		}
+		else {
+			result = MMIOERR_UNBUFFERED;
+		}
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100ccd00
 MxU16 MXIOINFO::Advance(MxU16 p_option)
 {
-  MxU16 result = 0;
-  MxULong rwmode = m_info.dwFlags & MMIO_RWMODE;
+	MxU16 result = 0;
+	MxULong rwmode = m_info.dwFlags & MMIO_RWMODE;
 
-  if (m_info.pchBuffer) {
-    MxLong cch = m_info.cchBuffer;
+	if (m_info.pchBuffer) {
+		MxLong cch = m_info.cchBuffer;
 
-    // If we can and should write to the file,
-    // if we are being asked to write to the file,
-    // and if there is a buffer *to* write:
-    if ((rwmode == MMIO_WRITE || rwmode == MMIO_READWRITE) &&
-        (m_info.dwFlags & MMIO_DIRTY) && 
-        ((p_option & MMIO_WRITE) || (rwmode == MMIO_READWRITE)) &&
-        cch > 0) {
+		// If we can and should write to the file,
+		// if we are being asked to write to the file,
+		// and if there is a buffer *to* write:
+		if ((rwmode == MMIO_WRITE || rwmode == MMIO_READWRITE) && (m_info.dwFlags & MMIO_DIRTY) &&
+			((p_option & MMIO_WRITE) || (rwmode == MMIO_READWRITE)) && cch > 0) {
 
-      if (m_info.lBufOffset != m_info.lDiskOffset) {
-        m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, m_info.lBufOffset, SEEK_SET);
-      }
+			if (m_info.lBufOffset != m_info.lDiskOffset) {
+				m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, m_info.lBufOffset, SEEK_SET);
+			}
 
-      if (m_info.lBufOffset != m_info.lDiskOffset) {
-        result = MMIOERR_CANNOTSEEK;
-      } else {
-        MxLong bytes_written = _hwrite((HFILE)m_info.hmmio, m_info.pchBuffer, cch);
+			if (m_info.lBufOffset != m_info.lDiskOffset) {
+				result = MMIOERR_CANNOTSEEK;
+			}
+			else {
+				MxLong bytes_written = _hwrite((HFILE) m_info.hmmio, m_info.pchBuffer, cch);
 
-        if (bytes_written != -1 && bytes_written == cch) {
-          m_info.lDiskOffset += bytes_written;
-          m_info.pchNext = m_info.pchBuffer;
-          m_info.pchEndRead = m_info.pchBuffer;
-          m_info.dwFlags &= ~MMIO_DIRTY;
-        } else {
-          result = MMIOERR_CANNOTWRITE;
-        }
-      }  
+				if (bytes_written != -1 && bytes_written == cch) {
+					m_info.lDiskOffset += bytes_written;
+					m_info.pchNext = m_info.pchBuffer;
+					m_info.pchEndRead = m_info.pchBuffer;
+					m_info.dwFlags &= ~MMIO_DIRTY;
+				}
+				else {
+					result = MMIOERR_CANNOTWRITE;
+				}
+			}
 
-      m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
+			m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+		}
 
-    }
+		m_info.lBufOffset += cch;
+		if ((!rwmode || rwmode == MMIO_READWRITE) && cch > 0) {
+			if (m_info.lBufOffset != m_info.lDiskOffset) {
+				m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, m_info.lBufOffset, SEEK_SET);
+			}
 
-    m_info.lBufOffset += cch;
-    if ((!rwmode || rwmode == MMIO_READWRITE) && cch > 0) {
-      if (m_info.lBufOffset != m_info.lDiskOffset) {
-        m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, m_info.lBufOffset, SEEK_SET);
-      }
+			// if previous seek failed
+			if (m_info.lBufOffset != m_info.lDiskOffset) {
+				result = MMIOERR_CANNOTSEEK;
+				m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+			}
+			else {
+				int bytes_read = _hread((HFILE) m_info.hmmio, m_info.pchBuffer, cch);
 
-      // if previous seek failed
-      if (m_info.lBufOffset != m_info.lDiskOffset) {
-        result = MMIOERR_CANNOTSEEK;
-        m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-      } else {
-        int bytes_read = _hread((HFILE)m_info.hmmio, m_info.pchBuffer, cch);
+				if (bytes_read == -1) {
+					result = MMIOERR_CANNOTREAD;
+					m_info.lDiskOffset = _llseek((HFILE) m_info.hmmio, 0, SEEK_CUR);
+				}
+				else {
+					m_info.lDiskOffset += bytes_read;
+					m_info.pchNext = m_info.pchBuffer;
+					m_info.pchEndRead = m_info.pchBuffer + bytes_read;
+				}
+			}
+		}
+	}
+	else {
+		result = MMIOERR_UNBUFFERED;
+	}
 
-        if (bytes_read == -1) {
-          result = MMIOERR_CANNOTREAD;
-          m_info.lDiskOffset = _llseek((HFILE)m_info.hmmio, 0, SEEK_CUR);
-        } else {
-          m_info.lDiskOffset += bytes_read;
-          m_info.pchNext = m_info.pchBuffer;
-          m_info.pchEndRead = m_info.pchBuffer + bytes_read;
-        }
-      }
-    }
-  } else {
-    result = MMIOERR_UNBUFFERED;
-  }
-
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100cce60
-MxU16 MXIOINFO::Descend(MMCKINFO *p_chunkInfo, const MMCKINFO *p_parentInfo, MxU16 p_descend)
+MxU16 MXIOINFO::Descend(MMCKINFO* p_chunkInfo, const MMCKINFO* p_parentInfo, MxU16 p_descend)
 {
-  MxU16 result = 0;
-  
-  if (!p_chunkInfo) 
-    return MMIOERR_BASE; // ?
+	MxU16 result = 0;
 
-  if (!p_descend) {
-    p_chunkInfo->dwFlags = 0;
-    if (Read(p_chunkInfo, 8) != 8) {
-      result = MMIOERR_CANNOTREAD;
-    } else {
-      if (m_info.pchBuffer) {
-        p_chunkInfo->dwDataOffset = m_info.pchNext - m_info.pchBuffer + m_info.lBufOffset;
-      } else {
-        p_chunkInfo->dwDataOffset = m_info.lDiskOffset;
-      }
+	if (!p_chunkInfo)
+		return MMIOERR_BASE; // ?
 
-      if (p_chunkInfo->ckid == FOURCC_RIFF || p_chunkInfo->ckid == FOURCC_LIST) {
-        if (Read(&p_chunkInfo->fccType, 4) != 4) {
-          result = MMIOERR_CANNOTREAD;
-        }
-      }
-    }
-  } else {
-    MxULong ofs = MAXLONG;
+	if (!p_descend) {
+		p_chunkInfo->dwFlags = 0;
+		if (Read(p_chunkInfo, 8) != 8) {
+			result = MMIOERR_CANNOTREAD;
+		}
+		else {
+			if (m_info.pchBuffer) {
+				p_chunkInfo->dwDataOffset = m_info.pchNext - m_info.pchBuffer + m_info.lBufOffset;
+			}
+			else {
+				p_chunkInfo->dwDataOffset = m_info.lDiskOffset;
+			}
 
-    if (p_parentInfo)
-      ofs = p_parentInfo->cksize + p_parentInfo->dwDataOffset;
+			if (p_chunkInfo->ckid == FOURCC_RIFF || p_chunkInfo->ckid == FOURCC_LIST) {
+				if (Read(&p_chunkInfo->fccType, 4) != 4) {
+					result = MMIOERR_CANNOTREAD;
+				}
+			}
+		}
+	}
+	else {
+		MxULong ofs = MAXLONG;
 
-    BOOL running = TRUE;
-    BOOL read_ok = FALSE;
-    MMCKINFO tmp;
-    tmp.dwFlags = 0;
+		if (p_parentInfo)
+			ofs = p_parentInfo->cksize + p_parentInfo->dwDataOffset;
 
-    // This loop is... something
-    do {
-      if (Read(&tmp, 8) != 8) {
-        // If the first read fails, report read error. Else EOF.
-        result = read_ok ? MMIOERR_CHUNKNOTFOUND : MMIOERR_CANNOTREAD;
-        running = FALSE;
-      } else {
-        read_ok = TRUE;
-        if (m_info.pchBuffer) {
-          tmp.dwDataOffset = m_info.pchNext - m_info.pchBuffer + m_info.lBufOffset;
-        } else {
-          tmp.dwDataOffset = m_info.lDiskOffset;
-        }
+		BOOL running = TRUE;
+		BOOL read_ok = FALSE;
+		MMCKINFO tmp;
+		tmp.dwFlags = 0;
 
-        if (ofs < tmp.dwDataOffset) {
-          result = MMIOERR_CHUNKNOTFOUND;
-          running = FALSE;
-        } else {
-          if ((p_descend == MMIO_FINDLIST && tmp.ckid == FOURCC_LIST) ||
-              (p_descend == MMIO_FINDRIFF && tmp.ckid == FOURCC_RIFF)) {
-            if (Read(&tmp.fccType, 4) != 4) {
-              result = MMIOERR_CANNOTREAD;
-            } else {
-              if (p_chunkInfo->fccType != tmp.fccType)
-                continue;
-            }
-            running = FALSE;
-          } else {
-            if (p_chunkInfo->ckid != tmp.ckid) {
-              if (Seek((tmp.cksize&1)+tmp.cksize, SEEK_CUR) != -1) {
-                continue;
-              } else {
-                result = MMIOERR_CANNOTSEEK;
-              }
-            }
-            running = FALSE;
-          }
-        }
-      }
+		// This loop is... something
+		do {
+			if (Read(&tmp, 8) != 8) {
+				// If the first read fails, report read error. Else EOF.
+				result = read_ok ? MMIOERR_CHUNKNOTFOUND : MMIOERR_CANNOTREAD;
+				running = FALSE;
+			}
+			else {
+				read_ok = TRUE;
+				if (m_info.pchBuffer) {
+					tmp.dwDataOffset = m_info.pchNext - m_info.pchBuffer + m_info.lBufOffset;
+				}
+				else {
+					tmp.dwDataOffset = m_info.lDiskOffset;
+				}
 
-    } while (running);
+				if (ofs < tmp.dwDataOffset) {
+					result = MMIOERR_CHUNKNOTFOUND;
+					running = FALSE;
+				}
+				else {
+					if ((p_descend == MMIO_FINDLIST && tmp.ckid == FOURCC_LIST) ||
+						(p_descend == MMIO_FINDRIFF && tmp.ckid == FOURCC_RIFF)) {
+						if (Read(&tmp.fccType, 4) != 4) {
+							result = MMIOERR_CANNOTREAD;
+						}
+						else {
+							if (p_chunkInfo->fccType != tmp.fccType)
+								continue;
+						}
+						running = FALSE;
+					}
+					else {
+						if (p_chunkInfo->ckid != tmp.ckid) {
+							if (Seek((tmp.cksize & 1) + tmp.cksize, SEEK_CUR) != -1) {
+								continue;
+							}
+							else {
+								result = MMIOERR_CANNOTSEEK;
+							}
+						}
+						running = FALSE;
+					}
+				}
+			}
 
-    if (!result)
-      memcpy(p_chunkInfo, &tmp, sizeof(MMCKINFO));
+		} while (running);
 
-  }
+		if (!result)
+			memcpy(p_chunkInfo, &tmp, sizeof(MMCKINFO));
+	}
 
-  return result;
+	return result;
 }

--- a/LEGO1/mxioinfo.h
+++ b/LEGO1/mxioinfo.h
@@ -1,29 +1,31 @@
 #ifndef MXIOINFO_H
 #define MXIOINFO_H
 
-#include <windows.h>
-#include <mmsystem.h>
-
 #include "mxtypes.h"
 
-class MXIOINFO
-{
+// mmsystem.h requires inclusion of windows.h before
+// clang-format off
+#include <windows.h>
+#include <mmsystem.h>
+// clang-format on
+
+class MXIOINFO {
 public:
-  MXIOINFO();
-  __declspec(dllexport) ~MXIOINFO();
+	MXIOINFO();
+	__declspec(dllexport) ~MXIOINFO();
 
-  MxU16 Open(const char *, MxULong);
-  MxU16 Close(MxLong);
-  MxLong Read(void *, MxLong);
-  MxLong Seek(MxLong, int);
-  MxU16 SetBuffer(char *, MxLong, MxLong);
-  MxU16 Flush(MxU16);
-  MxU16 Advance(MxU16);
-  MxU16 Descend(MMCKINFO *, const MMCKINFO *, MxU16);
+	MxU16 Open(const char*, MxULong);
+	MxU16 Close(MxLong);
+	MxLong Read(void*, MxLong);
+	MxLong Seek(MxLong, int);
+	MxU16 SetBuffer(char*, MxLong, MxLong);
+	MxU16 Flush(MxU16);
+	MxU16 Advance(MxU16);
+	MxU16 Descend(MMCKINFO*, const MMCKINFO*, MxU16);
 
-  // NOTE: In MXIOINFO, the `hmmio` member of MMIOINFO is used like
-  // an HFILE (int) instead of an HMMIO (WORD).
-  MMIOINFO m_info;
+	// NOTE: In MXIOINFO, the `hmmio` member of MMIOINFO is used like
+	// an HFILE (int) instead of an HMMIO (WORD).
+	MMIOINFO m_info;
 };
 
 #endif // MXIOINFO_H

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -1,8 +1,8 @@
 #ifndef MXLIST_H
 #define MXLIST_H
 
-#include "mxtypes.h"
 #include "mxcore.h"
+#include "mxtypes.h"
 
 template <class T>
 class MxList;
@@ -10,228 +10,229 @@ template <class T>
 class MxListCursor;
 
 template <class T>
-class MxListEntry
-{
+class MxListEntry {
 public:
-  MxListEntry() {}
-  MxListEntry(T p_obj, MxListEntry *p_prev) {
-    m_obj = p_obj;
-    m_prev = p_prev;
-    m_next = NULL;
-  }
-  MxListEntry(T p_obj, MxListEntry *p_prev, MxListEntry *p_next) {
-    m_obj = p_obj;
-    m_prev = p_prev;
-    m_next = p_next;
-  }
+	MxListEntry() {}
+	MxListEntry(T p_obj, MxListEntry* p_prev)
+	{
+		m_obj = p_obj;
+		m_prev = p_prev;
+		m_next = NULL;
+	}
+	MxListEntry(T p_obj, MxListEntry* p_prev, MxListEntry* p_next)
+	{
+		m_obj = p_obj;
+		m_prev = p_prev;
+		m_next = p_next;
+	}
 
-  T GetValue() { return this->m_obj; }
+	T GetValue() { return this->m_obj; }
 
-  friend class MxList<T>;
-  friend class MxListCursor<T>;
+	friend class MxList<T>;
+	friend class MxListCursor<T>;
+
 private:
-  T m_obj;
-  MxListEntry *m_prev;
-  MxListEntry *m_next;
+	T m_obj;
+	MxListEntry* m_prev;
+	MxListEntry* m_next;
 };
 
 // SIZE 0x10
 template <class T>
-class MxListParent : public MxCore
-{
+class MxListParent : public MxCore {
 public:
-  MxListParent() {
-    m_count = 0;
-    m_customDestructor = Destroy;
-  }
+	MxListParent()
+	{
+		m_count = 0;
+		m_customDestructor = Destroy;
+	}
 
-  virtual ~MxListParent() {}
-  virtual MxS8 Compare(T, T) { return 0; };
+	virtual ~MxListParent() {}
+	virtual MxS8 Compare(T, T) { return 0; };
 
-  static void Destroy(T) {};
+	static void Destroy(T){};
+
 protected:
-  MxU32 m_count;                   // +0x8
-  void (*m_customDestructor)(T); // +0xc
+	MxU32 m_count;                 // +0x8
+	void (*m_customDestructor)(T); // +0xc
 };
 
 // SIZE 0x18
 template <class T>
-class MxList : protected MxListParent<T>
-{
+class MxList : protected MxListParent<T> {
 public:
-  MxList() {
-    m_last = NULL;
-    m_first = NULL;
-  }
+	MxList()
+	{
+		m_last = NULL;
+		m_first = NULL;
+	}
 
-  virtual ~MxList();
+	virtual ~MxList();
 
-  void Append(T);
-  void OtherAppend(T p_obj) { _InsertEntry(p_obj, this->m_last, NULL); };
-  void DeleteAll();
-  MxU32 GetCount() { return this->m_count; }
-  void SetDestroy(void (*p_customDestructor)(T)) { this->m_customDestructor = p_customDestructor; }
+	void Append(T);
+	void OtherAppend(T p_obj) { _InsertEntry(p_obj, this->m_last, NULL); };
+	void DeleteAll();
+	MxU32 GetCount() { return this->m_count; }
+	void SetDestroy(void (*p_customDestructor)(T)) { this->m_customDestructor = p_customDestructor; }
 
-  friend class MxListCursor<T>;
+	friend class MxListCursor<T>;
+
 protected:
-  MxListEntry<T> *m_first; // +0x10
-  MxListEntry<T> *m_last;  // +0x14
+	MxListEntry<T>* m_first; // +0x10
+	MxListEntry<T>* m_last;  // +0x14
 
 private:
-  void _DeleteEntry(MxListEntry<T> *match);
-  void _InsertEntry(T, MxListEntry<T> *, MxListEntry<T> *);
+	void _DeleteEntry(MxListEntry<T>* match);
+	void _InsertEntry(T, MxListEntry<T>*, MxListEntry<T>*);
 };
 
 template <class T>
-class MxListCursor : public MxCore
-{
+class MxListCursor : public MxCore {
 public:
-  MxListCursor(MxList<T> *p_list) {
-    m_list = p_list;
-    m_match = NULL;
-  }
+	MxListCursor(MxList<T>* p_list)
+	{
+		m_list = p_list;
+		m_match = NULL;
+	}
 
-  MxBool Find(T p_obj);
-  void Detach();
-  MxBool Next(T& p_obj);
-  void SetValue(T p_obj);
-  void Head() { m_match = m_list->m_first; }
-  void Reset() { m_match = NULL; }
+	MxBool Find(T p_obj);
+	void Detach();
+	MxBool Next(T& p_obj);
+	void SetValue(T p_obj);
+	void Head() { m_match = m_list->m_first; }
+	void Reset() { m_match = NULL; }
 
 private:
-  MxList<T> *m_list;
-  MxListEntry<T> *m_match;
+	MxList<T>* m_list;
+	MxListEntry<T>* m_match;
 };
 
 // Unclear purpose
 template <class T>
-class MxListCursorChild : public MxListCursor<T> 
-{
+class MxListCursorChild : public MxListCursor<T> {
 public:
-  MxListCursorChild(MxList<T> *p_list) : MxListCursor<T>(p_list) {}
+	MxListCursorChild(MxList<T>* p_list) : MxListCursor<T>(p_list) {}
 };
 
 // Unclear purpose
 template <class T>
-class MxListCursorChildChild : public MxListCursorChild<T>
-{
+class MxListCursorChildChild : public MxListCursorChild<T> {
 public:
-  MxListCursorChildChild(MxList<T> *p_list) : MxListCursorChild<T>(p_list) {}
+	MxListCursorChildChild(MxList<T>* p_list) : MxListCursorChild<T>(p_list) {}
 };
 
 template <class T>
 MxList<T>::~MxList()
 {
-  DeleteAll();
+	DeleteAll();
 }
 
 template <class T>
 inline void MxList<T>::DeleteAll()
 {
-  for (MxListEntry<T> *t = m_first;;) {
-    if (!t)
-      break;
+	for (MxListEntry<T>* t = m_first;;) {
+		if (!t)
+			break;
 
-    MxListEntry<T> *next = t->m_next;
-    this->m_customDestructor(t->GetValue());
-    delete t;
-    t = next;
-  }
+		MxListEntry<T>* next = t->m_next;
+		this->m_customDestructor(t->GetValue());
+		delete t;
+		t = next;
+	}
 
-  this->m_count = 0;
-  m_last = NULL;
-  m_first = NULL;
+	this->m_count = 0;
+	m_last = NULL;
+	m_first = NULL;
 }
 
 template <class T>
 inline void MxList<T>::Append(T p_newobj)
 {
-  MxListEntry<T> *currentLast = this->m_last;
-  MxListEntry<T> *newEntry = new MxListEntry<T>(p_newobj, currentLast);
+	MxListEntry<T>* currentLast = this->m_last;
+	MxListEntry<T>* newEntry = new MxListEntry<T>(p_newobj, currentLast);
 
-  if (currentLast)
-    currentLast->m_next = newEntry;
-  else
-    this->m_first = newEntry;
-    
-  this->m_last = newEntry;
-  this->m_count++;
+	if (currentLast)
+		currentLast->m_next = newEntry;
+	else
+		this->m_first = newEntry;
+
+	this->m_last = newEntry;
+	this->m_count++;
 }
 
 template <class T>
-inline void MxList<T>::_InsertEntry(T p_newobj, MxListEntry<T> *p_prev, MxListEntry<T> *p_next)
+inline void MxList<T>::_InsertEntry(T p_newobj, MxListEntry<T>* p_prev, MxListEntry<T>* p_next)
 {
-  MxListEntry<T> *newEntry = new MxListEntry<T>(p_newobj, p_prev, p_next);
+	MxListEntry<T>* newEntry = new MxListEntry<T>(p_newobj, p_prev, p_next);
 
-  if (p_prev)
-    p_prev->m_next = newEntry;
-  else
-    this->m_first = newEntry;
+	if (p_prev)
+		p_prev->m_next = newEntry;
+	else
+		this->m_first = newEntry;
 
-  if (p_next)
-    p_next->m_prev = newEntry;
-  else
-    this->m_last = newEntry;
+	if (p_next)
+		p_next->m_prev = newEntry;
+	else
+		this->m_last = newEntry;
 
-  this->m_count++;
+	this->m_count++;
 }
 
 template <class T>
-inline void MxList<T>::_DeleteEntry(MxListEntry<T> *match)
+inline void MxList<T>::_DeleteEntry(MxListEntry<T>* match)
 {
-  MxListEntry<T> **pPrev = &match->m_prev;
-  MxListEntry<T> **pNext = &match->m_next;
+	MxListEntry<T>** pPrev = &match->m_prev;
+	MxListEntry<T>** pNext = &match->m_next;
 
-  if (match->m_prev)
-    match->m_prev->m_next = *pNext;
-  else
-    m_first = *pNext;
+	if (match->m_prev)
+		match->m_prev->m_next = *pNext;
+	else
+		m_first = *pNext;
 
-  if (*pNext)
-    (*pNext)->m_prev = *pPrev;
-  else
-    m_last = *pPrev;
+	if (*pNext)
+		(*pNext)->m_prev = *pPrev;
+	else
+		m_last = *pPrev;
 
-  delete match;
-  this->m_count--;
+	delete match;
+	this->m_count--;
 }
 
 template <class T>
 inline MxBool MxListCursor<T>::Find(T p_obj)
 {
-  for (m_match = m_list->m_first;
-    m_match && m_list->Compare(m_match->m_obj, p_obj);
-    m_match = m_match->m_next);
+	for (m_match = m_list->m_first; m_match && m_list->Compare(m_match->m_obj, p_obj); m_match = m_match->m_next)
+		;
 
-  return m_match != NULL;
+	return m_match != NULL;
 }
 
 template <class T>
 inline void MxListCursor<T>::Detach()
 {
-  m_list->_DeleteEntry(m_match);
-  m_match = NULL;
+	m_list->_DeleteEntry(m_match);
+	m_match = NULL;
 }
 
 template <class T>
 inline MxBool MxListCursor<T>::Next(T& p_obj)
 {
-  if (!m_match)
-    m_match = m_list->m_first;
-  else
-    m_match = m_match->m_next;
+	if (!m_match)
+		m_match = m_list->m_first;
+	else
+		m_match = m_match->m_next;
 
-  if (m_match)
-    p_obj = m_match->GetValue();
+	if (m_match)
+		p_obj = m_match->GetValue();
 
-  return m_match != NULL;
+	return m_match != NULL;
 }
 
 template <class T>
 inline void MxListCursor<T>::SetValue(T p_obj)
 {
-  if (m_match)
-    m_match->m_obj = p_obj;
+	if (m_match)
+		m_match->m_obj = p_obj;
 }
 
 #endif // MXLIST_H

--- a/LEGO1/mxloopingflcpresenter.cpp
+++ b/LEGO1/mxloopingflcpresenter.cpp
@@ -7,25 +7,25 @@ DECOMP_SIZE_ASSERT(MxLoopingFlcPresenter, 0x6c);
 // OFFSET: LEGO1 0x100b4310
 MxLoopingFlcPresenter::MxLoopingFlcPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100b43b0
 MxLoopingFlcPresenter::~MxLoopingFlcPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100b4410
 void MxLoopingFlcPresenter::Init()
 {
-  this->m_unk68 = 0;
-  this->m_flags &= 0xfd;
-  this->m_flags &= 0xfb;
+	this->m_unk68 = 0;
+	this->m_flags &= 0xfd;
+	this->m_flags &= 0xfb;
 }
 
 // OFFSET: LEGO1 0x100b4432 STUB
 void MxLoopingFlcPresenter::Destroy(MxBool p_fromDestructor)
 {
-  // TODO 
+	// TODO
 }

--- a/LEGO1/mxloopingflcpresenter.h
+++ b/LEGO1/mxloopingflcpresenter.h
@@ -1,30 +1,28 @@
 #ifndef MXLOOPINGFLCPRESENTER_H
 #define MXLOOPINGFLCPRESENTER_H
 
-#include "mxflcpresenter.h"
-
 #include "decomp.h"
+#include "mxflcpresenter.h"
 
 // VTABLE 0x100dc480
 // SIZE 0x6c
-class MxLoopingFlcPresenter : public MxFlcPresenter
-{
+class MxLoopingFlcPresenter : public MxFlcPresenter {
 public:
-  MxLoopingFlcPresenter();
-  virtual ~MxLoopingFlcPresenter() override;
+	MxLoopingFlcPresenter();
+	virtual ~MxLoopingFlcPresenter() override;
 
-  // OFFSET: LEGO1 0x100b4380
-  inline virtual const char* ClassName() const override // vtable+0xc
-  {
-    // 0x10101e20
-    return "MxLoopingFlcPresenter";
-  }
+	// OFFSET: LEGO1 0x100b4380
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10101e20
+		return "MxLoopingFlcPresenter";
+	}
 
 private:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 
-  undefined4 m_unk68;
+	undefined4 m_unk68;
 };
 
 #endif // MXLOOPINGFLCPRESENTER_H

--- a/LEGO1/mxloopingmidipresenter.h
+++ b/LEGO1/mxloopingmidipresenter.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100dc240
 // SIZE 0x58
-class MxLoopingMIDIPresenter : public MxMIDIPresenter
-{
+class MxLoopingMIDIPresenter : public MxMIDIPresenter {
 public:
-  // OFFSET: LEGO1 0x100b1830
-  inline virtual const char* ClassName() const override // vtable+0xc
-  {
-    // 0x10101de0
-    return "MxLoopingMIDIPresenter";
-  }
+	// OFFSET: LEGO1 0x100b1830
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10101de0
+		return "MxLoopingMIDIPresenter";
+	}
 
-  // OFFSET: LEGO1 0x100b1840
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxLoopingMIDIPresenter::ClassName()) || MxMIDIPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100b1840
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxLoopingMIDIPresenter::ClassName()) || MxMIDIPresenter::IsA(name);
+	}
 };
 
 #endif // MXLOOPINGMIDIPRESENTER_H

--- a/LEGO1/mxloopingsmkpresenter.cpp
+++ b/LEGO1/mxloopingsmkpresenter.cpp
@@ -7,21 +7,21 @@ DECOMP_SIZE_ASSERT(MxLoopingSmkPresenter, 0x724);
 // OFFSET: LEGO1 0x100b48b0
 MxLoopingSmkPresenter::MxLoopingSmkPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100b4950
 MxLoopingSmkPresenter::~MxLoopingSmkPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100b49b0
 void MxLoopingSmkPresenter::Init()
 {
-  this->m_unk720 = 0;
-  this->m_flags &= 0xfd;
-  this->m_flags &= 0xfb;
+	this->m_unk720 = 0;
+	this->m_flags &= 0xfd;
+	this->m_flags &= 0xfb;
 }
 
 // OFFSET: LEGO1 0x100b49d0 STUB

--- a/LEGO1/mxloopingsmkpresenter.h
+++ b/LEGO1/mxloopingsmkpresenter.h
@@ -1,30 +1,28 @@
 #ifndef MXLOOPINGSMKPRESENTER_H
 #define MXLOOPINGSMKPRESENTER_H
 
-#include "mxsmkpresenter.h"
-
 #include "decomp.h"
+#include "mxsmkpresenter.h"
 
 // VTABLE 0x100dc540
 // SIZE 0x724
-class MxLoopingSmkPresenter : public MxSmkPresenter
-{
+class MxLoopingSmkPresenter : public MxSmkPresenter {
 public:
-  MxLoopingSmkPresenter();
-  virtual ~MxLoopingSmkPresenter() override; // vtable+0x0
+	MxLoopingSmkPresenter();
+	virtual ~MxLoopingSmkPresenter() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x100b4920
-  inline virtual const char* ClassName() const override // vtable+0xc
-  {
-    // 0x10101e08
-    return "MxLoopingSmkPresenter";
-  }
+	// OFFSET: LEGO1 0x100b4920
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10101e08
+		return "MxLoopingSmkPresenter";
+	}
 
 private:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 
-  undefined4 m_unk720;
+	undefined4 m_unk720;
 };
 
 #endif // MXLOOPINGSMKPRESENTER_H

--- a/LEGO1/mxmatrix.cpp
+++ b/LEGO1/mxmatrix.cpp
@@ -1,187 +1,183 @@
 
 #include "mxmatrix.h"
 
-#include <memory.h>
+#include "decomp.h"
 #include "math.h"
 
-#include "decomp.h"
+#include <memory.h>
 
 DECOMP_SIZE_ASSERT(MxMatrix, 0x8);
 DECOMP_SIZE_ASSERT(MxMatrixData, 0x48);
 
 // OFFSET: LEGO1 0x10002340
-void MxMatrix::EqualsMxMatrix(const MxMatrix *p_other)
+void MxMatrix::EqualsMxMatrix(const MxMatrix* p_other)
 {
-  memcpy(m_data, p_other->m_data, 16 * sizeof(float));
+	memcpy(m_data, p_other->m_data, 16 * sizeof(float));
 }
 
 // OFFSET: LEGO1 0x10002320
-void MxMatrix::EqualsMatrixData(const float *p_matrix)
+void MxMatrix::EqualsMatrixData(const float* p_matrix)
 {
-  memcpy(m_data, p_matrix, 16 * sizeof(float));
+	memcpy(m_data, p_matrix, 16 * sizeof(float));
 }
 
 // OFFSET: LEGO1 0x10002370
-void MxMatrix::SetData(float *p_data)
+void MxMatrix::SetData(float* p_data)
 {
-  m_data = p_data;
+	m_data = p_data;
 }
 
 // OFFSET: LEGO1 0x10002360
-void MxMatrix::AnotherSetData(float *p_data)
+void MxMatrix::AnotherSetData(float* p_data)
 {
-  m_data = p_data;
+	m_data = p_data;
 }
 
 // OFFSET: LEGO1 0x10002390
-float *MxMatrix::GetData()
+float* MxMatrix::GetData()
 {
-  return m_data;
+	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002380
-const float *MxMatrix::GetData() const
+const float* MxMatrix::GetData() const
 {
-  return m_data;
+	return m_data;
 }
 
 // OFFSET: LEGO1 0x100023c0
-float *MxMatrix::Element(int p_row, int p_col)
+float* MxMatrix::Element(int p_row, int p_col)
 {
-  return &m_data[p_row * 4 + p_col];
+	return &m_data[p_row * 4 + p_col];
 }
 
 // OFFSET: LEGO1 0x100023a0
-const float *MxMatrix::Element(int p_row, int p_col) const
+const float* MxMatrix::Element(int p_row, int p_col) const
 {
-  return &m_data[p_row * 4 + p_col];
+	return &m_data[p_row * 4 + p_col];
 }
 
 // OFFSET: LEGO1 0x100023e0
 void MxMatrix::Clear()
 {
-  memset(m_data, 0, 16 * sizeof(float));
+	memset(m_data, 0, 16 * sizeof(float));
 }
 
 // OFFSET: LEGO1 0x100023f0
 void MxMatrix::SetIdentity()
 {
-  Clear();
-  m_data[0] = 1.0f;
-  m_data[5] = 1.0f;
-  m_data[10] = 1.0f;
-  m_data[15] = 1.0f;
+	Clear();
+	m_data[0] = 1.0f;
+	m_data[5] = 1.0f;
+	m_data[10] = 1.0f;
+	m_data[15] = 1.0f;
 }
 
 // OFFSET: LEGO1 0x10002850
 void MxMatrix::operator=(const MxMatrix& p_other)
 {
-  EqualsMxMatrix(&p_other);
+	EqualsMxMatrix(&p_other);
 }
 
 // OFFSET: LEGO1 0x10002430
-MxMatrix* MxMatrix::operator+=(const float *p_matrix)
+MxMatrix* MxMatrix::operator+=(const float* p_matrix)
 {
-  for (int i = 0; i < 16; ++i)
-    m_data[i] += p_matrix[i];
-  return this;
+	for (int i = 0; i < 16; ++i)
+		m_data[i] += p_matrix[i];
+	return this;
 }
 
 // Matches but instructions are significantly out of order. Probably not wrong
 // code given that the very similar SetTranslation does match.
 // OFFSET: LEGO1 0x10002460
-void MxMatrix::TranslateBy(const float *p_x, const float *p_y, const float *p_z)
+void MxMatrix::TranslateBy(const float* p_x, const float* p_y, const float* p_z)
 {
-  m_data[12] += *p_x;
-  m_data[13] += *p_y;
-  m_data[14] += *p_z;
+	m_data[12] += *p_x;
+	m_data[13] += *p_y;
+	m_data[14] += *p_z;
 }
 
 // OFFSET: LEGO1 0x100024a0
-void MxMatrix::SetTranslation(const float *p_x, const float *p_y, const float *p_z)
+void MxMatrix::SetTranslation(const float* p_x, const float* p_y, const float* p_z)
 {
-  m_data[12] = *p_x;
-  m_data[13] = *p_y;
-  m_data[14] = *p_z;
+	m_data[12] = *p_x;
+	m_data[13] = *p_y;
+	m_data[14] = *p_z;
 }
 
 // OFFSET: LEGO1 0x10002530
-void MxMatrix::EqualsMxProduct(const MxMatrix *p_a, const MxMatrix *p_b)
+void MxMatrix::EqualsMxProduct(const MxMatrix* p_a, const MxMatrix* p_b)
 {
-  EqualsDataProduct(p_a->m_data, p_b->m_data);
+	EqualsDataProduct(p_a->m_data, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100024d0
-void MxMatrix::EqualsDataProduct(const float *p_a, const float *p_b)
+void MxMatrix::EqualsDataProduct(const float* p_a, const float* p_b)
 {
-  float *cur = m_data;
-  for (int row = 0; row < 4; ++row)
-  {
-    for (int col = 0; col < 4; ++col)
-    {
-      *cur = 0.0f;
-      for (int k = 0; k < 4; ++k)
-      {
-        *cur += p_a[row * 4 + k] * p_b[k * 4 + col];
-      }
-      cur++;
-    }
-  }
+	float* cur = m_data;
+	for (int row = 0; row < 4; ++row) {
+		for (int col = 0; col < 4; ++col) {
+			*cur = 0.0f;
+			for (int k = 0; k < 4; ++k) {
+				*cur += p_a[row * 4 + k] * p_b[k * 4 + col];
+			}
+			cur++;
+		}
+	}
 }
 
 // Not close, Ghidra struggles understinging this method so it will have to
 // be manually worked out. Included since I at least figured out what it was
 // doing with rotateIndex and what overall operation it's trying to do.
 // OFFSET: LEGO1 0x10002550 STUB
-void MxMatrix::ToQuaternion(MxVector4 *p_outQuat)
+void MxMatrix::ToQuaternion(MxVector4* p_outQuat)
 {
-  float trace = m_data[0] + m_data[5] + m_data[10];
-  if (trace > 0)
-  {
-    trace = sqrt(trace + 1.0);
-    p_outQuat->GetData()[3] = trace * 0.5f;
-    p_outQuat->GetData()[0] = (m_data[9] - m_data[6]) * trace;
-    p_outQuat->GetData()[1] = (m_data[2] - m_data[8]) * trace;
-    p_outQuat->GetData()[2] = (m_data[4] - m_data[1]) * trace;
-    return;
-  }
+	float trace = m_data[0] + m_data[5] + m_data[10];
+	if (trace > 0) {
+		trace = sqrt(trace + 1.0);
+		p_outQuat->GetData()[3] = trace * 0.5f;
+		p_outQuat->GetData()[0] = (m_data[9] - m_data[6]) * trace;
+		p_outQuat->GetData()[1] = (m_data[2] - m_data[8]) * trace;
+		p_outQuat->GetData()[2] = (m_data[4] - m_data[1]) * trace;
+		return;
+	}
 
-  // OFFSET: LEGO1 0x100d4090
-  static int rotateIndex[] = {1, 2, 0};
+	// OFFSET: LEGO1 0x100d4090
+	static int rotateIndex[] = {1, 2, 0};
 
-  // Largest element along the trace
-  int largest = m_data[0] < m_data[5];
-  if (*Element(largest, largest) < m_data[10])
-    largest = 2;
+	// Largest element along the trace
+	int largest = m_data[0] < m_data[5];
+	if (*Element(largest, largest) < m_data[10])
+		largest = 2;
 
-  int next = rotateIndex[largest];
-  int nextNext = rotateIndex[next];
-  float valueA = *Element(nextNext, nextNext);
-  float valueB = *Element(next, next);
-  float valueC = *Element(largest, largest);
+	int next = rotateIndex[largest];
+	int nextNext = rotateIndex[next];
+	float valueA = *Element(nextNext, nextNext);
+	float valueB = *Element(next, next);
+	float valueC = *Element(largest, largest);
 
-  // Above is somewhat decomped, below is pure speculation since the automatic
-  // decomp becomes very garbled.
-  float traceValue = sqrt(valueA - valueB - valueC + 1.0);
+	// Above is somewhat decomped, below is pure speculation since the automatic
+	// decomp becomes very garbled.
+	float traceValue = sqrt(valueA - valueB - valueC + 1.0);
 
-  p_outQuat->GetData()[largest] = traceValue * 0.5f;
-  traceValue = 0.5f / traceValue;
+	p_outQuat->GetData()[largest] = traceValue * 0.5f;
+	traceValue = 0.5f / traceValue;
 
-  p_outQuat->GetData()[3] = (m_data[next + 4 * nextNext] - m_data[nextNext + 4 * next]) * traceValue;
-  p_outQuat->GetData()[next] = (m_data[next + 4 * largest] + m_data[largest + 4 * next]) * traceValue;
-  p_outQuat->GetData()[nextNext] = (m_data[nextNext + 4 * largest] + m_data[largest + 4 * nextNext]) * traceValue;
+	p_outQuat->GetData()[3] = (m_data[next + 4 * nextNext] - m_data[nextNext + 4 * next]) * traceValue;
+	p_outQuat->GetData()[next] = (m_data[next + 4 * largest] + m_data[largest + 4 * next]) * traceValue;
+	p_outQuat->GetData()[nextNext] = (m_data[nextNext + 4 * largest] + m_data[largest + 4 * nextNext]) * traceValue;
 }
 
 // No idea what this function is doing and it will be hard to tell until
 // we have a confirmed usage site.
 // OFFSET: LEGO1 0x10002710 STUB
-MxResult MxMatrix::FUN_10002710(const MxVector3 *p_vec)
+MxResult MxMatrix::FUN_10002710(const MxVector3* p_vec)
 {
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x10002860
 void MxMatrixData::operator=(const MxMatrixData& p_other)
 {
-  EqualsMxMatrix(&p_other);
+	EqualsMxMatrix(&p_other);
 }

--- a/LEGO1/mxmatrix.h
+++ b/LEGO1/mxmatrix.h
@@ -5,68 +5,64 @@
 
 // VTABLE 0x100d4350
 // SIZE 0x8
-class MxMatrix
-{
+class MxMatrix {
 public:
-  inline MxMatrix(float *p_data) : m_data(p_data) {}
+	inline MxMatrix(float* p_data) : m_data(p_data) {}
 
-  // vtable + 0x00
-  virtual void EqualsMxMatrix(const MxMatrix *p_other);
-  virtual void EqualsMatrixData(const float *p_matrix);
-  virtual void SetData(float *p_data);
-  virtual void AnotherSetData(float *p_data);
+	// vtable + 0x00
+	virtual void EqualsMxMatrix(const MxMatrix* p_other);
+	virtual void EqualsMatrixData(const float* p_matrix);
+	virtual void SetData(float* p_data);
+	virtual void AnotherSetData(float* p_data);
 
-  // vtable + 0x10
-  virtual float *GetData();
-  virtual const float *GetData() const;
-  virtual float *Element(int p_row, int p_col);
-  virtual const float *Element(int p_row, int p_col) const;
+	// vtable + 0x10
+	virtual float* GetData();
+	virtual const float* GetData() const;
+	virtual float* Element(int p_row, int p_col);
+	virtual const float* Element(int p_row, int p_col) const;
 
-  // vtable + 0x20
-  virtual void Clear();
-  virtual void SetIdentity();
-  virtual void operator=(const MxMatrix& p_other);
-  virtual MxMatrix *operator+=(const float *p_matrix);
+	// vtable + 0x20
+	virtual void Clear();
+	virtual void SetIdentity();
+	virtual void operator=(const MxMatrix& p_other);
+	virtual MxMatrix* operator+=(const float* p_matrix);
 
-  // vtable + 0x30
-  virtual void TranslateBy(const float *p_x, const float *p_y, const float *p_z);
-  virtual void SetTranslation(const float *p_x, const float *p_y, const float *p_z);
-  virtual void EqualsMxProduct(const MxMatrix *p_a, const MxMatrix *p_b);
-  virtual void EqualsDataProduct(const float *p_a, const float *p_b);
+	// vtable + 0x30
+	virtual void TranslateBy(const float* p_x, const float* p_y, const float* p_z);
+	virtual void SetTranslation(const float* p_x, const float* p_y, const float* p_z);
+	virtual void EqualsMxProduct(const MxMatrix* p_a, const MxMatrix* p_b);
+	virtual void EqualsDataProduct(const float* p_a, const float* p_b);
 
-  // vtable + 0x40
-  virtual void ToQuaternion(MxVector4 *p_resultQuat);
-  virtual MxResult FUN_10002710(const MxVector3 *p_vec);
+	// vtable + 0x40
+	virtual void ToQuaternion(MxVector4* p_resultQuat);
+	virtual MxResult FUN_10002710(const MxVector3* p_vec);
 
-  inline float& operator[](size_t idx) { return m_data[idx]; }
+	inline float& operator[](size_t idx) { return m_data[idx]; }
 
 private:
-  float *m_data;
+	float* m_data;
 };
 
 // VTABLE 0x100d4300
 // SIZE 0x48
-class MxMatrixData : public MxMatrix
-{
+class MxMatrixData : public MxMatrix {
 public:
-  inline MxMatrixData() : MxMatrix(e) {}
+	inline MxMatrixData() : MxMatrix(e) {}
 
-  // No idea why there's another equals. Maybe to some other type like the
-  // DirectX Retained Mode Matrix type which is also a float* alias?
-  // vtable + 0x44
-  virtual void operator=(const MxMatrixData& p_other);
+	// No idea why there's another equals. Maybe to some other type like the
+	// DirectX Retained Mode Matrix type which is also a float* alias?
+	// vtable + 0x44
+	virtual void operator=(const MxMatrixData& p_other);
 
-  // Alias an easy way to access the translation part of the matrix, because
-  // various members / other functions benefit from the clarity.
-  union
-  {
-    float e[16];
-    struct
-    {
-      float _[12];
-      float x, y, z, w;
-    };
-  };
+	// Alias an easy way to access the translation part of the matrix, because
+	// various members / other functions benefit from the clarity.
+	union {
+		float e[16];
+		struct {
+			float _[12];
+			float x, y, z, w;
+		};
+	};
 };
 
 #endif // MXMATRIX_H

--- a/LEGO1/mxmediamanager.cpp
+++ b/LEGO1/mxmediamanager.cpp
@@ -1,101 +1,102 @@
 #include "mxmediamanager.h"
-#include "mxautolocker.h"
-#include "mxpresenter.h"
+
 #include "decomp.h"
-#include "mxticklemanager.h"
+#include "mxautolocker.h"
 #include "mxomni.h"
+#include "mxpresenter.h"
+#include "mxticklemanager.h"
 
 DECOMP_SIZE_ASSERT(MxMediaManager, 0x2c);
 
 // OFFSET: LEGO1 0x100b84c0
 MxMediaManager::MxMediaManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100b8560
 MxMediaManager::~MxMediaManager()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x100b85d0
 MxResult MxMediaManager::Init()
 {
-  this->m_presenters = NULL;
-  this->m_thread = NULL;
-  return SUCCESS;
+	this->m_presenters = NULL;
+	this->m_thread = NULL;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b8790
 MxResult MxMediaManager::Tickle()
 {
-  MxAutoLocker lock(&this->m_criticalSection);
-  MxPresenter *presenter;
-  MxPresenterListCursor cursor(this->m_presenters);
+	MxAutoLocker lock(&this->m_criticalSection);
+	MxPresenter* presenter;
+	MxPresenterListCursor cursor(this->m_presenters);
 
-  while (cursor.Next(presenter))
-    presenter->Tickle();
+	while (cursor.Next(presenter))
+		presenter->Tickle();
 
-  cursor.Reset();
+	cursor.Reset();
 
-  while (cursor.Next(presenter))
-    presenter->PutData();
+	while (cursor.Next(presenter))
+		presenter->PutData();
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b85e0
 MxResult MxMediaManager::InitPresenters()
 {
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  this->m_presenters = new MxPresenterList;
+	this->m_presenters = new MxPresenterList;
 
-  if (!this->m_presenters) {
-    this->Destroy();
-    return FAILURE;
-  }
+	if (!this->m_presenters) {
+		this->Destroy();
+		return FAILURE;
+	}
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b8710
 void MxMediaManager::Destroy()
 {
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  if (this->m_presenters)
-    delete this->m_presenters;
+	if (this->m_presenters)
+		delete this->m_presenters;
 
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100b88c0
-void MxMediaManager::AddPresenter(MxPresenter &p_presenter)
+void MxMediaManager::AddPresenter(MxPresenter& p_presenter)
 {
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  this->m_presenters->Append(&p_presenter);
+	this->m_presenters->Append(&p_presenter);
 }
 
 // OFFSET: LEGO1 0x100b8980
-void MxMediaManager::RemovePresenter(MxPresenter &p_presenter)
+void MxMediaManager::RemovePresenter(MxPresenter& p_presenter)
 {
-  MxAutoLocker lock(&this->m_criticalSection);
-  MxPresenterListCursor cursor(this->m_presenters);
+	MxAutoLocker lock(&this->m_criticalSection);
+	MxPresenterListCursor cursor(this->m_presenters);
 
-  if (cursor.Find(&p_presenter))
-    cursor.Detach();
+	if (cursor.Find(&p_presenter))
+		cursor.Detach();
 }
 
 // OFFSET: LEGO1 0x100b8ac0
 void MxMediaManager::StopPresenters()
 {
-  MxAutoLocker lock(&this->m_criticalSection);
-  MxPresenter *presenter;
-  MxPresenterListCursor cursor(this->m_presenters);
+	MxAutoLocker lock(&this->m_criticalSection);
+	MxPresenter* presenter;
+	MxPresenterListCursor cursor(this->m_presenters);
 
-  while (cursor.Next(presenter))
-    presenter->EndAction();
+	while (cursor.Next(presenter))
+		presenter->EndAction();
 }

--- a/LEGO1/mxmediamanager.h
+++ b/LEGO1/mxmediamanager.h
@@ -3,31 +3,30 @@
 
 #include "mxcore.h"
 #include "mxcriticalsection.h"
-#include "mxthread.h"
 #include "mxpresenterlist.h"
+#include "mxthread.h"
 #include "mxtypes.h"
 
 // VTABLE 0x100dc6b0
 // SIZE 0x2c
-class MxMediaManager : public MxCore
-{
+class MxMediaManager : public MxCore {
 public:
-  MxMediaManager();
-  virtual ~MxMediaManager() override;
+	MxMediaManager();
+	virtual ~MxMediaManager() override;
 
-  virtual MxResult Tickle() override; // vtable+08
-  virtual MxResult InitPresenters(); // vtable+14
-  virtual void Destroy(); // vtable+18
-  virtual void AddPresenter(MxPresenter &p_presenter); // vtable+1c
-  virtual void RemovePresenter(MxPresenter &p_presenter); // vtable+20
-  virtual void StopPresenters(); // vtable+24
+	virtual MxResult Tickle() override;                     // vtable+08
+	virtual MxResult InitPresenters();                      // vtable+14
+	virtual void Destroy();                                 // vtable+18
+	virtual void AddPresenter(MxPresenter& p_presenter);    // vtable+1c
+	virtual void RemovePresenter(MxPresenter& p_presenter); // vtable+20
+	virtual void StopPresenters();                          // vtable+24
 
-  MxResult Init();
+	MxResult Init();
 
 protected:
-  MxPresenterList *m_presenters;
-  MxThread *m_thread; // 0xc
-  MxCriticalSection m_criticalSection; // 0x10
+	MxPresenterList* m_presenters;
+	MxThread* m_thread;                  // 0xc
+	MxCriticalSection m_criticalSection; // 0x10
 };
 
 #endif // MXMEDIAMANGER_H

--- a/LEGO1/mxmediapresenter.cpp
+++ b/LEGO1/mxmediapresenter.cpp
@@ -5,77 +5,77 @@ DECOMP_SIZE_ASSERT(MxMediaPresenter, 0x50);
 // OFFSET: LEGO1 0x1000c550
 MxMediaPresenter::~MxMediaPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100b5d10 STUB
 MxResult MxMediaPresenter::Tickle()
 {
-  // TODO
-  return SUCCESS;
+	// TODO
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b54e0
 void MxMediaPresenter::Init()
 {
-  this->m_unk40 = NULL;
-  this->m_unk44 = NULL;
-  this->m_unk48 = NULL;
-  this->m_unk4c = NULL;
+	this->m_unk40 = NULL;
+	this->m_unk44 = NULL;
+	this->m_unk48 = NULL;
+	this->m_unk4c = NULL;
 }
 
 // OFFSET: LEGO1 0x100b54f0 STUB
 void MxMediaPresenter::Destroy(MxBool p_fromDestructor)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b5d90 STUB
 void MxMediaPresenter::StreamingTickle()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b5e10 STUB
 void MxMediaPresenter::RepeatingTickle()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b5ef0
 void MxMediaPresenter::DoneTickle()
 {
-  m_previousTickleStates |= 1 << m_currentTickleState;
-  m_currentTickleState = TickleState_Idle;
-  EndAction();
+	m_previousTickleStates |= 1 << m_currentTickleState;
+	m_currentTickleState = TickleState_Idle;
+	EndAction();
 }
 
 // OFFSET: LEGO1 0x100b6030 STUB
 void MxMediaPresenter::Enable(MxBool p_enable)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1000c5b0
 void MxMediaPresenter::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100b5700 STUB
-MxLong MxMediaPresenter::StartAction(MxStreamController * p_controller, MxDSAction * p_action)
+MxLong MxMediaPresenter::StartAction(MxStreamController* p_controller, MxDSAction* p_action)
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100b5bc0 STUB
 void MxMediaPresenter::EndAction()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b5f10 STUB
 void MxMediaPresenter::VTable0x58()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/mxmediapresenter.h
+++ b/LEGO1/mxmediapresenter.h
@@ -1,52 +1,47 @@
 #ifndef MXMEDIAPRESENTER_H
 #define MXMEDIAPRESENTER_H
 
+#include "decomp.h"
 #include "mxpresenter.h"
 
-#include "decomp.h"
-
 // VTABLE 0x100d4cd8
-class MxMediaPresenter : public MxPresenter
-{
+class MxMediaPresenter : public MxPresenter {
 public:
-  inline MxMediaPresenter()
-  {
-    Init();
-  }
-  virtual ~MxMediaPresenter() override;
+	inline MxMediaPresenter() { Init(); }
+	virtual ~MxMediaPresenter() override;
 
-  virtual MxResult Tickle() override;
+	virtual MxResult Tickle() override;
 
-  // OFFSET: LEGO1 0x1000c5c0
-  inline virtual const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f074c
-    return "MxMediaPresenter";
-  }
+	// OFFSET: LEGO1 0x1000c5c0
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f074c
+		return "MxMediaPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000c5d0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxMediaPresenter::ClassName()) || MxPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000c5d0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxMediaPresenter::ClassName()) || MxPresenter::IsA(name);
+	}
 
-  virtual void StreamingTickle() override;
-  virtual void RepeatingTickle() override;
-  virtual void DoneTickle() override;
-  virtual void Destroy() override;
-  virtual MxLong StartAction(MxStreamController *, MxDSAction *) override;
-  virtual void EndAction() override;
-  virtual void Enable(MxBool p_enable) override;
-  virtual void VTable0x58();
+	virtual void StreamingTickle() override;
+	virtual void RepeatingTickle() override;
+	virtual void DoneTickle() override;
+	virtual void Destroy() override;
+	virtual MxLong StartAction(MxStreamController*, MxDSAction*) override;
+	virtual void EndAction() override;
+	virtual void Enable(MxBool p_enable) override;
+	virtual void VTable0x58();
 
-  undefined4 m_unk40;
-  undefined4 m_unk44;
-  undefined4 m_unk48;
-  undefined4 m_unk4c;
+	undefined4 m_unk40;
+	undefined4 m_unk44;
+	undefined4 m_unk48;
+	undefined4 m_unk4c;
+
 protected:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
-
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 };
 
 #endif // MXMEDIAPRESENTER_H

--- a/LEGO1/mxmidipresenter.cpp
+++ b/LEGO1/mxmidipresenter.cpp
@@ -9,31 +9,31 @@ DECOMP_SIZE_ASSERT(MxMIDIPresenter, 0x58);
 // OFFSET: LEGO1 0x100c25e0
 MxMIDIPresenter::MxMIDIPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100c27c0
 MxMIDIPresenter::~MxMIDIPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100c2820
 void MxMIDIPresenter::Init()
 {
-  m_unk54 = 0;
+	m_unk54 = 0;
 }
 
 // OFFSET: LEGO1 0x100c2830 STUB
 void MxMIDIPresenter::Destroy(MxBool p_fromDestructor)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c2940
 void MxMIDIPresenter::DoneTickle()
 {
-  if (!MusicManager()->GetMIDIInitialized()) {
-    this->EndAction();
-  }
+	if (!MusicManager()->GetMIDIInitialized()) {
+		this->EndAction();
+	}
 }

--- a/LEGO1/mxmidipresenter.h
+++ b/LEGO1/mxmidipresenter.h
@@ -4,32 +4,31 @@
 #include "mxmusicpresenter.h"
 
 // VTABLE 0x100dca20
-class MxMIDIPresenter : public MxMusicPresenter
-{
+class MxMIDIPresenter : public MxMusicPresenter {
 public:
-  MxMIDIPresenter();
-  virtual ~MxMIDIPresenter() override;
+	MxMIDIPresenter();
+	virtual ~MxMIDIPresenter() override;
 
-  // OFFSET: LEGO1 0x100c2650
-  inline virtual const char *ClassName() const override // vtable+0xc
-  {
-    // 0x10101df8
-    return "MxMIDIPresenter";
-  }
+	// OFFSET: LEGO1 0x100c2650
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10101df8
+		return "MxMIDIPresenter";
+	}
 
-  // OFFSET: LEGO1 0x100c2660
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxMIDIPresenter::ClassName()) || MxMusicPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c2660
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxMIDIPresenter::ClassName()) || MxMusicPresenter::IsA(name);
+	}
 
-  virtual void DoneTickle() override; // vtable+0x2c
+	virtual void DoneTickle() override; // vtable+0x2c
 
 private:
-  void Init();
-  void Destroy(MxBool);
+	void Init();
+	void Destroy(MxBool);
 
-  undefined4 m_unk54;
+	undefined4 m_unk54;
 };
 
 #endif // MXMIDIPRESENTER_H

--- a/LEGO1/mxmusicmanager.cpp
+++ b/LEGO1/mxmusicmanager.cpp
@@ -1,6 +1,7 @@
 #include "mxmusicmanager.h"
-#include "mxticklemanager.h"
+
 #include "mxomni.h"
+#include "mxticklemanager.h"
 
 #include <windows.h>
 
@@ -9,143 +10,137 @@ DECOMP_SIZE_ASSERT(MxMusicManager, 0x58);
 // OFFSET: LEGO1 0x100c05a0
 MxMusicManager::MxMusicManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100c0630
 MxMusicManager::~MxMusicManager()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100c0b20
 void MxMusicManager::DeinitializeMIDI()
 {
-  m_criticalSection.Enter();
+	m_criticalSection.Enter();
 
-  if (m_MIDIInitialized)
-  {
-    m_MIDIInitialized = FALSE;
-    midiStreamStop(m_MIDIStreamH);
-    midiOutUnprepareHeader((HMIDIOUT)m_MIDIStreamH, m_MIDIHdrP, sizeof(MIDIHDR));
-    midiOutSetVolume((HMIDIOUT)m_MIDIStreamH, m_MIDIVolume);
-    midiStreamClose(m_MIDIStreamH);
-    delete m_MIDIHdrP;
-    InitData();
-  }
+	if (m_MIDIInitialized) {
+		m_MIDIInitialized = FALSE;
+		midiStreamStop(m_MIDIStreamH);
+		midiOutUnprepareHeader((HMIDIOUT) m_MIDIStreamH, m_MIDIHdrP, sizeof(MIDIHDR));
+		midiOutSetVolume((HMIDIOUT) m_MIDIStreamH, m_MIDIVolume);
+		midiStreamClose(m_MIDIStreamH);
+		delete m_MIDIHdrP;
+		InitData();
+	}
 
-  m_criticalSection.Leave();
+	m_criticalSection.Leave();
 }
 
 // OFFSET: LEGO1 0x100c0690
 void MxMusicManager::Init()
 {
-  m_multiplier = 100;
-  InitData();
+	m_multiplier = 100;
+	InitData();
 }
 
 // OFFSET: LEGO1 0x100c06a0
 void MxMusicManager::InitData()
 {
-  m_MIDIStreamH = 0;
-  m_MIDIInitialized = FALSE;
-  m_unk38 = 0;
-  m_unk3c = 0;
-  m_unk40 = 0;
-  m_unk44 = 0;
-  m_unk48 = 0;
-  m_MIDIHdrP = NULL;
+	m_MIDIStreamH = 0;
+	m_MIDIInitialized = FALSE;
+	m_unk38 = 0;
+	m_unk3c = 0;
+	m_unk40 = 0;
+	m_unk44 = 0;
+	m_unk48 = 0;
+	m_MIDIHdrP = NULL;
 }
 
 // OFFSET: LEGO1 0x100c06c0
 void MxMusicManager::Destroy(MxBool p_fromDestructor)
 {
-  if (m_thread)
-  {
-    m_thread->Terminate();
-    if (m_thread)
-    {
-      delete m_thread;
-    }
-  }
-  else
-  {
-    TickleManager()->UnregisterClient(this);
-  }
+	if (m_thread) {
+		m_thread->Terminate();
+		if (m_thread) {
+			delete m_thread;
+		}
+	}
+	else {
+		TickleManager()->UnregisterClient(this);
+	}
 
-  m_criticalSection.Enter();
-  DeinitializeMIDI();
-  Init();
-  m_criticalSection.Leave();
+	m_criticalSection.Enter();
+	DeinitializeMIDI();
+	Init();
+	m_criticalSection.Leave();
 
-  if (!p_fromDestructor)
-  {
-    MxAudioManager::Destroy();
-  }
+	if (!p_fromDestructor) {
+		MxAudioManager::Destroy();
+	}
 }
 
 // OFFSET: LEGO1 0x100c0930
 void MxMusicManager::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100c09a0
 MxS32 MxMusicManager::CalculateVolume(MxS32 p_volume)
 {
-  MxS32 result = (p_volume * 0xffff) / 100;
-  return (result << 0x10) | result;
+	MxS32 result = (p_volume * 0xffff) / 100;
+	return (result << 0x10) | result;
 }
 
 // OFFSET: LEGO1 0x100c07f0
 void MxMusicManager::SetMIDIVolume()
 {
-  MxS32 result = (m_volume * m_multiplier) / 0x64;
-  HMIDISTRM streamHandle = m_MIDIStreamH;
+	MxS32 result = (m_volume * m_multiplier) / 0x64;
+	HMIDISTRM streamHandle = m_MIDIStreamH;
 
-  if (streamHandle)
-  {
-    MxS32 volume = CalculateVolume(result);
-    midiOutSetVolume((HMIDIOUT)streamHandle, volume);
-  }
+	if (streamHandle) {
+		MxS32 volume = CalculateVolume(result);
+		midiOutSetVolume((HMIDIOUT) streamHandle, volume);
+	}
 }
 
 // OFFSET: LEGO1 0x100c0940
 void MxMusicManager::SetVolume(MxS32 p_volume)
 {
-  MxAudioManager::SetVolume(p_volume);
-  m_criticalSection.Enter();
-  SetMIDIVolume();
-  m_criticalSection.Leave();
+	MxAudioManager::SetVolume(p_volume);
+	m_criticalSection.Enter();
+	SetMIDIVolume();
+	m_criticalSection.Leave();
 }
 
 // OFFSET: LEGO1 0x100c0840
 MxResult MxMusicManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  MxResult status = FAILURE;
-  MxBool locked = FALSE;
+	MxResult status = FAILURE;
+	MxBool locked = FALSE;
 
-  if (MxAudioManager::InitPresenters() == SUCCESS) {
-    if (p_createThread) {
-      m_criticalSection.Enter();
-      locked = TRUE;
-      m_thread = new MxTickleThread(this, p_frequencyMS);
+	if (MxAudioManager::InitPresenters() == SUCCESS) {
+		if (p_createThread) {
+			m_criticalSection.Enter();
+			locked = TRUE;
+			m_thread = new MxTickleThread(this, p_frequencyMS);
 
-      if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
-        goto done;
-    }
-    else
-      TickleManager()->RegisterClient(this, p_frequencyMS);
-    
-    status = SUCCESS;
-  }
+			if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
+				goto done;
+		}
+		else
+			TickleManager()->RegisterClient(this, p_frequencyMS);
+
+		status = SUCCESS;
+	}
 
 done:
-  if (status != SUCCESS)
-    Destroy();
+	if (status != SUCCESS)
+		Destroy();
 
-  if (locked)
-    m_criticalSection.Leave();
+	if (locked)
+		m_criticalSection.Leave();
 
-  return status;
+	return status;
 }

--- a/LEGO1/mxmusicmanager.h
+++ b/LEGO1/mxmusicmanager.h
@@ -6,39 +6,38 @@
 
 // VTABLE 0x100dc930
 // SIZE 0x58
-class MxMusicManager : public MxAudioManager
-{
+class MxMusicManager : public MxAudioManager {
 public:
-  MxMusicManager();
-  virtual ~MxMusicManager() override;
+	MxMusicManager();
+	virtual ~MxMusicManager() override;
 
-  virtual void Destroy() override; // vtable+18
-  virtual void SetVolume(MxS32 p_volume) override; // vtable+2c
-  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+30
+	virtual void Destroy() override;                                     // vtable+18
+	virtual void SetVolume(MxS32 p_volume) override;                     // vtable+2c
+	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+30
 
-  inline MxBool GetMIDIInitialized() { return m_MIDIInitialized; }
+	inline MxBool GetMIDIInitialized() { return m_MIDIInitialized; }
 
 private:
-  void Destroy(MxBool p_fromDestructor);
-  void DeinitializeMIDI();
+	void Destroy(MxBool p_fromDestructor);
+	void DeinitializeMIDI();
 
-  MxS32 CalculateVolume(MxS32 p_volume);
-  void SetMIDIVolume();
+	MxS32 CalculateVolume(MxS32 p_volume);
+	void SetMIDIVolume();
 
-  HMIDISTRM m_MIDIStreamH;  // 0x30
-  MxBool m_MIDIInitialized; // 0x34
-  undefined4 m_unk38;       // 0x38
-  undefined4 m_unk3c;       // 0x3c
-  undefined4 m_unk40;       // 0x40
-  undefined4 m_unk44;       // 0x44
-  undefined4 m_unk48;       // 0x48
-  MIDIHDR *m_MIDIHdrP;      // 0x4c
-  MxS32 m_multiplier;       // 0x50
-  DWORD m_MIDIVolume;       // 0x54
+	HMIDISTRM m_MIDIStreamH;  // 0x30
+	MxBool m_MIDIInitialized; // 0x34
+	undefined4 m_unk38;       // 0x38
+	undefined4 m_unk3c;       // 0x3c
+	undefined4 m_unk40;       // 0x40
+	undefined4 m_unk44;       // 0x44
+	undefined4 m_unk48;       // 0x48
+	MIDIHDR* m_MIDIHdrP;      // 0x4c
+	MxS32 m_multiplier;       // 0x50
+	DWORD m_MIDIVolume;       // 0x54
 
 protected:
-  void Init();
-  void InitData();
+	void Init();
+	void InitData();
 };
 
 #endif // MXMUSICMANAGER_H

--- a/LEGO1/mxmusicpresenter.cpp
+++ b/LEGO1/mxmusicpresenter.cpp
@@ -9,13 +9,13 @@ DECOMP_SIZE_ASSERT(MxMusicPresenter, 0x54);
 // OFFSET: LEGO1 0x100c22c0
 MxMusicPresenter::MxMusicPresenter()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100c24e0
 MxMusicPresenter::~MxMusicPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100c2540
@@ -26,30 +26,30 @@ void MxMusicPresenter::Init()
 // OFFSET: LEGO1 0x100c2550
 void MxMusicPresenter::Destroy(MxBool p_fromDestructor)
 {
-  if (MusicManager()) {
-    MusicManager()->RemovePresenter(*this);
-  }
-  m_criticalSection.Enter();
-  Init();
-  m_criticalSection.Leave();
-  if (!p_fromDestructor) {
-    MxMediaPresenter::Destroy(FALSE);
-  }
+	if (MusicManager()) {
+		MusicManager()->RemovePresenter(*this);
+	}
+	m_criticalSection.Enter();
+	Init();
+	m_criticalSection.Leave();
+	if (!p_fromDestructor) {
+		MxMediaPresenter::Destroy(FALSE);
+	}
 }
 
 // OFFSET: LEGO1 0x100c25a0
 MxResult MxMusicPresenter::AddToManager()
 {
-  MxResult result = FAILURE;
-  if (MusicManager()) {
-    result = SUCCESS;
-    MusicManager()->AddPresenter(*this);
-  }
-  return result;
-} 
+	MxResult result = FAILURE;
+	if (MusicManager()) {
+		result = SUCCESS;
+		MusicManager()->AddPresenter(*this);
+	}
+	return result;
+}
 
 // OFFSET: LEGO1 0x100c25d0
 void MxMusicPresenter::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }

--- a/LEGO1/mxmusicpresenter.h
+++ b/LEGO1/mxmusicpresenter.h
@@ -5,31 +5,30 @@
 
 // VTABLE 0x100dc9b8
 // SIZE 0x54
-class MxMusicPresenter : public MxAudioPresenter
-{
+class MxMusicPresenter : public MxAudioPresenter {
 public:
-  // OFFSET: LEGO1 0x100c23a0
-  inline virtual const char *ClassName() const override // vtable+0xc
-  {
-    // 0x10101e48
-    return "MxMusicPresenter";
-  }
+	// OFFSET: LEGO1 0x100c23a0
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10101e48
+		return "MxMusicPresenter";
+	}
 
-  // OFFSET: LEGO1 0x100c23b0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxMusicPresenter::ClassName()) || MxAudioPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c23b0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxMusicPresenter::ClassName()) || MxAudioPresenter::IsA(name);
+	}
 
-  MxMusicPresenter();
-  virtual ~MxMusicPresenter() override;
+	MxMusicPresenter();
+	virtual ~MxMusicPresenter() override;
 
-  virtual MxResult AddToManager() override; // vtable+0x34
-  virtual void Destroy() override; // vtable+0x38
+	virtual MxResult AddToManager() override; // vtable+0x34
+	virtual void Destroy() override;          // vtable+0x38
 
 private:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 };
 
 #endif // MXMUSICPRESENTER_H

--- a/LEGO1/mxnextactiondatastart.h
+++ b/LEGO1/mxnextactiondatastart.h
@@ -4,9 +4,6 @@
 #include "mxcore.h"
 
 // VTABLE 0x100dc9a0
-class MxNextActionDataStart : public MxCore
-{
-  
-};
+class MxNextActionDataStart : public MxCore {};
 
 #endif // MXNEXTACTIONDATASTART_H

--- a/LEGO1/mxnotificationmanager.cpp
+++ b/LEGO1/mxnotificationmanager.cpp
@@ -1,186 +1,186 @@
 #include "mxnotificationmanager.h"
 
-#include "legoomni.h"
-#include "mxautolocker.h"
-#include "mxticklemanager.h"
-#include "mxparam.h"
-#include "mxtypes.h"
-
 #include "compat.h"
 #include "decomp.h"
+#include "legoomni.h"
+#include "mxautolocker.h"
+#include "mxparam.h"
+#include "mxticklemanager.h"
+#include "mxtypes.h"
 
 DECOMP_SIZE_ASSERT(MxNotification, 0x8);
 DECOMP_SIZE_ASSERT(MxNotificationManager, 0x40);
 
 // OFFSET: LEGO1 0x100ac220
-MxNotification::MxNotification(MxCore *p_target, MxNotificationParam *p_param)
+MxNotification::MxNotification(MxCore* p_target, MxNotificationParam* p_param)
 {
-  m_target = p_target;
-  m_param = p_param->Clone();
+	m_target = p_target;
+	m_param = p_param->Clone();
 }
 
 // OFFSET: LEGO1 0x100ac240
 MxNotification::~MxNotification()
 {
-  delete m_param;
+	delete m_param;
 }
 
 // OFFSET: LEGO1 0x100ac250
 MxNotificationManager::MxNotificationManager() : MxCore(), m_lock(), m_listenerIds()
 {
-  m_unk2c = 0;
-  m_queue = NULL;
-  m_active = TRUE;
-  m_sendList = NULL;
+	m_unk2c = 0;
+	m_queue = NULL;
+	m_active = TRUE;
+	m_sendList = NULL;
 }
 
 // OFFSET: LEGO1 0x100ac450
 MxNotificationManager::~MxNotificationManager()
 {
-  MxAutoLocker lock(&m_lock);
-  Tickle();
-  delete m_queue;
-  m_queue = NULL;
+	MxAutoLocker lock(&m_lock);
+	Tickle();
+	delete m_queue;
+	m_queue = NULL;
 
-  TickleManager()->UnregisterClient(this);
+	TickleManager()->UnregisterClient(this);
 }
 
 // OFFSET: LEGO1 0x100ac800
 MxResult MxNotificationManager::Tickle()
 {
-  m_sendList = new MxNotificationPtrList();
-  if (m_sendList == NULL) {
-    return FAILURE;
-  }
-  else {
-    {
-      MxAutoLocker lock(&m_lock);
-      swap(m_queue, m_sendList);
-    }
+	m_sendList = new MxNotificationPtrList();
+	if (m_sendList == NULL) {
+		return FAILURE;
+	}
+	else {
+		{
+			MxAutoLocker lock(&m_lock);
+			swap(m_queue, m_sendList);
+		}
 
-    while (m_sendList->size() != 0) {
-      MxNotification *notif = m_sendList->front();
-      m_sendList->pop_front();
-      notif->GetTarget()->Notify(*notif->GetParam());
-      delete notif;
-    }
+		while (m_sendList->size() != 0) {
+			MxNotification* notif = m_sendList->front();
+			m_sendList->pop_front();
+			notif->GetTarget()->Notify(*notif->GetParam());
+			delete notif;
+		}
 
-    delete m_sendList;
-    m_sendList = NULL;
-    return SUCCESS;
-  }
+		delete m_sendList;
+		m_sendList = NULL;
+		return SUCCESS;
+	}
 }
 
 // OFFSET: LEGO1 0x100ac600
 MxResult MxNotificationManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  MxResult result = SUCCESS;
-  m_queue = new MxNotificationPtrList();
+	MxResult result = SUCCESS;
+	m_queue = new MxNotificationPtrList();
 
-  if (m_queue == NULL) {
-    result = FAILURE;
-  }
-  else {
-    TickleManager()->RegisterClient(this, 10);
-  }
+	if (m_queue == NULL) {
+		result = FAILURE;
+	}
+	else {
+		TickleManager()->RegisterClient(this, 10);
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100acd20
-void MxNotificationManager::Register(MxCore *p_listener)
+void MxNotificationManager::Register(MxCore* p_listener)
 {
-  MxAutoLocker lock(&m_lock);
+	MxAutoLocker lock(&m_lock);
 
-  MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
-  if (it != m_listenerIds.end())
-    return;
+	MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
+	if (it != m_listenerIds.end())
+		return;
 
-  m_listenerIds.push_back(p_listener->GetId());
+	m_listenerIds.push_back(p_listener->GetId());
 }
 
 // OFFSET: LEGO1 0x100acdf0
-void MxNotificationManager::Unregister(MxCore *p_listener)
+void MxNotificationManager::Unregister(MxCore* p_listener)
 {
-  MxAutoLocker lock(&m_lock);
+	MxAutoLocker lock(&m_lock);
 
-  MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
+	MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
 
-  if (it != m_listenerIds.end()) {
-    m_listenerIds.erase(it);
-    FlushPending(p_listener);
-  }
+	if (it != m_listenerIds.end()) {
+		m_listenerIds.erase(it);
+		FlushPending(p_listener);
+	}
 }
 
 // OFFSET: LEGO1 0x100ac990
-void MxNotificationManager::FlushPending(MxCore *p_listener)
+void MxNotificationManager::FlushPending(MxCore* p_listener)
 {
-  MxNotificationPtrList pending;
-  MxNotification *notif;
+	MxNotificationPtrList pending;
+	MxNotification* notif;
 
-  {
-    MxAutoLocker lock(&m_lock);
+	{
+		MxAutoLocker lock(&m_lock);
 
-    // Find all notifications from, and addressed to, p_listener.
-    if (m_sendList != NULL) {
-      MxNotificationPtrList::iterator it = m_sendList->begin();
-      while (it != m_sendList->end()) {
-        notif = *it;
-        if ((notif->GetTarget()->GetId() == p_listener->GetId()) ||
-            (notif->GetParam()->GetSender()) && (notif->GetParam()->GetSender()->GetId() == p_listener->GetId())) {
-          m_sendList->erase(it++);
-          pending.push_back(notif);
-        }
-        else {
-          it++;
-        }
-      }
-    }
+		// Find all notifications from, and addressed to, p_listener.
+		if (m_sendList != NULL) {
+			MxNotificationPtrList::iterator it = m_sendList->begin();
+			while (it != m_sendList->end()) {
+				notif = *it;
+				if ((notif->GetTarget()->GetId() == p_listener->GetId()) ||
+					(notif->GetParam()->GetSender()) &&
+						(notif->GetParam()->GetSender()->GetId() == p_listener->GetId())) {
+					m_sendList->erase(it++);
+					pending.push_back(notif);
+				}
+				else {
+					it++;
+				}
+			}
+		}
 
-    MxNotificationPtrList::iterator it = m_queue->begin();
-    while (it != m_queue->end()) {
-      notif = *it;
-      if ((notif->GetTarget()->GetId() == p_listener->GetId()) ||
-          (notif->GetParam()->GetSender()) && (notif->GetParam()->GetSender()->GetId() == p_listener->GetId())) {
-        m_queue->erase(it++);
-        pending.push_back(notif);
-      }
-      else {
-        it++;
-      }
-    }
-  }
+		MxNotificationPtrList::iterator it = m_queue->begin();
+		while (it != m_queue->end()) {
+			notif = *it;
+			if ((notif->GetTarget()->GetId() == p_listener->GetId()) ||
+				(notif->GetParam()->GetSender()) && (notif->GetParam()->GetSender()->GetId() == p_listener->GetId())) {
+				m_queue->erase(it++);
+				pending.push_back(notif);
+			}
+			else {
+				it++;
+			}
+		}
+	}
 
-  // Deliver those notifications.
-  while (pending.size() != 0) {
-    notif = pending.front();
-    pending.pop_front();
-    notif->GetTarget()->Notify(*notif->GetParam());
-    delete notif;
-  }
+	// Deliver those notifications.
+	while (pending.size() != 0) {
+		notif = pending.front();
+		pending.pop_front();
+		notif->GetTarget()->Notify(*notif->GetParam());
+		delete notif;
+	}
 }
 
 // OFFSET: LEGO1 0x100ac6c0
-MxResult MxNotificationManager::Send(MxCore *p_listener, MxNotificationParam *p_param)
+MxResult MxNotificationManager::Send(MxCore* p_listener, MxNotificationParam* p_param)
 {
-  MxAutoLocker lock(&m_lock);
+	MxAutoLocker lock(&m_lock);
 
-  if (m_active == FALSE) {
-    return FAILURE;
-  }
-  else {
-    MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
-    if (it == m_listenerIds.end()) {
-      return FAILURE;
-    }
-    else {
-      MxNotification *notif = new MxNotification(p_listener, p_param);
-      if (notif != NULL) {
-        m_queue->push_back(notif);
-        return SUCCESS;
-      }
-    }
-  }
+	if (m_active == FALSE) {
+		return FAILURE;
+	}
+	else {
+		MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
+		if (it == m_listenerIds.end()) {
+			return FAILURE;
+		}
+		else {
+			MxNotification* notif = new MxNotification(p_listener, p_param);
+			if (notif != NULL) {
+				m_queue->push_back(notif);
+				return SUCCESS;
+			}
+		}
+	}
 
-  return FAILURE;
+	return FAILURE;
 }

--- a/LEGO1/mxnotificationmanager.h
+++ b/LEGO1/mxnotificationmanager.h
@@ -1,59 +1,54 @@
 #ifndef MXNOTIFICATIONMANAGER_H
 #define MXNOTIFICATIONMANAGER_H
 
+#include "compat.h"
 #include "mxcore.h"
 #include "mxcriticalsection.h"
 #include "mxnotificationparam.h"
 #include "mxtypes.h"
 
-#include "compat.h"
-
-class MxNotification
-{
+class MxNotification {
 public:
-  MxNotification(MxCore *p_target, MxNotificationParam *p_param);
-  ~MxNotification();
+	MxNotification(MxCore* p_target, MxNotificationParam* p_param);
+	~MxNotification();
 
-  inline MxCore *GetTarget() { return m_target; }
-  inline MxNotificationParam *GetParam() { return m_param; }
+	inline MxCore* GetTarget() { return m_target; }
+	inline MxNotificationParam* GetParam() { return m_param; }
 
 private:
-  MxCore *m_target; // 0x0
-  MxNotificationParam *m_param; // 0x4
+	MxCore* m_target;             // 0x0
+	MxNotificationParam* m_param; // 0x4
 };
 
-class MxIdList : public list<MxU32>
-{};
+class MxIdList : public list<MxU32> {};
 
-class MxNotificationPtrList : public list<MxNotification *>
-{};
+class MxNotificationPtrList : public list<MxNotification*> {};
 
 // VTABLE 0x100dc078
-class MxNotificationManager : public MxCore
-{
+class MxNotificationManager : public MxCore {
 private:
-  MxNotificationPtrList *m_queue; // 0x8
-  MxNotificationPtrList *m_sendList; // 0xc
-  MxCriticalSection m_lock; // 0x10
-  MxS32 m_unk2c; // 0x2c
-  MxIdList m_listenerIds; // 0x30
-  MxBool m_active; // 0x3c
+	MxNotificationPtrList* m_queue;    // 0x8
+	MxNotificationPtrList* m_sendList; // 0xc
+	MxCriticalSection m_lock;          // 0x10
+	MxS32 m_unk2c;                     // 0x2c
+	MxIdList m_listenerIds;            // 0x30
+	MxBool m_active;                   // 0x3c
 
 public:
-  MxNotificationManager();
-  virtual ~MxNotificationManager(); // vtable+0x0 (scalar deleting destructor)
+	MxNotificationManager();
+	virtual ~MxNotificationManager(); // vtable+0x0 (scalar deleting destructor)
 
-  virtual MxResult Tickle(); // vtable+0x8
-  // TODO: Where does this method come from?
-  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x14
-  void Register(MxCore *p_listener);
-  void Unregister(MxCore *p_listener);
-  MxResult Send(MxCore *p_listener, MxNotificationParam *p_param);
+	virtual MxResult Tickle(); // vtable+0x8
+	// TODO: Where does this method come from?
+	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x14
+	void Register(MxCore* p_listener);
+	void Unregister(MxCore* p_listener);
+	MxResult Send(MxCore* p_listener, MxNotificationParam* p_param);
 
-  inline MxNotificationPtrList *GetQueue() { return m_queue; }
+	inline MxNotificationPtrList* GetQueue() { return m_queue; }
 
 private:
-  void FlushPending(MxCore *p_listener);
+	void FlushPending(MxCore* p_listener);
 };
 
 #endif // MXNOTIFICATIONMANAGER_H

--- a/LEGO1/mxnotificationparam.cpp
+++ b/LEGO1/mxnotificationparam.cpp
@@ -7,5 +7,5 @@ DECOMP_SIZE_ASSERT(MxNotificationParam, 0xc);
 // OFFSET: LEGO1 0x10010390
 MxNotificationParam* MxNotificationParam::Clone()
 {
-  return new MxNotificationParam(m_type, m_sender);
+	return new MxNotificationParam(m_type, m_sender);
 }

--- a/LEGO1/mxnotificationparam.h
+++ b/LEGO1/mxnotificationparam.h
@@ -7,45 +7,43 @@
 
 class MxCore;
 
-enum MxParamType
-{
-  PARAM_NONE = 0,
-  PAINT = 1, // 100dc210:100d8350
-  MXSTREAMER_UNKNOWN = 2, // 100d8358:100d8350
-  TYPE4 = 4, // 100dc208:100d8350
-  MXPRESENTER_NOTIFICATION = 5,
-  MXSTREAMER_DELETE_NOTIFY = 6, // 100dc760
-  APP_MESSAGE = 7, // 100d6aa0
-  MOUSE_RELEASE = 8, // 100d6aa0
-  MOUSE_PRESS = 9, // 100d6aa0
-  MOUSE_MOVE = 10, // 100d6aa0
-  TYPE11 = 11, // 100d6aa0
-  PARAM_TIMER = 15, // 100d6aa0
-  TYPE17 = 17,
-  TYPE18 = 18, // 100d7e80
-  TYPE19 = 19, // 100d6230
-  TYPE20 = 20,
-  TYPE21 = 21,
-  TYPE22 = 22,
-  TYPE23 = 23,
-  MXTRANSITIONMANAGER_TRANSITIONENDED = 24
+enum MxParamType {
+	PARAM_NONE = 0,
+	PAINT = 1,              // 100dc210:100d8350
+	MXSTREAMER_UNKNOWN = 2, // 100d8358:100d8350
+	TYPE4 = 4,              // 100dc208:100d8350
+	MXPRESENTER_NOTIFICATION = 5,
+	MXSTREAMER_DELETE_NOTIFY = 6, // 100dc760
+	APP_MESSAGE = 7,              // 100d6aa0
+	MOUSE_RELEASE = 8,            // 100d6aa0
+	MOUSE_PRESS = 9,              // 100d6aa0
+	MOUSE_MOVE = 10,              // 100d6aa0
+	TYPE11 = 11,                  // 100d6aa0
+	PARAM_TIMER = 15,             // 100d6aa0
+	TYPE17 = 17,
+	TYPE18 = 18, // 100d7e80
+	TYPE19 = 19, // 100d6230
+	TYPE20 = 20,
+	TYPE21 = 21,
+	TYPE22 = 22,
+	TYPE23 = 23,
+	MXTRANSITIONMANAGER_TRANSITIONENDED = 24
 };
 
 // VTABLE 0x100d56e0
-class MxNotificationParam : public MxParam
-{
+class MxNotificationParam : public MxParam {
 public:
-  inline MxNotificationParam(MxParamType p_type, MxCore *p_sender) : MxParam(), m_type(p_type), m_sender(p_sender){}
+	inline MxNotificationParam(MxParamType p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender) {}
 
-  virtual ~MxNotificationParam() override {} // vtable+0x0 (scalar deleting destructor)
-  virtual MxNotificationParam *Clone(); // vtable+0x4
+	virtual ~MxNotificationParam() override {} // vtable+0x0 (scalar deleting destructor)
+	virtual MxNotificationParam* Clone();      // vtable+0x4
 
-  inline MxParamType GetType() const { return m_type; }
-  inline MxCore *GetSender() const { return m_sender; }
+	inline MxParamType GetType() const { return m_type; }
+	inline MxCore* GetSender() const { return m_sender; }
 
 protected:
-  MxParamType m_type; // 0x4
-  MxCore *m_sender; // 0x8
+	MxParamType m_type; // 0x4
+	MxCore* m_sender;   // 0x8
 };
 
 #endif // MXNOTIFICATIONPARAM_H

--- a/LEGO1/mxobjectfactory.cpp
+++ b/LEGO1/mxobjectfactory.cpp
@@ -1,19 +1,18 @@
 #include "mxobjectfactory.h"
 
-#include "mxpresenter.h"
+#include "decomp.h"
 #include "mxcompositepresenter.h"
-#include "mxvideopresenter.h"
+#include "mxeventpresenter.h"
 #include "mxflcpresenter.h"
+#include "mxloopingflcpresenter.h"
+#include "mxloopingmidipresenter.h"
+#include "mxloopingsmkpresenter.h"
+#include "mxmidipresenter.h"
+#include "mxpresenter.h"
 #include "mxsmkpresenter.h"
 #include "mxstillpresenter.h"
+#include "mxvideopresenter.h"
 #include "mxwavepresenter.h"
-#include "mxmidipresenter.h"
-#include "mxeventpresenter.h"
-#include "mxloopingflcpresenter.h"
-#include "mxloopingsmkpresenter.h"
-#include "mxloopingmidipresenter.h"
-
-#include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxObjectFactory, 0x38); // 100af1db
 
@@ -21,25 +20,30 @@ DECOMP_SIZE_ASSERT(MxObjectFactory, 0x38); // 100af1db
 MxObjectFactory::MxObjectFactory()
 {
 #define X(V) this->m_id##V = MxAtomId(#V, LookupMode_Exact);
-  FOR_MXOBJECTFACTORY_OBJECTS(X)
+	FOR_MXOBJECTFACTORY_OBJECTS(X)
 #undef X
 }
 
 // OFFSET: LEGO1 0x100b12c0
-MxCore *MxObjectFactory::Create(const char *p_name)
+MxCore* MxObjectFactory::Create(const char* p_name)
 {
-  MxCore* object = NULL;
-  MxAtomId atom(p_name, LookupMode_Exact);
+	MxCore* object = NULL;
+	MxAtomId atom(p_name, LookupMode_Exact);
 
-  if (0) {}
-#define X(V) else if (this->m_id##V == atom) { object = new V; }
-  FOR_MXOBJECTFACTORY_OBJECTS(X)
+	if (0) {
+	}
+#define X(V)                                                                                                           \
+	else if (this->m_id##V == atom)                                                                                    \
+	{                                                                                                                  \
+		object = new V;                                                                                                \
+	}
+	FOR_MXOBJECTFACTORY_OBJECTS(X)
 #undef X
-  return object;
+	return object;
 }
 
 // OFFSET: LEGO1 0x100b1a30
-void MxObjectFactory::Destroy(MxCore *p_object)
+void MxObjectFactory::Destroy(MxCore* p_object)
 {
-  delete p_object;
+	delete p_object;
 }

--- a/LEGO1/mxobjectfactory.h
+++ b/LEGO1/mxobjectfactory.h
@@ -1,47 +1,46 @@
 #ifndef MXOBJECTFACTORY_H
 #define MXOBJECTFACTORY_H
 
-#include "mxcore.h"
 #include "mxatomid.h"
+#include "mxcore.h"
 
-#define FOR_MXOBJECTFACTORY_OBJECTS(X)  \
-  X(MxPresenter)                        \
-  X(MxCompositePresenter)               \
-  X(MxVideoPresenter)                   \
-  X(MxFlcPresenter)                     \
-  X(MxSmkPresenter)                     \
-  X(MxStillPresenter)                   \
-  X(MxWavePresenter)                    \
-  X(MxMIDIPresenter)                    \
-  X(MxEventPresenter)                   \
-  X(MxLoopingFlcPresenter)              \
-  X(MxLoopingSmkPresenter)              \
-  X(MxLoopingMIDIPresenter)
+#define FOR_MXOBJECTFACTORY_OBJECTS(X)                                                                                 \
+	X(MxPresenter)                                                                                                     \
+	X(MxCompositePresenter)                                                                                            \
+	X(MxVideoPresenter)                                                                                                \
+	X(MxFlcPresenter)                                                                                                  \
+	X(MxSmkPresenter)                                                                                                  \
+	X(MxStillPresenter)                                                                                                \
+	X(MxWavePresenter)                                                                                                 \
+	X(MxMIDIPresenter)                                                                                                 \
+	X(MxEventPresenter)                                                                                                \
+	X(MxLoopingFlcPresenter)                                                                                           \
+	X(MxLoopingSmkPresenter)                                                                                           \
+	X(MxLoopingMIDIPresenter)
 
 // VTABLE 0x100dc220
-class MxObjectFactory : public MxCore
-{
+class MxObjectFactory : public MxCore {
 public:
-  MxObjectFactory();
+	MxObjectFactory();
 
-  // OFFSET: LEGO1 0x10008f70
-  inline virtual const char *ClassName() const override // vtable+0xc
-  {
-    // 0x100f0730
-    return "MxObjectFactory";
-  }
+	// OFFSET: LEGO1 0x10008f70
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0730
+		return "MxObjectFactory";
+	}
 
-  // OFFSET: LEGO1 0x10008f80
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxObjectFactory::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10008f80
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxObjectFactory::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxCore *Create(const char *p_name); // vtable 0x14
-  virtual void Destroy(MxCore *p_object); // vtable 0x18
+	virtual MxCore* Create(const char* p_name); // vtable 0x14
+	virtual void Destroy(MxCore* p_object);     // vtable 0x18
 private:
 #define X(V) MxAtomId m_id##V;
-  FOR_MXOBJECTFACTORY_OBJECTS(X)
+	FOR_MXOBJECTFACTORY_OBJECTS(X)
 #undef X
 };
 

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -1,6 +1,7 @@
 #include "mxomni.h"
 
 #include "mxatomidcounter.h"
+#include "mxautolocker.h"
 #include "mxeventmanager.h"
 #include "mxmusicmanager.h"
 #include "mxnotificationmanager.h"
@@ -11,7 +12,6 @@
 #include "mxticklemanager.h"
 #include "mxtimer.h"
 #include "mxvideomanager.h"
-#include "mxautolocker.h"
 
 // 0x101015b8
 char g_hdPath[1024];
@@ -23,403 +23,398 @@ char g_cdPath[1024];
 MxBool g_use3dSound;
 
 // 0x101015b0
-MxOmni *MxOmni::g_instance = NULL;
+MxOmni* MxOmni::g_instance = NULL;
 
 // OFFSET: LEGO1 0x100aef10
 MxOmni::MxOmni()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100aeff0
 MxOmni::~MxOmni()
 {
-  Destroy();
+	Destroy();
 }
 
 // OFFSET: LEGO1 0x100af080
 void MxOmni::Init()
 {
-  m_windowHandle = NULL;
-  m_objectFactory = NULL;
-  m_variableTable = NULL;
-  m_tickleManager = NULL;
-  m_notificationManager = NULL;
-  m_videoManager = NULL;
-  m_soundManager = NULL;
-  m_musicManager = NULL;
-  m_eventManager = NULL;
-  m_timer = NULL;
-  m_streamer = NULL;
-  m_atomIdCounterSet = NULL;
-  m_timerRunning = NULL;
+	m_windowHandle = NULL;
+	m_objectFactory = NULL;
+	m_variableTable = NULL;
+	m_tickleManager = NULL;
+	m_notificationManager = NULL;
+	m_videoManager = NULL;
+	m_soundManager = NULL;
+	m_musicManager = NULL;
+	m_eventManager = NULL;
+	m_timer = NULL;
+	m_streamer = NULL;
+	m_atomIdCounterSet = NULL;
+	m_timerRunning = NULL;
 }
 
 // OFFSET: LEGO1 0x100b0090
-MxResult MxOmni::Start(MxDSAction *p_dsAction)
+MxResult MxOmni::Start(MxDSAction* p_dsAction)
 {
-  MxResult result = FAILURE;
-  if(p_dsAction->GetAtomId().GetInternal() != NULL && p_dsAction->GetObjectId() != -1 && m_streamer != NULL)
-  {
-    result = m_streamer->FUN_100b99b0(p_dsAction);
-  }
+	MxResult result = FAILURE;
+	if (p_dsAction->GetAtomId().GetInternal() != NULL && p_dsAction->GetObjectId() != -1 && m_streamer != NULL) {
+		result = m_streamer->FUN_100b99b0(p_dsAction);
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100b00c0 STUB
-MxResult MxOmni::DeleteObject(MxDSAction &p_dsAction)
+MxResult MxOmni::DeleteObject(MxDSAction& p_dsAction)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b09a0
-MxBool MxOmni::DoesEntityExist(MxDSAction &p_dsAction)
+MxBool MxOmni::DoesEntityExist(MxDSAction& p_dsAction)
 {
-  if (m_streamer->FUN_100b9b30(p_dsAction)) {
-    MxNotificationPtrList *queue = m_notificationManager->GetQueue();
+	if (m_streamer->FUN_100b9b30(p_dsAction)) {
+		MxNotificationPtrList* queue = m_notificationManager->GetQueue();
 
-    if (!queue || queue->size() == 0)
-      return TRUE;
-  }
-  return FALSE;
+		if (!queue || queue->size() == 0)
+			return TRUE;
+	}
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x100b00e0 STUB
 void MxOmni::Vtable0x2c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100aefb0 STUB
-int MxOmni::Vtable0x30(char *, int, MxCore *)
+int MxOmni::Vtable0x30(char*, int, MxCore*)
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100aefc0
-void MxOmni::NotifyCurrentEntity(MxNotificationParam *p_param)
+void MxOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
 {
 }
 
 // OFFSET: LEGO1 0x100b09d0
 void MxOmni::StartTimer()
 {
-  if (m_timerRunning == FALSE && m_timer != NULL && m_soundManager != NULL)
-  {
-    m_timer->Start();
-    m_soundManager->vtable0x34();
-    m_timerRunning = TRUE;
-  }
+	if (m_timerRunning == FALSE && m_timer != NULL && m_soundManager != NULL) {
+		m_timer->Start();
+		m_soundManager->vtable0x34();
+		m_timerRunning = TRUE;
+	}
 }
 
 // OFFSET: LEGO1 0x100b0a00
 void MxOmni::StopTimer()
 {
-  if (m_timerRunning != FALSE && m_timer != NULL && m_soundManager != NULL)
-  {
-    m_timer->Stop();
-    m_soundManager->vtable0x38();
-    m_timerRunning = FALSE;
-  }
+	if (m_timerRunning != FALSE && m_timer != NULL && m_soundManager != NULL) {
+		m_timer->Stop();
+		m_soundManager->vtable0x38();
+		m_timerRunning = FALSE;
+	}
 }
 
 // OFFSET: LEGO1 0x10058a90
 MxBool MxOmni::IsTimerRunning()
 {
-  return m_timerRunning;
+	return m_timerRunning;
 }
 
 // OFFSET: LEGO1 0x100b0690
 void MxOmni::DestroyInstance()
 {
-  if (g_instance != NULL)
-  {
-    delete g_instance;
-    g_instance = NULL;
-  }
+	if (g_instance != NULL) {
+		delete g_instance;
+		g_instance = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x100b0900
-const char *MxOmni::GetHD()
+const char* MxOmni::GetHD()
 {
-  return g_hdPath;
+	return g_hdPath;
 }
 
 // OFFSET: LEGO1 0x100b0940
-const char *MxOmni::GetCD()
+const char* MxOmni::GetCD()
 {
-  return g_cdPath;
+	return g_cdPath;
 }
 
 // OFFSET: LEGO1 0x100b0980
 MxBool MxOmni::IsSound3D()
 {
-  return g_use3dSound;
+	return g_use3dSound;
 }
 
 // OFFSET: LEGO1 0x100b0910
-void MxOmni::SetHD(const char *p_hd)
+void MxOmni::SetHD(const char* p_hd)
 {
-  strcpy(g_hdPath, p_hd);
+	strcpy(g_hdPath, p_hd);
 }
 
 // OFFSET: LEGO1 0x100b0950
-void MxOmni::SetCD(const char *p_cd)
+void MxOmni::SetCD(const char* p_cd)
 {
-  strcpy(g_cdPath, p_cd);
+	strcpy(g_cdPath, p_cd);
 }
 
 // OFFSET: LEGO1 0x100b0990
 void MxOmni::SetSound3D(MxBool p_3dsound)
 {
-  g_use3dSound = p_3dsound;
+	g_use3dSound = p_3dsound;
 }
 
-
 // OFFSET: LEGO1 0x100b0680
-MxOmni *MxOmni::GetInstance()
+MxOmni* MxOmni::GetInstance()
 {
-  return g_instance;
+	return g_instance;
 }
 
 // OFFSET: LEGO1 0x100af0b0
-void MxOmni::SetInstance(MxOmni *instance)
+void MxOmni::SetInstance(MxOmni* instance)
 {
-  g_instance = instance;
+	g_instance = instance;
 }
 
 // OFFSET: LEGO1 0x100af0c0
-MxResult MxOmni::Create(MxOmniCreateParam &p)
+MxResult MxOmni::Create(MxOmniCreateParam& p)
 {
-  MxResult result = FAILURE;
+	MxResult result = FAILURE;
 
-  if (!(m_atomIdCounterSet = new MxAtomIdCounterSet()))
-    goto done;
+	if (!(m_atomIdCounterSet = new MxAtomIdCounterSet()))
+		goto done;
 
-  m_mediaPath = p.GetMediaPath();
-  m_windowHandle = p.GetWindowHandle();
+	m_mediaPath = p.GetMediaPath();
+	m_windowHandle = p.GetWindowHandle();
 
-  if (p.CreateFlags().CreateObjectFactory()) {
-    if (!(m_objectFactory = new MxObjectFactory()))
-      goto done;
-  }
+	if (p.CreateFlags().CreateObjectFactory()) {
+		if (!(m_objectFactory = new MxObjectFactory()))
+			goto done;
+	}
 
-  if (p.CreateFlags().CreateVariableTable()) {
-    if (!(m_variableTable = new MxVariableTable()))
-      goto done;
-  }
+	if (p.CreateFlags().CreateVariableTable()) {
+		if (!(m_variableTable = new MxVariableTable()))
+			goto done;
+	}
 
-  if (p.CreateFlags().CreateTimer()) {
-    if (!(m_timer = new MxTimer()))
-      goto done;
-  }
+	if (p.CreateFlags().CreateTimer()) {
+		if (!(m_timer = new MxTimer()))
+			goto done;
+	}
 
-  if (p.CreateFlags().CreateTickleManager()) {
-    if (!(m_tickleManager = new MxTickleManager()))
-      goto done;
-  }
+	if (p.CreateFlags().CreateTickleManager()) {
+		if (!(m_tickleManager = new MxTickleManager()))
+			goto done;
+	}
 
-  if (p.CreateFlags().CreateNotificationManager()) {
-    if (m_notificationManager = new MxNotificationManager()) {
-      if (m_notificationManager->Create(100, 0) != SUCCESS)
-        goto done;
-    }
-    else
-      goto done;
-  }
+	if (p.CreateFlags().CreateNotificationManager()) {
+		if (m_notificationManager = new MxNotificationManager()) {
+			if (m_notificationManager->Create(100, 0) != SUCCESS)
+				goto done;
+		}
+		else
+			goto done;
+	}
 
-  if (p.CreateFlags().CreateStreamer()) {
-    if (!(m_streamer = new MxStreamer()) || m_streamer->Create() != SUCCESS)
-      goto done;
-  }
+	if (p.CreateFlags().CreateStreamer()) {
+		if (!(m_streamer = new MxStreamer()) || m_streamer->Create() != SUCCESS)
+			goto done;
+	}
 
-  if (p.CreateFlags().CreateVideoManager()) {
-    if (m_videoManager = new MxVideoManager()) {
-      if (m_videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
-        delete m_videoManager;
-        m_videoManager = NULL;
-      }
-    }
-  }
+	if (p.CreateFlags().CreateVideoManager()) {
+		if (m_videoManager = new MxVideoManager()) {
+			if (m_videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
+				delete m_videoManager;
+				m_videoManager = NULL;
+			}
+		}
+	}
 
-  if (p.CreateFlags().CreateSoundManager()) {
-    if (m_soundManager = new MxSoundManager()) {
-      if (m_soundManager->Create(10, 0) != SUCCESS) {
-        delete m_soundManager;
-        m_soundManager = NULL;
-      }
-    }
-  }
+	if (p.CreateFlags().CreateSoundManager()) {
+		if (m_soundManager = new MxSoundManager()) {
+			if (m_soundManager->Create(10, 0) != SUCCESS) {
+				delete m_soundManager;
+				m_soundManager = NULL;
+			}
+		}
+	}
 
-  if (p.CreateFlags().CreateMusicManager()) {
-    if (m_musicManager = new MxMusicManager()) {
-      if (m_musicManager->Create(50, 0) != SUCCESS) {
-        delete m_musicManager;
-        m_musicManager = NULL;
-      }
-    }
-  }
+	if (p.CreateFlags().CreateMusicManager()) {
+		if (m_musicManager = new MxMusicManager()) {
+			if (m_musicManager->Create(50, 0) != SUCCESS) {
+				delete m_musicManager;
+				m_musicManager = NULL;
+			}
+		}
+	}
 
-  if (p.CreateFlags().CreateEventManager()) {
-    if (m_eventManager = new MxEventManager()) {
-      if (m_eventManager->Create(50, 0) != SUCCESS) {
-        delete m_eventManager;
-        m_eventManager = NULL;
-      }
-    }
-  }
+	if (p.CreateFlags().CreateEventManager()) {
+		if (m_eventManager = new MxEventManager()) {
+			if (m_eventManager->Create(50, 0) != SUCCESS) {
+				delete m_eventManager;
+				m_eventManager = NULL;
+			}
+		}
+	}
 
-  result = SUCCESS;
+	result = SUCCESS;
 done:
-  if (result != SUCCESS)
-    Destroy();
+	if (result != SUCCESS)
+		Destroy();
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100afe90
 void MxOmni::Destroy()
 {
-  // FIXME: Stub
+	// FIXME: Stub
 
-  /*
-  // TODO: private members
-  if (m_notificationManager) {
-    while (m_notificationManager->m_queue->size()) {
-      m_notificationManager->Tickle();
-    }
-  }
+	/*
+	// TODO: private members
+	if (m_notificationManager) {
+	  while (m_notificationManager->m_queue->size()) {
+		m_notificationManager->Tickle();
+	  }
+	}
 
-  m_notificationManager->m_active = 0;
-  */
+	m_notificationManager->m_active = 0;
+	*/
 
-  delete m_eventManager;
-  delete m_soundManager;
-  delete m_musicManager;
-  delete m_videoManager;
-  delete m_streamer;
-  delete m_timer;
-  delete m_objectFactory;
-  delete m_variableTable;
-  delete m_notificationManager;
-  delete m_tickleManager;
+	delete m_eventManager;
+	delete m_soundManager;
+	delete m_musicManager;
+	delete m_videoManager;
+	delete m_streamer;
+	delete m_timer;
+	delete m_objectFactory;
+	delete m_variableTable;
+	delete m_notificationManager;
+	delete m_tickleManager;
 
-  // There could be a tree/iterator function that does this inline
-  if (m_atomIdCounterSet) {
-    while (!m_atomIdCounterSet->empty()) {
-      // Pop each node and delete its value
-      MxAtomIdCounterSet::iterator begin = m_atomIdCounterSet->begin();
-      MxAtomIdCounter *value = *begin;
-      m_atomIdCounterSet->erase(begin);
-      delete value;
-    }
-    delete m_atomIdCounterSet;
-  }
+	// There could be a tree/iterator function that does this inline
+	if (m_atomIdCounterSet) {
+		while (!m_atomIdCounterSet->empty()) {
+			// Pop each node and delete its value
+			MxAtomIdCounterSet::iterator begin = m_atomIdCounterSet->begin();
+			MxAtomIdCounter* value = *begin;
+			m_atomIdCounterSet->erase(begin);
+			delete value;
+		}
+		delete m_atomIdCounterSet;
+	}
 }
 
 // OFFSET: LEGO1 0x100b07f0
-MxLong MxOmni::Notify(MxParam &p)
+MxLong MxOmni::Notify(MxParam& p)
 {
-  MxAutoLocker lock(&this->m_criticalsection);
+	MxAutoLocker lock(&this->m_criticalsection);
 
-  if (((MxNotificationParam&) p).GetType() != MXSTREAMER_UNKNOWN)
-    return 0;
+	if (((MxNotificationParam&) p).GetType() != MXSTREAMER_UNKNOWN)
+		return 0;
 
-  return HandleNotificationType2(p);
+	return HandleNotificationType2(p);
 }
 
 // OFFSET: LEGO1 0x100b0880 STUB
-MxResult MxOmni::HandleNotificationType2(MxParam &p_param)
+MxResult MxOmni::HandleNotificationType2(MxParam& p_param)
 {
-  // TODO STUB
-  return FAILURE;
+	// TODO STUB
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100acea0
-MxObjectFactory *ObjectFactory()
+MxObjectFactory* ObjectFactory()
 {
-  return MxOmni::GetInstance()->GetObjectFactory();
+	return MxOmni::GetInstance()->GetObjectFactory();
 }
 
 // OFFSET: LEGO1 0x100aceb0
-MxNotificationManager *NotificationManager()
+MxNotificationManager* NotificationManager()
 {
-  return MxOmni::GetInstance()->GetNotificationManager();
+	return MxOmni::GetInstance()->GetNotificationManager();
 }
 
 // OFFSET: LEGO1 0x100acec0
-MxTickleManager *TickleManager()
+MxTickleManager* TickleManager()
 {
-  return MxOmni::GetInstance()->GetTickleManager();
+	return MxOmni::GetInstance()->GetTickleManager();
 }
 
 // OFFSET: LEGO1 0x100aced0
-MxTimer *Timer()
+MxTimer* Timer()
 {
-  return MxOmni::GetInstance()->GetTimer();
+	return MxOmni::GetInstance()->GetTimer();
 }
 
 // OFFSET: LEGO1 0x100acee0
-MxAtomIdCounterSet *AtomIdCounterSet()
+MxAtomIdCounterSet* AtomIdCounterSet()
 {
-  return MxOmni::GetInstance()->GetAtomIdCounterSet();
+	return MxOmni::GetInstance()->GetAtomIdCounterSet();
 }
 
 // OFFSET: LEGO1 0x100acef0
-MxStreamer *Streamer()
+MxStreamer* Streamer()
 {
-  return MxOmni::GetInstance()->GetStreamer();
+	return MxOmni::GetInstance()->GetStreamer();
 }
 
 // OFFSET: LEGO1 0x100acf00
-MxSoundManager *MSoundManager()
+MxSoundManager* MSoundManager()
 {
-  return MxOmni::GetInstance()->GetSoundManager();
+	return MxOmni::GetInstance()->GetSoundManager();
 }
 
 // OFFSET: LEGO1 0x100acf10
-MxVideoManager *MVideoManager()
+MxVideoManager* MVideoManager()
 {
-  return MxOmni::GetInstance()->GetVideoManager();
+	return MxOmni::GetInstance()->GetVideoManager();
 }
 
 // OFFSET: LEGO1 0x100acf20
-MxVariableTable *VariableTable()
+MxVariableTable* VariableTable()
 {
-  return MxOmni::GetInstance()->GetVariableTable();
+	return MxOmni::GetInstance()->GetVariableTable();
 }
 
 // OFFSET: LEGO1 0x100acf30
-MxMusicManager *MusicManager()
+MxMusicManager* MusicManager()
 {
-  return MxOmni::GetInstance()->GetMusicManager();
+	return MxOmni::GetInstance()->GetMusicManager();
 }
 
 // OFFSET: LEGO1 0x100acf40
-MxEventManager *EventManager()
+MxEventManager* EventManager()
 {
-  return MxOmni::GetInstance()->GetEventManager();
+	return MxOmni::GetInstance()->GetEventManager();
 }
 
 // OFFSET: LEGO1 0x100acf70
-MxResult DeleteObject(MxDSAction &p_dsAction)
+MxResult DeleteObject(MxDSAction& p_dsAction)
 {
-  return MxOmni::GetInstance()->DeleteObject(p_dsAction);
+	return MxOmni::GetInstance()->DeleteObject(p_dsAction);
 }
 
 // OFFSET: LEGO1 0x100159e0
-void DeleteObjects(MxAtomId *p_id, MxS32 p_first, MxS32 p_last)
+void DeleteObjects(MxAtomId* p_id, MxS32 p_first, MxS32 p_last)
 {
-  MxDSAction action;
+	MxDSAction action;
 
-  action.SetAtomId(*p_id);
-  action.SetUnknown24(-2);
+	action.SetAtomId(*p_id);
+	action.SetUnknown24(-2);
 
-  for (MxS32 l_first = p_first, l_last = p_last; l_first <= l_last; l_first++) {
-    action.SetObjectId(l_first);
-    DeleteObject(action);
-  }
+	for (MxS32 l_first = p_first, l_last = p_last; l_first <= l_last; l_first++) {
+		action.SetObjectId(l_first);
+		DeleteObject(action);
+	}
 }

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -2,8 +2,8 @@
 #define MXOMNI_H
 
 #include "mxcore.h"
-#include "mxstring.h"
 #include "mxcriticalsection.h"
+#include "mxstring.h"
 
 class MxAtomId;
 class MxAtomIdCounterSet;
@@ -23,84 +23,84 @@ class MxVideoManager;
 
 // VTABLE 0x100dc168
 // SIZE 0x68
-class MxOmni : public MxCore
-{
+class MxOmni : public MxCore {
 public:
-  __declspec(dllexport) static void DestroyInstance();
-  __declspec(dllexport) static const char *GetCD();
-  __declspec(dllexport) static const char *GetHD();
-  __declspec(dllexport) static MxOmni *GetInstance();
-  __declspec(dllexport) static MxBool IsSound3D();
-  __declspec(dllexport) static void SetCD(const char *p_cd);
-  __declspec(dllexport) static void SetHD(const char *p_hd);
-  __declspec(dllexport) static void SetSound3D(MxBool p_3dsound);
+	__declspec(dllexport) static void DestroyInstance();
+	__declspec(dllexport) static const char* GetCD();
+	__declspec(dllexport) static const char* GetHD();
+	__declspec(dllexport) static MxOmni* GetInstance();
+	__declspec(dllexport) static MxBool IsSound3D();
+	__declspec(dllexport) static void SetCD(const char* p_cd);
+	__declspec(dllexport) static void SetHD(const char* p_hd);
+	__declspec(dllexport) static void SetSound3D(MxBool p_3dsound);
 
-  MxOmni();
-  virtual ~MxOmni() override;
+	MxOmni();
+	virtual ~MxOmni() override;
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+04
-  virtual void Init(); // vtable+14
-  virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
-  virtual void Destroy(); // vtable+1c
-  virtual MxResult Start(MxDSAction *p_dsAction); // vtable+20
-  virtual MxResult DeleteObject(MxDSAction &p_dsAction); // vtable+24
-  virtual MxBool DoesEntityExist(MxDSAction &p_dsAction); // vtable+28
-  virtual void Vtable0x2c(); // vtable+2c
-  virtual int Vtable0x30(char*, int, MxCore *); // vtable+30
-  virtual void NotifyCurrentEntity(MxNotificationParam *p_param); // vtable+34
-  virtual void StartTimer(); // vtable+38
-  virtual void StopTimer(); // vtable+3c
-  virtual MxBool IsTimerRunning(); //vtable+40
-  static void SetInstance(MxOmni *instance);
-  HWND GetWindowHandle() const { return this->m_windowHandle; }
-  MxObjectFactory *GetObjectFactory() const { return this->m_objectFactory; }
-  MxNotificationManager *GetNotificationManager() const { return this->m_notificationManager; }
-  MxTickleManager *GetTickleManager() const { return this->m_tickleManager; }
-  MxTimer *GetTimer() const { return this->m_timer; }
-  MxStreamer *GetStreamer() const { return this->m_streamer; }
-  MxSoundManager *GetSoundManager() const { return this->m_soundManager; }
-  MxVideoManager *GetVideoManager() const { return this->m_videoManager; }
-  MxVariableTable *GetVariableTable() const { return this->m_variableTable; }
-  MxMusicManager *GetMusicManager() const { return this->m_musicManager; }
-  MxEventManager *GetEventManager() const { return this->m_eventManager; }
-  MxAtomIdCounterSet *GetAtomIdCounterSet() const { return this->m_atomIdCounterSet; }
-  MxResult HandleNotificationType2(MxParam &p_param);
+	virtual MxLong Notify(MxParam& p) override;                     // vtable+04
+	virtual void Init();                                            // vtable+14
+	virtual MxResult Create(MxOmniCreateParam& p);                  // vtable+18
+	virtual void Destroy();                                         // vtable+1c
+	virtual MxResult Start(MxDSAction* p_dsAction);                 // vtable+20
+	virtual MxResult DeleteObject(MxDSAction& p_dsAction);          // vtable+24
+	virtual MxBool DoesEntityExist(MxDSAction& p_dsAction);         // vtable+28
+	virtual void Vtable0x2c();                                      // vtable+2c
+	virtual int Vtable0x30(char*, int, MxCore*);                    // vtable+30
+	virtual void NotifyCurrentEntity(MxNotificationParam* p_param); // vtable+34
+	virtual void StartTimer();                                      // vtable+38
+	virtual void StopTimer();                                       // vtable+3c
+	virtual MxBool IsTimerRunning();                                // vtable+40
+	static void SetInstance(MxOmni* instance);
+	HWND GetWindowHandle() const { return this->m_windowHandle; }
+	MxObjectFactory* GetObjectFactory() const { return this->m_objectFactory; }
+	MxNotificationManager* GetNotificationManager() const { return this->m_notificationManager; }
+	MxTickleManager* GetTickleManager() const { return this->m_tickleManager; }
+	MxTimer* GetTimer() const { return this->m_timer; }
+	MxStreamer* GetStreamer() const { return this->m_streamer; }
+	MxSoundManager* GetSoundManager() const { return this->m_soundManager; }
+	MxVideoManager* GetVideoManager() const { return this->m_videoManager; }
+	MxVariableTable* GetVariableTable() const { return this->m_variableTable; }
+	MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
+	MxEventManager* GetEventManager() const { return this->m_eventManager; }
+	MxAtomIdCounterSet* GetAtomIdCounterSet() const { return this->m_atomIdCounterSet; }
+	MxResult HandleNotificationType2(MxParam& p_param);
+
 protected:
-  static MxOmni *g_instance;
+	static MxOmni* g_instance;
 
-  MxString m_mediaPath; // 0x8
-  HWND m_windowHandle; // 0x18;
-  MxObjectFactory *m_objectFactory; // 0x1C
-  MxVariableTable *m_variableTable; //0x20
-  MxTickleManager *m_tickleManager; //0x24
-  MxNotificationManager *m_notificationManager; //0x28
-  MxVideoManager *m_videoManager; //0x2C
-  MxSoundManager *m_soundManager; //0x30
-  MxMusicManager *m_musicManager; //0x34
-  MxEventManager *m_eventManager; //0x38
-  MxTimer *m_timer; //0x3C
-  MxStreamer *m_streamer; //0x40
+	MxString m_mediaPath;                         // 0x8
+	HWND m_windowHandle;                          // 0x18;
+	MxObjectFactory* m_objectFactory;             // 0x1C
+	MxVariableTable* m_variableTable;             // 0x20
+	MxTickleManager* m_tickleManager;             // 0x24
+	MxNotificationManager* m_notificationManager; // 0x28
+	MxVideoManager* m_videoManager;               // 0x2C
+	MxSoundManager* m_soundManager;               // 0x30
+	MxMusicManager* m_musicManager;               // 0x34
+	MxEventManager* m_eventManager;               // 0x38
+	MxTimer* m_timer;                             // 0x3C
+	MxStreamer* m_streamer;                       // 0x40
 
-  MxAtomIdCounterSet *m_atomIdCounterSet; // 0x44
+	MxAtomIdCounterSet* m_atomIdCounterSet; // 0x44
 
-  MxCriticalSection m_criticalsection; // 0x48
+	MxCriticalSection m_criticalsection; // 0x48
 
-  MxBool m_timerRunning; // 0x64
+	MxBool m_timerRunning; // 0x64
 };
-__declspec(dllexport) MxTickleManager *TickleManager();
-__declspec(dllexport) MxTimer *Timer();
-__declspec(dllexport) MxStreamer *Streamer();
-__declspec(dllexport) MxSoundManager *MSoundManager();
-__declspec(dllexport) MxVariableTable *VariableTable();
-__declspec(dllexport) MxMusicManager *MusicManager();
-__declspec(dllexport) MxEventManager *EventManager();
-__declspec(dllexport) MxNotificationManager *NotificationManager();
+__declspec(dllexport) MxTickleManager* TickleManager();
+__declspec(dllexport) MxTimer* Timer();
+__declspec(dllexport) MxStreamer* Streamer();
+__declspec(dllexport) MxSoundManager* MSoundManager();
+__declspec(dllexport) MxVariableTable* VariableTable();
+__declspec(dllexport) MxMusicManager* MusicManager();
+__declspec(dllexport) MxEventManager* EventManager();
+__declspec(dllexport) MxNotificationManager* NotificationManager();
 
-MxResult DeleteObject(MxDSAction &p_dsAction);
-MxVideoManager *MVideoManager();
-MxAtomIdCounterSet *AtomIdCounterSet();
-MxObjectFactory *ObjectFactory();
-MxResult DeleteObject(MxDSAction &p_dsAction);
-void DeleteObjects(MxAtomId *p_id, MxS32 p_first, MxS32 p_last);
+MxResult DeleteObject(MxDSAction& p_dsAction);
+MxVideoManager* MVideoManager();
+MxAtomIdCounterSet* AtomIdCounterSet();
+MxObjectFactory* ObjectFactory();
+MxResult DeleteObject(MxDSAction& p_dsAction);
+void DeleteObjects(MxAtomId* p_id, MxS32 p_first, MxS32 p_last);
 
 #endif // MXOMNI_H

--- a/LEGO1/mxomnicreateflags.cpp
+++ b/LEGO1/mxomnicreateflags.cpp
@@ -3,15 +3,15 @@
 // OFFSET: LEGO1 0x100b0a30
 MxOmniCreateFlags::MxOmniCreateFlags()
 {
-  this->CreateObjectFactory(TRUE);
-  this->CreateVariableTable(TRUE);
-  this->CreateTickleManager(TRUE);
-  this->CreateNotificationManager(TRUE);
-  this->CreateVideoManager(TRUE);
-  this->CreateSoundManager(TRUE);
-  this->CreateMusicManager(TRUE);
-  this->CreateEventManager(TRUE);
+	this->CreateObjectFactory(TRUE);
+	this->CreateVariableTable(TRUE);
+	this->CreateTickleManager(TRUE);
+	this->CreateNotificationManager(TRUE);
+	this->CreateVideoManager(TRUE);
+	this->CreateSoundManager(TRUE);
+	this->CreateMusicManager(TRUE);
+	this->CreateEventManager(TRUE);
 
-  this->CreateTimer(TRUE);
-  this->CreateStreamer(TRUE);
+	this->CreateTimer(TRUE);
+	this->CreateStreamer(TRUE);
 }

--- a/LEGO1/mxomnicreateflags.h
+++ b/LEGO1/mxomnicreateflags.h
@@ -3,54 +3,92 @@
 
 #include "mxtypes.h"
 
-class MxOmniCreateFlags
-{
+class MxOmniCreateFlags {
 public:
-  enum LowFlags {
-    Flag_CreateObjectFactory       = 0x01,
-    Flag_CreateVariableTable       = 0x02,
-    Flag_CreateTickleManager       = 0x04,
-    Flag_CreateNotificationManager = 0x08,
-    Flag_CreateVideoManager        = 0x10,
-    Flag_CreateSoundManager        = 0x20,
-    Flag_CreateMusicManager        = 0x40,
-    Flag_CreateEventManager        = 0x80
-  };
+	enum LowFlags {
+		Flag_CreateObjectFactory = 0x01,
+		Flag_CreateVariableTable = 0x02,
+		Flag_CreateTickleManager = 0x04,
+		Flag_CreateNotificationManager = 0x08,
+		Flag_CreateVideoManager = 0x10,
+		Flag_CreateSoundManager = 0x20,
+		Flag_CreateMusicManager = 0x40,
+		Flag_CreateEventManager = 0x80
+	};
 
-  enum HighFlags {
-    Flag_CreateTimer     = 0x02,
-    Flag_CreateStreamer  = 0x04
-  };
+	enum HighFlags {
+		Flag_CreateTimer = 0x02,
+		Flag_CreateStreamer = 0x04
+	};
 
-  __declspec(dllexport) MxOmniCreateFlags();
-  
-  const inline MxBool CreateObjectFactory() const { return this->m_flags1 & Flag_CreateObjectFactory; }
-  const inline MxBool CreateVariableTable() const { return this->m_flags1 & Flag_CreateVariableTable; }
-  const inline MxBool CreateTickleManager() const { return this->m_flags1 & Flag_CreateTickleManager; }
-  const inline MxBool CreateNotificationManager() const { return this->m_flags1 & Flag_CreateNotificationManager; }
-  const inline MxBool CreateVideoManager() const { return this->m_flags1 & Flag_CreateVideoManager; }
-  const inline MxBool CreateSoundManager() const { return this->m_flags1 & Flag_CreateSoundManager; }
-  const inline MxBool CreateMusicManager() const { return this->m_flags1 & Flag_CreateMusicManager; }
-  const inline MxBool CreateEventManager() const { return this->m_flags1 & Flag_CreateEventManager; }
+	__declspec(dllexport) MxOmniCreateFlags();
 
-  const inline MxBool CreateTimer() const { return this->m_flags2 & Flag_CreateTimer; }
-  const inline MxBool CreateStreamer() const { return this->m_flags2 & Flag_CreateStreamer; }
+	const inline MxBool CreateObjectFactory() const { return this->m_flags1 & Flag_CreateObjectFactory; }
+	const inline MxBool CreateVariableTable() const { return this->m_flags1 & Flag_CreateVariableTable; }
+	const inline MxBool CreateTickleManager() const { return this->m_flags1 & Flag_CreateTickleManager; }
+	const inline MxBool CreateNotificationManager() const { return this->m_flags1 & Flag_CreateNotificationManager; }
+	const inline MxBool CreateVideoManager() const { return this->m_flags1 & Flag_CreateVideoManager; }
+	const inline MxBool CreateSoundManager() const { return this->m_flags1 & Flag_CreateSoundManager; }
+	const inline MxBool CreateMusicManager() const { return this->m_flags1 & Flag_CreateMusicManager; }
+	const inline MxBool CreateEventManager() const { return this->m_flags1 & Flag_CreateEventManager; }
 
-  inline void CreateObjectFactory(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateObjectFactory : this->m_flags1 & ~Flag_CreateObjectFactory); }
-  inline void CreateVariableTable(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateVariableTable : this->m_flags1 & ~Flag_CreateVariableTable); }
-  inline void CreateTickleManager(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateTickleManager : this->m_flags1 & ~Flag_CreateTickleManager); }
-  inline void CreateNotificationManager(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateNotificationManager : this->m_flags1 & ~Flag_CreateNotificationManager); }
-  inline void CreateVideoManager(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateVideoManager : this->m_flags1 & ~Flag_CreateVideoManager); }
-  inline void CreateSoundManager(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateSoundManager : this->m_flags1 & ~Flag_CreateSoundManager); }
-  inline void CreateMusicManager(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateMusicManager : this->m_flags1 & ~Flag_CreateMusicManager); }
-  inline void CreateEventManager(MxBool b) { this->m_flags1 = (b == TRUE ? this->m_flags1 | Flag_CreateEventManager : this->m_flags1 & ~Flag_CreateEventManager); }
+	const inline MxBool CreateTimer() const { return this->m_flags2 & Flag_CreateTimer; }
+	const inline MxBool CreateStreamer() const { return this->m_flags2 & Flag_CreateStreamer; }
 
-  inline void CreateTimer(MxBool b) { this->m_flags2 = (b == TRUE ? this->m_flags2 | Flag_CreateTimer : this->m_flags2 & ~Flag_CreateTimer); }
-  inline void CreateStreamer(MxBool b) { this->m_flags2 = (b == TRUE ? this->m_flags2 | Flag_CreateStreamer : this->m_flags2 & ~Flag_CreateStreamer); }
+	inline void CreateObjectFactory(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateObjectFactory : this->m_flags1 & ~Flag_CreateObjectFactory);
+	}
+	inline void CreateVariableTable(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateVariableTable : this->m_flags1 & ~Flag_CreateVariableTable);
+	}
+	inline void CreateTickleManager(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateTickleManager : this->m_flags1 & ~Flag_CreateTickleManager);
+	}
+	inline void CreateNotificationManager(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateNotificationManager
+					   : this->m_flags1 & ~Flag_CreateNotificationManager);
+	}
+	inline void CreateVideoManager(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateVideoManager : this->m_flags1 & ~Flag_CreateVideoManager);
+	}
+	inline void CreateSoundManager(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateSoundManager : this->m_flags1 & ~Flag_CreateSoundManager);
+	}
+	inline void CreateMusicManager(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateMusicManager : this->m_flags1 & ~Flag_CreateMusicManager);
+	}
+	inline void CreateEventManager(MxBool b)
+	{
+		this->m_flags1 =
+			(b == TRUE ? this->m_flags1 | Flag_CreateEventManager : this->m_flags1 & ~Flag_CreateEventManager);
+	}
+
+	inline void CreateTimer(MxBool b)
+	{
+		this->m_flags2 = (b == TRUE ? this->m_flags2 | Flag_CreateTimer : this->m_flags2 & ~Flag_CreateTimer);
+	}
+	inline void CreateStreamer(MxBool b)
+	{
+		this->m_flags2 = (b == TRUE ? this->m_flags2 | Flag_CreateStreamer : this->m_flags2 & ~Flag_CreateStreamer);
+	}
 
 private:
-  unsigned char m_flags1;
-  unsigned char m_flags2;
+	unsigned char m_flags1;
+	unsigned char m_flags2;
 };
 
 #endif // MXOMNICREATEFLAGS_H

--- a/LEGO1/mxomnicreateparam.cpp
+++ b/LEGO1/mxomnicreateparam.cpp
@@ -1,10 +1,15 @@
 #include "mxomnicreateparam.h"
 
 // OFFSET: LEGO1 0x100b0b00
-MxOmniCreateParam::MxOmniCreateParam(const char *mediaPath, struct HWND__ *windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags)
+MxOmniCreateParam::MxOmniCreateParam(
+	const char* mediaPath,
+	struct HWND__* windowHandle,
+	MxVideoParam& vparam,
+	MxOmniCreateFlags flags
+)
 {
-  this->m_mediaPath = mediaPath;
-  this->m_windowHandle = (HWND) windowHandle;
-  this->m_videoParam = vparam;
-  this->m_createFlags = flags;
+	this->m_mediaPath = mediaPath;
+	this->m_windowHandle = (HWND) windowHandle;
+	this->m_videoParam = vparam;
+	this->m_createFlags = flags;
 }

--- a/LEGO1/mxomnicreateparam.h
+++ b/LEGO1/mxomnicreateparam.h
@@ -1,29 +1,33 @@
 #ifndef MXOMNICREATEPARAM_H
 #define MXOMNICREATEPARAM_H
 
-#include <windows.h>
-
 #include "mxomnicreateflags.h"
 #include "mxparam.h"
 #include "mxstring.h"
 #include "mxvideoparam.h"
 
-class MxOmniCreateParam : public MxParam
-{
-public:
-  __declspec(dllexport) MxOmniCreateParam(const char *mediaPath, struct HWND__ *windowHandle, MxVideoParam &vparam, MxOmniCreateFlags flags);
+#include <windows.h>
 
-  const MxOmniCreateFlags& CreateFlags() const { return this->m_createFlags; }
-  const MxString& GetMediaPath() const { return m_mediaPath; }
-  const HWND GetWindowHandle() const { return m_windowHandle; }
-  MxVideoParam& GetVideoParam() { return m_videoParam; }
-  const MxVideoParam& GetVideoParam() const { return m_videoParam; }
+class MxOmniCreateParam : public MxParam {
+public:
+	__declspec(dllexport) MxOmniCreateParam(
+		const char* mediaPath,
+		struct HWND__* windowHandle,
+		MxVideoParam& vparam,
+		MxOmniCreateFlags flags
+	);
+
+	const MxOmniCreateFlags& CreateFlags() const { return this->m_createFlags; }
+	const MxString& GetMediaPath() const { return m_mediaPath; }
+	const HWND GetWindowHandle() const { return m_windowHandle; }
+	MxVideoParam& GetVideoParam() { return m_videoParam; }
+	const MxVideoParam& GetVideoParam() const { return m_videoParam; }
 
 private:
-  MxString m_mediaPath;
-  HWND m_windowHandle;
-  MxVideoParam m_videoParam;
-  MxOmniCreateFlags m_createFlags;
+	MxString m_mediaPath;
+	HWND m_windowHandle;
+	MxVideoParam m_videoParam;
+	MxOmniCreateFlags m_createFlags;
 };
 
 #endif // MXOMNICREATEPARAM_H

--- a/LEGO1/mxpalette.cpp
+++ b/LEGO1/mxpalette.cpp
@@ -4,488 +4,277 @@
 #include "mxvideomanager.h"
 
 // GLOBAL: LEGO1 0x10102188 0x400
-PALETTEENTRY g_defaultPaletteEntries[256] =
-{
-  { 0u, 0u, 0u, 0u },
-  { 128u, 0u, 0u, 0u },
-  { 0u, 128u, 0u, 0u },
-  { 128u, 128u, 0u, 0u },
-  { 0u, 0u, 128u, 0u },
-  { 128u, 0u, 128u, 0u },
-  { 0u, 128u, 128u, 0u },
-  { 128u, 128u, 128u, 0u },
-  { 192u, 220u, 192u, 0u },
-  { 166u, 202u, 240u, 0u },
-  { 255u, 255u, 255u, 0u },
-  { 250u, 250u, 250u, 0u },
-  { 239u, 239u, 239u, 0u },
-  { 228u, 228u, 228u, 0u },
-  { 217u, 217u, 217u, 0u },
-  { 206u, 206u, 206u, 0u },
-  { 195u, 195u, 195u, 0u },
-  { 185u, 185u, 185u, 0u },
-  { 174u, 174u, 174u, 0u },
-  { 163u, 163u, 163u, 0u },
-  { 152u, 152u, 152u, 0u },
-  { 141u, 141u, 141u, 0u },
-  { 130u, 130u, 130u, 0u },
-  { 123u, 123u, 123u, 0u },
-  { 115u, 115u, 115u, 0u },
-  { 108u, 108u, 108u, 0u },
-  { 101u, 101u, 101u, 0u },
-  { 93u, 93u, 93u, 0u },
-  { 86u, 86u, 86u, 0u },
-  { 79u, 79u, 79u, 0u },
-  { 71u, 71u, 71u, 0u },
-  { 64u, 64u, 64u, 0u },
-  { 54u, 54u, 54u, 0u },
-  { 43u, 43u, 43u, 0u },
-  { 33u, 33u, 33u, 0u },
-  { 22u, 22u, 22u, 0u },
-  { 12u, 12u, 12u, 0u },
-  { 8u, 8u, 8u, 0u },
-  { 4u, 4u, 4u, 0u },
-  { 0u, 0u, 0u, 0u },
-  { 225u, 218u, 217u, 0u },
-  { 195u, 182u, 179u, 0u },
-  { 165u, 145u, 141u, 0u },
-  { 134u, 108u, 102u, 0u },
-  { 104u, 72u, 64u, 0u },
-  { 74u, 35u, 26u, 0u },
-  { 59u, 28u, 21u, 0u },
-  { 44u, 21u, 16u, 0u },
-  { 30u, 14u, 10u, 0u },
-  { 15u, 7u, 5u, 0u },
-  { 250u, 231u, 232u, 0u },
-  { 240u, 185u, 189u, 0u },
-  { 233u, 154u, 160u, 0u },
-  { 226u, 124u, 131u, 0u },
-  { 219u, 93u, 102u, 0u },
-  { 213u, 62u, 73u, 0u },
-  { 203u, 18u, 32u, 0u },
-  { 172u, 15u, 27u, 0u },
-  { 159u, 14u, 25u, 0u },
-  { 146u, 13u, 23u, 0u },
-  { 133u, 12u, 21u, 0u },
-  { 120u, 11u, 19u, 0u },
-  { 107u, 10u, 17u, 0u },
-  { 94u, 8u, 15u, 0u },
-  { 81u, 7u, 13u, 0u },
-  { 68u, 6u, 11u, 0u },
-  { 55u, 5u, 9u, 0u },
-  { 42u, 4u, 7u, 0u },
-  { 29u, 3u, 5u, 0u },
-  { 10u, 1u, 2u, 0u },
-  { 227u, 236u, 242u, 0u },
-  { 178u, 203u, 220u, 0u },
-  { 145u, 181u, 205u, 0u },
-  { 112u, 159u, 191u, 0u },
-  { 79u, 137u, 176u, 0u },
-  { 30u, 104u, 154u, 0u },
-  { 0u, 84u, 140u, 0u },
-  { 0u, 79u, 132u, 0u },
-  { 0u, 72u, 119u, 0u },
-  { 0u, 66u, 110u, 0u },
-  { 0u, 61u, 101u, 0u },
-  { 0u, 55u, 92u, 0u },
-  { 0u, 47u, 78u, 0u },
-  { 0u, 39u, 65u, 0u },
-  { 0u, 34u, 56u, 0u },
-  { 0u, 28u, 47u, 0u },
-  { 0u, 23u, 38u, 0u },
-  { 0u, 18u, 29u, 0u },
-  { 0u, 12u, 20u, 0u },
-  { 0u, 4u, 7u, 0u },
-  { 230u, 242u, 234u, 0u },
-  { 180u, 215u, 193u, 0u },
-  { 147u, 198u, 166u, 0u },
-  { 113u, 180u, 138u, 0u },
-  { 80u, 162u, 111u, 0u },
-  { 30u, 136u, 70u, 0u },
-  { 0u, 120u, 45u, 0u },
-  { 0u, 114u, 43u, 0u },
-  { 0u, 102u, 38u, 0u },
-  { 0u, 95u, 35u, 0u },
-  { 0u, 83u, 31u, 0u },
-  { 0u, 72u, 27u, 0u },
-  { 0u, 63u, 24u, 0u },
-  { 0u, 56u, 21u, 0u },
-  { 0u, 48u, 18u, 0u },
-  { 0u, 36u, 14u, 0u },
-  { 0u, 25u, 9u, 0u },
-  { 0u, 17u, 6u, 0u },
-  { 0u, 9u, 3u, 0u },
-  { 0u, 1u, 1u, 0u },
-  { 254u, 244u, 220u, 0u },
-  { 255u, 239u, 181u, 0u },
-  { 255u, 231u, 156u, 0u },
-  { 255u, 222u, 132u, 0u },
-  { 255u, 222u, 115u, 0u },
-  { 255u, 214u, 99u, 0u },
-  { 255u, 206u, 66u, 0u },
-  { 255u, 198u, 41u, 0u },
-  { 255u, 185u, 0u, 0u },
-  { 255u, 189u, 8u, 0u },
-  { 247u, 181u, 0u, 0u },
-  { 222u, 156u, 0u, 0u },
-  { 189u, 140u, 0u, 0u },
-  { 173u, 123u, 0u, 0u },
-  { 148u, 107u, 0u, 0u },
-  { 132u, 90u, 0u, 0u },
-  { 107u, 74u, 0u, 0u },
-  { 74u, 49u, 0u, 0u },
-  { 57u, 41u, 0u, 0u },
-  { 33u, 24u, 0u, 0u },
-  { 117u, 52u, 87u, 0u },
-  { 176u, 158u, 50u, 0u },
-  { 122u, 165u, 29u, 0u },
-  { 242u, 142u, 8u, 0u },
-  { 164u, 43u, 36u, 0u },
-  { 113u, 67u, 20u, 0u },
-  { 255u, 0u, 255u, 0u },
-  { 255u, 0u, 255u, 0u },
-  { 255u, 0u, 255u, 0u },
-  { 255u, 0u, 255u, 0u },
-  { 255u, 0u, 255u, 0u },
-  { 57u, 163u, 217u, 0u },
-  { 255u, 255u, 255u, 0u },
-  { 254u, 255u, 247u, 0u },
-  { 253u, 253u, 239u, 0u },
-  { 248u, 247u, 247u, 0u },
-  { 248u, 247u, 231u, 0u },
-  { 240u, 240u, 240u, 0u },
-  { 239u, 239u, 218u, 0u },
-  { 227u, 232u, 236u, 0u },
-  { 224u, 221u, 209u, 0u },
-  { 215u, 222u, 215u, 0u },
-  { 213u, 214u, 215u, 0u },
-  { 214u, 214u, 203u, 0u },
-  { 255u, 219u, 57u, 0u },
-  { 206u, 206u, 206u, 0u },
-  { 206u, 206u, 198u, 0u },
-  { 255u, 214u, 18u, 0u },
-  { 207u, 203u, 186u, 0u },
-  { 197u, 199u, 199u, 0u },
-  { 255u, 206u, 0u, 0u },
-  { 207u, 198u, 159u, 0u },
-  { 247u, 204u, 0u, 0u },
-  { 189u, 198u, 189u, 0u },
-  { 189u, 189u, 189u, 0u },
-  { 238u, 199u, 0u, 0u },
-  { 189u, 189u, 181u, 0u },
-  { 238u, 190u, 24u, 0u },
-  { 181u, 189u, 184u, 0u },
-  { 161u, 186u, 224u, 0u },
-  { 181u, 181u, 181u, 0u },
-  { 231u, 189u, 0u, 0u },
-  { 173u, 182u, 173u, 0u },
-  { 222u, 181u, 0u, 0u },
-  { 173u, 173u, 173u, 0u },
-  { 213u, 182u, 0u, 0u },
-  { 172u, 173u, 160u, 0u },
-  { 214u, 173u, 0u, 0u },
-  { 165u, 165u, 165u, 0u },
-  { 206u, 173u, 0u, 0u },
-  { 160u, 168u, 151u, 0u },
-  { 206u, 164u, 0u, 0u },
-  { 198u, 165u, 0u, 0u },
-  { 157u, 156u, 156u, 0u },
-  { 134u, 156u, 200u, 0u },
-  { 153u, 156u, 144u, 0u },
-  { 142u, 156u, 161u, 0u },
-  { 189u, 156u, 0u, 0u },
-  { 148u, 148u, 148u, 0u },
-  { 146u, 148u, 138u, 0u },
-  { 133u, 143u, 161u, 0u },
-  { 189u, 143u, 0u, 0u },
-  { 140u, 140u, 140u, 0u },
-  { 177u, 147u, 0u, 0u },
-  { 131u, 140u, 136u, 0u },
-  { 146u, 130u, 126u, 0u },
-  { 170u, 137u, 0u, 0u },
-  { 132u, 132u, 130u, 0u },
-  { 123u, 125u, 125u, 0u },
-  { 123u, 123u, 133u, 0u },
-  { 153u, 126u, 0u, 0u },
-  { 114u, 116u, 118u, 0u },
-  { 110u, 112u, 108u, 0u },
-  { 97u, 109u, 136u, 0u },
-  { 127u, 108u, 6u, 0u },
-  { 0u, 173u, 0u, 0u },
-  { 100u, 99u, 101u, 0u },
-  { 176u, 71u, 41u, 0u },
-  { 36u, 142u, 33u, 0u },
-  { 98u, 91u, 75u, 0u },
-  { 80u, 88u, 104u, 0u },
-  { 252u, 0u, 0u, 0u },
-  { 78u, 71u, 73u, 0u },
-  { 73u, 71u, 78u, 0u },
-  { 62u, 63u, 61u, 0u },
-  { 0u, 66u, 211u, 0u },
-  { 99u, 51u, 14u, 0u },
-  { 198u, 0u, 0u, 0u },
-  { 189u, 0u, 0u, 0u },
-  { 0u, 57u, 206u, 0u },
-  { 181u, 0u, 0u, 0u },
-  { 0u, 56u, 185u, 0u },
-  { 173u, 0u, 0u, 0u },
-  { 165u, 0u, 0u, 0u },
-  { 49u, 49u, 49u, 0u },
-  { 0u, 49u, 165u, 0u },
-  { 156u, 0u, 0u, 0u },
-  { 42u, 45u, 60u, 0u },
-  { 148u, 0u, 0u, 0u },
-  { 140u, 0u, 0u, 0u },
-  { 41u, 41u, 41u, 0u },
-  { 0u, 41u, 144u, 0u },
-  { 132u, 0u, 0u, 0u },
-  { 123u, 0u, 0u, 0u },
-  { 7u, 35u, 114u, 0u },
-  { 34u, 36u, 32u, 0u },
-  { 115u, 0u, 0u, 0u },
-  { 107u, 0u, 0u, 0u },
-  { 90u, 0u, 0u, 0u },
-  { 23u, 24u, 27u, 0u },
-  { 74u, 0u, 0u, 0u },
-  { 15u, 15u, 16u, 0u },
-  { 49u, 0u, 0u, 0u },
-  { 16u, 12u, 4u, 0u },
-  { 7u, 8u, 8u, 0u },
-  { 0u, 0u, 8u, 0u },
-  { 255u, 251u, 240u, 0u },
-  { 160u, 160u, 164u, 0u },
-  { 128u, 128u, 128u, 0u },
-  { 255u, 0u, 0u, 0u },
-  { 0u, 255u, 0u, 0u },
-  { 255u, 255u, 0u, 0u },
-  { 0u, 0u, 255u, 0u },
-  { 255u, 0u, 255u, 0u },
-  { 0u, 255u, 255u, 0u },
-  { 255u, 255u, 255u, 0u }
+PALETTEENTRY g_defaultPaletteEntries[256] = {
+	{0u, 0u, 0u, 0u},       {128u, 0u, 0u, 0u},     {0u, 128u, 0u, 0u},     {128u, 128u, 0u, 0u},
+	{0u, 0u, 128u, 0u},     {128u, 0u, 128u, 0u},   {0u, 128u, 128u, 0u},   {128u, 128u, 128u, 0u},
+	{192u, 220u, 192u, 0u}, {166u, 202u, 240u, 0u}, {255u, 255u, 255u, 0u}, {250u, 250u, 250u, 0u},
+	{239u, 239u, 239u, 0u}, {228u, 228u, 228u, 0u}, {217u, 217u, 217u, 0u}, {206u, 206u, 206u, 0u},
+	{195u, 195u, 195u, 0u}, {185u, 185u, 185u, 0u}, {174u, 174u, 174u, 0u}, {163u, 163u, 163u, 0u},
+	{152u, 152u, 152u, 0u}, {141u, 141u, 141u, 0u}, {130u, 130u, 130u, 0u}, {123u, 123u, 123u, 0u},
+	{115u, 115u, 115u, 0u}, {108u, 108u, 108u, 0u}, {101u, 101u, 101u, 0u}, {93u, 93u, 93u, 0u},
+	{86u, 86u, 86u, 0u},    {79u, 79u, 79u, 0u},    {71u, 71u, 71u, 0u},    {64u, 64u, 64u, 0u},
+	{54u, 54u, 54u, 0u},    {43u, 43u, 43u, 0u},    {33u, 33u, 33u, 0u},    {22u, 22u, 22u, 0u},
+	{12u, 12u, 12u, 0u},    {8u, 8u, 8u, 0u},       {4u, 4u, 4u, 0u},       {0u, 0u, 0u, 0u},
+	{225u, 218u, 217u, 0u}, {195u, 182u, 179u, 0u}, {165u, 145u, 141u, 0u}, {134u, 108u, 102u, 0u},
+	{104u, 72u, 64u, 0u},   {74u, 35u, 26u, 0u},    {59u, 28u, 21u, 0u},    {44u, 21u, 16u, 0u},
+	{30u, 14u, 10u, 0u},    {15u, 7u, 5u, 0u},      {250u, 231u, 232u, 0u}, {240u, 185u, 189u, 0u},
+	{233u, 154u, 160u, 0u}, {226u, 124u, 131u, 0u}, {219u, 93u, 102u, 0u},  {213u, 62u, 73u, 0u},
+	{203u, 18u, 32u, 0u},   {172u, 15u, 27u, 0u},   {159u, 14u, 25u, 0u},   {146u, 13u, 23u, 0u},
+	{133u, 12u, 21u, 0u},   {120u, 11u, 19u, 0u},   {107u, 10u, 17u, 0u},   {94u, 8u, 15u, 0u},
+	{81u, 7u, 13u, 0u},     {68u, 6u, 11u, 0u},     {55u, 5u, 9u, 0u},      {42u, 4u, 7u, 0u},
+	{29u, 3u, 5u, 0u},      {10u, 1u, 2u, 0u},      {227u, 236u, 242u, 0u}, {178u, 203u, 220u, 0u},
+	{145u, 181u, 205u, 0u}, {112u, 159u, 191u, 0u}, {79u, 137u, 176u, 0u},  {30u, 104u, 154u, 0u},
+	{0u, 84u, 140u, 0u},    {0u, 79u, 132u, 0u},    {0u, 72u, 119u, 0u},    {0u, 66u, 110u, 0u},
+	{0u, 61u, 101u, 0u},    {0u, 55u, 92u, 0u},     {0u, 47u, 78u, 0u},     {0u, 39u, 65u, 0u},
+	{0u, 34u, 56u, 0u},     {0u, 28u, 47u, 0u},     {0u, 23u, 38u, 0u},     {0u, 18u, 29u, 0u},
+	{0u, 12u, 20u, 0u},     {0u, 4u, 7u, 0u},       {230u, 242u, 234u, 0u}, {180u, 215u, 193u, 0u},
+	{147u, 198u, 166u, 0u}, {113u, 180u, 138u, 0u}, {80u, 162u, 111u, 0u},  {30u, 136u, 70u, 0u},
+	{0u, 120u, 45u, 0u},    {0u, 114u, 43u, 0u},    {0u, 102u, 38u, 0u},    {0u, 95u, 35u, 0u},
+	{0u, 83u, 31u, 0u},     {0u, 72u, 27u, 0u},     {0u, 63u, 24u, 0u},     {0u, 56u, 21u, 0u},
+	{0u, 48u, 18u, 0u},     {0u, 36u, 14u, 0u},     {0u, 25u, 9u, 0u},      {0u, 17u, 6u, 0u},
+	{0u, 9u, 3u, 0u},       {0u, 1u, 1u, 0u},       {254u, 244u, 220u, 0u}, {255u, 239u, 181u, 0u},
+	{255u, 231u, 156u, 0u}, {255u, 222u, 132u, 0u}, {255u, 222u, 115u, 0u}, {255u, 214u, 99u, 0u},
+	{255u, 206u, 66u, 0u},  {255u, 198u, 41u, 0u},  {255u, 185u, 0u, 0u},   {255u, 189u, 8u, 0u},
+	{247u, 181u, 0u, 0u},   {222u, 156u, 0u, 0u},   {189u, 140u, 0u, 0u},   {173u, 123u, 0u, 0u},
+	{148u, 107u, 0u, 0u},   {132u, 90u, 0u, 0u},    {107u, 74u, 0u, 0u},    {74u, 49u, 0u, 0u},
+	{57u, 41u, 0u, 0u},     {33u, 24u, 0u, 0u},     {117u, 52u, 87u, 0u},   {176u, 158u, 50u, 0u},
+	{122u, 165u, 29u, 0u},  {242u, 142u, 8u, 0u},   {164u, 43u, 36u, 0u},   {113u, 67u, 20u, 0u},
+	{255u, 0u, 255u, 0u},   {255u, 0u, 255u, 0u},   {255u, 0u, 255u, 0u},   {255u, 0u, 255u, 0u},
+	{255u, 0u, 255u, 0u},   {57u, 163u, 217u, 0u},  {255u, 255u, 255u, 0u}, {254u, 255u, 247u, 0u},
+	{253u, 253u, 239u, 0u}, {248u, 247u, 247u, 0u}, {248u, 247u, 231u, 0u}, {240u, 240u, 240u, 0u},
+	{239u, 239u, 218u, 0u}, {227u, 232u, 236u, 0u}, {224u, 221u, 209u, 0u}, {215u, 222u, 215u, 0u},
+	{213u, 214u, 215u, 0u}, {214u, 214u, 203u, 0u}, {255u, 219u, 57u, 0u},  {206u, 206u, 206u, 0u},
+	{206u, 206u, 198u, 0u}, {255u, 214u, 18u, 0u},  {207u, 203u, 186u, 0u}, {197u, 199u, 199u, 0u},
+	{255u, 206u, 0u, 0u},   {207u, 198u, 159u, 0u}, {247u, 204u, 0u, 0u},   {189u, 198u, 189u, 0u},
+	{189u, 189u, 189u, 0u}, {238u, 199u, 0u, 0u},   {189u, 189u, 181u, 0u}, {238u, 190u, 24u, 0u},
+	{181u, 189u, 184u, 0u}, {161u, 186u, 224u, 0u}, {181u, 181u, 181u, 0u}, {231u, 189u, 0u, 0u},
+	{173u, 182u, 173u, 0u}, {222u, 181u, 0u, 0u},   {173u, 173u, 173u, 0u}, {213u, 182u, 0u, 0u},
+	{172u, 173u, 160u, 0u}, {214u, 173u, 0u, 0u},   {165u, 165u, 165u, 0u}, {206u, 173u, 0u, 0u},
+	{160u, 168u, 151u, 0u}, {206u, 164u, 0u, 0u},   {198u, 165u, 0u, 0u},   {157u, 156u, 156u, 0u},
+	{134u, 156u, 200u, 0u}, {153u, 156u, 144u, 0u}, {142u, 156u, 161u, 0u}, {189u, 156u, 0u, 0u},
+	{148u, 148u, 148u, 0u}, {146u, 148u, 138u, 0u}, {133u, 143u, 161u, 0u}, {189u, 143u, 0u, 0u},
+	{140u, 140u, 140u, 0u}, {177u, 147u, 0u, 0u},   {131u, 140u, 136u, 0u}, {146u, 130u, 126u, 0u},
+	{170u, 137u, 0u, 0u},   {132u, 132u, 130u, 0u}, {123u, 125u, 125u, 0u}, {123u, 123u, 133u, 0u},
+	{153u, 126u, 0u, 0u},   {114u, 116u, 118u, 0u}, {110u, 112u, 108u, 0u}, {97u, 109u, 136u, 0u},
+	{127u, 108u, 6u, 0u},   {0u, 173u, 0u, 0u},     {100u, 99u, 101u, 0u},  {176u, 71u, 41u, 0u},
+	{36u, 142u, 33u, 0u},   {98u, 91u, 75u, 0u},    {80u, 88u, 104u, 0u},   {252u, 0u, 0u, 0u},
+	{78u, 71u, 73u, 0u},    {73u, 71u, 78u, 0u},    {62u, 63u, 61u, 0u},    {0u, 66u, 211u, 0u},
+	{99u, 51u, 14u, 0u},    {198u, 0u, 0u, 0u},     {189u, 0u, 0u, 0u},     {0u, 57u, 206u, 0u},
+	{181u, 0u, 0u, 0u},     {0u, 56u, 185u, 0u},    {173u, 0u, 0u, 0u},     {165u, 0u, 0u, 0u},
+	{49u, 49u, 49u, 0u},    {0u, 49u, 165u, 0u},    {156u, 0u, 0u, 0u},     {42u, 45u, 60u, 0u},
+	{148u, 0u, 0u, 0u},     {140u, 0u, 0u, 0u},     {41u, 41u, 41u, 0u},    {0u, 41u, 144u, 0u},
+	{132u, 0u, 0u, 0u},     {123u, 0u, 0u, 0u},     {7u, 35u, 114u, 0u},    {34u, 36u, 32u, 0u},
+	{115u, 0u, 0u, 0u},     {107u, 0u, 0u, 0u},     {90u, 0u, 0u, 0u},      {23u, 24u, 27u, 0u},
+	{74u, 0u, 0u, 0u},      {15u, 15u, 16u, 0u},    {49u, 0u, 0u, 0u},      {16u, 12u, 4u, 0u},
+	{7u, 8u, 8u, 0u},       {0u, 0u, 8u, 0u},       {255u, 251u, 240u, 0u}, {160u, 160u, 164u, 0u},
+	{128u, 128u, 128u, 0u}, {255u, 0u, 0u, 0u},     {0u, 255u, 0u, 0u},     {255u, 255u, 0u, 0u},
+	{0u, 0u, 255u, 0u},     {255u, 0u, 255u, 0u},   {0u, 255u, 255u, 0u},   {255u, 255u, 255u, 0u}
 };
-
 
 // OFFSET: LEGO1 0x100bee30
 MxPalette::MxPalette()
 {
-  this->m_overrideSkyColor = FALSE;
-  this->m_palette = NULL;
-  GetDefaultPalette(this->m_entries);
-  this->m_skyColor = this->m_entries[141];
+	this->m_overrideSkyColor = FALSE;
+	this->m_palette = NULL;
+	GetDefaultPalette(this->m_entries);
+	this->m_skyColor = this->m_entries[141];
 }
 
 // OFFSET: LEGO1 0x100BEED0
-MxPalette::MxPalette(const RGBQUAD *p_colors)
+MxPalette::MxPalette(const RGBQUAD* p_colors)
 {
-  this->m_overrideSkyColor = FALSE;
-  this->m_palette = NULL;
-  ApplySystemEntriesToPalette(this->m_entries);
+	this->m_overrideSkyColor = FALSE;
+	this->m_palette = NULL;
+	ApplySystemEntriesToPalette(this->m_entries);
 
-  for ( MxS32 i = 10; i < 246; i++ )
-  {
-    this->m_entries[i].peRed = p_colors[i].rgbRed;
-    this->m_entries[i].peGreen = p_colors[i].rgbGreen;
-    this->m_entries[i].peBlue = p_colors[i].rgbBlue;
-    this->m_entries[i].peFlags = 0;
-  }
+	for (MxS32 i = 10; i < 246; i++) {
+		this->m_entries[i].peRed = p_colors[i].rgbRed;
+		this->m_entries[i].peGreen = p_colors[i].rgbGreen;
+		this->m_entries[i].peBlue = p_colors[i].rgbBlue;
+		this->m_entries[i].peFlags = 0;
+	}
 
-  this->m_skyColor = this->m_entries[141];
+	this->m_skyColor = this->m_entries[141];
 }
 
 // OFFSET: LEGO1 100bef90
 MxPalette::~MxPalette()
 {
-  if (m_palette) {
-    m_palette->Release();
-  }
+	if (m_palette) {
+		m_palette->Release();
+	}
 }
 
 // OFFSET: LEGO1 0x100bf390
 void MxPalette::ApplySystemEntriesToPalette(LPPALETTEENTRY p_entries)
 {
-  HDC hdc;
+	HDC hdc;
 
-  hdc = GetDC(0);
-  if ( (GetDeviceCaps(hdc, RASTERCAPS) & RC_PALETTE) != 0 && GetDeviceCaps(hdc, SIZEPALETTE) == 256 )
-  {
-    GetSystemPaletteEntries(hdc, 0, 10, p_entries);
-    GetSystemPaletteEntries(hdc, 246, 10, &p_entries[246]);
-  }
-  else
-  {
-    memcpy(p_entries, g_defaultPaletteEntries, sizeof(PALETTEENTRY) * 10);
-    memcpy(&p_entries[246], &g_defaultPaletteEntries[246], sizeof(PALETTEENTRY) * 10);
-  }
-  ReleaseDC(0, hdc);
+	hdc = GetDC(0);
+	if ((GetDeviceCaps(hdc, RASTERCAPS) & RC_PALETTE) != 0 && GetDeviceCaps(hdc, SIZEPALETTE) == 256) {
+		GetSystemPaletteEntries(hdc, 0, 10, p_entries);
+		GetSystemPaletteEntries(hdc, 246, 10, &p_entries[246]);
+	}
+	else {
+		memcpy(p_entries, g_defaultPaletteEntries, sizeof(PALETTEENTRY) * 10);
+		memcpy(&p_entries[246], &g_defaultPaletteEntries[246], sizeof(PALETTEENTRY) * 10);
+	}
+	ReleaseDC(0, hdc);
 }
 
 // OFFSET: LEGO1 0x100bf0b0
 MxPalette* MxPalette::Clone()
 {
-  MxPalette *result = new MxPalette;
-  this->GetEntries(result->m_entries);
-  result->m_overrideSkyColor = this->m_overrideSkyColor;
-  return result;
+	MxPalette* result = new MxPalette;
+	this->GetEntries(result->m_entries);
+	result->m_overrideSkyColor = this->m_overrideSkyColor;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100bf420
 void MxPalette::GetDefaultPalette(LPPALETTEENTRY p_entries)
 {
-  HDC hdc;
+	HDC hdc;
 
-  hdc = GetDC(0);
-  if ( (GetDeviceCaps(hdc, RASTERCAPS) & RC_PALETTE) != 0 && GetDeviceCaps(hdc, SIZEPALETTE) == 256 )
-  {
-    GetSystemPaletteEntries(hdc, 0, 256, p_entries);
-    memcpy(&p_entries[10], &g_defaultPaletteEntries[10], sizeof(PALETTEENTRY) * 236);
-  }
-  else
-  {
-    memcpy(p_entries, g_defaultPaletteEntries, sizeof(PALETTEENTRY) * 256);
-  }
-  
-  ReleaseDC(0, hdc);
+	hdc = GetDC(0);
+	if ((GetDeviceCaps(hdc, RASTERCAPS) & RC_PALETTE) != 0 && GetDeviceCaps(hdc, SIZEPALETTE) == 256) {
+		GetSystemPaletteEntries(hdc, 0, 256, p_entries);
+		memcpy(&p_entries[10], &g_defaultPaletteEntries[10], sizeof(PALETTEENTRY) * 236);
+	}
+	else {
+		memcpy(p_entries, g_defaultPaletteEntries, sizeof(PALETTEENTRY) * 256);
+	}
+
+	ReleaseDC(0, hdc);
 }
 
 // OFFSET: LEGO1 0x100bf150
 MxResult MxPalette::GetEntries(LPPALETTEENTRY p_entries)
 {
-  memcpy(p_entries, this->m_entries, sizeof(this->m_entries));
-  return SUCCESS;
+	memcpy(p_entries, this->m_entries, sizeof(this->m_entries));
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100bf340
-MxBool MxPalette::operator==(MxPalette &other)
+MxBool MxPalette::operator==(MxPalette& other)
 {
-  for (MxS32 i = 0; i < 256; i++)
-  {
-    if (this->m_entries[i].peRed != other.m_entries[i].peRed)
-      return FALSE;
-    if (this->m_entries[i].peGreen != other.m_entries[i].peGreen)
-      return FALSE;
-    if (this->m_entries[i].peBlue != other.m_entries[i].peBlue)
-      return FALSE;
-  }
-  return TRUE;
+	for (MxS32 i = 0; i < 256; i++) {
+		if (this->m_entries[i].peRed != other.m_entries[i].peRed)
+			return FALSE;
+		if (this->m_entries[i].peGreen != other.m_entries[i].peGreen)
+			return FALSE;
+		if (this->m_entries[i].peBlue != other.m_entries[i].peBlue)
+			return FALSE;
+	}
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x100bf330
 void MxPalette::Detach()
 {
-  this->m_palette = NULL;
+	this->m_palette = NULL;
 }
-  
+
 // OFFSET: LEGO1 0x100bf170
 MxResult MxPalette::SetEntries(LPPALETTEENTRY p_entries)
 {
-  MxS32 i;
-  MxResult status = SUCCESS;
+	MxS32 i;
+	MxResult status = SUCCESS;
 
-  if ( this->m_palette )
-  {
-    for ( i = 0; i < 10; i++ )
-      this->m_entries[i].peFlags = 0x80;
-    for ( i = 10; i < 136; i++ )
-    {
-      this->m_entries[i].peFlags = 68;
-      this->m_entries[i].peRed = p_entries[i].peRed;
-      this->m_entries[i].peGreen = p_entries[i].peGreen;
-      this->m_entries[i].peBlue = p_entries[i].peBlue;
-    }
-    for ( i = 136; i < 140; i++ )
-    {
-      this->m_entries[i].peFlags = 132;
-      this->m_entries[i].peRed = p_entries[i].peRed;
-      this->m_entries[i].peGreen = p_entries[i].peGreen;
-      this->m_entries[i].peBlue = p_entries[i].peBlue;
-    }
-    if ( !this->m_overrideSkyColor )
-    {
-      this->m_entries[140].peFlags = 0x44;
-      this->m_entries[140].peRed = p_entries[140].peRed;
-      this->m_entries[140].peGreen = p_entries[140].peGreen;
-      this->m_entries[140].peBlue = p_entries[140].peBlue;
-      this->m_entries[141].peFlags = 0x84;
-      this->m_entries[141].peRed = p_entries[141].peRed;
-      this->m_entries[141].peGreen = p_entries[141].peGreen;
-      this->m_entries[141].peBlue = p_entries[141].peBlue;
-    }
+	if (this->m_palette) {
+		for (i = 0; i < 10; i++)
+			this->m_entries[i].peFlags = 0x80;
+		for (i = 10; i < 136; i++) {
+			this->m_entries[i].peFlags = 68;
+			this->m_entries[i].peRed = p_entries[i].peRed;
+			this->m_entries[i].peGreen = p_entries[i].peGreen;
+			this->m_entries[i].peBlue = p_entries[i].peBlue;
+		}
+		for (i = 136; i < 140; i++) {
+			this->m_entries[i].peFlags = 132;
+			this->m_entries[i].peRed = p_entries[i].peRed;
+			this->m_entries[i].peGreen = p_entries[i].peGreen;
+			this->m_entries[i].peBlue = p_entries[i].peBlue;
+		}
+		if (!this->m_overrideSkyColor) {
+			this->m_entries[140].peFlags = 0x44;
+			this->m_entries[140].peRed = p_entries[140].peRed;
+			this->m_entries[140].peGreen = p_entries[140].peGreen;
+			this->m_entries[140].peBlue = p_entries[140].peBlue;
+			this->m_entries[141].peFlags = 0x84;
+			this->m_entries[141].peRed = p_entries[141].peRed;
+			this->m_entries[141].peGreen = p_entries[141].peGreen;
+			this->m_entries[141].peBlue = p_entries[141].peBlue;
+		}
 
-    for ( i = 142; i < 246; i++ )
-    {
-      this->m_entries[i].peFlags = 132;
-      this->m_entries[i].peRed = p_entries[i].peRed;
-      this->m_entries[i].peGreen = p_entries[i].peGreen;
-      this->m_entries[i].peBlue = p_entries[i].peBlue;
-    }
+		for (i = 142; i < 246; i++) {
+			this->m_entries[i].peFlags = 132;
+			this->m_entries[i].peRed = p_entries[i].peRed;
+			this->m_entries[i].peGreen = p_entries[i].peGreen;
+			this->m_entries[i].peBlue = p_entries[i].peBlue;
+		}
 
-    for ( i = 246; i < 256; i++ )
-      this->m_entries[i].peFlags = 0x80;
-    
-    if ( this->m_palette->SetEntries(0, 0, 256, this->m_entries) )
-      status = FAILURE;
-  }
+		for (i = 246; i < 256; i++)
+			this->m_entries[i].peFlags = 0x80;
 
-  return status;
+		if (this->m_palette->SetEntries(0, 0, 256, this->m_entries))
+			status = FAILURE;
+	}
+
+	return status;
 }
 
 // OFFSET: LEGO1 0x100bf2d0
 MxResult MxPalette::SetSkyColor(LPPALETTEENTRY p_sky_color)
 {
-  MxResult status = 0;
-  if ( this->m_palette != NULL )
-  {
-    this->m_entries[141].peRed = p_sky_color->peRed;
-    this->m_entries[141].peGreen = p_sky_color->peGreen;
-    this->m_entries[141].peBlue = p_sky_color->peBlue;
-    this->m_skyColor = this->m_entries[141];
-    if ( this->m_palette->SetEntries(0, 141, 1, &this->m_skyColor) )
-    {
-      status = -1;
-    }
-  }
-  return status;
+	MxResult status = 0;
+	if (this->m_palette != NULL) {
+		this->m_entries[141].peRed = p_sky_color->peRed;
+		this->m_entries[141].peGreen = p_sky_color->peGreen;
+		this->m_entries[141].peBlue = p_sky_color->peBlue;
+		this->m_skyColor = this->m_entries[141];
+		if (this->m_palette->SetEntries(0, 141, 1, &this->m_skyColor)) {
+			status = -1;
+		}
+	}
+	return status;
 }
 
 // OFFSET: LEGO1 0x100BF490
 void MxPalette::Reset(MxBool p_ignoreSkyColor)
 {
-  if ( this->m_palette != NULL )
-  {
-    GetDefaultPalette(this->m_entries);
-    if ( !p_ignoreSkyColor )
-    {
-      this->m_entries[140] = this->m_entries[141] = this->m_skyColor;
-    }
-    SetEntries(this->m_entries);
-    this->m_palette->SetEntries(0, 0, 256, this->m_entries);
-  }
+	if (this->m_palette != NULL) {
+		GetDefaultPalette(this->m_entries);
+		if (!p_ignoreSkyColor) {
+			this->m_entries[140] = this->m_entries[141] = this->m_skyColor;
+		}
+		SetEntries(this->m_entries);
+		this->m_palette->SetEntries(0, 0, 256, this->m_entries);
+	}
 }
 
 // OFFSET: LEGO1 0x100BF000
 LPDIRECTDRAWPALETTE MxPalette::CreateNativePalette()
 {
-  MxS32 i;
-  if ( this->m_palette == NULL )
-  {
-    for (i = 0; i < 10; i++)
-      this->m_entries[i].peFlags = 0x80;
-    for (i = 10; i < 136; i++)
-      this->m_entries[i].peFlags = 0x44;
-    for (i = 136; i < 140; i++)
-      this->m_entries[i].peFlags = 0x84;
-    this->m_entries[140].peFlags = 0x84;
-    this->m_entries[141].peFlags = 0x44;
-    for (i = 142; i < 246; i++)
-      this->m_entries[i].peFlags = 0x84;
-    for (i = 246; i < 256; i++)
-      this->m_entries[i].peFlags = 0x80;
+	MxS32 i;
+	if (this->m_palette == NULL) {
+		for (i = 0; i < 10; i++)
+			this->m_entries[i].peFlags = 0x80;
+		for (i = 10; i < 136; i++)
+			this->m_entries[i].peFlags = 0x44;
+		for (i = 136; i < 140; i++)
+			this->m_entries[i].peFlags = 0x84;
+		this->m_entries[140].peFlags = 0x84;
+		this->m_entries[141].peFlags = 0x44;
+		for (i = 142; i < 246; i++)
+			this->m_entries[i].peFlags = 0x84;
+		for (i = 246; i < 256; i++)
+			this->m_entries[i].peFlags = 0x80;
 
-    if (MVideoManager() && MVideoManager()->GetDirectDraw())
-    {
-      MVideoManager()->GetDirectDraw()->CreatePalette(4, this->m_entries, &this->m_palette, NULL);
-    }
-  }
+		if (MVideoManager() && MVideoManager()->GetDirectDraw()) {
+			MVideoManager()->GetDirectDraw()->CreatePalette(4, this->m_entries, &this->m_palette, NULL);
+		}
+	}
 
-  return this->m_palette;
+	return this->m_palette;
 }

--- a/LEGO1/mxpalette.h
+++ b/LEGO1/mxpalette.h
@@ -1,37 +1,37 @@
 #ifndef MXPALETTE_H
 #define MXPALETTE_H
 
-#include <ddraw.h>
-
 #include "mxcore.h"
 #include "mxtypes.h"
 
+#include <ddraw.h>
+
 // VTABLE 0x100dc848
 // SIZE 0x414
-class MxPalette : public MxCore
-{
+class MxPalette : public MxCore {
 public:
-  __declspec(dllexport) MxBool operator==(MxPalette &);
-  __declspec(dllexport) void Detach();
+	__declspec(dllexport) MxBool operator==(MxPalette&);
+	__declspec(dllexport) void Detach();
 
-  MxPalette();
-  MxPalette(const RGBQUAD *);
-  virtual ~MxPalette();
+	MxPalette();
+	MxPalette(const RGBQUAD*);
+	virtual ~MxPalette();
 
-  void ApplySystemEntriesToPalette(LPPALETTEENTRY p_entries);
-  MxPalette* Clone();
-  void GetDefaultPalette(LPPALETTEENTRY p_entries);
-  MxResult GetEntries(LPPALETTEENTRY p_entries);
-  MxResult SetEntries(LPPALETTEENTRY p_palette);
-  MxResult SetSkyColor(LPPALETTEENTRY p_sky_color);
-  void Reset(MxBool p_ignoreSkyColor);
-  LPDIRECTDRAWPALETTE CreateNativePalette();
-  inline void SetOverrideSkyColor(MxBool p_value) { this->m_overrideSkyColor = p_value; }
+	void ApplySystemEntriesToPalette(LPPALETTEENTRY p_entries);
+	MxPalette* Clone();
+	void GetDefaultPalette(LPPALETTEENTRY p_entries);
+	MxResult GetEntries(LPPALETTEENTRY p_entries);
+	MxResult SetEntries(LPPALETTEENTRY p_palette);
+	MxResult SetSkyColor(LPPALETTEENTRY p_sky_color);
+	void Reset(MxBool p_ignoreSkyColor);
+	LPDIRECTDRAWPALETTE CreateNativePalette();
+	inline void SetOverrideSkyColor(MxBool p_value) { this->m_overrideSkyColor = p_value; }
+
 private:
-  LPDIRECTDRAWPALETTE m_palette;
-  PALETTEENTRY m_entries[256]; // 0xc
-  MxBool m_overrideSkyColor; // 0x40c
-  PALETTEENTRY m_skyColor; // 0x40d
+	LPDIRECTDRAWPALETTE m_palette;
+	PALETTEENTRY m_entries[256]; // 0xc
+	MxBool m_overrideSkyColor;   // 0x40c
+	PALETTEENTRY m_skyColor;     // 0x40d
 };
 
 #endif // MXPALETTE_H

--- a/LEGO1/mxparam.h
+++ b/LEGO1/mxparam.h
@@ -1,10 +1,9 @@
 #ifndef MXPARAM_H
 #define MXPARAM_H
 
-class MxParam
-{
+class MxParam {
 public:
-  virtual ~MxParam() {}
+	virtual ~MxParam() {}
 };
 
 #endif // MXPARAM_H

--- a/LEGO1/mxpoint32.h
+++ b/LEGO1/mxpoint32.h
@@ -3,18 +3,17 @@
 
 #include "mxtypes.h"
 
-class MxPoint32
-{
+class MxPoint32 {
 public:
-  MxPoint32() { }
-  MxPoint32(MxS32 p_x, MxS32 p_y)
-  {
-    this->m_x = p_x;
-    this->m_y = p_y;
-  }
+	MxPoint32() {}
+	MxPoint32(MxS32 p_x, MxS32 p_y)
+	{
+		this->m_x = p_x;
+		this->m_y = p_y;
+	}
 
-  MxS32 m_x;
-  MxS32 m_y;
+	MxS32 m_x;
+	MxS32 m_y;
 };
 
 #endif // MXPOINT32_H

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -1,15 +1,15 @@
 #include "mxpresenter.h"
 
+#include "decomp.h"
+#include "define.h"
 #include "legoomni.h"
+#include "mxactionnotificationparam.h"
 #include "mxautolocker.h"
-#include "mxparam.h"
 #include "mxdsanim.h"
 #include "mxdssound.h"
 #include "mxnotificationmanager.h"
-#include "mxactionnotificationparam.h"
+#include "mxparam.h"
 #include "mxstreamer.h"
-#include "decomp.h"
-#include "define.h"
 
 #include <string.h>
 
@@ -18,56 +18,56 @@ DECOMP_SIZE_ASSERT(MxPresenter, 0x40);
 // OFFSET: LEGO1 0x100b4d50
 void MxPresenter::Init()
 {
-  m_currentTickleState = TickleState_Idle;
-  m_action = NULL;
-  m_location = MxPoint32(0, 0);
-  m_displayZ = 0;
-  m_unkPresenter = NULL;
-  m_previousTickleStates = 0;
+	m_currentTickleState = TickleState_Idle;
+	m_action = NULL;
+	m_location = MxPoint32(0, 0);
+	m_displayZ = 0;
+	m_unkPresenter = NULL;
+	m_previousTickleStates = 0;
 }
 
 // OFFSET: LEGO1 0x100b4fc0
 void MxPresenter::ParseExtra()
 {
-  MxAutoLocker lock(&m_criticalSection);
-  MxU32 len = m_action->GetExtraLength();
-  char *extraData = m_action->GetExtraData();
+	MxAutoLocker lock(&m_criticalSection);
+	MxU32 len = m_action->GetExtraLength();
+	char* extraData = m_action->GetExtraData();
 
-  if (len) {
-    len &= MAXWORD;
-    char extraCopy[512];
-    memcpy(extraCopy, extraData, len);
-    extraCopy[len] = '\0';
+	if (len) {
+		len &= MAXWORD;
+		char extraCopy[512];
+		memcpy(extraCopy, extraData, len);
+		extraCopy[len] = '\0';
 
-    char t_worldValue[512];
-    if (KeyValueStringParse(t_worldValue, g_strWORLD, extraCopy)) {
-      char *token = strtok(t_worldValue, g_parseExtraTokens);
-      char t_token[256];
-      strcpy(t_token, token);
+		char t_worldValue[512];
+		if (KeyValueStringParse(t_worldValue, g_strWORLD, extraCopy)) {
+			char* token = strtok(t_worldValue, g_parseExtraTokens);
+			char t_token[256];
+			strcpy(t_token, token);
 
-      token = strtok(NULL, g_parseExtraTokens);
-      MxS32 val = token ? atoi(token) : 0;
-      MxS32 result = MxOmni::GetInstance()->Vtable0x30(t_token, val, this);
+			token = strtok(NULL, g_parseExtraTokens);
+			MxS32 val = token ? atoi(token) : 0;
+			MxS32 result = MxOmni::GetInstance()->Vtable0x30(t_token, val, this);
 
-      m_action->SetFlags(m_action->GetFlags() | MxDSAction::Flag_Parsed);
+			m_action->SetFlags(m_action->GetFlags() | MxDSAction::Flag_Parsed);
 
-      if (result)
-        SendTo_unkPresenter(MxOmni::GetInstance());
-    }
-  }
+			if (result)
+				SendTo_unkPresenter(MxOmni::GetInstance());
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100b5120
-void MxPresenter::SendTo_unkPresenter(MxOmni *p_omni)
+void MxPresenter::SendTo_unkPresenter(MxOmni* p_omni)
 {
-  if (m_unkPresenter) {
-    MxAutoLocker lock(&m_criticalSection);
+	if (m_unkPresenter) {
+		MxAutoLocker lock(&m_criticalSection);
 
-    NotificationManager()->Send(m_unkPresenter, &MxNotificationParam(MXPRESENTER_NOTIFICATION, this));
+		NotificationManager()->Send(m_unkPresenter, &MxNotificationParam(MXPRESENTER_NOTIFICATION, this));
 
-    m_action->SetOmni(p_omni ? p_omni : MxOmni::GetInstance());
-    m_unkPresenter = NULL;
-  }
+		m_action->SetOmni(p_omni ? p_omni : MxOmni::GetInstance());
+		m_unkPresenter = NULL;
+	}
 }
 
 // OFFSET: LEGO1 0x1000bf00
@@ -78,152 +78,147 @@ MxPresenter::~MxPresenter()
 // OFFSET: LEGO1 0x100b5200
 MxResult MxPresenter::Tickle()
 {
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  switch (this->m_currentTickleState) {
-    case TickleState_Ready:
-      this->ReadyTickle();
+	switch (this->m_currentTickleState) {
+	case TickleState_Ready:
+		this->ReadyTickle();
 
-      if (m_currentTickleState != TickleState_Starting)
-        break;
-    case TickleState_Starting:
-      this->StartingTickle();
+		if (m_currentTickleState != TickleState_Starting)
+			break;
+	case TickleState_Starting:
+		this->StartingTickle();
 
-      if (m_currentTickleState != TickleState_Streaming)
-        break;
-    case TickleState_Streaming:
-      this->StreamingTickle();
+		if (m_currentTickleState != TickleState_Streaming)
+			break;
+	case TickleState_Streaming:
+		this->StreamingTickle();
 
-      if (m_currentTickleState != TickleState_Repeating)
-        break;
-    case TickleState_Repeating:
-      this->RepeatingTickle();
+		if (m_currentTickleState != TickleState_Repeating)
+			break;
+	case TickleState_Repeating:
+		this->RepeatingTickle();
 
-      if (m_currentTickleState != TickleState_unk5)
-        break;
-    case TickleState_unk5:
-      this->Unk5Tickle();
+		if (m_currentTickleState != TickleState_unk5)
+			break;
+	case TickleState_unk5:
+		this->Unk5Tickle();
 
-      if (m_currentTickleState != TickleState_Done)
-        break;
-    case TickleState_Done:
-      this->DoneTickle();
-    default:
-      break;
-  }
+		if (m_currentTickleState != TickleState_Done)
+			break;
+	case TickleState_Done:
+		this->DoneTickle();
+	default:
+		break;
+	}
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b4d80
-MxLong MxPresenter::StartAction(MxStreamController *, MxDSAction *p_action)
+MxLong MxPresenter::StartAction(MxStreamController*, MxDSAction* p_action)
 {
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  this->m_action = p_action;
+	this->m_action = p_action;
 
-  const MxVector3Data& location = this->m_action->GetLocation();
-  MxS32 previousTickleState = this->m_currentTickleState;
+	const MxVector3Data& location = this->m_action->GetLocation();
+	MxS32 previousTickleState = this->m_currentTickleState;
 
-  this->m_location = MxPoint32(this->m_action->GetLocation()[0], this->m_action->GetLocation()[1]);
-  this->m_displayZ = this->m_action->GetLocation()[2];
-  this->m_previousTickleStates |= 1 << (unsigned char)previousTickleState;
-  this->m_currentTickleState = TickleState_Ready;
+	this->m_location = MxPoint32(this->m_action->GetLocation()[0], this->m_action->GetLocation()[1]);
+	this->m_displayZ = this->m_action->GetLocation()[2];
+	this->m_previousTickleStates |= 1 << (unsigned char) previousTickleState;
+	this->m_currentTickleState = TickleState_Ready;
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b4e40
 void MxPresenter::EndAction()
 {
-  if (this->m_action == FALSE)
-    return;
-  MxAutoLocker lock(&this->m_criticalSection);
-  if (!this->m_unkPresenter)
-  {
-    MxOmni::GetInstance()->NotifyCurrentEntity(&MxEndActionNotificationParam(MXSTREAMER_UNKNOWN, NULL, this->m_action, TRUE));
-  }
+	if (this->m_action == FALSE)
+		return;
+	MxAutoLocker lock(&this->m_criticalSection);
+	if (!this->m_unkPresenter) {
+		MxOmni::GetInstance()->NotifyCurrentEntity(
+			&MxEndActionNotificationParam(MXSTREAMER_UNKNOWN, NULL, this->m_action, TRUE)
+		);
+	}
 
-  this->m_action = FALSE;
-  MxS32 previousTickleState = 1 << m_currentTickleState;
-  this->m_previousTickleStates |= previousTickleState;
-  this->m_currentTickleState = TickleState_Idle;
+	this->m_action = FALSE;
+	MxS32 previousTickleState = 1 << m_currentTickleState;
+	this->m_previousTickleStates |= previousTickleState;
+	this->m_currentTickleState = TickleState_Idle;
 }
 
 // OFFSET: LEGO1 0x100b52d0
 void MxPresenter::Enable(MxBool p_enable)
 {
-  if (this->m_action && this->IsEnabled() != p_enable) {
-    MxU32 flags = this->m_action->GetFlags();
+	if (this->m_action && this->IsEnabled() != p_enable) {
+		MxU32 flags = this->m_action->GetFlags();
 
-    if (p_enable)
-      this->m_action->SetFlags(flags | MxDSAction::Flag_Enabled);
-    else
-      this->m_action->SetFlags(flags & ~MxDSAction::Flag_Enabled);
-  }
+		if (p_enable)
+			this->m_action->SetFlags(flags | MxDSAction::Flag_Enabled);
+		else
+			this->m_action->SetFlags(flags & ~MxDSAction::Flag_Enabled);
+	}
 }
 
 // OFFSET: LEGO1 0x100b5310
-const char *PresenterNameDispatch(const MxDSAction &p_action)
+const char* PresenterNameDispatch(const MxDSAction& p_action)
 {
-  const char *name = p_action.GetSourceName();
-  MxS32 format;
+	const char* name = p_action.GetSourceName();
+	MxS32 format;
 
-  if (!name || strlen(name) == 0) {
-    switch (p_action.GetType()) {
-      case MxDSType_Anim:
-        format = ((MxDSAnim&)p_action).GetMediaFormat();
-        switch (format) {
-          case FOURCC(' ', 'F', 'L', 'C'):
-            name = !p_action.IsLooping() ?
-              "MxFlcPresenter" :
-              "MxLoopingFlcPresenter";
-            break;
-          case FOURCC(' ', 'S', 'M', 'K'):
-            name = !p_action.IsLooping() ?
-              "MxSmkPresenter" :
-              "MxLoopingSmkPresenter";
-            break;
-        }
-        break;
+	if (!name || strlen(name) == 0) {
+		switch (p_action.GetType()) {
+		case MxDSType_Anim:
+			format = ((MxDSAnim&) p_action).GetMediaFormat();
+			switch (format) {
+			case FOURCC(' ', 'F', 'L', 'C'):
+				name = !p_action.IsLooping() ? "MxFlcPresenter" : "MxLoopingFlcPresenter";
+				break;
+			case FOURCC(' ', 'S', 'M', 'K'):
+				name = !p_action.IsLooping() ? "MxSmkPresenter" : "MxLoopingSmkPresenter";
+				break;
+			}
+			break;
 
-      case MxDSType_Sound:
-        format = ((MxDSSound&)p_action).GetMediaFormat();
-        switch(format) {
-          case FOURCC(' ', 'M', 'I', 'D'):
-            name = !p_action.IsLooping() ?
-              "MxMIDIPresenter" :
-              "MxLoopingMIDIPresenter";
-            break;
-          case FOURCC(' ', 'W', 'A', 'V'):
-            name = "MxWavePresenter";
-            break;
-        }
-        break;
+		case MxDSType_Sound:
+			format = ((MxDSSound&) p_action).GetMediaFormat();
+			switch (format) {
+			case FOURCC(' ', 'M', 'I', 'D'):
+				name = !p_action.IsLooping() ? "MxMIDIPresenter" : "MxLoopingMIDIPresenter";
+				break;
+			case FOURCC(' ', 'W', 'A', 'V'):
+				name = "MxWavePresenter";
+				break;
+			}
+			break;
 
-      case MxDSType_SerialAction:
-      case MxDSType_ParallelAction:
-      case MxDSType_SelectAction:
-        name = "MxCompositePresenter";
-        break;
+		case MxDSType_SerialAction:
+		case MxDSType_ParallelAction:
+		case MxDSType_SelectAction:
+			name = "MxCompositePresenter";
+			break;
 
-      case MxDSType_Event:
-        name = "MxEventPresenter";
-        break;
+		case MxDSType_Event:
+			name = "MxEventPresenter";
+			break;
 
-      case MxDSType_Still:
-        name = "MxStillPresenter";
-        break;
-    }
-  }
+		case MxDSType_Still:
+			name = "MxStillPresenter";
+			break;
+		}
+	}
 
-  return name;
+	return name;
 }
 
 // OFFSET: LEGO1 0x100b54c0
 MxBool MxPresenter::IsEnabled()
 {
-  return this->m_action && this->m_action->GetFlags() & MxDSAction::Flag_Enabled;
+	return this->m_action && this->m_action->GetFlags() & MxDSAction::Flag_Enabled;
 }
 
 // OFFSET: LEGO1 0x1000be30
@@ -234,80 +229,80 @@ void MxPresenter::VTable0x14()
 // OFFSET: LEGO1 0x1000be40
 void MxPresenter::ReadyTickle()
 {
-  ParseExtra();
+	ParseExtra();
 
-  m_previousTickleStates |= 1 << (unsigned char)m_currentTickleState;
-  m_currentTickleState = TickleState_Starting;
+	m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+	m_currentTickleState = TickleState_Starting;
 }
 
 // OFFSET: LEGO1 0x1000be60
 void MxPresenter::StartingTickle()
 {
-  m_previousTickleStates |= 1 << (unsigned char)m_currentTickleState;
-  m_currentTickleState = TickleState_Streaming;
+	m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+	m_currentTickleState = TickleState_Streaming;
 }
 
 // OFFSET: LEGO1 0x1000be80
 void MxPresenter::StreamingTickle()
 {
-  m_previousTickleStates |= 1 << (unsigned char)m_currentTickleState;
-  m_currentTickleState = TickleState_Repeating;
+	m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+	m_currentTickleState = TickleState_Repeating;
 }
 
 // OFFSET: LEGO1 0x1000bea0
 void MxPresenter::RepeatingTickle()
 {
-  m_previousTickleStates |= 1 << (unsigned char)m_currentTickleState;
-  m_currentTickleState = TickleState_unk5;
+	m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+	m_currentTickleState = TickleState_unk5;
 }
 
 // OFFSET: LEGO1 0x1000bec0
 void MxPresenter::Unk5Tickle()
 {
-  m_previousTickleStates |= 1 << (unsigned char)m_currentTickleState;
-  m_currentTickleState = TickleState_Done;
+	m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+	m_currentTickleState = TickleState_Done;
 }
 
 // OFFSET: LEGO1 0x1000bee0
 void MxPresenter::DoneTickle()
 {
-  m_previousTickleStates |= 1 << m_currentTickleState;
-  m_currentTickleState = TickleState_Idle;
+	m_previousTickleStates |= 1 << m_currentTickleState;
+	m_currentTickleState = TickleState_Idle;
 }
 
 // OFFSET: LEGO1 0x1000bf70
 MxResult MxPresenter::AddToManager()
 {
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1000bf80
 void MxPresenter::Destroy()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x1000bf90
 void MxPresenter::SetTickleState(TickleState p_tickleState)
 {
-  m_previousTickleStates |= 1 << (unsigned char)m_currentTickleState;
-  m_currentTickleState = p_tickleState;
+	m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+	m_currentTickleState = p_tickleState;
 }
 
 // OFFSET: LEGO1 0x1000bfb0
 MxBool MxPresenter::HasTickleStatePassed(TickleState p_tickleState)
 {
-  return m_previousTickleStates & (1 << (unsigned char)p_tickleState);
+	return m_previousTickleStates & (1 << (unsigned char) p_tickleState);
 }
 
 // OFFSET: LEGO1 0x1000bfc0
 undefined4 MxPresenter::PutData()
 {
-  return 0;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x1000bfd0
 MxBool MxPresenter::IsHit(MxS32 p_x, MxS32 p_y)
 {
-  return FALSE;
+	return FALSE;
 }

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -1,92 +1,89 @@
 #ifndef MXPRESENTER_H
 #define MXPRESENTER_H
 
-#include "mxcore.h"
-#include "mxpoint32.h"
-#include "mxdsaction.h"
-#include "mxcriticalsection.h"
-#include "mxomni.h"
-
 #include "decomp.h"
+#include "mxcore.h"
+#include "mxcriticalsection.h"
+#include "mxdsaction.h"
+#include "mxomni.h"
+#include "mxpoint32.h"
 
 class MxStreamController;
 
 // VTABLE 0x100d4d38
-class MxPresenter : public MxCore
-{
+class MxPresenter : public MxCore {
 public:
-  enum TickleState
-  {
-    TickleState_Idle = 0,
-    TickleState_Ready,
-    TickleState_Starting,
-    TickleState_Streaming,
-    TickleState_Repeating,
-    TickleState_unk5,
-    TickleState_Done,
-  };
+	enum TickleState {
+		TickleState_Idle = 0,
+		TickleState_Ready,
+		TickleState_Starting,
+		TickleState_Streaming,
+		TickleState_Repeating,
+		TickleState_unk5,
+		TickleState_Done,
+	};
 
-  MxPresenter() { Init(); }
+	MxPresenter() { Init(); }
 
-  __declspec(dllexport) virtual ~MxPresenter(); // vtable+0x0
-  __declspec(dllexport) virtual MxResult Tickle() override; // vtable+0x8
+	__declspec(dllexport) virtual ~MxPresenter();             // vtable+0x0
+	__declspec(dllexport) virtual MxResult Tickle() override; // vtable+0x8
 
-  // OFFSET: LEGO1 0x1000bfe0
-  inline virtual const char *ClassName() const override// vtable+0xc
-  {
-    // 0x100f0740
-    return "MxPresenter";
-  }
+	// OFFSET: LEGO1 0x1000bfe0
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0740
+		return "MxPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000bff0
-  inline virtual MxBool IsA(const char *name) const override// vtable+0x10
-  {
-    return !strcmp(name, MxPresenter::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000bff0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxPresenter::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual void VTable0x14(); // vtable+0x14
-  virtual void ReadyTickle(); // vtable+0x18
-  virtual void StartingTickle(); // vtable+0x1c
-  virtual void StreamingTickle(); // vtable+0x20
-  virtual void RepeatingTickle(); // vtable+0x24
-  virtual void Unk5Tickle(); // vtable+0x28
+	virtual void VTable0x14();      // vtable+0x14
+	virtual void ReadyTickle();     // vtable+0x18
+	virtual void StartingTickle();  // vtable+0x1c
+	virtual void StreamingTickle(); // vtable+0x20
+	virtual void RepeatingTickle(); // vtable+0x24
+	virtual void Unk5Tickle();      // vtable+0x28
 
 protected:
-  __declspec(dllexport) virtual void DoneTickle(); // vtable+0x2c
-  __declspec(dllexport) virtual void ParseExtra(); // vtable+0x30
+	__declspec(dllexport) virtual void DoneTickle(); // vtable+0x2c
+	__declspec(dllexport) virtual void ParseExtra(); // vtable+0x30
 
 public:
-  virtual MxResult AddToManager(); // vtable+0x34
-  virtual void Destroy(); // vtable+0x38
-  __declspec(dllexport) virtual MxLong StartAction(MxStreamController *, MxDSAction *); // vtable+0x3c
-  __declspec(dllexport) virtual void EndAction(); // vtable+0x40
-  virtual void SetTickleState(TickleState p_tickleState); // vtable+0x44
-  virtual MxBool HasTickleStatePassed(TickleState p_tickleState); // vtable+0x48
-  virtual undefined4 PutData(); // vtable+0x4c
-  virtual MxBool IsHit(MxS32 p_x, MxS32 p_y); // vtable+0x50
-  __declspec(dllexport) virtual void Enable(MxBool p_enable); // vtable+0x54
+	virtual MxResult AddToManager();                                                    // vtable+0x34
+	virtual void Destroy();                                                             // vtable+0x38
+	__declspec(dllexport) virtual MxLong StartAction(MxStreamController*, MxDSAction*); // vtable+0x3c
+	__declspec(dllexport) virtual void EndAction();                                     // vtable+0x40
+	virtual void SetTickleState(TickleState p_tickleState);                             // vtable+0x44
+	virtual MxBool HasTickleStatePassed(TickleState p_tickleState);                     // vtable+0x48
+	virtual undefined4 PutData();                                                       // vtable+0x4c
+	virtual MxBool IsHit(MxS32 p_x, MxS32 p_y);                                         // vtable+0x50
+	__declspec(dllexport) virtual void Enable(MxBool p_enable);                         // vtable+0x54
 
-  MxBool IsEnabled();
+	MxBool IsEnabled();
 
-  inline MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
-  inline MxPoint32 GetLocation() const { return this->m_location; }
-  inline MxS32 GetLocationX() const { return this->m_location.m_x; }
-  inline MxS32 GetLocationY() const { return this->m_location.m_y; }
-  inline MxS32 GetDisplayZ() const { return this->m_displayZ; }
-  inline MxDSAction *GetAction() const { return this->m_action; }
+	inline MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
+	inline MxPoint32 GetLocation() const { return this->m_location; }
+	inline MxS32 GetLocationX() const { return this->m_location.m_x; }
+	inline MxS32 GetLocationY() const { return this->m_location.m_y; }
+	inline MxS32 GetDisplayZ() const { return this->m_displayZ; }
+	inline MxDSAction* GetAction() const { return this->m_action; }
 
 protected:
-  __declspec(dllexport) void Init();
-  void SendTo_unkPresenter(MxOmni *);
-  TickleState m_currentTickleState; // 0x8
-  MxU32 m_previousTickleStates; // 0x0c
-  MxPoint32 m_location; // 0x10
-  MxS32 m_displayZ; // 0x18
-  MxDSAction *m_action; // 0x1c
-  MxCriticalSection m_criticalSection; // 0x20
-  MxPresenter *m_unkPresenter; // 0x3c
+	__declspec(dllexport) void Init();
+	void SendTo_unkPresenter(MxOmni*);
+	TickleState m_currentTickleState;    // 0x8
+	MxU32 m_previousTickleStates;        // 0x0c
+	MxPoint32 m_location;                // 0x10
+	MxS32 m_displayZ;                    // 0x18
+	MxDSAction* m_action;                // 0x1c
+	MxCriticalSection m_criticalSection; // 0x20
+	MxPresenter* m_unkPresenter;         // 0x3c
 };
 
-const char *PresenterNameDispatch(const MxDSAction &);
+const char* PresenterNameDispatch(const MxDSAction&);
 
 #endif // MXPRESENTER_H

--- a/LEGO1/mxpresenterlist.cpp
+++ b/LEGO1/mxpresenterlist.cpp
@@ -1,15 +1,16 @@
 #include "mxpresenterlist.h"
+
 #include "mxpresenter.h"
 
 DECOMP_SIZE_ASSERT(MxPresenterList, 0x18);
 DECOMP_SIZE_ASSERT(MxPresenterListCursor, 0x10);
 
 // OFFSET: LEGO1 0x1001cd00
-MxS8 MxPresenterList::Compare(MxPresenter *p_var0, MxPresenter *p_var1)
+MxS8 MxPresenterList::Compare(MxPresenter* p_var0, MxPresenter* p_var1)
 {
-  if (p_var1 == p_var0)
-    return 0;
-  if (p_var1 <= p_var0)
-    return 1;
-  return -1;
+	if (p_var1 == p_var0)
+		return 0;
+	if (p_var1 <= p_var0)
+		return 1;
+	return -1;
 }

--- a/LEGO1/mxpresenterlist.h
+++ b/LEGO1/mxpresenterlist.h
@@ -8,20 +8,16 @@ class MxPresenter;
 // Unclear what the purpose of this class is
 // VTABLE 0x100d62f0
 // SIZE 0x18
-class MxPresenterListParent : public MxList<MxPresenter*>
-{
+class MxPresenterListParent : public MxList<MxPresenter*> {
 public:
-  MxPresenterListParent() {
-    m_customDestructor = Destroy;
-  }
+	MxPresenterListParent() { m_customDestructor = Destroy; }
 };
 
 // VTABLE 0x100d6308
 // SIZE 0x18
-class MxPresenterList : public MxPresenterListParent
-{
+class MxPresenterList : public MxPresenterListParent {
 public:
-  virtual MxS8 Compare(MxPresenter *, MxPresenter *); // +0x14
+	virtual MxS8 Compare(MxPresenter*, MxPresenter*); // +0x14
 };
 
 typedef MxListCursorChildChild<MxPresenter*> MxPresenterListCursor;

--- a/LEGO1/mxramstreamcontroller.cpp
+++ b/LEGO1/mxramstreamcontroller.cpp
@@ -1,25 +1,26 @@
 #include "mxramstreamcontroller.h"
+
 #include "mxramstreamprovider.h"
 
 DECOMP_SIZE_ASSERT(MxRAMStreamController, 0x98);
 
 // OFFSET: LEGO1 0x100c6110 STUB
-MxResult MxRAMStreamController::Open(const char *p_filename)
+MxResult MxRAMStreamController::Open(const char* p_filename)
 {
-  // TODO STUB
-  return FAILURE;
+	// TODO STUB
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c6210 STUB
 MxResult MxRAMStreamController::vtable0x20(MxDSAction* p_action)
 {
-  // TODO STUB
-  return FAILURE;
+	// TODO STUB
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c6320 STUB
 MxResult MxRAMStreamController::vtable0x24(undefined4 p_unknown)
 {
-  // TODO STUB
-  return FAILURE;
+	// TODO STUB
+	return FAILURE;
 }

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -6,31 +6,30 @@
 
 // VTABLE 0x100dc728
 // SIZE 0x98
-class MxRAMStreamController : public MxStreamController
-{
+class MxRAMStreamController : public MxStreamController {
 public:
-  inline MxRAMStreamController() {}
+	inline MxRAMStreamController() {}
 
-  // OFFSET: LEGO1 0x100b9430
-  inline virtual const char *ClassName() const override // vtable+0xc
-  {
-    // 0x10102130
-    return "MxRAMStreamController";
-  }
+	// OFFSET: LEGO1 0x100b9430
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10102130
+		return "MxRAMStreamController";
+	}
 
-  // OFFSET: LEGO1 0x100b9440
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxRAMStreamController::ClassName()) || !strcmp(name, MxStreamController::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100b9440
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxRAMStreamController::ClassName()) || !strcmp(name, MxStreamController::ClassName()) ||
+			   MxCore::IsA(name);
+	}
 
-  virtual MxResult Open(const char *p_filename) override;
-  virtual MxResult vtable0x20(MxDSAction* p_action) override;
-  virtual MxResult vtable0x24(undefined4 p_unknown) override;
+	virtual MxResult Open(const char* p_filename) override;
+	virtual MxResult vtable0x20(MxDSAction* p_action) override;
+	virtual MxResult vtable0x24(undefined4 p_unknown) override;
 
 private:
-  MxDSBuffer m_buffer;
-
+	MxDSBuffer m_buffer;
 };
 
 #endif // MXRAMSTREAMCONTROLLER_H

--- a/LEGO1/mxramstreamprovider.cpp
+++ b/LEGO1/mxramstreamprovider.cpp
@@ -1,4 +1,5 @@
 #include "mxramstreamprovider.h"
+
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxRAMStreamProvider, 0x24);
@@ -6,54 +7,54 @@ DECOMP_SIZE_ASSERT(MxRAMStreamProvider, 0x24);
 // OFFSET: LEGO1 0x100d0730
 MxRAMStreamProvider::MxRAMStreamProvider()
 {
-  m_bufferSize = 0;
-  m_fileSize = 0;
-  m_pBufferOfFileSize = NULL;
-  m_lengthInDWords = 0;
-  m_bufferForDWords = NULL;
+	m_bufferSize = 0;
+	m_fileSize = 0;
+	m_pBufferOfFileSize = NULL;
+	m_lengthInDWords = 0;
+	m_bufferForDWords = NULL;
 }
 
 // OFFSET: LEGO1 0x100d0a50
 MxRAMStreamProvider::~MxRAMStreamProvider()
 {
-  m_bufferSize = 0;
-  m_fileSize = 0;
+	m_bufferSize = 0;
+	m_fileSize = 0;
 
-  free(m_pBufferOfFileSize);
-  m_pBufferOfFileSize = NULL;
+	free(m_pBufferOfFileSize);
+	m_pBufferOfFileSize = NULL;
 
-  m_lengthInDWords = 0;
+	m_lengthInDWords = 0;
 
-  free(m_bufferForDWords);
-  m_bufferForDWords = NULL;
+	free(m_bufferForDWords);
+	m_bufferForDWords = NULL;
 }
 
 // OFFSET: LEGO1 0x100d0ae0 STUB
 MxResult MxRAMStreamProvider::SetResourceToGet(void* p_resource)
 {
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100d0930
 MxU32 MxRAMStreamProvider::GetFileSize()
 {
-  return m_fileSize;
+	return m_fileSize;
 }
 
 // OFFSET: LEGO1 0x100d0940
 MxU32 MxRAMStreamProvider::GetStreamBuffersNum()
 {
-  return 1;
+	return 1;
 }
 
 // OFFSET: LEGO1 0x100d0950
 MxU32 MxRAMStreamProvider::GetLengthInDWords()
 {
-  return m_lengthInDWords;
+	return m_lengthInDWords;
 }
 
 // OFFSET: LEGO1 0x100d0960
 MxU32* MxRAMStreamProvider::GetBufferForDWords()
 {
-  return m_bufferForDWords;
+	return m_bufferForDWords;
 }

--- a/LEGO1/mxramstreamprovider.h
+++ b/LEGO1/mxramstreamprovider.h
@@ -4,24 +4,23 @@
 #include "mxstreamprovider.h"
 
 // VTABLE 0x100dd0d0
-class MxRAMStreamProvider : public MxStreamProvider
-{
+class MxRAMStreamProvider : public MxStreamProvider {
 public:
-  MxRAMStreamProvider();
-  virtual ~MxRAMStreamProvider() override;
+	MxRAMStreamProvider();
+	virtual ~MxRAMStreamProvider() override;
 
-  virtual MxResult SetResourceToGet(void* p_resource) override; //vtable+0x14
-  virtual MxU32 GetFileSize() override; //vtable+0x18
-  virtual MxU32 GetStreamBuffersNum() override; //vtable+0x1c
-  virtual MxU32 GetLengthInDWords() override; //vtable+0x24
-  virtual MxU32* GetBufferForDWords() override; //vtable+0x28
+	virtual MxResult SetResourceToGet(void* p_resource) override; // vtable+0x14
+	virtual MxU32 GetFileSize() override;                         // vtable+0x18
+	virtual MxU32 GetStreamBuffersNum() override;                 // vtable+0x1c
+	virtual MxU32 GetLengthInDWords() override;                   // vtable+0x24
+	virtual MxU32* GetBufferForDWords() override;                 // vtable+0x28
 
 protected:
-  MxU32 m_bufferSize;
-  MxU32 m_fileSize;
-  void* m_pBufferOfFileSize;
-  MxU32 m_lengthInDWords;
-  MxU32* m_bufferForDWords;
+	MxU32 m_bufferSize;
+	MxU32 m_fileSize;
+	void* m_pBufferOfFileSize;
+	MxU32 m_lengthInDWords;
+	MxU32* m_bufferForDWords;
 };
 
 #endif // MXRAMSTREAMPROVIDER_H

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -1,32 +1,25 @@
 #ifndef MXRECT32_H
 #define MXRECT32_H
 
-class MxRect32
-{
+class MxRect32 {
 public:
-  MxRect32() { }
-  MxRect32(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_bottom)
-  {
-    this->m_left = p_left;
-    this->m_top = p_top;
-    this->m_right = p_right;
-    this->m_bottom = p_bottom;
-  }
+	MxRect32() {}
+	MxRect32(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_bottom)
+	{
+		this->m_left = p_left;
+		this->m_top = p_top;
+		this->m_right = p_right;
+		this->m_bottom = p_bottom;
+	}
 
-  MxS32 m_left;
-  MxS32 m_top;
-  MxS32 m_right;
-  MxS32 m_bottom;
+	MxS32 m_left;
+	MxS32 m_top;
+	MxS32 m_right;
+	MxS32 m_bottom;
 
-  inline MxS32 GetWidth()
-  {
-    return (m_right - m_left) + 1;
-  }
+	inline MxS32 GetWidth() { return (m_right - m_left) + 1; }
 
-  inline MxS32 GetHeight()
-  {
-    return (m_bottom - m_top) + 1;
-  }
+	inline MxS32 GetHeight() { return (m_bottom - m_top) + 1; }
 };
 
 #endif // MXRECT32_H

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -5,36 +5,36 @@ DECOMP_SIZE_ASSERT(MxRegion, 0x1c);
 // OFFSET: LEGO1 0x100c31c0 STUB
 MxRegion::MxRegion()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c3690 STUB
 MxRegion::~MxRegion()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c3700 STUB
 void MxRegion::Reset()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c3750 STUB
-void MxRegion::vtable18(MxRect32 &p_rect)
+void MxRegion::vtable18(MxRect32& p_rect)
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c3e20 STUB
 void MxRegion::vtable1c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c3660 STUB
 MxBool MxRegion::vtable20()
 {
-  // TODO
-  return FALSE;
+	// TODO
+	return FALSE;
 }

--- a/LEGO1/mxregion.h
+++ b/LEGO1/mxregion.h
@@ -1,30 +1,29 @@
 #ifndef MXREGION_H
 #define MXREGION_H
 
+#include "decomp.h"
 #include "mxcore.h"
 #include "mxrect32.h"
-#include "decomp.h"
 
 // VTABLE 0x100dcae8
 // SIZE 0x1c
-class MxRegion : public MxCore
-{
+class MxRegion : public MxCore {
 public:
-  MxRegion();
-  virtual ~MxRegion() override;
+	MxRegion();
+	virtual ~MxRegion() override;
 
-  virtual void Reset();
-  virtual void vtable18(MxRect32 &p_rect);
-  virtual void vtable1c();
-  virtual MxBool vtable20();
+	virtual void Reset();
+	virtual void vtable18(MxRect32& p_rect);
+	virtual void vtable1c();
+	virtual MxBool vtable20();
 
-  inline MxRect32 &GetRect() { return this->m_rect; }
+	inline MxRect32& GetRect() { return this->m_rect; }
 
 private:
-  // A container (probably MxList) holding MxRect32
-  // MxList<MxRect32*> *m_rects;
-  undefined4 m_unk08;
-  MxRect32 m_rect;
+	// A container (probably MxList) holding MxRect32
+	// MxList<MxRect32*> *m_rects;
+	undefined4 m_unk08;
+	MxRect32 m_rect;
 };
 
 #endif // MXREGION_H

--- a/LEGO1/mxscheduler.cpp
+++ b/LEGO1/mxscheduler.cpp
@@ -1,15 +1,14 @@
 #include "mxscheduler.h"
 
 // OFFSET: LEGO1 0x100bf4f0
-MxScheduler *MxScheduler::GetInstance()
+MxScheduler* MxScheduler::GetInstance()
 {
-  // Intentionally empty
-  return 0;
+	// Intentionally empty
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100bf500
 void MxScheduler::StartMultiTasking(MxULong)
 {
-  // Intentionally empty
+	// Intentionally empty
 }
-

--- a/LEGO1/mxscheduler.h
+++ b/LEGO1/mxscheduler.h
@@ -3,11 +3,10 @@
 
 #include "mxtypes.h"
 
-class MxScheduler
-{
+class MxScheduler {
 public:
-  __declspec(dllexport) static MxScheduler *GetInstance();
-  __declspec(dllexport) void StartMultiTasking(MxULong);
+	__declspec(dllexport) static MxScheduler* GetInstance();
+	__declspec(dllexport) void StartMultiTasking(MxULong);
 };
 
 #endif // MXSCHEDULER_H

--- a/LEGO1/mxsemaphore.cpp
+++ b/LEGO1/mxsemaphore.cpp
@@ -4,26 +4,26 @@
 // OFFSET: LEGO1 0x100c87d0
 MxSemaphore::MxSemaphore()
 {
-  m_hSemaphore = NULL;
+	m_hSemaphore = NULL;
 }
 
 // OFFSET: LEGO1 0x100c8800
 MxResult MxSemaphore::Init(MxU32 p_initialCount, MxU32 p_maxCount)
 {
-  MxResult result = FAILURE;
-  if (m_hSemaphore = CreateSemaphoreA(NULL, p_initialCount, p_maxCount, NULL))
-    result = SUCCESS;
-  return result;
+	MxResult result = FAILURE;
+	if (m_hSemaphore = CreateSemaphoreA(NULL, p_initialCount, p_maxCount, NULL))
+		result = SUCCESS;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100c8830
 void MxSemaphore::Wait(MxU32 p_timeoutMS)
 {
-  WaitForSingleObject(m_hSemaphore, p_timeoutMS);
+	WaitForSingleObject(m_hSemaphore, p_timeoutMS);
 }
 
 // OFFSET: LEGO1 0x100c8850
 void MxSemaphore::Release(MxU32 p_releaseCount)
 {
-  ReleaseSemaphore(m_hSemaphore, p_releaseCount, NULL);
+	ReleaseSemaphore(m_hSemaphore, p_releaseCount, NULL);
 }

--- a/LEGO1/mxsemaphore.h
+++ b/LEGO1/mxsemaphore.h
@@ -2,26 +2,23 @@
 #define MX_SEMAPHORE_H
 
 #include "mxtypes.h"
+
 #include <windows.h>
 
-class MxSemaphore
-{
+class MxSemaphore {
 public:
-  MxSemaphore();
+	MxSemaphore();
 
-  // Inlined only, no offset
-  ~MxSemaphore()
-  {
-    CloseHandle(m_hSemaphore);
-  }
+	// Inlined only, no offset
+	~MxSemaphore() { CloseHandle(m_hSemaphore); }
 
-  virtual MxResult Init(MxU32 p_initialCount, MxU32 p_maxCount);
+	virtual MxResult Init(MxU32 p_initialCount, MxU32 p_maxCount);
 
-  void Wait(MxU32 p_timeoutMS);
-  void Release(MxU32 p_releaseCount);
+	void Wait(MxU32 p_timeoutMS);
+	void Release(MxU32 p_releaseCount);
 
 private:
-  HANDLE m_hSemaphore;
+	HANDLE m_hSemaphore;
 };
 
 #endif // MX_SEMAPHORE_H

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -7,22 +7,22 @@ DECOMP_SIZE_ASSERT(MxSmkPresenter, 0x720);
 // OFFSET: LEGO1 0x100b3650 STUB
 MxSmkPresenter::MxSmkPresenter()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b38d0 STUB
 void MxSmkPresenter::Init()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b3960
 void MxSmkPresenter::VTable0x60()
 {
-  if (m_bitmap) {
-    delete m_bitmap;
-  }
+	if (m_bitmap) {
+		delete m_bitmap;
+	}
 
-  m_bitmap = new MxBitmap();
-  m_bitmap->SetSize(m_smkWidth, m_smkHeight, NULL, FALSE);
+	m_bitmap = new MxBitmap();
+	m_bitmap->SetSize(m_smkWidth, m_smkHeight, NULL, FALSE);
 }

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -1,26 +1,25 @@
 #ifndef MXSMKPRESENTER_H
 #define MXSMKPRESENTER_H
 
-#include "mxvideopresenter.h"
-
 #include "decomp.h"
+#include "mxvideopresenter.h"
 
 // VTABLE 0x100dc348
 // SIZE 0x720
-class MxSmkPresenter : public MxVideoPresenter
-{
+class MxSmkPresenter : public MxVideoPresenter {
 public:
-  MxSmkPresenter();
+	MxSmkPresenter();
 
-  virtual void VTable0x60() override;
+	virtual void VTable0x60() override;
 
-  undefined4 m_unk64;
-  MxS32 m_smkWidth; // 0x68
-  MxS32 m_smkHeight; // 0x6c
-  undefined4 m_unk70[427];
-  undefined4 m_unk71c;
+	undefined4 m_unk64;
+	MxS32 m_smkWidth;  // 0x68
+	MxS32 m_smkHeight; // 0x6c
+	undefined4 m_unk70[427];
+	undefined4 m_unk71c;
+
 private:
-  void Init();
+	void Init();
 };
 
 #endif // MXSMKPRESENTER_H

--- a/LEGO1/mxsoundmanager.cpp
+++ b/LEGO1/mxsoundmanager.cpp
@@ -1,80 +1,81 @@
 #include "mxsoundmanager.h"
-#include "mxticklemanager.h"
+
 #include "mxomni.h"
+#include "mxticklemanager.h"
 
 DECOMP_SIZE_ASSERT(MxSoundManager, 0x3c);
 
 // OFFSET: LEGO1 0x100ae740
 MxSoundManager::MxSoundManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100ae7d0
 MxSoundManager::~MxSoundManager()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100ae830
 void MxSoundManager::Init()
 {
-  m_unk30 = 0;
-  m_dsBuffer = NULL;
+	m_unk30 = 0;
+	m_dsBuffer = NULL;
 }
 
 // OFFSET: LEGO1 0x100ae840
 void MxSoundManager::Destroy(MxBool p_fromDestructor)
 {
-  if (this->m_thread) {
-    this->m_thread->Terminate();
-    delete this->m_thread;
-  }
-  else {
-    TickleManager()->UnregisterClient(this);
-  }
+	if (this->m_thread) {
+		this->m_thread->Terminate();
+		delete this->m_thread;
+	}
+	else {
+		TickleManager()->UnregisterClient(this);
+	}
 
-  this->m_criticalSection.Enter();
+	this->m_criticalSection.Enter();
 
-  if (this->m_dsBuffer) {
-    this->m_dsBuffer->Release();
-  }
+	if (this->m_dsBuffer) {
+		this->m_dsBuffer->Release();
+	}
 
-  Init();
-  this->m_criticalSection.Leave();
+	Init();
+	this->m_criticalSection.Leave();
 
-  if (!p_fromDestructor) {
-    MxAudioManager::Destroy();
-  }
+	if (!p_fromDestructor) {
+		MxAudioManager::Destroy();
+	}
 }
 
 // OFFSET: LEGO1 0x100ae8b0 STUB
 MxResult MxSoundManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  // TODO
-  return FAILURE;
+	// TODO
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100aed10 STUB
 void MxSoundManager::vtable0x34()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100aee10 STUB
 void MxSoundManager::vtable0x38()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100aeab0
 void MxSoundManager::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100aeac0 STUB
 void MxSoundManager::SetVolume(MxS32 p_volume)
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -8,25 +8,24 @@
 
 // VTABLE 0x100dc128
 // SIZE 0x3c
-class MxSoundManager : public MxAudioManager
-{
+class MxSoundManager : public MxAudioManager {
 public:
-  MxSoundManager();
-  virtual ~MxSoundManager() override; // vtable+0x0
+	MxSoundManager();
+	virtual ~MxSoundManager() override; // vtable+0x0
 
-  virtual void Destroy() override; // vtable+18
-  virtual void SetVolume(MxS32 p_volume) override; // vtable+2c
-  virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); //vtable+0x30
-  virtual void vtable0x34(); // vtable+0x34
-  virtual void vtable0x38(); // vtable+0x38
+	virtual void Destroy() override;                                     // vtable+18
+	virtual void SetVolume(MxS32 p_volume) override;                     // vtable+2c
+	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x30
+	virtual void vtable0x34();                                           // vtable+0x34
+	virtual void vtable0x38();                                           // vtable+0x38
 
 private:
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 
-  undefined4 m_unk30;
-  LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x34
-  undefined m_unk35[4];
+	undefined4 m_unk30;
+	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x34
+	undefined m_unk35[4];
 };
 
 #endif // MXSOUNDMANAGER_H

--- a/LEGO1/mxsoundpresenter.cpp
+++ b/LEGO1/mxsoundpresenter.cpp
@@ -8,38 +8,38 @@ DECOMP_SIZE_ASSERT(MxSoundPresenter, 0x54)
 // OFFSET: LEGO1 0x1000d430
 MxSoundPresenter::~MxSoundPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100b1a50
 void MxSoundPresenter::Destroy(MxBool p_fromDestructor)
 {
-  if (MSoundManager())
-    MSoundManager()->RemovePresenter(*this);
+	if (MSoundManager())
+		MSoundManager()->RemovePresenter(*this);
 
-  this->m_criticalSection.Enter();
-  MxMediaPresenter::Init();
-  this->m_criticalSection.Leave();
+	this->m_criticalSection.Enter();
+	MxMediaPresenter::Init();
+	this->m_criticalSection.Leave();
 
-  if (!p_fromDestructor)
-    MxMediaPresenter::Destroy(FALSE);
+	if (!p_fromDestructor)
+		MxMediaPresenter::Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100b1aa0
 MxResult MxSoundPresenter::AddToManager()
 {
-  MxResult ret = FAILURE;
+	MxResult ret = FAILURE;
 
-  if (MSoundManager()) {
-    ret = SUCCESS;
-    MSoundManager()->AddPresenter(*this);
-  }
+	if (MSoundManager()) {
+		ret = SUCCESS;
+		MSoundManager()->AddPresenter(*this);
+	}
 
-  return ret;
+	return ret;
 }
 
 // OFFSET: LEGO1 0x1000d490
 void MxSoundPresenter::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }

--- a/LEGO1/mxsoundpresenter.h
+++ b/LEGO1/mxsoundpresenter.h
@@ -5,29 +5,28 @@
 #include "mxomni.h"
 
 // VTABLE 0x100d4b08
-class MxSoundPresenter : public MxAudioPresenter
-{
+class MxSoundPresenter : public MxAudioPresenter {
 public:
-  virtual ~MxSoundPresenter() override;
+	virtual ~MxSoundPresenter() override;
 
-  // OFFSET: LEGO1 0x1000d4a0
-  inline virtual const char *ClassName() const // vtable+0x0c
-  { 
-    // 0x100f07a0
-    return "MxSoundPresenter";
-  }; 
+	// OFFSET: LEGO1 0x1000d4a0
+	inline virtual const char* ClassName() const // vtable+0x0c
+	{
+		// 0x100f07a0
+		return "MxSoundPresenter";
+	};
 
-  // OFFSET: LEGO1 0x1000d4b0
-  inline virtual MxBool IsA(const char *name) const // vtable+0x10
-  {
-    return !strcmp(name, MxSoundPresenter::ClassName()) || MxAudioPresenter::IsA(name);
-  };
+	// OFFSET: LEGO1 0x1000d4b0
+	inline virtual MxBool IsA(const char* name) const // vtable+0x10
+	{
+		return !strcmp(name, MxSoundPresenter::ClassName()) || MxAudioPresenter::IsA(name);
+	};
 
-  virtual MxResult AddToManager() override; // vtable+0x34
-  virtual void Destroy() override; // vtable+0x38
+	virtual MxResult AddToManager() override; // vtable+0x34
+	virtual void Destroy() override;          // vtable+0x38
 
 private:
-  void Destroy(MxBool);
+	void Destroy(MxBool);
 };
 
 #endif // MXSOUNDPRESENTER_H

--- a/LEGO1/mxstillpresenter.h
+++ b/LEGO1/mxstillpresenter.h
@@ -1,20 +1,16 @@
 #ifndef MXSTILLPRESENTER_H
 #define MXSTILLPRESENTER_H
 
-#include "mxvideopresenter.h"
-
 #include "decomp.h"
+#include "mxvideopresenter.h"
 
 // VTABLE 0x100d7a38
 // SIZE 0x6c
-class MxStillPresenter : public MxVideoPresenter
-{
+class MxStillPresenter : public MxVideoPresenter {
 public:
-  MxStillPresenter() {
-    m_unk68 = 0;
-  }
-  undefined4 m_unk64;
-  undefined4 m_unk68;
+	MxStillPresenter() { m_unk68 = 0; }
+	undefined4 m_unk64;
+	undefined4 m_unk68;
 };
 
 #endif // MXSTILLPRESENTER_H

--- a/LEGO1/mxstl.h
+++ b/LEGO1/mxstl.h
@@ -1,3 +1,5 @@
+// clang-format off
+
 #ifndef MXSTL_H
 #define MXSTL_H
 
@@ -216,3 +218,5 @@ class Stack : public stack<_C::value_type, _C, _C::allocator_type>
 #endif
 
 #endif // MXSTL_H
+
+// clang-format on

--- a/LEGO1/mxstreamchunk.h
+++ b/LEGO1/mxstreamchunk.h
@@ -4,9 +4,6 @@
 #include "mxdschunk.h"
 
 // VTABLE 0x100dc2a8
-class MxStreamChunk : public MxDSChunk
-{
-
-};
+class MxStreamChunk : public MxDSChunk {};
 
 #endif // MXSTREAMCHUNK_H

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -1,93 +1,93 @@
 #include "mxstreamcontroller.h"
 
-#include "mxautolocker.h"
 #include "legoomni.h"
+#include "mxautolocker.h"
 
 // OFFSET: LEGO1 0x100c0b90 STUB
 MxStreamController::MxStreamController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c1290 STUB
 MxStreamController::~MxStreamController()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100c20d0 STUB
-MxBool MxStreamController::FUN_100c20d0(MxDSObject &p_obj)
+MxBool MxStreamController::FUN_100c20d0(MxDSObject& p_obj)
 {
-  // TODO
-  return TRUE;
+	// TODO
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x100c1520
-MxResult MxStreamController::Open(const char *p_filename)
+MxResult MxStreamController::Open(const char* p_filename)
 {
-  char sourceName [256];
-  MxAutoLocker locker(&m_criticalSection);
+	char sourceName[256];
+	MxAutoLocker locker(&m_criticalSection);
 
-  MakeSourceName(sourceName, p_filename);
-  this->atom = MxAtomId(sourceName, LookupMode_LowerCase2);
-  return SUCCESS;
+	MakeSourceName(sourceName, p_filename);
+	this->atom = MxAtomId(sourceName, LookupMode_LowerCase2);
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b9400
 MxResult MxStreamController::vtable0x18(undefined4 p_unknown, undefined4 p_unknown2)
 {
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b9410
 MxResult MxStreamController::vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2)
 {
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c1690
 MxResult MxStreamController::vtable0x20(MxDSAction* p_action)
 {
-  MxAutoLocker locker(&m_criticalSection);
+	MxAutoLocker locker(&m_criticalSection);
 
-  MxResult result;
-  MxU32 offset = 0;
+	MxResult result;
+	MxU32 offset = 0;
 
-  MxS32 objectId = p_action->GetObjectId();
-  MxStreamProvider *provider = m_provider;
+	MxS32 objectId = p_action->GetObjectId();
+	MxStreamProvider* provider = m_provider;
 
-  if ((MxS32) provider->GetLengthInDWords() > objectId)
-    offset = provider->GetBufferForDWords()[objectId];
+	if ((MxS32) provider->GetLengthInDWords() > objectId)
+		offset = provider->GetBufferForDWords()[objectId];
 
-  if (offset)
-    result = vtable0x2c(p_action, offset);
-  else
-    result = FAILURE;
+	if (offset)
+		result = vtable0x2c(p_action, offset);
+	else
+		result = FAILURE;
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x100c1740 STUB
 MxResult MxStreamController::vtable0x24(undefined4 p_unknown)
 {
-  // TODO STUB
-  return FAILURE;
+	// TODO STUB
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b9420
 MxResult MxStreamController::vtable0x28()
 {
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100c1c10 STUB
 MxResult MxStreamController::vtable0x2c(MxDSAction* p_action, MxU32 p_bufferval)
 {
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c1ce0 STUB
 MxResult MxStreamController::vtable0x30(undefined4 p_unknown)
 {
-  return FAILURE;
+	return FAILURE;
 }

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -3,52 +3,52 @@
 
 #include "decomp.h"
 #include "mxatomid.h"
-#include "mxcriticalsection.h"
 #include "mxcore.h"
-#include "mxdsobject.h"
+#include "mxcriticalsection.h"
 #include "mxdsaction.h"
+#include "mxdsobject.h"
 #include "mxstreamprovider.h"
 
 // VTABLE 0x100dc968
 // SIZE 0x64
-class MxStreamController : public MxCore
-{
+class MxStreamController : public MxCore {
 public:
-  MxStreamController();
+	MxStreamController();
 
-  virtual ~MxStreamController() override; // vtable+0x0
+	virtual ~MxStreamController() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x100c0f10
-  inline virtual const char *ClassName() const override // vtable+0xc
-  {
-    // 0x10102130
-    return "MxStreamController";
-  }
+	// OFFSET: LEGO1 0x100c0f10
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x10102130
+		return "MxStreamController";
+	}
 
-  // OFFSET: LEGO1 0x100c0f20
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxStreamController::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100c0f20
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxStreamController::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxResult Open(const char *p_filename); // vtable+0x14
-  virtual MxResult vtable0x18(undefined4 p_unknown, undefined4 p_unknown2); //vtable+0x18
-  virtual MxResult vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2); //vtable+0x1c
-  virtual MxResult vtable0x20(MxDSAction* p_action); //vtable+0x20
-  virtual MxResult vtable0x24(undefined4 p_unknown); //vtable+0x24
-  virtual MxResult vtable0x28(); //vtable+0x28
-  virtual MxResult vtable0x2c(MxDSAction* p_action, MxU32 p_bufferval); //vtable+0x2c
-  virtual MxResult vtable0x30(undefined4 p_unknown); //vtable+0x30
+	virtual MxResult Open(const char* p_filename);                            // vtable+0x14
+	virtual MxResult vtable0x18(undefined4 p_unknown, undefined4 p_unknown2); // vtable+0x18
+	virtual MxResult vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2); // vtable+0x1c
+	virtual MxResult vtable0x20(MxDSAction* p_action);                        // vtable+0x20
+	virtual MxResult vtable0x24(undefined4 p_unknown);                        // vtable+0x24
+	virtual MxResult vtable0x28();                                            // vtable+0x28
+	virtual MxResult vtable0x2c(MxDSAction* p_action, MxU32 p_bufferval);     // vtable+0x2c
+	virtual MxResult vtable0x30(undefined4 p_unknown);                        // vtable+0x30
 
-  MxBool FUN_100c20d0(MxDSObject &p_obj);
+	MxBool FUN_100c20d0(MxDSObject& p_obj);
 
-  inline MxAtomId &GetAtom() { return atom; };
+	inline MxAtomId& GetAtom() { return atom; };
+
 protected:
-  MxCriticalSection m_criticalSection;
-  MxAtomId atom;
-  MxStreamProvider* m_provider; // MxStreamProvider*
-  undefined4 m_unk2c;
-  undefined m_unk30[0x34];
+	MxCriticalSection m_criticalSection;
+	MxAtomId atom;
+	MxStreamProvider* m_provider; // MxStreamProvider*
+	undefined4 m_unk2c;
+	undefined m_unk30[0x34];
 };
 
 #endif // MXSTREAMCONTROLLER_H

--- a/LEGO1/mxstreamer.cpp
+++ b/LEGO1/mxstreamer.cpp
@@ -2,8 +2,8 @@
 
 #include "legoomni.h"
 #include "mxdiskstreamcontroller.h"
-#include "mxramstreamcontroller.h"
 #include "mxnotificationmanager.h"
+#include "mxramstreamcontroller.h"
 
 #include <algorithm>
 
@@ -12,178 +12,176 @@ DECOMP_SIZE_ASSERT(MxStreamer, 0x2c);
 // OFFSET: LEGO1 0x100b8f00
 MxStreamer::MxStreamer()
 {
-  NotificationManager()->Register(this);
+	NotificationManager()->Register(this);
 }
 
 // OFFSET: LEGO1 0x100b9190
 MxResult MxStreamer::Create()
 {
-  undefined *b = new undefined[m_subclass1.GetSize() * 0x5800];
-  m_subclass1.SetBuffer(b);
-  if (b) {
-    b = new undefined[m_subclass2.GetSize() * 0x800];
-    m_subclass2.SetBuffer(b);
-    if (b) {
-      return SUCCESS;
-    }
-  }
+	undefined* b = new undefined[m_subclass1.GetSize() * 0x5800];
+	m_subclass1.SetBuffer(b);
+	if (b) {
+		b = new undefined[m_subclass2.GetSize() * 0x800];
+		m_subclass2.SetBuffer(b);
+		if (b) {
+			return SUCCESS;
+		}
+	}
 
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b91d0
 MxStreamer::~MxStreamer()
 {
-  while (!m_openStreams.empty()) {
-    MxStreamController *c = m_openStreams.front();
-    m_openStreams.pop_front();
-    delete c;
-  }
+	while (!m_openStreams.empty()) {
+		MxStreamController* c = m_openStreams.front();
+		m_openStreams.pop_front();
+		delete c;
+	}
 
-  NotificationManager()->Unregister(this);
+	NotificationManager()->Unregister(this);
 }
 
 // OFFSET: LEGO1 0x100b92c0
-MxStreamController *MxStreamer::Open(const char *p_name, MxU16 p_lookupType)
+MxStreamController* MxStreamer::Open(const char* p_name, MxU16 p_lookupType)
 {
-  // TODO
-  MxStreamController *stream = NULL;
+	// TODO
+	MxStreamController* stream = NULL;
 
-  if (!GetOpenStream(p_name)) {
-    switch (p_lookupType) {
-    case e_DiskStream:
-      stream = new MxDiskStreamController();
-      break;
-    case e_RAMStream:
-      stream = new MxRAMStreamController();
-      break;
-    }
+	if (!GetOpenStream(p_name)) {
+		switch (p_lookupType) {
+		case e_DiskStream:
+			stream = new MxDiskStreamController();
+			break;
+		case e_RAMStream:
+			stream = new MxRAMStreamController();
+			break;
+		}
 
-    if (!stream
-      || stream->Open(p_name) != SUCCESS
-      || AddStreamControllerToOpenList(stream) != SUCCESS) {
-      delete stream;
-      stream = NULL;
-    }
-  }
+		if (!stream || stream->Open(p_name) != SUCCESS || AddStreamControllerToOpenList(stream) != SUCCESS) {
+			delete stream;
+			stream = NULL;
+		}
+	}
 
-  return stream;
+	return stream;
 }
 
 // OFFSET: LEGO1 0x100b9570
-MxLong MxStreamer::Close(const char *p)
+MxLong MxStreamer::Close(const char* p)
 {
-  MxDSAction ds;
+	MxDSAction ds;
 
-  ds.SetUnknown24(-2);
+	ds.SetUnknown24(-2);
 
-  for (list<MxStreamController *>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
-    MxStreamController *c = *it;
+	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
+		MxStreamController* c = *it;
 
-    if (!p || !strcmp(p, c->GetAtom().GetInternal())) {
-      m_openStreams.erase(it);
+		if (!p || !strcmp(p, c->GetAtom().GetInternal())) {
+			m_openStreams.erase(it);
 
-      if (!c->FUN_100c20d0(ds)) {
-        MxStreamerNotification notif(MXSTREAMER_DELETE_NOTIFY, NULL, c);
+			if (!c->FUN_100c20d0(ds)) {
+				MxStreamerNotification notif(MXSTREAMER_DELETE_NOTIFY, NULL, c);
 
-        NotificationManager()->Send(this, &notif);
-      } else {
-        delete c;
-      }
+				NotificationManager()->Send(this, &notif);
+			}
+			else {
+				delete c;
+			}
 
-      return SUCCESS;
-    }
-  }
+			return SUCCESS;
+		}
+	}
 
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b9700
-MxNotificationParam *MxStreamerNotification::Clone()
+MxNotificationParam* MxStreamerNotification::Clone()
 {
-  return new MxStreamerNotification(m_type, m_sender, m_controller);
+	return new MxStreamerNotification(m_type, m_sender, m_controller);
 }
 
 // OFFSET: LEGO1 0x100b9870
-MxStreamController *MxStreamer::GetOpenStream(const char *p_name)
+MxStreamController* MxStreamer::GetOpenStream(const char* p_name)
 {
-  for (list<MxStreamController *>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
-    MxStreamController *c = *it;
-    MxAtomId &atom = c->GetAtom();
-    if (p_name) {
-      if (!strcmp(atom.GetInternal(), p_name)) {
-       return *it;
-      }
-    }
-  }
+	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
+		MxStreamController* c = *it;
+		MxAtomId& atom = c->GetAtom();
+		if (p_name) {
+			if (!strcmp(atom.GetInternal(), p_name)) {
+				return *it;
+			}
+		}
+	}
 
-  return NULL;
+	return NULL;
 }
 
 // OFFSET: LEGO1 0x100b9930
-MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController *stream)
+MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController* stream)
 {
-  if (find(m_openStreams.begin(), m_openStreams.end(), stream) == m_openStreams.end()) {
-    m_openStreams.push_back(stream);
-    return SUCCESS;
-  }
+	if (find(m_openStreams.begin(), m_openStreams.end(), stream) == m_openStreams.end()) {
+		m_openStreams.push_back(stream);
+		return SUCCESS;
+	}
 
-  return FAILURE;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b99b0
 MxResult MxStreamer::FUN_100b99b0(MxDSAction* p_action)
 {
-  MxStreamController* controller;
-  if (p_action != NULL && p_action->GetAtomId().GetInternal() != NULL && p_action->GetObjectId() != -1)
-  {
-    controller = GetOpenStream(p_action->GetAtomId().GetInternal());
-    if (controller == NULL)
-    {
-      return FAILURE;
-    }
-    return controller->vtable0x20(p_action);
-  }
-  return FAILURE;
+	MxStreamController* controller;
+	if (p_action != NULL && p_action->GetAtomId().GetInternal() != NULL && p_action->GetObjectId() != -1) {
+		controller = GetOpenStream(p_action->GetAtomId().GetInternal());
+		if (controller == NULL) {
+			return FAILURE;
+		}
+		return controller->vtable0x20(p_action);
+	}
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100b9b30
-MxBool MxStreamer::FUN_100b9b30(MxDSObject &p_dsObject)
+MxBool MxStreamer::FUN_100b9b30(MxDSObject& p_dsObject)
 {
-  MxStreamController *controller = GetOpenStream(p_dsObject.GetAtomId().GetInternal());
-  if (controller)
-    return controller->FUN_100c20d0(p_dsObject);
-  return TRUE;
+	MxStreamController* controller = GetOpenStream(p_dsObject.GetAtomId().GetInternal());
+	if (controller)
+		return controller->FUN_100c20d0(p_dsObject);
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x100b9b60
-MxLong MxStreamer::Notify(MxParam &p)
+MxLong MxStreamer::Notify(MxParam& p)
 {
-  if (((MxNotificationParam&) p).GetType() == MXSTREAMER_DELETE_NOTIFY) {
-    MxDSAction ds;
+	if (((MxNotificationParam&) p).GetType() == MXSTREAMER_DELETE_NOTIFY) {
+		MxDSAction ds;
 
-    ds.SetUnknown24(-2);
+		ds.SetUnknown24(-2);
 
-    MxStreamController *c = static_cast<MxStreamerNotification&>(p).GetController();
+		MxStreamController* c = static_cast<MxStreamerNotification&>(p).GetController();
 
-    if (!c->FUN_100c20d0(ds)) {
-      MxStreamerNotification notif(MXSTREAMER_DELETE_NOTIFY, NULL, c);
-      NotificationManager()->Send(this, &notif);
-    } else {
-      delete c;
-    }
-  }
+		if (!c->FUN_100c20d0(ds)) {
+			MxStreamerNotification notif(MXSTREAMER_DELETE_NOTIFY, NULL, c);
+			NotificationManager()->Send(this, &notif);
+		}
+		else {
+			delete c;
+		}
+	}
 
-  return 0;
+	return 0;
 }
 
 // No offset, function is always inlined
 MxStreamerSubClass1::MxStreamerSubClass1(undefined4 size)
 {
-  m_buffer = NULL;
-  m_size = size;
-  undefined4 *ptr = &m_unk08;
-  for (int i = 0; i >= 0; i--) {
-    ptr[i] = 0;
-  }
+	m_buffer = NULL;
+	m_size = size;
+	undefined4* ptr = &m_unk08;
+	for (int i = 0; i >= 0; i--) {
+		ptr[i] = 0;
+	}
 }

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -1,107 +1,102 @@
 #ifndef MXSTREAMER_H
 #define MXSTREAMER_H
 
-#include <list>
-
 #include "decomp.h"
 #include "mxcore.h"
+#include "mxdsobject.h"
 #include "mxnotificationparam.h"
 #include "mxstreamcontroller.h"
-#include "mxdsobject.h"
 #include "mxtypes.h"
+
+#include <list>
 
 // NOTE: This feels like some kind of templated class, maybe something from the
 //       STL. But I haven't figured out what yet (it's definitely not a vector).
-class MxStreamerSubClass1
-{
+class MxStreamerSubClass1 {
 public:
-  inline MxStreamerSubClass1(undefined4 size);
+	inline MxStreamerSubClass1(undefined4 size);
 
-  ~MxStreamerSubClass1() { delete [] m_buffer; }
+	~MxStreamerSubClass1() { delete[] m_buffer; }
 
-  undefined4 GetSize() { return m_size; }
+	undefined4 GetSize() { return m_size; }
 
-  void SetBuffer(undefined *p_buf) { m_buffer = p_buf; }
+	void SetBuffer(undefined* p_buf) { m_buffer = p_buf; }
 
 private:
-  undefined *m_buffer;
-  undefined4 m_size;
-  undefined4 m_unk08;
+	undefined* m_buffer;
+	undefined4 m_size;
+	undefined4 m_unk08;
 };
 
-class MxStreamerSubClass2 : public MxStreamerSubClass1
-{
+class MxStreamerSubClass2 : public MxStreamerSubClass1 {
 public:
-  inline MxStreamerSubClass2() : MxStreamerSubClass1(0x40) {}
+	inline MxStreamerSubClass2() : MxStreamerSubClass1(0x40) {}
 };
 
-class MxStreamerSubClass3 : public MxStreamerSubClass1
-{
+class MxStreamerSubClass3 : public MxStreamerSubClass1 {
 public:
-  inline MxStreamerSubClass3() : MxStreamerSubClass1(0x80) {}
+	inline MxStreamerSubClass3() : MxStreamerSubClass1(0x80) {}
 };
 
-class MxStreamerNotification : public MxNotificationParam
-{
+class MxStreamerNotification : public MxNotificationParam {
 public:
-  inline MxStreamerNotification(MxParamType p_type, MxCore *p_sender, MxStreamController *p_ctrlr) : MxNotificationParam(p_type, p_sender)
-  {
-    m_controller = p_ctrlr;
-  }
+	inline MxStreamerNotification(MxParamType p_type, MxCore* p_sender, MxStreamController* p_ctrlr)
+		: MxNotificationParam(p_type, p_sender)
+	{
+		m_controller = p_ctrlr;
+	}
 
-  virtual ~MxStreamerNotification() override {}
+	virtual ~MxStreamerNotification() override {}
 
-  virtual MxNotificationParam *Clone() override;
+	virtual MxNotificationParam* Clone() override;
 
-  MxStreamController *GetController() { return m_controller; }
+	MxStreamController* GetController() { return m_controller; }
 
 private:
-  MxStreamController *m_controller;
+	MxStreamController* m_controller;
 };
 
 // VTABLE 0x100dc710
 // SIZE 0x2c
-class MxStreamer : public MxCore
-{
+class MxStreamer : public MxCore {
 public:
-  enum OpenMode
-  {
-    e_DiskStream,
-    e_RAMStream
-  };
+	enum OpenMode {
+		e_DiskStream,
+		e_RAMStream
+	};
 
-  MxStreamer();
-  virtual ~MxStreamer() override; // vtable+0x0
+	MxStreamer();
+	virtual ~MxStreamer() override; // vtable+0x0
 
-  __declspec(dllexport) MxStreamController *Open(const char *p_name, MxU16 p_openMode);
-  __declspec(dllexport) MxLong Close(const char *p_name);
+	__declspec(dllexport) MxStreamController* Open(const char* p_name, MxU16 p_openMode);
+	__declspec(dllexport) MxLong Close(const char* p_name);
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x100b9000
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x1010210c
-    return "MxStreamer";
-  }
+	// OFFSET: LEGO1 0x100b9000
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x1010210c
+		return "MxStreamer";
+	}
 
-  // OFFSET: LEGO1 0x100b9010
-  inline virtual MxBool IsA(const char *p_name) const override // vtable+0x10
-  {
-    return !strcmp(p_name, MxStreamer::ClassName()) || MxCore::IsA(p_name);
-  }
+	// OFFSET: LEGO1 0x100b9010
+	inline virtual MxBool IsA(const char* p_name) const override // vtable+0x10
+	{
+		return !strcmp(p_name, MxStreamer::ClassName()) || MxCore::IsA(p_name);
+	}
 
-  virtual MxResult Create(); // vtable+0x14
+	virtual MxResult Create(); // vtable+0x14
 
-  MxBool FUN_100b9b30(MxDSObject &p_dsObject);
-  MxStreamController *GetOpenStream(const char *p_name);
-  MxResult AddStreamControllerToOpenList(MxStreamController *p_stream);
-  MxResult FUN_100b99b0(MxDSAction* p_action);
+	MxBool FUN_100b9b30(MxDSObject& p_dsObject);
+	MxStreamController* GetOpenStream(const char* p_name);
+	MxResult AddStreamControllerToOpenList(MxStreamController* p_stream);
+	MxResult FUN_100b99b0(MxDSAction* p_action);
 
 private:
-  list<MxStreamController *> m_openStreams; // 0x8
-  MxStreamerSubClass2 m_subclass1; // 0x14
-  MxStreamerSubClass3 m_subclass2; // 0x20
+	list<MxStreamController*> m_openStreams; // 0x8
+	MxStreamerSubClass2 m_subclass1;         // 0x14
+	MxStreamerSubClass3 m_subclass2;         // 0x20
 };
 
 #endif // MXSTREAMER_H

--- a/LEGO1/mxstreamprovider.cpp
+++ b/LEGO1/mxstreamprovider.cpp
@@ -1,17 +1,17 @@
-#include "decomp.h"
 #include "mxstreamprovider.h"
+
+#include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxStreamProvider, 0x10);
 
 // OFFSET: LEGO1 0x100d07c0
 MxResult MxStreamProvider::SetResourceToGet(void* p_resource)
 {
-  m_pLookup = p_resource;
-  return SUCCESS;
+	m_pLookup = p_resource;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100d07d0
 void MxStreamProvider::vtable0x20(undefined4 p_unknown1)
 {
-
 }

--- a/LEGO1/mxstreamprovider.h
+++ b/LEGO1/mxstreamprovider.h
@@ -7,33 +7,32 @@
 
 // VTABLE 0x100dd100
 // SIZE 0x10
-class MxStreamProvider : public MxCore
-{
+class MxStreamProvider : public MxCore {
 public:
-  inline MxStreamProvider() : m_pLookup(NULL), m_pFile(NULL) {}
+	inline MxStreamProvider() : m_pLookup(NULL), m_pFile(NULL) {}
 
-  // OFFSET: LEGO1 0x100d07e0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    return "MxStreamProvider";
-  }
+	// OFFSET: LEGO1 0x100d07e0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		return "MxStreamProvider";
+	}
 
-  // OFFSET: LEGO1 0x100d07f0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxStreamProvider::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100d07f0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxStreamProvider::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxResult SetResourceToGet(void* p_resource); //vtable+0x14
-  virtual MxU32 GetFileSize() = 0; //vtable+0x18
-  virtual MxU32 GetStreamBuffersNum() = 0; //vtable+0x1c
-  virtual void vtable0x20(undefined4 p_unknown1); //vtable+0x20
-  virtual MxU32 GetLengthInDWords() = 0; //vtable+0x24
-  virtual MxU32* GetBufferForDWords() = 0; //vtable+0x28
+	virtual MxResult SetResourceToGet(void* p_resource); // vtable+0x14
+	virtual MxU32 GetFileSize() = 0;                     // vtable+0x18
+	virtual MxU32 GetStreamBuffersNum() = 0;             // vtable+0x1c
+	virtual void vtable0x20(undefined4 p_unknown1);      // vtable+0x20
+	virtual MxU32 GetLengthInDWords() = 0;               // vtable+0x24
+	virtual MxU32* GetBufferForDWords() = 0;             // vtable+0x28
 
 protected:
-  void *m_pLookup;
-  MxDSFile* m_pFile;
+	void* m_pLookup;
+	MxDSFile* m_pFile;
 };
 
 #endif // MXSTREAMPROVIDER_H

--- a/LEGO1/mxstring.cpp
+++ b/LEGO1/mxstring.cpp
@@ -1,4 +1,5 @@
 #include "mxstring.h"
+
 #include "decomp.h"
 
 #include <stdlib.h>
@@ -9,110 +10,109 @@ DECOMP_SIZE_ASSERT(MxString, 0x10)
 // OFFSET: LEGO1 0x100ae200
 MxString::MxString()
 {
-  // Set string to one char in length and set that char to null terminator
-  this->m_data = new char[1];
-  this->m_data[0] = 0;
-  this->m_length = 0;
+	// Set string to one char in length and set that char to null terminator
+	this->m_data = new char[1];
+	this->m_data[0] = 0;
+	this->m_length = 0;
 }
 
 // OFFSET: LEGO1 0x100ae2a0
-MxString::MxString(const MxString &str)
+MxString::MxString(const MxString& str)
 {
-  this->m_length = str.m_length;
-  this->m_data = new char[this->m_length + 1];
-  strcpy(this->m_data, str.m_data);
+	this->m_length = str.m_length;
+	this->m_data = new char[this->m_length + 1];
+	strcpy(this->m_data, str.m_data);
 }
 
 // OFFSET: LEGO1 0x100ae350
-MxString::MxString(const char *str)
+MxString::MxString(const char* str)
 {
-  if (str) {
-    this->m_length = strlen(str);
-    this->m_data = new char[this->m_length + 1];
-    strcpy(this->m_data, str);
-  } else {
-    this->m_data = new char[1];
-    this->m_data[0] = 0;
-    this->m_length = 0;
-  }
+	if (str) {
+		this->m_length = strlen(str);
+		this->m_data = new char[this->m_length + 1];
+		strcpy(this->m_data, str);
+	}
+	else {
+		this->m_data = new char[1];
+		this->m_data[0] = 0;
+		this->m_length = 0;
+	}
 }
 
 // OFFSET: LEGO1 0x100ae420
 MxString::~MxString()
 {
-  delete[] this->m_data;
+	delete[] this->m_data;
 }
 
 // OFFSET: LEGO1 0x100ae490
 void MxString::ToUpperCase()
 {
-  strupr(this->m_data);
+	strupr(this->m_data);
 }
 
 // OFFSET: LEGO1 0x100ae4a0
 void MxString::ToLowerCase()
 {
-  strlwr(this->m_data);
+	strlwr(this->m_data);
 }
 
 // OFFSET: LEGO1 0x100ae4b0
-MxString &MxString::operator=(const MxString &param)
+MxString& MxString::operator=(const MxString& param)
 {
-  if (this->m_data != param.m_data)
-  {
-    delete[] this->m_data;
-    this->m_length = param.m_length;
-    this->m_data = new char[this->m_length + 1];
-    strcpy(this->m_data, param.m_data);
-  }
+	if (this->m_data != param.m_data) {
+		delete[] this->m_data;
+		this->m_length = param.m_length;
+		this->m_data = new char[this->m_length + 1];
+		strcpy(this->m_data, param.m_data);
+	}
 
-  return *this;
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100ae510
-const MxString &MxString::operator=(const char *param)
+const MxString& MxString::operator=(const char* param)
 {
-  if (this->m_data != param)
-  {
-    delete[] this->m_data;
-    this->m_length = strlen(param);
-    this->m_data = new char[this->m_length + 1];
-    strcpy(this->m_data, param);
-  }
+	if (this->m_data != param) {
+		delete[] this->m_data;
+		this->m_length = strlen(param);
+		this->m_data = new char[this->m_length + 1];
+		strcpy(this->m_data, param);
+	}
 
-  return *this;
+	return *this;
 }
 
 // Return type is intentionally just MxString, not MxString&.
 // This forces MSVC to add $ReturnUdt$ to the stack for 100% match.
 // OFFSET: LEGO1 0x100ae580
-MxString MxString::operator+(const char *str)
+MxString MxString::operator+(const char* str)
 {
-  // MxString constructor allocates 1 byte for m_data, so free that first
-  MxString tmp;
-  delete[] tmp.m_data;
+	// MxString constructor allocates 1 byte for m_data, so free that first
+	MxString tmp;
+	delete[] tmp.m_data;
 
-  tmp.m_length = strlen(str) + this->m_length;
-  tmp.m_data = new char[tmp.m_length + 1];
-  
-  strcpy(tmp.m_data, this->m_data);
-  strcpy(tmp.m_data + this->m_length, str);
+	tmp.m_length = strlen(str) + this->m_length;
+	tmp.m_data = new char[tmp.m_length + 1];
 
-  return MxString(tmp);
+	strcpy(tmp.m_data, this->m_data);
+	strcpy(tmp.m_data + this->m_length, str);
+
+	return MxString(tmp);
 }
 
 // OFFSET: LEGO1 0x100ae690
-MxString& MxString::operator+=(const char *str)
+MxString& MxString::operator+=(const char* str)
 {
-  int newlen = this->m_length + strlen(str);
+	int newlen = this->m_length + strlen(str);
 
-  char *tmp = new char[newlen + 1];
-  strcpy(tmp, this->m_data);
-  strcpy(tmp + this->m_length, str);
-  
-  delete[] this->m_data;
-  this->m_length = newlen;
-  this->m_data = tmp;
+	char* tmp = new char[newlen + 1];
+	strcpy(tmp, this->m_data);
+	strcpy(tmp + this->m_length, str);
 
-  return *this;
+	delete[] this->m_data;
+	this->m_length = newlen;
+	this->m_data = tmp;
+
+	return *this;
 }

--- a/LEGO1/mxstring.h
+++ b/LEGO1/mxstring.h
@@ -4,27 +4,25 @@
 #include "mxcore.h"
 
 // VTABLE 0x100dc110
-class MxString : public MxCore
-{
+class MxString : public MxCore {
 public:
-  __declspec(dllexport) MxString(const MxString &);
-  __declspec(dllexport) virtual ~MxString();
-  __declspec(dllexport) const MxString &operator=(const char *);
+	__declspec(dllexport) MxString(const MxString&);
+	__declspec(dllexport) virtual ~MxString();
+	__declspec(dllexport) const MxString& operator=(const char*);
 
-  MxString();
-  MxString(const char *);
-  void ToUpperCase();
-  void ToLowerCase();
-  MxString&  operator=(const MxString &);
-  MxString   operator+(const char *);
-  MxString& operator+=(const char *);
+	MxString();
+	MxString(const char*);
+	void ToUpperCase();
+	void ToLowerCase();
+	MxString& operator=(const MxString&);
+	MxString operator+(const char*);
+	MxString& operator+=(const char*);
 
-  inline const char *GetData() const { return m_data; }
+	inline const char* GetData() const { return m_data; }
 
 private:
-  char *m_data;
-  MxU16 m_length;
-
+	char* m_data;
+	MxU16 m_length;
 };
 
 #endif // MXSTRING_H

--- a/LEGO1/mxthread.cpp
+++ b/LEGO1/mxthread.cpp
@@ -9,92 +9,91 @@
 // OFFSET: LEGO1 0x100bf690
 MxResult MxThread::Run()
 {
-  m_semaphore.Release(1);
-  return SUCCESS;
+	m_semaphore.Release(1);
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100bf510
 MxThread::MxThread()
 {
-  m_hThread = NULL;
-  m_running = TRUE;
-  m_threadId = 0;
+	m_hThread = NULL;
+	m_running = TRUE;
+	m_threadId = 0;
 }
 
 // OFFSET: LEGO1 0x100bf5a0
 MxThread::~MxThread()
 {
-  if (m_hThread)
-    CloseHandle((HANDLE)m_hThread);
+	if (m_hThread)
+		CloseHandle((HANDLE) m_hThread);
 }
 
-typedef unsigned(__stdcall *ThreadFunc)(void *);
+typedef unsigned(__stdcall* ThreadFunc)(void*);
 
 // OFFSET: LEGO1 0x100bf610
 MxResult MxThread::Start(int p_stack, int p_flag)
 {
-  MxResult result = FAILURE;
-  if (m_semaphore.Init(0, 1) == SUCCESS)
-  {
-    if (m_hThread = _beginthreadex(NULL, p_stack << 2, (ThreadFunc)&MxThread::ThreadProc, this, p_flag, &m_threadId))
-      result = SUCCESS;
-  }
-  return result;
+	MxResult result = FAILURE;
+	if (m_semaphore.Init(0, 1) == SUCCESS) {
+		if (m_hThread =
+				_beginthreadex(NULL, p_stack << 2, (ThreadFunc) &MxThread::ThreadProc, this, p_flag, &m_threadId))
+			result = SUCCESS;
+	}
+	return result;
 }
 
 // OFFSET: LEGO1 0x100bf670
 void MxThread::Terminate()
 {
-  m_running = FALSE;
-  m_semaphore.Wait(INFINITE);
+	m_running = FALSE;
+	m_semaphore.Wait(INFINITE);
 }
 
 // OFFSET: LEGO1 0x100bf680
-unsigned MxThread::ThreadProc(void *p_thread)
+unsigned MxThread::ThreadProc(void* p_thread)
 {
-  return static_cast<MxThread*>(p_thread)->Run();
+	return static_cast<MxThread*>(p_thread)->Run();
 }
 
 // OFFSET: LEGO1 0x100bf660
 void MxThread::Sleep(MxS32 p_milliseconds)
 {
-  ::Sleep(p_milliseconds);
+	::Sleep(p_milliseconds);
 }
 
 // OFFSET: LEGO1 0x100b8bb0
-MxTickleThread::MxTickleThread(MxCore *p_target, int p_frequencyMS)
+MxTickleThread::MxTickleThread(MxCore* p_target, int p_frequencyMS)
 {
-  m_target = p_target;
-  m_frequencyMS = p_frequencyMS;
+	m_target = p_target;
+	m_frequencyMS = p_frequencyMS;
 }
 
 // OFFSET: LEGO1 0x100d0f50
 MxResult MxTickleThread::StartWithTarget(MxCore* p_target)
 {
-  m_target = p_target;
-  return Start(0x1000, 0);
+	m_target = p_target;
+	return Start(0x1000, 0);
 }
 
 // Match except for register allocation
 // OFFSET: LEGO1 0x100b8c90
 MxResult MxTickleThread::Run()
 {
-  MxTimer* timer = Timer();
-  int lastTickled = -m_frequencyMS;
-  while (IsRunning())
-  {
-    int currentTime = timer->GetTime();
+	MxTimer* timer = Timer();
+	int lastTickled = -m_frequencyMS;
+	while (IsRunning()) {
+		int currentTime = timer->GetTime();
 
-    if (currentTime < lastTickled) {
-      lastTickled = -m_frequencyMS;
-    }
-    int timeRemainingMS = (m_frequencyMS - currentTime) + lastTickled;
-    if (timeRemainingMS <= 0) {
-      m_target->Tickle();
-      timeRemainingMS = 0;
-      lastTickled = currentTime;
-    }
-    Sleep(timeRemainingMS);
-  }
-  return MxThread::Run();
+		if (currentTime < lastTickled) {
+			lastTickled = -m_frequencyMS;
+		}
+		int timeRemainingMS = (m_frequencyMS - currentTime) + lastTickled;
+		if (timeRemainingMS <= 0) {
+			m_target->Tickle();
+			timeRemainingMS = 0;
+			lastTickled = currentTime;
+		}
+		Sleep(timeRemainingMS);
+	}
+	return MxThread::Run();
 }

--- a/LEGO1/mxthread.h
+++ b/LEGO1/mxthread.h
@@ -2,59 +2,57 @@
 #define MXTHREAD_H
 
 #include "compat.h"
-#include "mxtypes.h"
 #include "mxsemaphore.h"
+#include "mxtypes.h"
 
 class MxCore;
 
-class MxThread
-{
+class MxThread {
 public:
-  // Note: Comes before virtual destructor
-  virtual MxResult Run();
+	// Note: Comes before virtual destructor
+	virtual MxResult Run();
 
-  MxResult Start(int p_stack, int p_flag);
+	MxResult Start(int p_stack, int p_flag);
 
-  void Terminate();
+	void Terminate();
 
-  void Sleep(MxS32 p_milliseconds);
+	void Sleep(MxS32 p_milliseconds);
 
-  // Inferred, not in DLL
-  inline MxBool IsRunning() { return m_running; }
+	// Inferred, not in DLL
+	inline MxBool IsRunning() { return m_running; }
 
 protected:
-  MxThread();
+	MxThread();
 
 public:
-  virtual ~MxThread();
+	virtual ~MxThread();
 
 private:
-  static unsigned ThreadProc(void *p_thread);
+	static unsigned ThreadProc(void* p_thread);
 
-  MxULong m_hThread;
-  MxU32 m_threadId;
-  MxBool m_running;
-  MxSemaphore m_semaphore;
+	MxULong m_hThread;
+	MxU32 m_threadId;
+	MxBool m_running;
+	MxSemaphore m_semaphore;
 };
 
-class MxTickleThread : public MxThread
-{
+class MxTickleThread : public MxThread {
 public:
-  MxTickleThread(MxCore *p_target, int p_frequencyMS);
+	MxTickleThread(MxCore* p_target, int p_frequencyMS);
 
-  // Unclear at this time whether this function and the m_target field are
-  // actually a general "userdata" pointer in the base MxThread, but it seems
-  // like the only usage is with an MxTickleThread.
-  MxResult StartWithTarget(MxCore* p_target);
+	// Unclear at this time whether this function and the m_target field are
+	// actually a general "userdata" pointer in the base MxThread, but it seems
+	// like the only usage is with an MxTickleThread.
+	MxResult StartWithTarget(MxCore* p_target);
 
-  // Only inlined, no offset
-  virtual ~MxTickleThread() {}
+	// Only inlined, no offset
+	virtual ~MxTickleThread() {}
 
-  MxResult Run() override;
+	MxResult Run() override;
 
 private:
-  MxCore *m_target;
-  MxS32 m_frequencyMS;
+	MxCore* m_target;
+	MxS32 m_frequencyMS;
 };
 
 #endif // MXTHREAD_H

--- a/LEGO1/mxticklemanager.cpp
+++ b/LEGO1/mxticklemanager.cpp
@@ -1,9 +1,9 @@
-#include "mxomni.h"
 #include "mxticklemanager.h"
-#include "mxtimer.h"
-#include "mxtypes.h"
 
 #include "decomp.h"
+#include "mxomni.h"
+#include "mxtimer.h"
+#include "mxtypes.h"
 
 #define TICKLE_MANAGER_FLAG_DESTROY 0x1
 
@@ -11,103 +11,103 @@ DECOMP_SIZE_ASSERT(MxTickleClient, 0x10);
 DECOMP_SIZE_ASSERT(MxTickleManager, 0x14);
 
 // OFFSET: LEGO1 0x100bdd10
-MxTickleClient::MxTickleClient(MxCore *p_client, MxTime p_interval)
+MxTickleClient::MxTickleClient(MxCore* p_client, MxTime p_interval)
 {
-  m_flags = 0;
-  m_client = p_client;
-  m_interval = p_interval;
-  m_lastUpdateTime = -m_interval;
+	m_flags = 0;
+	m_client = p_client;
+	m_interval = p_interval;
+	m_lastUpdateTime = -m_interval;
 }
 
 // OFFSET: LEGO1 0x100bdd30
 MxTickleManager::~MxTickleManager()
 {
-  while (m_clients.size() != 0) {
-    MxTickleClient *client = m_clients.front();
-    m_clients.pop_front();
-    delete client;
-  }
+	while (m_clients.size() != 0) {
+		MxTickleClient* client = m_clients.front();
+		m_clients.pop_front();
+		delete client;
+	}
 }
 
 // TODO: Match.
 // OFFSET: LEGO1 0x100bdde0
 MxResult MxTickleManager::Tickle()
 {
-  MxTime time = Timer()->GetTime();
+	MxTime time = Timer()->GetTime();
 
-  MxTickleClientPtrList::iterator it = m_clients.begin();
+	MxTickleClientPtrList::iterator it = m_clients.begin();
 
-  while (it != m_clients.end()) {
-    MxTickleClient *client = *it;
-    if ((client->GetFlags() & TICKLE_MANAGER_FLAG_DESTROY) == 0) {
-      if (client->GetLastUpdateTime() >= time)
-        client->SetLastUpdateTime(-client->GetTickleInterval());
+	while (it != m_clients.end()) {
+		MxTickleClient* client = *it;
+		if ((client->GetFlags() & TICKLE_MANAGER_FLAG_DESTROY) == 0) {
+			if (client->GetLastUpdateTime() >= time)
+				client->SetLastUpdateTime(-client->GetTickleInterval());
 
-      if ((client->GetTickleInterval() + client->GetLastUpdateTime()) < time) {
-        client->GetClient()->Tickle();
-        client->SetLastUpdateTime(time);
-      }
+			if ((client->GetTickleInterval() + client->GetLastUpdateTime()) < time) {
+				client->GetClient()->Tickle();
+				client->SetLastUpdateTime(time);
+			}
 
-      it++;
-    }
-    else {
-      m_clients.erase(it++);
-      delete client;
-    }
-  }
+			it++;
+		}
+		else {
+			m_clients.erase(it++);
+			delete client;
+		}
+	}
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100bde80
-void MxTickleManager::RegisterClient(MxCore *p_client, MxTime p_interval)
+void MxTickleManager::RegisterClient(MxCore* p_client, MxTime p_interval)
 {
-  MxTime interval = GetClientTickleInterval(p_client);
-  if (interval == TICKLE_MANAGER_NOT_FOUND) {
-    MxTickleClient *client = new MxTickleClient(p_client, p_interval);
-    if (client != NULL)
-      m_clients.push_back(client);
-  }
+	MxTime interval = GetClientTickleInterval(p_client);
+	if (interval == TICKLE_MANAGER_NOT_FOUND) {
+		MxTickleClient* client = new MxTickleClient(p_client, p_interval);
+		if (client != NULL)
+			m_clients.push_back(client);
+	}
 }
 
 // OFFSET: LEGO1 0x100bdf60
-void MxTickleManager::UnregisterClient(MxCore *p_client)
+void MxTickleManager::UnregisterClient(MxCore* p_client)
 {
-  MxTickleClientPtrList::iterator it = m_clients.begin();
-  while (it != m_clients.end()) {
-    MxTickleClient *client = *it;
-    if (client->GetClient() == p_client) {
-      client->SetFlags(client->GetFlags() | TICKLE_MANAGER_FLAG_DESTROY);
-      return;
-    }
+	MxTickleClientPtrList::iterator it = m_clients.begin();
+	while (it != m_clients.end()) {
+		MxTickleClient* client = *it;
+		if (client->GetClient() == p_client) {
+			client->SetFlags(client->GetFlags() | TICKLE_MANAGER_FLAG_DESTROY);
+			return;
+		}
 
-    it++;
-  }
+		it++;
+	}
 }
 
 // OFFSET: LEGO1 0x100bdfa0
-void MxTickleManager::SetClientTickleInterval(MxCore *p_client, MxTime p_interval)
+void MxTickleManager::SetClientTickleInterval(MxCore* p_client, MxTime p_interval)
 {
-  for (MxTickleClientPtrList::iterator it = m_clients.begin(); it != m_clients.end(); it++) {
-    MxTickleClient *client = *it;
-    if ((client->GetClient() == p_client) && ((client->GetFlags() & TICKLE_MANAGER_FLAG_DESTROY) == 0)) {
-      client->SetTickleInterval(p_interval);
-      return;
-    }
-  }
+	for (MxTickleClientPtrList::iterator it = m_clients.begin(); it != m_clients.end(); it++) {
+		MxTickleClient* client = *it;
+		if ((client->GetClient() == p_client) && ((client->GetFlags() & TICKLE_MANAGER_FLAG_DESTROY) == 0)) {
+			client->SetTickleInterval(p_interval);
+			return;
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100be000
-MxTime MxTickleManager::GetClientTickleInterval(MxCore *p_client)
+MxTime MxTickleManager::GetClientTickleInterval(MxCore* p_client)
 {
-  MxTickleClientPtrList::iterator it = m_clients.begin();
-  while (it != m_clients.end()) {
-    MxTickleClient *client = *it;
-    if ((client->GetClient() == p_client) && ((client->GetFlags() & TICKLE_MANAGER_FLAG_DESTROY) == 0))
-      return client->GetTickleInterval();
+	MxTickleClientPtrList::iterator it = m_clients.begin();
+	while (it != m_clients.end()) {
+		MxTickleClient* client = *it;
+		if ((client->GetClient() == p_client) && ((client->GetFlags() & TICKLE_MANAGER_FLAG_DESTROY) == 0))
+			return client->GetTickleInterval();
 
-    it++;
-  }
+		it++;
+	}
 
-  return TICKLE_MANAGER_NOT_FOUND;
+	return TICKLE_MANAGER_NOT_FOUND;
 }

--- a/LEGO1/mxticklemanager.h
+++ b/LEGO1/mxticklemanager.h
@@ -1,75 +1,51 @@
 #ifndef MXTICKLEMANAGER_H
 #define MXTICKLEMANAGER_H
 
+#include "compat.h"
 #include "mxcore.h"
 #include "mxtypes.h"
 
-#include "compat.h"
-
-class MxTickleClient
-{
+class MxTickleClient {
 public:
-  MxTickleClient(MxCore *p_client, MxTime p_interval);
+	MxTickleClient(MxCore* p_client, MxTime p_interval);
 
-  inline MxCore *GetClient() const
-  {
-    return m_client;
-  }
+	inline MxCore* GetClient() const { return m_client; }
 
-  inline MxTime GetTickleInterval() const
-  {
-    return m_interval;
-  }
+	inline MxTime GetTickleInterval() const { return m_interval; }
 
-  inline MxTime GetLastUpdateTime() const
-  {
-    return m_lastUpdateTime;
-  }
+	inline MxTime GetLastUpdateTime() const { return m_lastUpdateTime; }
 
-  inline MxU16 GetFlags() const
-  {
-    return m_flags;
-  }
+	inline MxU16 GetFlags() const { return m_flags; }
 
-  inline void SetTickleInterval(MxTime p_interval)
-  {
-    m_interval = p_interval;
-  }
+	inline void SetTickleInterval(MxTime p_interval) { m_interval = p_interval; }
 
-  inline void SetLastUpdateTime(MxTime p_lastUpdateTime)
-  {
-    m_lastUpdateTime = p_lastUpdateTime;
-  }
+	inline void SetLastUpdateTime(MxTime p_lastUpdateTime) { m_lastUpdateTime = p_lastUpdateTime; }
 
-  inline void SetFlags(MxU16 flags)
-  {
-    m_flags = flags;
-  }
+	inline void SetFlags(MxU16 flags) { m_flags = flags; }
 
 private:
-  MxCore *m_client; // 0x0
-  MxTime m_interval; // 0x4
-  MxTime m_lastUpdateTime; // 0x8
-  MxU16 m_flags; // 0xc
+	MxCore* m_client;        // 0x0
+	MxTime m_interval;       // 0x4
+	MxTime m_lastUpdateTime; // 0x8
+	MxU16 m_flags;           // 0xc
 };
 
 typedef list<MxTickleClient*> MxTickleClientPtrList;
 
 // VTABLE 0x100d86d8
-class MxTickleManager : public MxCore
-{
+class MxTickleManager : public MxCore {
 public:
-  inline MxTickleManager() {}
-  virtual ~MxTickleManager(); // vtable+0x0 (scalar deleting destructor)
+	inline MxTickleManager() {}
+	virtual ~MxTickleManager(); // vtable+0x0 (scalar deleting destructor)
 
-  virtual MxResult Tickle(); // vtable+0x8
-  virtual void RegisterClient(MxCore *p_client, MxTime p_interval); // vtable+0x14
-  virtual void UnregisterClient(MxCore *p_client); // vtable+0x18
-  virtual void SetClientTickleInterval(MxCore *p_client, MxTime p_interval); // vtable+0x1c
-  virtual MxTime GetClientTickleInterval(MxCore *p_client); // vtable+0x20
+	virtual MxResult Tickle();                                                 // vtable+0x8
+	virtual void RegisterClient(MxCore* p_client, MxTime p_interval);          // vtable+0x14
+	virtual void UnregisterClient(MxCore* p_client);                           // vtable+0x18
+	virtual void SetClientTickleInterval(MxCore* p_client, MxTime p_interval); // vtable+0x1c
+	virtual MxTime GetClientTickleInterval(MxCore* p_client);                  // vtable+0x20
 
 private:
-  MxTickleClientPtrList m_clients; // 0x8
+	MxTickleClientPtrList m_clients; // 0x8
 };
 
 #define TICKLE_MANAGER_NOT_FOUND 0x80000000

--- a/LEGO1/mxtimer.cpp
+++ b/LEGO1/mxtimer.cpp
@@ -11,32 +11,32 @@ MxLong MxTimer::s_LastTimeTimerStarted = 0;
 // OFFSET: LEGO1 0x100ae060
 MxTimer::MxTimer()
 {
-  this->m_isRunning = FALSE;
-  m_startTime = timeGetTime();
-  // yeah this is somehow what the asm is
-  s_LastTimeCalculated = m_startTime;
+	this->m_isRunning = FALSE;
+	m_startTime = timeGetTime();
+	// yeah this is somehow what the asm is
+	s_LastTimeCalculated = m_startTime;
 }
 
 // OFFSET: LEGO1 0x100ae160
 void MxTimer::Start()
 {
-  s_LastTimeTimerStarted = this->GetRealTime();
-  this->m_isRunning = TRUE;
+	s_LastTimeTimerStarted = this->GetRealTime();
+	this->m_isRunning = TRUE;
 }
 
 // OFFSET: LEGO1 0x100ae180
 void MxTimer::Stop()
 {
-  MxLong elapsed = this->GetRealTime();
-  MxLong startTime = elapsed - MxTimer::s_LastTimeTimerStarted;
-  this->m_isRunning = FALSE;
-  // this feels very stupid but it's what the assembly does
-  this->m_startTime = this->m_startTime + startTime - 5;
+	MxLong elapsed = this->GetRealTime();
+	MxLong startTime = elapsed - MxTimer::s_LastTimeTimerStarted;
+	this->m_isRunning = FALSE;
+	// this feels very stupid but it's what the assembly does
+	this->m_startTime = this->m_startTime + startTime - 5;
 }
 
 // OFFSET: LEGO1 0x100ae140
 MxLong MxTimer::GetRealTime()
 {
-  MxTimer::s_LastTimeCalculated = timeGetTime();
-  return MxTimer::s_LastTimeCalculated - this->m_startTime;
+	MxTimer::s_LastTimeCalculated = timeGetTime();
+	return MxTimer::s_LastTimeCalculated - this->m_startTime;
 }

--- a/LEGO1/mxtimer.h
+++ b/LEGO1/mxtimer.h
@@ -5,29 +5,28 @@
 
 // VTABLE 0x100dc0e0
 // SIZE 0x10
-class MxTimer : public MxCore
-{
+class MxTimer : public MxCore {
 public:
-  MxTimer();
+	MxTimer();
 
-  void Start();
-  void Stop();
+	void Start();
+	void Stop();
 
-  __declspec(dllexport) MxLong GetRealTime();
+	__declspec(dllexport) MxLong GetRealTime();
 
-  inline MxLong GetTime()
-  {
-    if (this->m_isRunning)
-      return s_LastTimeTimerStarted;
-    else
-      return s_LastTimeCalculated - this->m_startTime;
-  }
+	inline MxLong GetTime()
+	{
+		if (this->m_isRunning)
+			return s_LastTimeTimerStarted;
+		else
+			return s_LastTimeCalculated - this->m_startTime;
+	}
 
 private:
-  MxLong m_startTime;
-  MxBool m_isRunning;
-  static MxLong s_LastTimeCalculated;
-  static MxLong s_LastTimeTimerStarted;
+	MxLong m_startTime;
+	MxBool m_isRunning;
+	static MxLong s_LastTimeCalculated;
+	static MxLong s_LastTimeTimerStarted;
 };
 
 #endif // MXTIMER_H

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -1,8 +1,8 @@
 #include "mxtransitionmanager.h"
 
-#include "legovideomanager.h"
 #include "legoinputmanager.h"
 #include "legoutil.h"
+#include "legovideomanager.h"
 #include "legoworld.h"
 #include "mxbackgroundaudiomanager.h"
 #include "mxparam.h"
@@ -16,562 +16,585 @@ RECT g_fullScreenRect = {0, 0, 640, 480};
 // OFFSET: LEGO1 0x1004b8d0
 MxTransitionManager::MxTransitionManager()
 {
-  m_animationTimer = 0;
-  m_transitionType = NOT_TRANSITIONING;
-  m_ddSurface = NULL;
-  m_waitIndicator = NULL;
-  m_copyBuffer = NULL;
-  m_copyFlags.bit0 = FALSE;
-  m_unk28.bit0 = FALSE;
-  m_unk24 = 0;
+	m_animationTimer = 0;
+	m_transitionType = NOT_TRANSITIONING;
+	m_ddSurface = NULL;
+	m_waitIndicator = NULL;
+	m_copyBuffer = NULL;
+	m_copyFlags.bit0 = FALSE;
+	m_unk28.bit0 = FALSE;
+	m_unk24 = 0;
 }
 
 // OFFSET: LEGO1 0x1004ba00
 MxTransitionManager::~MxTransitionManager()
 {
-  delete[] m_copyBuffer;
+	delete[] m_copyBuffer;
 
-  if (m_waitIndicator != NULL) {
-    delete m_waitIndicator->GetAction();
-    delete m_waitIndicator;
-  }
+	if (m_waitIndicator != NULL) {
+		delete m_waitIndicator->GetAction();
+		delete m_waitIndicator;
+	}
 
-  TickleManager()->UnregisterClient(this);
+	TickleManager()->UnregisterClient(this);
 }
 
 // OFFSET: LEGO1 0x1004bac0
 MxResult MxTransitionManager::Tickle()
 {
-  if (this->m_animationSpeed + this->m_systemTime > timeGetTime()) {
-    return SUCCESS;
-  }
+	if (this->m_animationSpeed + this->m_systemTime > timeGetTime()) {
+		return SUCCESS;
+	}
 
-  this->m_systemTime = timeGetTime();
+	this->m_systemTime = timeGetTime();
 
-  switch (this->m_transitionType) {
-    case NO_ANIMATION:
-      Transition_None();
-      break;
-    case DISSOLVE:
-      Transition_Dissolve();
-      break;
-    case PIXELATION:
-      Transition_Pixelation();
-      break;
-    case SCREEN_WIPE:
-      Transition_Wipe();
-      break;
-    case WINDOWS:
-      Transition_Windows();
-      break;
-    case BROKEN:
-      Transition_Broken();
-      break;
-  }
-  return SUCCESS;
+	switch (this->m_transitionType) {
+	case NO_ANIMATION:
+		Transition_None();
+		break;
+	case DISSOLVE:
+		Transition_Dissolve();
+		break;
+	case PIXELATION:
+		Transition_Pixelation();
+		break;
+	case SCREEN_WIPE:
+		Transition_Wipe();
+		break;
+	case WINDOWS:
+		Transition_Windows();
+		break;
+	case BROKEN:
+		Transition_Broken();
+		break;
+	}
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1004bc30
 void MxTransitionManager::EndTransition(MxBool p_notifyWorld)
 {
-  if (m_transitionType != NOT_TRANSITIONING) {
-    m_transitionType = NOT_TRANSITIONING;
+	if (m_transitionType != NOT_TRANSITIONING) {
+		m_transitionType = NOT_TRANSITIONING;
 
-    m_copyFlags.bit0 = FALSE;
+		m_copyFlags.bit0 = FALSE;
 
-    TickleManager()->UnregisterClient(this);
+		TickleManager()->UnregisterClient(this);
 
-    if (p_notifyWorld) {
-      LegoWorld *world = GetCurrentWorld();
+		if (p_notifyWorld) {
+			LegoWorld* world = GetCurrentWorld();
 
-      if (world) {
-        world->Notify(MxNotificationParam(MXTRANSITIONMANAGER_TRANSITIONENDED, this));
-      }
-    }
-  }
+			if (world) {
+				world->Notify(MxNotificationParam(MXTRANSITIONMANAGER_TRANSITIONENDED, this));
+			}
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x1004bd10
 void MxTransitionManager::Transition_Dissolve()
 {
-  // If the animation is finished
-  if (m_animationTimer == 40) {
-    m_animationTimer = 0;
-    EndTransition(TRUE);
-    return;
-  }
+	// If the animation is finished
+	if (m_animationTimer == 40) {
+		m_animationTimer = 0;
+		EndTransition(TRUE);
+		return;
+	}
 
-  // If we are starting the animation
-  if (m_animationTimer == 0) {
-    // Generate the list of columns in order...
-    MxS32 i;
-    for (i = 0; i < 640; i++) {
-      m_columnOrder[i] = i;
-    }
+	// If we are starting the animation
+	if (m_animationTimer == 0) {
+		// Generate the list of columns in order...
+		MxS32 i;
+		for (i = 0; i < 640; i++) {
+			m_columnOrder[i] = i;
+		}
 
-    // ...then shuffle the list (to ensure that we hit each column once)
-    for (i = 0; i < 640; i++) {
-      MxS32 swap = rand() % 640;
-      MxU16 t = m_columnOrder[i];
-      m_columnOrder[i] = m_columnOrder[swap];
-      m_columnOrder[swap] = t;
-    }
+		// ...then shuffle the list (to ensure that we hit each column once)
+		for (i = 0; i < 640; i++) {
+			MxS32 swap = rand() % 640;
+			MxU16 t = m_columnOrder[i];
+			m_columnOrder[i] = m_columnOrder[swap];
+			m_columnOrder[swap] = t;
+		}
 
-    // For each scanline, pick a random X offset
-    for (i = 0; i < 480; i++) {
-      m_randomShift[i] = rand() % 640;
-    }
-  }
+		// For each scanline, pick a random X offset
+		for (i = 0; i < 480; i++) {
+			m_randomShift[i] = rand() % 640;
+		}
+	}
 
-  // Run one tick of the animation
-  DDSURFACEDESC ddsd;
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
+	// Run one tick of the animation
+	DDSURFACEDESC ddsd;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
 
-  HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  if (res == DDERR_SURFACELOST) {
-    m_ddSurface->Restore();
-    res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  }
+	HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	if (res == DDERR_SURFACELOST) {
+		m_ddSurface->Restore();
+		res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	}
 
-  if (res == DD_OK) {
-    SubmitCopyRect(&ddsd);
+	if (res == DD_OK) {
+		SubmitCopyRect(&ddsd);
 
-    for (MxS32 col = 0; col < 640; col++) {
-      // Select 16 columns on each tick
-      if (m_animationTimer * 16 > m_columnOrder[col])
-        continue;
+		for (MxS32 col = 0; col < 640; col++) {
+			// Select 16 columns on each tick
+			if (m_animationTimer * 16 > m_columnOrder[col])
+				continue;
 
-      if (m_animationTimer * 16 + 15 < m_columnOrder[col])
-        continue;
+			if (m_animationTimer * 16 + 15 < m_columnOrder[col])
+				continue;
 
-      for (MxS32 row = 0; row < 480; row++) {
-        // Shift the chosen column a different amount at each scanline.
-        // We use the same shift for that scanline each time.
-        // By the end, every pixel gets hit.
-        MxS32 x_shift = (m_randomShift[row] + col) % 640;
+			for (MxS32 row = 0; row < 480; row++) {
+				// Shift the chosen column a different amount at each scanline.
+				// We use the same shift for that scanline each time.
+				// By the end, every pixel gets hit.
+				MxS32 x_shift = (m_randomShift[row] + col) % 640;
 
-        // Set the chosen pixel to black
-        if (ddsd.ddpfPixelFormat.dwRGBBitCount == 8) {
-          ((MxU8*)ddsd.lpSurface)[row * ddsd.lPitch + x_shift] = 0;
-        } else {
-          ((MxU16*)ddsd.lpSurface)[row * ddsd.lPitch + x_shift] = 0;
-        }
-      }
-    }
+				// Set the chosen pixel to black
+				if (ddsd.ddpfPixelFormat.dwRGBBitCount == 8) {
+					((MxU8*) ddsd.lpSurface)[row * ddsd.lPitch + x_shift] = 0;
+				}
+				else {
+					((MxU16*) ddsd.lpSurface)[row * ddsd.lPitch + x_shift] = 0;
+				}
+			}
+		}
 
-    SetupCopyRect(&ddsd);
-    m_ddSurface->Unlock(ddsd.lpSurface);
+		SetupCopyRect(&ddsd);
+		m_ddSurface->Unlock(ddsd.lpSurface);
 
-    if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
-      LPDIRECTDRAWSURFACE surf = VideoManager()->GetDisplaySurface()->GetDirectDrawSurface1();
-      surf->BltFast(NULL, NULL, m_ddSurface, &g_fullScreenRect, DDBLTFAST_WAIT);
-    }
+		if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
+			LPDIRECTDRAWSURFACE surf = VideoManager()->GetDisplaySurface()->GetDirectDrawSurface1();
+			surf->BltFast(NULL, NULL, m_ddSurface, &g_fullScreenRect, DDBLTFAST_WAIT);
+		}
 
-    m_animationTimer++;
-  }
+		m_animationTimer++;
+	}
 }
 
 // OFFSET: LEGO1 0x1004baa0
 MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 {
-  LegoVideoManager *videoManager = VideoManager();
-  this->m_ddSurface = videoManager->GetDisplaySurface()->GetDirectDrawSurface2();
-  return SUCCESS;
+	LegoVideoManager* videoManager = VideoManager();
+	this->m_ddSurface = videoManager->GetDisplaySurface()->GetDirectDrawSurface2();
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1004bb70
-MxResult MxTransitionManager::StartTransition(TransitionType p_animationType, MxS32 p_speed,
-                                              MxBool p_doCopy, MxBool p_playMusicInAnim)
+MxResult MxTransitionManager::StartTransition(
+	TransitionType p_animationType,
+	MxS32 p_speed,
+	MxBool p_doCopy,
+	MxBool p_playMusicInAnim
+)
 {
-  if (this->m_transitionType == NOT_TRANSITIONING) {
-    if (!p_playMusicInAnim) {
-      MxBackgroundAudioManager *backgroundAudioManager = BackgroundAudioManager();
-      backgroundAudioManager->Stop();
-    }
+	if (this->m_transitionType == NOT_TRANSITIONING) {
+		if (!p_playMusicInAnim) {
+			MxBackgroundAudioManager* backgroundAudioManager = BackgroundAudioManager();
+			backgroundAudioManager->Stop();
+		}
 
-    this->m_transitionType = p_animationType;
+		this->m_transitionType = p_animationType;
 
-    m_copyFlags.bit0 = p_doCopy;
+		m_copyFlags.bit0 = p_doCopy;
 
-    if (m_copyFlags.bit0 && m_waitIndicator != NULL) {
-      m_waitIndicator->Enable(TRUE);
+		if (m_copyFlags.bit0 && m_waitIndicator != NULL) {
+			m_waitIndicator->Enable(TRUE);
 
-      MxDSAction *action = m_waitIndicator->GetAction();
-      action->SetLoopCount(10000);
-      action->SetFlags(action->GetFlags() | MxDSAction::Flag_Bit9);
-    }
+			MxDSAction* action = m_waitIndicator->GetAction();
+			action->SetLoopCount(10000);
+			action->SetFlags(action->GetFlags() | MxDSAction::Flag_Bit9);
+		}
 
-    MxU32 time = timeGetTime();
-    this->m_systemTime = time;
+		MxU32 time = timeGetTime();
+		this->m_systemTime = time;
 
-    this->m_animationSpeed = p_speed;
+		this->m_animationSpeed = p_speed;
 
-    MxTickleManager *tickleManager = TickleManager();
-    tickleManager->RegisterClient(this, p_speed);
+		MxTickleManager* tickleManager = TickleManager();
+		tickleManager->RegisterClient(this, p_speed);
 
-    LegoInputManager *inputManager = InputManager();
-    inputManager->m_unk0x88 = TRUE;
-    inputManager->m_unk0x336 = FALSE;
+		LegoInputManager* inputManager = InputManager();
+		inputManager->m_unk0x88 = TRUE;
+		inputManager->m_unk0x336 = FALSE;
 
-    LegoVideoManager *videoManager = VideoManager();
-    videoManager->SetUnkE4(FALSE);
+		LegoVideoManager* videoManager = VideoManager();
+		videoManager->SetUnkE4(FALSE);
 
-    SetAppCursor(1);
-    return SUCCESS;
-  }
-  return FAILURE;
+		SetAppCursor(1);
+		return SUCCESS;
+	}
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x1004bcf0
 void MxTransitionManager::Transition_None()
 {
-  LegoVideoManager *videoManager = VideoManager();
-  videoManager->GetDisplaySurface()->FUN_100ba640();
-  EndTransition(TRUE);
+	LegoVideoManager* videoManager = VideoManager();
+	videoManager->GetDisplaySurface()->FUN_100ba640();
+	EndTransition(TRUE);
 }
 
 // OFFSET: LEGO1 0x1004bed0
 void MxTransitionManager::Transition_Pixelation()
 {
-  if (m_animationTimer == 16) {
-    m_animationTimer = 0;
-    EndTransition(TRUE);
-    return;
-  }
+	if (m_animationTimer == 16) {
+		m_animationTimer = 0;
+		EndTransition(TRUE);
+		return;
+	}
 
-  if (m_animationTimer == 0) {
-    // Same init/shuffle steps as the dissolve transition, except that
-    // we are using big blocky pixels and only need 64 columns.
-    MxS32 i;
-    for (i = 0; i < 64; i++) {
-      m_columnOrder[i] = i;
-    }
+	if (m_animationTimer == 0) {
+		// Same init/shuffle steps as the dissolve transition, except that
+		// we are using big blocky pixels and only need 64 columns.
+		MxS32 i;
+		for (i = 0; i < 64; i++) {
+			m_columnOrder[i] = i;
+		}
 
-    for (i = 0; i < 64; i++) {
-      MxS32 swap = rand() % 64;
-      MxU16 t = m_columnOrder[i];
-      m_columnOrder[i] = m_columnOrder[swap];
-      m_columnOrder[swap] = t;
-    }
+		for (i = 0; i < 64; i++) {
+			MxS32 swap = rand() % 64;
+			MxU16 t = m_columnOrder[i];
+			m_columnOrder[i] = m_columnOrder[swap];
+			m_columnOrder[swap] = t;
+		}
 
-    // The same is true here. We only need 48 rows.
-    for (i = 0; i < 48; i++) {
-      m_randomShift[i] = rand() % 64;
-    }
-  }
+		// The same is true here. We only need 48 rows.
+		for (i = 0; i < 48; i++) {
+			m_randomShift[i] = rand() % 64;
+		}
+	}
 
-  // Run one tick of the animation
-  DDSURFACEDESC ddsd;
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
+	// Run one tick of the animation
+	DDSURFACEDESC ddsd;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
 
-  HRESULT res = m_ddSurface->Lock(NULL, &ddsd, 1, NULL);
-  if (res == DDERR_SURFACELOST) {
-    m_ddSurface->Restore();
-    res = m_ddSurface->Lock(NULL, &ddsd, 1, NULL);
-  }
+	HRESULT res = m_ddSurface->Lock(NULL, &ddsd, 1, NULL);
+	if (res == DDERR_SURFACELOST) {
+		m_ddSurface->Restore();
+		res = m_ddSurface->Lock(NULL, &ddsd, 1, NULL);
+	}
 
-  if (res == DD_OK) {
-    SubmitCopyRect(&ddsd);
+	if (res == DD_OK) {
+		SubmitCopyRect(&ddsd);
 
-    for (MxS32 col = 0; col < 64; col++) {
-      // Select 4 columns on each tick
-      if (m_animationTimer * 4 > m_columnOrder[col])
-        continue;
+		for (MxS32 col = 0; col < 64; col++) {
+			// Select 4 columns on each tick
+			if (m_animationTimer * 4 > m_columnOrder[col])
+				continue;
 
-      if (m_animationTimer * 4 + 3 < m_columnOrder[col])
-        continue;
+			if (m_animationTimer * 4 + 3 < m_columnOrder[col])
+				continue;
 
-      for (MxS32 row = 0; row < 48; row++) {
-        MxS32 x_shift = 10 * ((m_randomShift[row] + col) % 64);
-        
-        // To do the pixelation, we subdivide the 640x480 surface into
-        // 10x10 pixel blocks. At the chosen block, we sample the top-leftmost
-        // color and set the other 99 pixels to that value.
+			for (MxS32 row = 0; row < 48; row++) {
+				MxS32 x_shift = 10 * ((m_randomShift[row] + col) % 64);
 
-        // Find the pixel to sample
-        MxS32 sample_ofs = 10 * row * ddsd.lPitch + x_shift;
-        MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
+				// To do the pixelation, we subdivide the 640x480 surface into
+				// 10x10 pixel blocks. At the chosen block, we sample the top-leftmost
+				// color and set the other 99 pixels to that value.
 
-        // Save this cast from void* to save time.
-        // Seems to help accuracy doing it this way.
-        MxU8 *surface = (MxU8*)ddsd.lpSurface;
-        MxU8 *source = surface + sample_ofs * bytesPerPixel;
+				// Find the pixel to sample
+				MxS32 sample_ofs = 10 * row * ddsd.lPitch + x_shift;
+				MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
 
-        MxU32 sample = bytesPerPixel == 1 ? *source
-                                          : *(MxU16*)source;
+				// Save this cast from void* to save time.
+				// Seems to help accuracy doing it this way.
+				MxU8* surface = (MxU8*) ddsd.lpSurface;
+				MxU8* source = surface + sample_ofs * bytesPerPixel;
 
-        for (MxS32 k = 10*row; k < 10*row + 10; k++) {
-          if (ddsd.ddpfPixelFormat.dwRGBBitCount == 8) {
-            // TODO: This block and the next don't match, but they are
-            // hopefully correct in principle.
-            MxU16 color_word = MAKEWORD(LOBYTE(sample), LOBYTE(sample));
-            MxU32 new_color = MAKELONG(color_word, color_word);
-            
-            MxU8 *pos = surface + k * ddsd.lPitch + x_shift;
-            MxU32 *dest = (MxU32*)pos;            
-            
-            // Sets 10 pixels (10 bytes)
-            dest[0] = new_color;
-            dest[1] = new_color;
-            MxU16 *half = (MxU16*)(dest+2);
-            *half = new_color;
-          } else {
-            MxU32 new_color = MAKELONG(sample, sample);
+				MxU32 sample = bytesPerPixel == 1 ? *source : *(MxU16*) source;
 
-            // You might expect a cast to MxU16* instead, but lPitch is
-            // bytes/scanline, not pixels/scanline. Therefore, we just
-            // need to double the x_shift to get to the right spot.
-            MxU8 *pos = surface + k * ddsd.lPitch + 2*x_shift;
-            MxU32 *dest = (MxU32*)pos;
-            // Sets 10 pixels (20 bytes)
-            dest[0] = new_color;
-            dest[1] = new_color;
-            dest[2] = new_color;
-            dest[3] = new_color;
-            dest[4] = new_color;
-          }
-        }
-      }
-    }
+				for (MxS32 k = 10 * row; k < 10 * row + 10; k++) {
+					if (ddsd.ddpfPixelFormat.dwRGBBitCount == 8) {
+						// TODO: This block and the next don't match, but they are
+						// hopefully correct in principle.
+						MxU16 color_word = MAKEWORD(LOBYTE(sample), LOBYTE(sample));
+						MxU32 new_color = MAKELONG(color_word, color_word);
 
-    SetupCopyRect(&ddsd);
-    m_ddSurface->Unlock(ddsd.lpSurface);
+						MxU8* pos = surface + k * ddsd.lPitch + x_shift;
+						MxU32* dest = (MxU32*) pos;
 
-    if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
-      LPDIRECTDRAWSURFACE surf = VideoManager()->GetDisplaySurface()->GetDirectDrawSurface1();
-      surf->BltFast(NULL, NULL, m_ddSurface, &g_fullScreenRect, DDBLTFAST_WAIT);
-    }
+						// Sets 10 pixels (10 bytes)
+						dest[0] = new_color;
+						dest[1] = new_color;
+						MxU16* half = (MxU16*) (dest + 2);
+						*half = new_color;
+					}
+					else {
+						MxU32 new_color = MAKELONG(sample, sample);
 
-    m_animationTimer++;
-  }
+						// You might expect a cast to MxU16* instead, but lPitch is
+						// bytes/scanline, not pixels/scanline. Therefore, we just
+						// need to double the x_shift to get to the right spot.
+						MxU8* pos = surface + k * ddsd.lPitch + 2 * x_shift;
+						MxU32* dest = (MxU32*) pos;
+						// Sets 10 pixels (20 bytes)
+						dest[0] = new_color;
+						dest[1] = new_color;
+						dest[2] = new_color;
+						dest[3] = new_color;
+						dest[4] = new_color;
+					}
+				}
+			}
+		}
 
+		SetupCopyRect(&ddsd);
+		m_ddSurface->Unlock(ddsd.lpSurface);
+
+		if (VideoManager()->GetVideoParam().flags().GetFlipSurfaces()) {
+			LPDIRECTDRAWSURFACE surf = VideoManager()->GetDisplaySurface()->GetDirectDrawSurface1();
+			surf->BltFast(NULL, NULL, m_ddSurface, &g_fullScreenRect, DDBLTFAST_WAIT);
+		}
+
+		m_animationTimer++;
+	}
 }
 
 // OFFSET: LEGO1 0x1004c270
 void MxTransitionManager::Transition_Windows()
 {
-  if (m_animationTimer == 240) {
-    m_animationTimer = 0;
-    EndTransition(TRUE);
-    return;
-  }
+	if (m_animationTimer == 240) {
+		m_animationTimer = 0;
+		EndTransition(TRUE);
+		return;
+	}
 
-  DDSURFACEDESC ddsd;
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
+	DDSURFACEDESC ddsd;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
 
-  HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  if (res == DDERR_SURFACELOST) {
-    m_ddSurface->Restore();
-    res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  }
+	HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	if (res == DDERR_SURFACELOST) {
+		m_ddSurface->Restore();
+		res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	}
 
-  if (res == DD_OK) {
-    SubmitCopyRect(&ddsd);
+	if (res == DD_OK) {
+		SubmitCopyRect(&ddsd);
 
-    MxU8 *line = (MxU8 *) ddsd.lpSurface + m_animationTimer * ddsd.lPitch;
+		MxU8* line = (MxU8*) ddsd.lpSurface + m_animationTimer * ddsd.lPitch;
 
-    MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
-    MxS32 bytesPerLine = bytesPerPixel * 640;
+		MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
+		MxS32 bytesPerLine = bytesPerPixel * 640;
 
-    memset(line, 0, bytesPerLine);
+		memset(line, 0, bytesPerLine);
 
-    for (MxS32 i = m_animationTimer + 1; i < 480 - m_animationTimer; i++) {
-      line += ddsd.lPitch;
+		for (MxS32 i = m_animationTimer + 1; i < 480 - m_animationTimer; i++) {
+			line += ddsd.lPitch;
 
-      memset(line + m_animationTimer * bytesPerPixel, 0, bytesPerPixel);
-      memset(line + 640 + (-1 - m_animationTimer) * bytesPerPixel, 0, bytesPerPixel);
-    }
+			memset(line + m_animationTimer * bytesPerPixel, 0, bytesPerPixel);
+			memset(line + 640 + (-1 - m_animationTimer) * bytesPerPixel, 0, bytesPerPixel);
+		}
 
-    line += ddsd.lPitch;
-    memset(line, 0, bytesPerLine);
+		line += ddsd.lPitch;
+		memset(line, 0, bytesPerLine);
 
-    SetupCopyRect(&ddsd);
-    m_ddSurface->Unlock(ddsd.lpSurface);
+		SetupCopyRect(&ddsd);
+		m_ddSurface->Unlock(ddsd.lpSurface);
 
-    m_animationTimer++;
-  }
+		m_animationTimer++;
+	}
 }
 
 // OFFSET: LEGO1 0x1004c3e0
 void MxTransitionManager::Transition_Broken()
 {
-  // This function has no actual animation logic.
-  // It also never calls EndTransition to
-  // properly terminate the transition, so
-  // the game just hangs forever.
+	// This function has no actual animation logic.
+	// It also never calls EndTransition to
+	// properly terminate the transition, so
+	// the game just hangs forever.
 
-  DDSURFACEDESC ddsd;
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
+	DDSURFACEDESC ddsd;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
 
-  HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  if (res == DDERR_SURFACELOST) {
-    m_ddSurface->Restore();
-    res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  }
+	HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	if (res == DDERR_SURFACELOST) {
+		m_ddSurface->Restore();
+		res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	}
 
-  if (res == DD_OK) {
-    SubmitCopyRect(&ddsd);
-    SetupCopyRect(&ddsd);
-    m_ddSurface->Unlock(ddsd.lpSurface);
-  }
+	if (res == DD_OK) {
+		SubmitCopyRect(&ddsd);
+		SetupCopyRect(&ddsd);
+		m_ddSurface->Unlock(ddsd.lpSurface);
+	}
 }
 
 // OFFSET: LEGO1 0x1004c170
 void MxTransitionManager::Transition_Wipe()
 {
-  // If the animation is finished
-  if (m_animationTimer == 240) {
-    m_animationTimer = 0;
-    EndTransition(TRUE);
-    return;
-  }
+	// If the animation is finished
+	if (m_animationTimer == 240) {
+		m_animationTimer = 0;
+		EndTransition(TRUE);
+		return;
+	}
 
-  DDSURFACEDESC ddsd;
-  memset(&ddsd, 0, sizeof(ddsd));
-  ddsd.dwSize = sizeof(ddsd);
+	DDSURFACEDESC ddsd;
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
 
-  HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  if (res == DDERR_SURFACELOST) {
-    m_ddSurface->Restore();
-    res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
-  }
+	HRESULT res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	if (res == DDERR_SURFACELOST) {
+		m_ddSurface->Restore();
+		res = m_ddSurface->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+	}
 
-  if (res == DD_OK) {
-    SubmitCopyRect(&ddsd);
+	if (res == DD_OK) {
+		SubmitCopyRect(&ddsd);
 
-    // For each of the 240 animation ticks, blank out two scanlines
-    // starting at the top of the screen.
-    // (dwRGBBitCount / 8) will tell how many bytes are used per pixel.
-    MxU8 *line = (MxU8*)ddsd.lpSurface + 2*ddsd.lPitch*m_animationTimer;
-    memset(line, 0, 640 * ddsd.ddpfPixelFormat.dwRGBBitCount / 8);
+		// For each of the 240 animation ticks, blank out two scanlines
+		// starting at the top of the screen.
+		// (dwRGBBitCount / 8) will tell how many bytes are used per pixel.
+		MxU8* line = (MxU8*) ddsd.lpSurface + 2 * ddsd.lPitch * m_animationTimer;
+		memset(line, 0, 640 * ddsd.ddpfPixelFormat.dwRGBBitCount / 8);
 
-    line += ddsd.lPitch;
-    memset(line, 0, 640 * ddsd.ddpfPixelFormat.dwRGBBitCount / 8);
+		line += ddsd.lPitch;
+		memset(line, 0, 640 * ddsd.ddpfPixelFormat.dwRGBBitCount / 8);
 
-    SetupCopyRect(&ddsd);
-    m_ddSurface->Unlock(ddsd.lpSurface);
+		SetupCopyRect(&ddsd);
+		m_ddSurface->Unlock(ddsd.lpSurface);
 
-    m_animationTimer++;
-  }
+		m_animationTimer++;
+	}
 }
 
 // OFFSET: LEGO1 0x1004c470
-void MxTransitionManager::SetWaitIndicator(MxVideoPresenter *p_waitIndicator)
+void MxTransitionManager::SetWaitIndicator(MxVideoPresenter* p_waitIndicator)
 {
-  // End current wait indicator
-  if (m_waitIndicator != NULL) {
-    m_waitIndicator->GetAction()->SetFlags(m_waitIndicator->GetAction()->GetFlags() & ~MxDSAction::Flag_Parsed);
-    m_waitIndicator->EndAction();
-    m_waitIndicator = NULL;
-  }
+	// End current wait indicator
+	if (m_waitIndicator != NULL) {
+		m_waitIndicator->GetAction()->SetFlags(m_waitIndicator->GetAction()->GetFlags() & ~MxDSAction::Flag_Parsed);
+		m_waitIndicator->EndAction();
+		m_waitIndicator = NULL;
+	}
 
-  // Check if we were given a new wait indicator
-  if (p_waitIndicator != NULL) {
-    // Setup the new wait indicator
-    m_waitIndicator = p_waitIndicator;
+	// Check if we were given a new wait indicator
+	if (p_waitIndicator != NULL) {
+		// Setup the new wait indicator
+		m_waitIndicator = p_waitIndicator;
 
-    LegoVideoManager *videoManager = VideoManager();
-    videoManager->RemovePresenter(*m_waitIndicator);
+		LegoVideoManager* videoManager = VideoManager();
+		videoManager->RemovePresenter(*m_waitIndicator);
 
-    if (m_waitIndicator->GetCurrentTickleState() < MxPresenter::TickleState_Streaming) {
-      m_waitIndicator->Tickle();
-    }
-  } else {
-    // Disable copy rect
-    m_copyFlags.bit0 = FALSE;
-  }
+		if (m_waitIndicator->GetCurrentTickleState() < MxPresenter::TickleState_Streaming) {
+			m_waitIndicator->Tickle();
+		}
+	}
+	else {
+		// Disable copy rect
+		m_copyFlags.bit0 = FALSE;
+	}
 }
 
 // OFFSET: LEGO1 0x1004c4d0
 void MxTransitionManager::SubmitCopyRect(LPDDSURFACEDESC ddsc)
 {
-  // Check if the copy rect is setup
-  if (m_copyFlags.bit0 == FALSE || m_waitIndicator == NULL || m_copyBuffer == NULL) {
-    return;
-  }
+	// Check if the copy rect is setup
+	if (m_copyFlags.bit0 == FALSE || m_waitIndicator == NULL || m_copyBuffer == NULL) {
+		return;
+	}
 
-  // Copy the copy rect onto the surface
-  MxU8 *dst;
+	// Copy the copy rect onto the surface
+	MxU8* dst;
 
-  MxU32 bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
+	MxU32 bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-  const MxU8 *src = (const MxU8 *)m_copyBuffer;
+	const MxU8* src = (const MxU8*) m_copyBuffer;
 
-  MxS32 copyPitch;
-  copyPitch = ((m_copyRect.right - m_copyRect.left) + 1) * bytesPerPixel;
+	MxS32 copyPitch;
+	copyPitch = ((m_copyRect.right - m_copyRect.left) + 1) * bytesPerPixel;
 
-  MxS32 y;
-  dst = (MxU8 *)ddsc->lpSurface + (ddsc->lPitch * m_copyRect.top) + (bytesPerPixel * m_copyRect.left);
+	MxS32 y;
+	dst = (MxU8*) ddsc->lpSurface + (ddsc->lPitch * m_copyRect.top) + (bytesPerPixel * m_copyRect.left);
 
-  for (y = 0; y < m_copyRect.bottom - m_copyRect.top + 1; ++y) {
-    memcpy(dst, src, copyPitch);
-    src += copyPitch;
-    dst += ddsc->lPitch;
-  }
+	for (y = 0; y < m_copyRect.bottom - m_copyRect.top + 1; ++y) {
+		memcpy(dst, src, copyPitch);
+		src += copyPitch;
+		dst += ddsc->lPitch;
+	}
 
-  // Free the copy buffer
-  delete[] m_copyBuffer;
-  m_copyBuffer = NULL;
+	// Free the copy buffer
+	delete[] m_copyBuffer;
+	m_copyBuffer = NULL;
 }
 
 // OFFSET: LEGO1 0x1004c580
 void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC ddsc)
 {
-  // Check if the copy rect is setup
-  if (m_copyFlags.bit0 == FALSE || m_waitIndicator == NULL) {
-    return;
-  }
+	// Check if the copy rect is setup
+	if (m_copyFlags.bit0 == FALSE || m_waitIndicator == NULL) {
+		return;
+	}
 
-  // Tickle wait indicator
-  m_waitIndicator->Tickle();
+	// Tickle wait indicator
+	m_waitIndicator->Tickle();
 
-  // Check if wait indicator has started
-  if (m_waitIndicator->GetCurrentTickleState() >= MxPresenter::TickleState_Streaming) {
-    // Setup the copy rect
-    MxU32 copyPitch = (ddsc->ddpfPixelFormat.dwRGBBitCount / 8) * (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
-    MxU32 bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
+	// Check if wait indicator has started
+	if (m_waitIndicator->GetCurrentTickleState() >= MxPresenter::TickleState_Streaming) {
+		// Setup the copy rect
+		MxU32 copyPitch = (ddsc->ddpfPixelFormat.dwRGBBitCount / 8) *
+						  (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
+		MxU32 bytesPerPixel = ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-    m_copyRect.left = m_waitIndicator->GetLocationX();
-    m_copyRect.top = m_waitIndicator->GetLocationY();
+		m_copyRect.left = m_waitIndicator->GetLocationX();
+		m_copyRect.top = m_waitIndicator->GetLocationY();
 
-    MxS32 height = m_waitIndicator->GetHeight();
-    MxS32 width = m_waitIndicator->GetWidth();
+		MxS32 height = m_waitIndicator->GetHeight();
+		MxS32 width = m_waitIndicator->GetWidth();
 
-    m_copyRect.right = m_copyRect.left + width - 1;
-    m_copyRect.bottom = m_copyRect.top + height - 1;
+		m_copyRect.right = m_copyRect.left + width - 1;
+		m_copyRect.bottom = m_copyRect.top + height - 1;
 
-    // Allocate the copy buffer
-    const MxU8 *src = (const MxU8*)ddsc->lpSurface + m_copyRect.top * ddsc->lPitch + bytesPerPixel * m_copyRect.left;
+		// Allocate the copy buffer
+		const MxU8* src =
+			(const MxU8*) ddsc->lpSurface + m_copyRect.top * ddsc->lPitch + bytesPerPixel * m_copyRect.left;
 
-    m_copyBuffer = new MxU8[bytesPerPixel * width * height];
-    if (!m_copyBuffer)
-      return;
+		m_copyBuffer = new MxU8[bytesPerPixel * width * height];
+		if (!m_copyBuffer)
+			return;
 
-    // Copy into the copy buffer
-    MxU8 *dst = m_copyBuffer;
+		// Copy into the copy buffer
+		MxU8* dst = m_copyBuffer;
 
-    for (MxS32 i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++)
-    {
-      memcpy(dst, src, copyPitch);
-      src += ddsc->lPitch;
-      dst += copyPitch;
-    }
-  }
+		for (MxS32 i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++) {
+			memcpy(dst, src, copyPitch);
+			src += ddsc->lPitch;
+			dst += copyPitch;
+		}
+	}
 
-  // Setup display surface
-  if ((m_waitIndicator->GetAction()->GetFlags() & MxDSAction::Flag_Bit5) != 0)
-  {
-    MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
-    MxBool unkbool = FALSE;
-    displaySurface->vtable2c(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetLocationX(), m_waitIndicator->GetLocationY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight(), unkbool);
-  }
-  else
-  {
-    MxDisplaySurface *displaySurface = VideoManager()->GetDisplaySurface();
-    displaySurface->vtable24(ddsc, m_waitIndicator->m_bitmap, 0, 0, m_waitIndicator->GetLocationX(), m_waitIndicator->GetLocationY(), m_waitIndicator->GetWidth(), m_waitIndicator->GetHeight());
-  }
+	// Setup display surface
+	if ((m_waitIndicator->GetAction()->GetFlags() & MxDSAction::Flag_Bit5) != 0) {
+		MxDisplaySurface* displaySurface = VideoManager()->GetDisplaySurface();
+		MxBool unkbool = FALSE;
+		displaySurface->vtable2c(
+			ddsc,
+			m_waitIndicator->m_bitmap,
+			0,
+			0,
+			m_waitIndicator->GetLocationX(),
+			m_waitIndicator->GetLocationY(),
+			m_waitIndicator->GetWidth(),
+			m_waitIndicator->GetHeight(),
+			unkbool
+		);
+	}
+	else {
+		MxDisplaySurface* displaySurface = VideoManager()->GetDisplaySurface();
+		displaySurface->vtable24(
+			ddsc,
+			m_waitIndicator->m_bitmap,
+			0,
+			0,
+			m_waitIndicator->GetLocationX(),
+			m_waitIndicator->GetLocationY(),
+			m_waitIndicator->GetWidth(),
+			m_waitIndicator->GetHeight()
+		);
+	}
 }

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -1,77 +1,75 @@
 #ifndef MXTRANSITIONMANAGER_H
 #define MXTRANSITIONMANAGER_H
 
+#include "legoomni.h"
 #include "mxcore.h"
 #include "mxvideopresenter.h"
-#include "legoomni.h"
 
 #include <ddraw.h>
 
 // VTABLE 0x100d7ea0
-class MxTransitionManager : public MxCore
-{
+class MxTransitionManager : public MxCore {
 public:
-  MxTransitionManager();
-  virtual ~MxTransitionManager() override; // vtable+0x0
+	MxTransitionManager();
+	virtual ~MxTransitionManager() override; // vtable+0x0
 
-  __declspec(dllexport) void SetWaitIndicator(MxVideoPresenter *p_waitIndicator);
+	__declspec(dllexport) void SetWaitIndicator(MxVideoPresenter* p_waitIndicator);
 
-  virtual MxResult Tickle(); // vtable+0x8
+	virtual MxResult Tickle(); // vtable+0x8
 
-  // OFFSET: LEGO1 0x1004b950
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    return "MxTransitionManager";
-  }
+	// OFFSET: LEGO1 0x1004b950
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		return "MxTransitionManager";
+	}
 
-  // OFFSET: LEGO1 0x1004b960
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxTransitionManager::ClassName()) || MxCore::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1004b960
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxTransitionManager::ClassName()) || MxCore::IsA(name);
+	}
 
-  virtual MxResult GetDDrawSurfaceFromVideoManager(); // vtable+0x14
+	virtual MxResult GetDDrawSurfaceFromVideoManager(); // vtable+0x14
 
-  enum TransitionType {
-    NOT_TRANSITIONING,
-    NO_ANIMATION,
-    DISSOLVE,
-    PIXELATION,
-    SCREEN_WIPE,
-    WINDOWS,
-    BROKEN // Unknown what this is supposed to be, it locks the game up
-  };
+	enum TransitionType {
+		NOT_TRANSITIONING,
+		NO_ANIMATION,
+		DISSOLVE,
+		PIXELATION,
+		SCREEN_WIPE,
+		WINDOWS,
+		BROKEN // Unknown what this is supposed to be, it locks the game up
+	};
 
-  MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, MxBool p_doCopy, MxBool p_playMusicInAnim);
-
+	MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, MxBool p_doCopy, MxBool p_playMusicInAnim);
 
 private:
-  void EndTransition(MxBool p_notifyWorld);
-  void Transition_None();
-  void Transition_Dissolve();
-  void Transition_Pixelation();
-  void Transition_Wipe();
-  void Transition_Windows();
-  void Transition_Broken();
+	void EndTransition(MxBool p_notifyWorld);
+	void Transition_None();
+	void Transition_Dissolve();
+	void Transition_Pixelation();
+	void Transition_Wipe();
+	void Transition_Windows();
+	void Transition_Broken();
 
-  void SubmitCopyRect(LPDDSURFACEDESC ddsc);
-  void SetupCopyRect(LPDDSURFACEDESC ddsc);
+	void SubmitCopyRect(LPDDSURFACEDESC ddsc);
+	void SetupCopyRect(LPDDSURFACEDESC ddsc);
 
-  MxVideoPresenter *m_waitIndicator;
-  RECT m_copyRect;
-  MxU8 *m_copyBuffer;
+	MxVideoPresenter* m_waitIndicator;
+	RECT m_copyRect;
+	MxU8* m_copyBuffer;
 
-  flag_bitfield m_copyFlags;
-  undefined4 m_unk24;
-  flag_bitfield m_unk28;
+	flag_bitfield m_copyFlags;
+	undefined4 m_unk24;
+	flag_bitfield m_unk28;
 
-  TransitionType m_transitionType;
-  LPDIRECTDRAWSURFACE m_ddSurface;
-  MxU16 m_animationTimer;
-  MxU16 m_columnOrder[640]; // 0x36
-  MxU16 m_randomShift[480]; // 0x536
-  MxULong m_systemTime; // 0x8f8
-  MxS32 m_animationSpeed; // 0x8fc
+	TransitionType m_transitionType;
+	LPDIRECTDRAWSURFACE m_ddSurface;
+	MxU16 m_animationTimer;
+	MxU16 m_columnOrder[640]; // 0x36
+	MxU16 m_randomShift[480]; // 0x536
+	MxULong m_systemTime;     // 0x8f8
+	MxS32 m_animationSpeed;   // 0x8fc
 };
 
 #endif // MXTRANSITIONMANAGER_H

--- a/LEGO1/mxtype17notificationparam.h
+++ b/LEGO1/mxtype17notificationparam.h
@@ -1,22 +1,20 @@
 #ifndef MXTYPE17NOTIFICATIONPARAM_H
 #define MXTYPE17NOTIFICATIONPARAM_H
 
+#include "decomp.h"
 #include "mxnotificationparam.h"
 
-#include "decomp.h"
-
 // ??? This type is handled, but seemingly never created and no VTABLE fits
-class MxType17NotificationParam : public MxNotificationParam
-{
+class MxType17NotificationParam : public MxNotificationParam {
 public:
-  inline MxU32 GetUnknown20() { return m_unk20; }
-  inline MxU16 GetUnknown28() { return m_unk28; }
+	inline MxU32 GetUnknown20() { return m_unk20; }
+	inline MxU16 GetUnknown28() { return m_unk28; }
 
 protected:
-  undefined m_unkc[0x14];
-  MxU32 m_unk20;
-  undefined4 m_unk24;
-  MxU16 m_unk28;
+	undefined m_unkc[0x14];
+	MxU32 m_unk20;
+	undefined4 m_unk24;
+	MxU16 m_unk28;
 };
 
 #endif // MXTYPE17NOTIFICATIONPARAM_H

--- a/LEGO1/mxtypes.h
+++ b/LEGO1/mxtypes.h
@@ -51,17 +51,17 @@ typedef MxU8 MxBool;
 
 // Must be union with struct for match.
 typedef union {
-  struct {
-    MxU8 bit0: 1;
-    MxU8 bit1: 1;
-    MxU8 bit2: 1;
-    MxU8 bit3: 1;
-    MxU8 bit4: 1;
-    MxU8 bit5: 1;
-    MxU8 bit6: 1;
-    MxU8 bit7: 1;
-  };
-  // BYTE all; // ?
+	struct {
+		MxU8 bit0 : 1;
+		MxU8 bit1 : 1;
+		MxU8 bit2 : 1;
+		MxU8 bit3 : 1;
+		MxU8 bit4 : 1;
+		MxU8 bit5 : 1;
+		MxU8 bit6 : 1;
+		MxU8 bit7 : 1;
+	};
+	// BYTE all; // ?
 } flag_bitfield;
 
 #endif // MXTYPE_H

--- a/LEGO1/mxunklist.h
+++ b/LEGO1/mxunklist.h
@@ -5,33 +5,34 @@
 #include "mxtypes.h"
 
 /*
-* This is an as-of-yet unknown list-like data structure.
-* The class hierarchy/structure isn't quite correct yet.
-*/
+ * This is an as-of-yet unknown list-like data structure.
+ * The class hierarchy/structure isn't quite correct yet.
+ */
 
 struct MxUnkListNode {
-  MxUnkListNode *m_unk00;
-  MxUnkListNode *m_unk04;
-  undefined4 m_unk08;
+	MxUnkListNode* m_unk00;
+	MxUnkListNode* m_unk04;
+	undefined4 m_unk08;
 };
 
 class MxUnkList {
 public:
-  inline MxUnkList() {
-    undefined unk;
-    this->m_unk00 = unk;
+	inline MxUnkList()
+	{
+		undefined unk;
+		this->m_unk00 = unk;
 
-    MxUnkListNode *node = new MxUnkListNode();
-    node->m_unk00 = node;
-    node->m_unk04 = node;
-    
-    this->m_head = node;
-    this->m_count = 0;
-  }
+		MxUnkListNode* node = new MxUnkListNode();
+		node->m_unk00 = node;
+		node->m_unk04 = node;
 
-  undefined m_unk00;
-  MxUnkListNode *m_head;
-  MxU32 m_count;
+		this->m_head = node;
+		this->m_count = 0;
+	}
+
+	undefined m_unk00;
+	MxUnkListNode* m_head;
+	MxU32 m_count;
 };
 
 #endif // MXUNKLIST_H

--- a/LEGO1/mxvariable.cpp
+++ b/LEGO1/mxvariable.cpp
@@ -1,23 +1,24 @@
 #include "mxvariable.h"
-#include "mxstring.h"
+
 #include "decomp.h"
+#include "mxstring.h"
 
 DECOMP_SIZE_ASSERT(MxVariable, 0x24)
 
 // OFFSET: LEGO1 0x1003bea0
-MxString *MxVariable::GetValue()
+MxString* MxVariable::GetValue()
 {
-  return &m_value;
+	return &m_value;
 }
 
 // OFFSET: LEGO1 0x1003beb0
-void MxVariable::SetValue(const char *value)
+void MxVariable::SetValue(const char* value)
 {
-  m_value = value;
+	m_value = value;
 }
 
 // OFFSET: LEGO1 0x1003bec0
 void MxVariable::Destroy()
 {
-  delete this;
+	delete this;
 }

--- a/LEGO1/mxvariable.h
+++ b/LEGO1/mxvariable.h
@@ -1,35 +1,34 @@
 #ifndef MXVARIABLE_H
 #define MXVARIABLE_H
 
-#include "mxstring.h"
 #include "mxcore.h"
+#include "mxstring.h"
 
 // VTABLE 0x100d7498
 // SIZE 0x24
-class MxVariable
-{
+class MxVariable {
 public:
-  MxVariable() {}
-  MxVariable(const char *p_key)
-  {
-    m_key = p_key;
-    m_key.ToUpperCase();    
-  }
-  MxVariable(const char *p_key, const char *p_value)
-  {
-    m_key = p_key;
-    m_key.ToUpperCase();
-    m_value = p_value;
-  }
-  virtual MxString *GetValue();
-  virtual void SetValue(const char *);
-  virtual void Destroy();
+	MxVariable() {}
+	MxVariable(const char* p_key)
+	{
+		m_key = p_key;
+		m_key.ToUpperCase();
+	}
+	MxVariable(const char* p_key, const char* p_value)
+	{
+		m_key = p_key;
+		m_key.ToUpperCase();
+		m_value = p_value;
+	}
+	virtual MxString* GetValue();
+	virtual void SetValue(const char*);
+	virtual void Destroy();
 
-  inline const MxString *GetKey() const { return &m_key; }
+	inline const MxString* GetKey() const { return &m_key; }
 
 protected:
-  MxString m_key;
-  MxString m_value;
+	MxString m_key;
+	MxString m_value;
 };
 
 #endif // MXVARIABLE_H

--- a/LEGO1/mxvariabletable.cpp
+++ b/LEGO1/mxvariabletable.cpp
@@ -1,66 +1,66 @@
 #include "mxvariabletable.h"
 
 // OFFSET: LEGO1 0x100b7330
-MxS8 MxVariableTable::Compare(MxVariable *p_var0, MxVariable *p_var1)
+MxS8 MxVariableTable::Compare(MxVariable* p_var0, MxVariable* p_var1)
 {
-  return strcmp(p_var0->GetKey()->GetData(),
-                p_var1->GetKey()->GetData());
+	return strcmp(p_var0->GetKey()->GetData(), p_var1->GetKey()->GetData());
 }
 
 // OFFSET: LEGO1 0x100b7370
-MxU32 MxVariableTable::Hash(MxVariable *p_var)
+MxU32 MxVariableTable::Hash(MxVariable* p_var)
 {
-  const char *str = p_var->GetKey()->GetData();
-  MxU32 value = 0;
-  
-  for (int i = 0; str[i]; i++) {
-    value += str[i];
-  }
+	const char* str = p_var->GetKey()->GetData();
+	MxU32 value = 0;
 
-  return value;
+	for (int i = 0; str[i]; i++) {
+		value += str[i];
+	}
+
+	return value;
 }
 
 // OFFSET: LEGO1 0x100b73a0
-void MxVariableTable::SetVariable(const char *p_key, const char *p_value)
+void MxVariableTable::SetVariable(const char* p_key, const char* p_value)
 {
-  MxHashTableCursor<MxVariable> cursor(this);
-  MxVariable *var = new MxVariable(p_key, p_value);
+	MxHashTableCursor<MxVariable> cursor(this);
+	MxVariable* var = new MxVariable(p_key, p_value);
 
-  if (cursor.Find(var)) {
-    delete var;
-    cursor.GetMatch(var);
-    var->SetValue(p_value);
-  } else {
-    MxHashTable<MxVariable>::Add(var);
-  }
+	if (cursor.Find(var)) {
+		delete var;
+		cursor.GetMatch(var);
+		var->SetValue(p_value);
+	}
+	else {
+		MxHashTable<MxVariable>::Add(var);
+	}
 }
 
 // OFFSET: LEGO1 0x100b7740
-void MxVariableTable::SetVariable(MxVariable *var)
+void MxVariableTable::SetVariable(MxVariable* var)
 {
-  MxHashTableCursor<MxVariable> cursor(this);
-  MxBool found = cursor.Find(var);
+	MxHashTableCursor<MxVariable> cursor(this);
+	MxBool found = cursor.Find(var);
 
-  if (found)
-    cursor.DeleteMatch();
+	if (found)
+		cursor.DeleteMatch();
 
-  MxHashTable<MxVariable>::Add(var);
+	MxHashTable<MxVariable>::Add(var);
 }
 
 // OFFSET: LEGO1 0x100b78f0
-const char *MxVariableTable::GetVariable(const char *p_key)
+const char* MxVariableTable::GetVariable(const char* p_key)
 {
-  const char *value = "";
-  MxHashTableCursor<MxVariable> cursor(this);
-  MxVariable *var = new MxVariable(p_key);
-  
-  MxBool found = cursor.Find(var);
-  delete var;
-  
-  if (found) {
-    cursor.GetMatch(var);
-    value = var->GetValue()->GetData();
-  }
+	const char* value = "";
+	MxHashTableCursor<MxVariable> cursor(this);
+	MxVariable* var = new MxVariable(p_key);
 
-  return value;
+	MxBool found = cursor.Find(var);
+	delete var;
+
+	if (found) {
+		cursor.GetMatch(var);
+		value = var->GetValue()->GetData();
+	}
+
+	return value;
 }

--- a/LEGO1/mxvariabletable.h
+++ b/LEGO1/mxvariabletable.h
@@ -1,28 +1,24 @@
 #ifndef MXVARIABLETABLE_H
 #define MXVARIABLETABLE_H
 
-#include "mxtypes.h"
 #include "mxhashtable.h"
+#include "mxtypes.h"
 #include "mxvariable.h"
-
 
 // VTABLE 0x100dc1c8
 // SIZE 0x28
-class MxVariableTable : public MxHashTable<MxVariable>
-{
+class MxVariableTable : public MxHashTable<MxVariable> {
 public:
-  MxVariableTable() {
-    m_customDestructor = Destroy;
-  }
-  __declspec(dllexport) void SetVariable(const char *key, const char *value);
-  __declspec(dllexport) void SetVariable(MxVariable *var);
-  __declspec(dllexport) const char * GetVariable(const char *key);
+	MxVariableTable() { m_customDestructor = Destroy; }
+	__declspec(dllexport) void SetVariable(const char* key, const char* value);
+	__declspec(dllexport) void SetVariable(MxVariable* var);
+	__declspec(dllexport) const char* GetVariable(const char* key);
 
-  // OFFSET: LEGO1 0x100afdb0
-  static void Destroy(MxVariable *p_obj) { p_obj->Destroy(); }
+	// OFFSET: LEGO1 0x100afdb0
+	static void Destroy(MxVariable* p_obj) { p_obj->Destroy(); }
 
-  virtual MxS8 Compare(MxVariable *, MxVariable *); // +0x14
-  virtual MxU32 Hash(MxVariable *); // +0x18
+	virtual MxS8 Compare(MxVariable*, MxVariable*); // +0x14
+	virtual MxU32 Hash(MxVariable*);                // +0x18
 };
 
 #endif // MXVARIABLETABLE_H

--- a/LEGO1/mxvector.cpp
+++ b/LEGO1/mxvector.cpp
@@ -1,10 +1,10 @@
 
 #include "mxvector.h"
 
+#include "decomp.h"
+
 #include <math.h>
 #include <memory.h>
-
-#include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxVector2, 0x8);
 DECOMP_SIZE_ASSERT(MxVector3, 0x8);
@@ -13,424 +13,411 @@ DECOMP_SIZE_ASSERT(MxVector3Data, 0x14);
 DECOMP_SIZE_ASSERT(MxVector4Data, 0x18);
 
 // OFFSET: LEGO1 0x100020a0
-const float *MxVector2::GetData() const
+const float* MxVector2::GetData() const
 {
-  return m_data;
+	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002090
-float *MxVector2::GetData()
+float* MxVector2::GetData()
 {
-  return m_data;
+	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002130
-float MxVector2::Dot(MxVector2 *p_a, float *p_b) const
+float MxVector2::Dot(MxVector2* p_a, float* p_b) const
 {
-  return DotImpl(p_a->m_data, p_b);
+	return DotImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x10002110
-float MxVector2::Dot(float *p_a, MxVector2 *p_b) const
+float MxVector2::Dot(float* p_a, MxVector2* p_b) const
 {
-  return DotImpl(p_a, p_b->m_data);
+	return DotImpl(p_a, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100020f0
-float MxVector2::Dot(MxVector2 *p_a, MxVector2 *p_b) const
+float MxVector2::Dot(MxVector2* p_a, MxVector2* p_b) const
 {
-  return DotImpl(p_a->m_data, p_b->m_data);
+	return DotImpl(p_a->m_data, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100020d0
-float MxVector2::Dot(float *p_a, float *p_b) const
+float MxVector2::Dot(float* p_a, float* p_b) const
 {
-  return DotImpl(p_a, p_b);
+	return DotImpl(p_a, p_b);
 }
 
 // OFFSET: LEGO1 0x10002160
 MxResult MxVector2::Unitize()
 {
-  float sq = LenSquared();
-  if (sq > 0.0f)
-  {
-    float root = sqrt(sq);
-    if (root > 0)
-    {
-      DivScalarImpl(&root);
-      return SUCCESS;
-    }
-  }
-  return FAILURE;
+	float sq = LenSquared();
+	if (sq > 0.0f) {
+		float root = sqrt(sq);
+		if (root > 0) {
+			DivScalarImpl(&root);
+			return SUCCESS;
+		}
+	}
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100021e0
-void MxVector2::AddVector(MxVector2 *p_other)
+void MxVector2::AddVector(MxVector2* p_other)
 {
-  AddVectorImpl(p_other->m_data);
+	AddVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x100021d0
-void MxVector2::AddVector(float *p_other)
+void MxVector2::AddVector(float* p_other)
 {
-  AddVectorImpl(p_other);
+	AddVectorImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x100021c0
 void MxVector2::AddScalar(float p_value)
 {
-  AddScalarImpl(p_value);
+	AddScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x10002200
-void MxVector2::SubVector(MxVector2 *p_other)
+void MxVector2::SubVector(MxVector2* p_other)
 {
-  SubVectorImpl(p_other->m_data);
+	SubVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x100021f0
-void MxVector2::SubVector(float *p_other)
+void MxVector2::SubVector(float* p_other)
 {
-  SubVectorImpl(p_other);
+	SubVectorImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x10002230
-void MxVector2::MullScalar(float *p_value)
+void MxVector2::MullScalar(float* p_value)
 {
-  MullScalarImpl(p_value);
+	MullScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x10002220
-void MxVector2::MullVector(MxVector2 *p_other)
+void MxVector2::MullVector(MxVector2* p_other)
 {
-  MullVectorImpl(p_other->m_data);
+	MullVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x10002210
-void MxVector2::MullVector(float *p_other)
+void MxVector2::MullVector(float* p_other)
 {
-  MullVectorImpl(p_other);
+	MullVectorImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x10002240
-void MxVector2::DivScalar(float *p_value)
+void MxVector2::DivScalar(float* p_value)
 {
-  DivScalarImpl(p_value);
+	DivScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x10002260
-void MxVector2::SetVector(MxVector2 *p_other)
+void MxVector2::SetVector(MxVector2* p_other)
 {
-  EqualsImpl(p_other->m_data);
+	EqualsImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x10002250
-void MxVector2::SetVector(float *p_other)
+void MxVector2::SetVector(float* p_other)
 {
-  EqualsImpl(p_other);
+	EqualsImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x10001fa0
 void MxVector2::AddScalarImpl(float p_value)
 {
-  m_data[0] += p_value;
-  m_data[1] += p_value;
+	m_data[0] += p_value;
+	m_data[1] += p_value;
 }
 
 // OFFSET: LEGO1 0x10001f80
-void MxVector2::AddVectorImpl(float *p_value)
+void MxVector2::AddVectorImpl(float* p_value)
 {
-  m_data[0] += p_value[0];
-  m_data[1] += p_value[1];
+	m_data[0] += p_value[0];
+	m_data[1] += p_value[1];
 }
 
 // OFFSET: LEGO1 0x10001fc0
-void MxVector2::SubVectorImpl(float *p_value)
+void MxVector2::SubVectorImpl(float* p_value)
 {
-  m_data[0] -= p_value[0];
-  m_data[1] -= p_value[1];
+	m_data[0] -= p_value[0];
+	m_data[1] -= p_value[1];
 }
 
 // OFFSET: LEGO1 0x10002000
-void MxVector2::MullScalarImpl(float *p_value)
+void MxVector2::MullScalarImpl(float* p_value)
 {
-  m_data[0] *= *p_value;
-  m_data[1] *= *p_value;
+	m_data[0] *= *p_value;
+	m_data[1] *= *p_value;
 }
 
 // OFFSET: LEGO1 0x10001fe0
-void MxVector2::MullVectorImpl(float *p_value)
+void MxVector2::MullVectorImpl(float* p_value)
 {
-  m_data[0] *= p_value[0];
-  m_data[1] *= p_value[1];
+	m_data[0] *= p_value[0];
+	m_data[1] *= p_value[1];
 }
 
 // OFFSET: LEGO1 0x10002020
-void MxVector2::DivScalarImpl(float *p_value)
+void MxVector2::DivScalarImpl(float* p_value)
 {
-  m_data[0] /= *p_value;
-  m_data[1] /= *p_value;
+	m_data[0] /= *p_value;
+	m_data[1] /= *p_value;
 }
 
 // OFFSET: LEGO1 0x10002040
-float MxVector2::DotImpl(float *p_a, float *p_b) const
+float MxVector2::DotImpl(float* p_a, float* p_b) const
 {
-  return p_b[0] * p_a[0] + p_b[1] * p_a[1];
+	return p_b[0] * p_a[0] + p_b[1] * p_a[1];
 }
 
 // OFFSET: LEGO1 0x10002070
-void MxVector2::EqualsImpl(float *p_data)
+void MxVector2::EqualsImpl(float* p_data)
 {
-  float *vec = m_data;
-  vec[0] = p_data[0];
-  vec[1] = p_data[1];
+	float* vec = m_data;
+	vec[0] = p_data[0];
+	vec[1] = p_data[1];
 }
 
 // OFFSET: LEGO1 0x100020b0
 void MxVector2::Clear()
 {
-  float *vec = m_data;
-  vec[0] = 0.0f;
-  vec[1] = 0.0f;
+	float* vec = m_data;
+	vec[0] = 0.0f;
+	vec[1] = 0.0f;
 }
 
 // OFFSET: LEGO1 0x10002150
 float MxVector2::LenSquared() const
 {
-  return m_data[0] * m_data[0] + m_data[1] * m_data[1];
+	return m_data[0] * m_data[0] + m_data[1] * m_data[1];
 }
 
 // OFFSET: LEGO1 0x10003a90
 void MxVector3::AddScalarImpl(float p_value)
 {
-  m_data[0] += p_value;
-  m_data[1] += p_value;
-  m_data[2] += p_value;
+	m_data[0] += p_value;
+	m_data[1] += p_value;
+	m_data[2] += p_value;
 }
 
 // OFFSET: LEGO1 0x10003a60
-void MxVector3::AddVectorImpl(float *p_value)
+void MxVector3::AddVectorImpl(float* p_value)
 {
-  m_data[0] += p_value[0];
-  m_data[1] += p_value[1];
-  m_data[2] += p_value[2];
+	m_data[0] += p_value[0];
+	m_data[1] += p_value[1];
+	m_data[2] += p_value[2];
 }
 
 // OFFSET: LEGO1 0x10003ac0
-void MxVector3::SubVectorImpl(float *p_value)
+void MxVector3::SubVectorImpl(float* p_value)
 {
-  m_data[0] -= p_value[0];
-  m_data[1] -= p_value[1];
-  m_data[2] -= p_value[2];
+	m_data[0] -= p_value[0];
+	m_data[1] -= p_value[1];
+	m_data[2] -= p_value[2];
 }
 
 // OFFSET: LEGO1 0x10003b20
-void MxVector3::MullScalarImpl(float *p_value)
+void MxVector3::MullScalarImpl(float* p_value)
 {
-  m_data[0] *= *p_value;
-  m_data[1] *= *p_value;
-  m_data[2] *= *p_value;
+	m_data[0] *= *p_value;
+	m_data[1] *= *p_value;
+	m_data[2] *= *p_value;
 }
 
 // OFFSET: LEGO1 0x10003af0
-void MxVector3::MullVectorImpl(float *p_value)
+void MxVector3::MullVectorImpl(float* p_value)
 {
-  m_data[0] *= p_value[0];
-  m_data[1] *= p_value[1];
-  m_data[2] *= p_value[2];
+	m_data[0] *= p_value[0];
+	m_data[1] *= p_value[1];
+	m_data[2] *= p_value[2];
 }
 
 // OFFSET: LEGO1 0x10003b50
-void MxVector3::DivScalarImpl(float *p_value)
+void MxVector3::DivScalarImpl(float* p_value)
 {
-  m_data[0] /= *p_value;
-  m_data[1] /= *p_value;
-  m_data[2] /= *p_value;
+	m_data[0] /= *p_value;
+	m_data[1] /= *p_value;
+	m_data[2] /= *p_value;
 }
 
 // OFFSET: LEGO1 0x10003b80
-float MxVector3::DotImpl(float *p_a, float *p_b) const
+float MxVector3::DotImpl(float* p_a, float* p_b) const
 {
-  return p_a[0] * p_b[0] + p_a[2] * p_b[2] + p_a[1] * p_b[1];
+	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + p_a[1] * p_b[1];
 }
 
 // OFFSET: LEGO1 0x10003ba0
-void MxVector3::EqualsImpl(float *p_data)
+void MxVector3::EqualsImpl(float* p_data)
 {
-  float *vec = m_data;
-  vec[0] = p_data[0];
-  vec[1] = p_data[1];
-  vec[2] = p_data[2];
+	float* vec = m_data;
+	vec[0] = p_data[0];
+	vec[1] = p_data[1];
+	vec[2] = p_data[2];
 }
 
 // OFFSET: LEGO1 0x10003bc0
 void MxVector3::Clear()
 {
-  float *vec = m_data;
-  vec[0] = 0.0f;
-  vec[1] = 0.0f;
-  vec[2] = 0.0f;
+	float* vec = m_data;
+	vec[0] = 0.0f;
+	vec[1] = 0.0f;
+	vec[2] = 0.0f;
 }
 
 // OFFSET: LEGO1 0x10003bd0
 float MxVector3::LenSquared() const
 {
-  return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2];
+	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2];
 }
 
 // OFFSET: LEGO1 0x10002270
 void MxVector3::EqualsCrossImpl(float* p_a, float* p_b)
 {
-  m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
-  m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
-  m_data[2] = p_a[0] * p_b[1] - p_a[1] * p_b[0];
+	m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
+	m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
+	m_data[2] = p_a[0] * p_b[1] - p_a[1] * p_b[0];
 }
 
 // OFFSET: LEGO1 0x10002300
-void MxVector3::EqualsCross(float *p_a, MxVector3 *p_b)
+void MxVector3::EqualsCross(float* p_a, MxVector3* p_b)
 {
-  EqualsCrossImpl(p_a, p_b->m_data);
+	EqualsCrossImpl(p_a, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100022e0
-void MxVector3::EqualsCross(MxVector3 *p_a, float *p_b)
+void MxVector3::EqualsCross(MxVector3* p_a, float* p_b)
 {
-  EqualsCrossImpl(p_a->m_data, p_b);
+	EqualsCrossImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x100022c0
-void MxVector3::EqualsCross(MxVector3 *p_a, MxVector3 *p_b)
+void MxVector3::EqualsCross(MxVector3* p_a, MxVector3* p_b)
 {
-  EqualsCrossImpl(p_a->m_data, p_b->m_data);
+	EqualsCrossImpl(p_a->m_data, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x10003bf0
-void MxVector3::EqualsScalar(float *p_value)
+void MxVector3::EqualsScalar(float* p_value)
 {
-  m_data[0] = *p_value;
-  m_data[1] = *p_value;
-  m_data[2] = *p_value;
+	m_data[0] = *p_value;
+	m_data[1] = *p_value;
+	m_data[2] = *p_value;
 }
 
 // OFFSET: LEGO1 0x100028b0
 void MxVector4::AddScalarImpl(float p_value)
 {
-  m_data[0] += p_value;
-  m_data[1] += p_value;
-  m_data[2] += p_value;
-  m_data[3] += p_value;
+	m_data[0] += p_value;
+	m_data[1] += p_value;
+	m_data[2] += p_value;
+	m_data[3] += p_value;
 }
 
 // OFFSET: LEGO1 0x10002870
-void MxVector4::AddVectorImpl(float *p_value)
+void MxVector4::AddVectorImpl(float* p_value)
 {
-  m_data[0] += p_value[0];
-  m_data[1] += p_value[1];
-  m_data[2] += p_value[2];
-  m_data[3] += p_value[3];
+	m_data[0] += p_value[0];
+	m_data[1] += p_value[1];
+	m_data[2] += p_value[2];
+	m_data[3] += p_value[3];
 }
 
 // OFFSET: LEGO1 0x100028f0
-void MxVector4::SubVectorImpl(float *p_value)
+void MxVector4::SubVectorImpl(float* p_value)
 {
-  m_data[0] -= p_value[0];
-  m_data[1] -= p_value[1];
-  m_data[2] -= p_value[2];
-  m_data[3] -= p_value[3];
+	m_data[0] -= p_value[0];
+	m_data[1] -= p_value[1];
+	m_data[2] -= p_value[2];
+	m_data[3] -= p_value[3];
 }
 
 // OFFSET: LEGO1 0x10002970
-void MxVector4::MullScalarImpl(float *p_value)
+void MxVector4::MullScalarImpl(float* p_value)
 {
-  m_data[0] *= *p_value;
-  m_data[1] *= *p_value;
-  m_data[2] *= *p_value;
-  m_data[3] *= *p_value;
+	m_data[0] *= *p_value;
+	m_data[1] *= *p_value;
+	m_data[2] *= *p_value;
+	m_data[3] *= *p_value;
 }
 
 // OFFSET: LEGO1 0x10002930
-void MxVector4::MullVectorImpl(float *p_value)
+void MxVector4::MullVectorImpl(float* p_value)
 {
-  m_data[0] *= p_value[0];
-  m_data[1] *= p_value[1];
-  m_data[2] *= p_value[2];
-  m_data[3] *= p_value[3];
+	m_data[0] *= p_value[0];
+	m_data[1] *= p_value[1];
+	m_data[2] *= p_value[2];
+	m_data[3] *= p_value[3];
 }
 
 // OFFSET: LEGO1 0x100029b0
-void MxVector4::DivScalarImpl(float *p_value)
+void MxVector4::DivScalarImpl(float* p_value)
 {
-  m_data[0] /= *p_value;
-  m_data[1] /= *p_value;
-  m_data[2] /= *p_value;
-  m_data[3] /= *p_value;
+	m_data[0] /= *p_value;
+	m_data[1] /= *p_value;
+	m_data[2] /= *p_value;
+	m_data[3] /= *p_value;
 }
 
 // OFFSET: LEGO1 0x100029f0
-float MxVector4::DotImpl(float *p_a, float *p_b) const
+float MxVector4::DotImpl(float* p_a, float* p_b) const
 {
-  return
-    p_a[0] * p_b[0] + p_a[2] * p_b[2] +
-    (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
+	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
 }
 
 // OFFSET: LEGO1 0x10002a20
-void MxVector4::EqualsImpl(float *p_data)
+void MxVector4::EqualsImpl(float* p_data)
 {
-  float *vec = m_data;
-  vec[0] = p_data[0];
-  vec[1] = p_data[1];
-  vec[2] = p_data[2];
-  vec[3] = p_data[3];
+	float* vec = m_data;
+	vec[0] = p_data[0];
+	vec[1] = p_data[1];
+	vec[2] = p_data[2];
+	vec[3] = p_data[3];
 }
 
 // OFFSET: LEGO1 0x10002b00
 void MxVector4::Clear()
 {
-  float *vec = m_data;
-  vec[0] = 0.0f;
-  vec[1] = 0.0f;
-  vec[2] = 0.0f;
-  vec[3] = 0.0f;
+	float* vec = m_data;
+	vec[0] = 0.0f;
+	vec[1] = 0.0f;
+	vec[2] = 0.0f;
+	vec[3] = 0.0f;
 }
 
 // OFFSET: LEGO1 0x10002b20
 float MxVector4::LenSquared() const
 {
-  return m_data[1] * m_data[1] + m_data[0] * m_data[0] + 
-    m_data[2] * m_data[2] + m_data[3] * m_data[3];
+	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2] + m_data[3] * m_data[3];
 }
 
 // OFFSET: LEGO1 0x10002b40
-void MxVector4::EqualsScalar(float *p_value)
+void MxVector4::EqualsScalar(float* p_value)
 {
-  m_data[0] = *p_value;
-  m_data[1] = *p_value;
-  m_data[2] = *p_value;
-  m_data[3] = *p_value;
+	m_data[0] = *p_value;
+	m_data[1] = *p_value;
+	m_data[2] = *p_value;
+	m_data[3] = *p_value;
 }
 
 // OFFSET: LEGO1 0x10002ae0
-void MxVector4::SetMatrixProduct(MxVector4 *p_a, float *p_b)
+void MxVector4::SetMatrixProduct(MxVector4* p_a, float* p_b)
 {
-  SetMatrixProductImpl(p_a->m_data, p_b);
+	SetMatrixProductImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x10002a40
-void MxVector4::SetMatrixProductImpl(float *p_vec, float *p_mat)
+void MxVector4::SetMatrixProductImpl(float* p_vec, float* p_mat)
 {
-  m_data[0] =
-      p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] +
-      p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
-  m_data[1] =
-      p_vec[0] * p_mat[1] + p_vec[1] * p_mat[5] +
-      p_vec[2] * p_mat[9] + p_vec[4] * p_mat[13];
-  m_data[2] =
-      p_vec[0] * p_mat[2] + p_vec[1] * p_mat[6] +
-      p_vec[2] * p_mat[10] + p_vec[4] * p_mat[14];
-  m_data[3] =
-      p_vec[0] * p_mat[3] + p_vec[1] * p_mat[7] +
-      p_vec[2] * p_mat[11] + p_vec[4] * p_mat[15];
+	m_data[0] = p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] + p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
+	m_data[1] = p_vec[0] * p_mat[1] + p_vec[1] * p_mat[5] + p_vec[2] * p_mat[9] + p_vec[4] * p_mat[13];
+	m_data[2] = p_vec[0] * p_mat[2] + p_vec[1] * p_mat[6] + p_vec[2] * p_mat[10] + p_vec[4] * p_mat[14];
+	m_data[3] = p_vec[0] * p_mat[3] + p_vec[1] * p_mat[7] + p_vec[2] * p_mat[11] + p_vec[4] * p_mat[15];
 }
 
 // Note close yet, included because I'm at least confident I know what operation
@@ -438,35 +425,33 @@ void MxVector4::SetMatrixProductImpl(float *p_vec, float *p_mat)
 // OFFSET: LEGO1 0x10002b70 STUB
 MxResult MxVector4::NormalizeQuaternion()
 {
-  float *v = m_data;
-  float magnitude = v[1] * v[1] + v[2] * v[2] + v[0] * v[0];
-  if (magnitude > 0.0f)
-  {
-    float theta = v[3] * 0.5f;
-    v[3] = cos(theta);
-    float frac = sin(theta);
-    magnitude = frac / sqrt(magnitude);
-    v[0] *= magnitude;
-    v[1] *= magnitude;
-    v[2] *= magnitude;
-    return SUCCESS;
-  }
-  return FAILURE;
+	float* v = m_data;
+	float magnitude = v[1] * v[1] + v[2] * v[2] + v[0] * v[0];
+	if (magnitude > 0.0f) {
+		float theta = v[3] * 0.5f;
+		v[3] = cos(theta);
+		float frac = sin(theta);
+		magnitude = frac / sqrt(magnitude);
+		v[0] *= magnitude;
+		v[1] *= magnitude;
+		v[2] *= magnitude;
+		return SUCCESS;
+	}
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x10002bf0
-void MxVector4::UnknownQuaternionOp(MxVector4 *p_a, MxVector4 *p_b)
+void MxVector4::UnknownQuaternionOp(MxVector4* p_a, MxVector4* p_b)
 {
-  MxFloat *bDat = p_b->m_data;
-  MxFloat *aDat = p_a->m_data;
+	MxFloat* bDat = p_b->m_data;
+	MxFloat* aDat = p_a->m_data;
 
-  this->m_data[3] = aDat[3] * bDat[3] - (bDat[0] * aDat[0] + aDat[2] *bDat[2] + aDat[1] * aDat[1]);
-  this->m_data[0] = bDat[2] * aDat[1] - bDat[1] * aDat[2];
-  this->m_data[1] = aDat[2] * bDat[0] - bDat[2] * aDat[0];
-  this->m_data[2] = bDat[1] * aDat[0] - aDat[1] * bDat[0];
+	this->m_data[3] = aDat[3] * bDat[3] - (bDat[0] * aDat[0] + aDat[2] * bDat[2] + aDat[1] * aDat[1]);
+	this->m_data[0] = bDat[2] * aDat[1] - bDat[1] * aDat[2];
+	this->m_data[1] = aDat[2] * bDat[0] - bDat[2] * aDat[0];
+	this->m_data[2] = bDat[1] * aDat[0] - aDat[1] * bDat[0];
 
-
-  m_data[0] = p_b->m_data[3] * p_a->m_data[0] + p_a->m_data[3] * p_b->m_data[0] + m_data[0];
-  m_data[1] = p_b->m_data[1] * p_a->m_data[3] + p_a->m_data[1] * p_b->m_data[3] + m_data[1];
-  m_data[2] = p_b->m_data[2] * p_a->m_data[3] + p_a->m_data[2] * p_b->m_data[3] + m_data[2];
+	m_data[0] = p_b->m_data[3] * p_a->m_data[0] + p_a->m_data[3] * p_b->m_data[0] + m_data[0];
+	m_data[1] = p_b->m_data[1] * p_a->m_data[3] + p_a->m_data[1] * p_b->m_data[3] + m_data[1];
+	m_data[2] = p_b->m_data[2] * p_a->m_data[3] + p_a->m_data[2] * p_b->m_data[3] + m_data[2];
 }

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -2,181 +2,176 @@
 #define MXVECTOR_H
 
 #include "mxtypes.h"
+
 #include <vec.h>
 
 // VTABLE 0x100d4288
 // SIZE 0x8
-class MxVector2
-{
+class MxVector2 {
 public:
-  // OFFSET: LEGO1 0x1000c0f0
-  inline MxVector2(float* p_data) { this->SetData(p_data); }
+	// OFFSET: LEGO1 0x1000c0f0
+	inline MxVector2(float* p_data) { this->SetData(p_data); }
 
-  // vtable + 0x00 (no virtual destructor)
-  virtual void AddScalarImpl(float p_value) = 0;
-  virtual void AddVectorImpl(float *p_value) = 0;
-  virtual void SubVectorImpl(float *p_value) = 0;
-  virtual void MullScalarImpl(float *p_value) = 0;
+	// vtable + 0x00 (no virtual destructor)
+	virtual void AddScalarImpl(float p_value) = 0;
+	virtual void AddVectorImpl(float* p_value) = 0;
+	virtual void SubVectorImpl(float* p_value) = 0;
+	virtual void MullScalarImpl(float* p_value) = 0;
 
-  // vtable + 0x10
-  virtual void MullVectorImpl(float *p_value) = 0;
-  virtual void DivScalarImpl(float *p_value) = 0;
-  virtual float DotImpl(float *p_a, float *p_b) const = 0;
+	// vtable + 0x10
+	virtual void MullVectorImpl(float* p_value) = 0;
+	virtual void DivScalarImpl(float* p_value) = 0;
+	virtual float DotImpl(float* p_a, float* p_b) const = 0;
 
-  // OFFSET: LEGO1 0x10002060
-  virtual void SetData(float *p_data) { this->m_data = p_data; }
+	// OFFSET: LEGO1 0x10002060
+	virtual void SetData(float* p_data) { this->m_data = p_data; }
 
-  // vtable + 0x20
-  virtual void EqualsImpl(float *p_data) = 0;
-  virtual const float *GetData() const;
-  virtual float *GetData();
-  virtual void Clear() = 0;
+	// vtable + 0x20
+	virtual void EqualsImpl(float* p_data) = 0;
+	virtual const float* GetData() const;
+	virtual float* GetData();
+	virtual void Clear() = 0;
 
-  // vtable + 0x30
-  virtual float Dot(MxVector2 *p_a, float *p_b) const;
-  virtual float Dot(float *p_a, MxVector2 *p_b) const;
-  virtual float Dot(MxVector2 *p_a, MxVector2 *p_b) const;
-  virtual float Dot(float *p_a, float *p_b) const;
+	// vtable + 0x30
+	virtual float Dot(MxVector2* p_a, float* p_b) const;
+	virtual float Dot(float* p_a, MxVector2* p_b) const;
+	virtual float Dot(MxVector2* p_a, MxVector2* p_b) const;
+	virtual float Dot(float* p_a, float* p_b) const;
 
-  // vtable + 0x40
-  virtual float LenSquared() const = 0;
-  virtual MxResult Unitize();
+	// vtable + 0x40
+	virtual float LenSquared() const = 0;
+	virtual MxResult Unitize();
 
-  // vtable + 0x48
-  virtual void AddVector(MxVector2 *p_other);
-  virtual void AddVector(float *p_other);
-  virtual void AddScalar(float p_value);
+	// vtable + 0x48
+	virtual void AddVector(MxVector2* p_other);
+	virtual void AddVector(float* p_other);
+	virtual void AddScalar(float p_value);
 
-  // vtable + 0x54
-  virtual void SubVector(MxVector2 *p_other);
-  virtual void SubVector(float *p_other);
+	// vtable + 0x54
+	virtual void SubVector(MxVector2* p_other);
+	virtual void SubVector(float* p_other);
 
-  // vtable + 0x5C
-  virtual void MullScalar(float *p_value);
-  virtual void MullVector(MxVector2 *p_other);
-  virtual void MullVector(float *p_other);
-  virtual void DivScalar(float *p_value);
+	// vtable + 0x5C
+	virtual void MullScalar(float* p_value);
+	virtual void MullVector(MxVector2* p_other);
+	virtual void MullVector(float* p_other);
+	virtual void DivScalar(float* p_value);
 
-  // vtable + 0x6C
-  virtual void SetVector(MxVector2 *p_other);
-  virtual void SetVector(float *p_other);
+	// vtable + 0x6C
+	virtual void SetVector(MxVector2* p_other);
+	virtual void SetVector(float* p_other);
 
-  inline float& operator[](size_t idx) { return m_data[idx]; }
-  inline const float& operator[](size_t idx) const { return m_data[idx]; }
+	inline float& operator[](size_t idx) { return m_data[idx]; }
+	inline const float& operator[](size_t idx) const { return m_data[idx]; }
+
 protected:
-  float *m_data;
+	float* m_data;
 };
 
 // VTABLE 0x100d4518
 // SIZE 0x8
-class MxVector3 : public MxVector2
-{
+class MxVector3 : public MxVector2 {
 public:
-  inline MxVector3(float* p_data) : MxVector2(p_data) {}
+	inline MxVector3(float* p_data) : MxVector2(p_data) {}
 
-  void AddScalarImpl(float p_value);
+	void AddScalarImpl(float p_value);
 
-  void AddVectorImpl(float *p_value);
+	void AddVectorImpl(float* p_value);
 
-  void SubVectorImpl(float *p_value);
-  void MullScalarImpl(float *p_value);
-  void MullVectorImpl(float *p_value);
-  void DivScalarImpl(float *p_value);
-  float DotImpl(float *p_a, float *p_b) const;
+	void SubVectorImpl(float* p_value);
+	void MullScalarImpl(float* p_value);
+	void MullVectorImpl(float* p_value);
+	void DivScalarImpl(float* p_value);
+	float DotImpl(float* p_a, float* p_b) const;
 
-  void EqualsImpl(float *p_data);
+	void EqualsImpl(float* p_data);
 
-  void Clear();
+	void Clear();
 
-  float LenSquared() const;
+	float LenSquared() const;
 
-  // vtable + 0x74
-  virtual void EqualsCrossImpl(float* p_a, float* p_b);
-  virtual void EqualsCross(float *p_a, MxVector3 *p_b);
-  virtual void EqualsCross(MxVector3 *p_a, float *p_b);
-  virtual void EqualsCross(MxVector3 *p_a, MxVector3 *p_b);
-  virtual void EqualsScalar(float *p_value);
+	// vtable + 0x74
+	virtual void EqualsCrossImpl(float* p_a, float* p_b);
+	virtual void EqualsCross(float* p_a, MxVector3* p_b);
+	virtual void EqualsCross(MxVector3* p_a, float* p_b);
+	virtual void EqualsCross(MxVector3* p_a, MxVector3* p_b);
+	virtual void EqualsScalar(float* p_value);
 
-  inline void Fill(float p_value) { EqualsScalar(&p_value); }
+	inline void Fill(float p_value) { EqualsScalar(&p_value); }
 };
 
 // VTABLE 0x100d45a0
 // SIZE 0x8
-class MxVector4 : public MxVector3
-{
+class MxVector4 : public MxVector3 {
 public:
-  inline MxVector4(float* p_data) : MxVector3(p_data) {}
+	inline MxVector4(float* p_data) : MxVector3(p_data) {}
 
-  void AddScalarImpl(float p_value);
+	void AddScalarImpl(float p_value);
 
-  void AddVectorImpl(float *p_value);
+	void AddVectorImpl(float* p_value);
 
-  void SubVectorImpl(float *p_value);
-  void MullScalarImpl(float *p_value);
-  void MullVectorImpl(float *p_value);
-  void DivScalarImpl(float *p_value);
-  float DotImpl(float *p_a, float *p_b) const;
+	void SubVectorImpl(float* p_value);
+	void MullScalarImpl(float* p_value);
+	void MullVectorImpl(float* p_value);
+	void DivScalarImpl(float* p_value);
+	float DotImpl(float* p_a, float* p_b) const;
 
-  void EqualsImpl(float *p_data);
+	void EqualsImpl(float* p_data);
 
-  void Clear();
+	void Clear();
 
-  float LenSquared() const;
+	float LenSquared() const;
 
-  void EqualsScalar(float *p_value);
+	void EqualsScalar(float* p_value);
 
-  // vtable + 0x84
-  virtual void SetMatrixProduct(MxVector4 *p_a, float *p_b);
-  virtual void SetMatrixProductImpl(float *p_vec, float *p_mat);
-  virtual MxResult NormalizeQuaternion();
-  virtual void UnknownQuaternionOp(MxVector4 *p_a, MxVector4 *p_b);
+	// vtable + 0x84
+	virtual void SetMatrixProduct(MxVector4* p_a, float* p_b);
+	virtual void SetMatrixProductImpl(float* p_vec, float* p_mat);
+	virtual MxResult NormalizeQuaternion();
+	virtual void UnknownQuaternionOp(MxVector4* p_a, MxVector4* p_b);
 };
 
 // VTABLE 0x100d4488
 // SIZE 0x14
-class MxVector3Data : public MxVector3
-{
+class MxVector3Data : public MxVector3 {
 public:
-  inline MxVector3Data() : MxVector3(storage) {}
-  inline MxVector3Data(float p_x, float p_y, float p_z)
-    : MxVector3(storage)
-    , x(p_x), y(p_y), z(p_z)
-    {}
+	inline MxVector3Data() : MxVector3(storage) {}
+	inline MxVector3Data(float p_x, float p_y, float p_z) : MxVector3(storage), x(p_x), y(p_y), z(p_z) {}
 
-  union {
-    float storage[3];
-    struct {
-      float x;
-      float y;
-      float z;
-    };
-  };
+	union {
+		float storage[3];
+		struct {
+			float x;
+			float y;
+			float z;
+		};
+	};
 
-  void CopyFrom(MxVector3Data &p_other) {
-    EqualsImpl(p_other.m_data);
+	void CopyFrom(MxVector3Data& p_other)
+	{
+		EqualsImpl(p_other.m_data);
 
-    float *dest = this->storage;
-    float *src = p_other.storage;
-    for (size_t i = sizeof(storage) / sizeof(float); i > 0; --i)
-      *dest++ = *src++; 
-  }
+		float* dest = this->storage;
+		float* src = p_other.storage;
+		for (size_t i = sizeof(storage) / sizeof(float); i > 0; --i)
+			*dest++ = *src++;
+	}
 };
 
 // VTABLE 0x100d41e8
 // SIZE 0x18
-class MxVector4Data : public MxVector4
-{
+class MxVector4Data : public MxVector4 {
 public:
-  inline MxVector4Data() : MxVector4(storage) {}
-  union {
-    float storage[4];
-    struct {
-      float x;
-      float y;
-      float z;
-      float w;
-    };
-  };
+	inline MxVector4Data() : MxVector4(storage) {}
+	union {
+		float storage[4];
+		struct {
+			float x;
+			float y;
+			float z;
+			float w;
+		};
+	};
 };
 
 #endif // MXVECTOR_H

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -1,338 +1,332 @@
 #include "mxvideomanager.h"
+
+#include "legoomni.h"
 #include "mxautolocker.h"
 #include "mxpresenter.h"
 #include "mxticklemanager.h"
-#include "legoomni.h"
 
 DECOMP_SIZE_ASSERT(MxVideoManager, 0x64)
 
 // OFFSET: LEGO1 0x100be1f0
 MxVideoManager::MxVideoManager()
 {
-  Init();
+	Init();
 }
 
 // OFFSET: LEGO1 0x100be270
 void MxVideoManager::vtable0x34(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height)
 {
-
 }
 
 // OFFSET: LEGO1 0x100be2a0
 MxVideoManager::~MxVideoManager()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100be320
 MxResult MxVideoManager::Init()
 {
-  this->m_pDirectDraw = NULL;
-  this->m_pDDSurface = NULL;
-  this->m_displaySurface = NULL;
-  this->m_region = NULL;
-  this->m_videoParam.SetPalette(NULL);
-  this->m_unk60 = FALSE;
-  return SUCCESS;
+	this->m_pDirectDraw = NULL;
+	this->m_pDDSurface = NULL;
+	this->m_displaySurface = NULL;
+	this->m_region = NULL;
+	this->m_videoParam.SetPalette(NULL);
+	this->m_unk60 = FALSE;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100be340
 void MxVideoManager::Destroy(MxBool p_fromDestructor)
 {
-  if (m_thread) {
-    m_thread->Terminate();
-    delete m_thread;
-  }
-  else
-    TickleManager()->UnregisterClient(this);
+	if (m_thread) {
+		m_thread->Terminate();
+		delete m_thread;
+	}
+	else
+		TickleManager()->UnregisterClient(this);
 
-  m_criticalSection.Enter();
+	m_criticalSection.Enter();
 
-  if (m_displaySurface)
-    delete m_displaySurface;
+	if (m_displaySurface)
+		delete m_displaySurface;
 
-  if (m_region)
-    delete m_region;
+	if (m_region)
+		delete m_region;
 
-  if (m_videoParam.GetPalette())
-    delete m_videoParam.GetPalette();
+	if (m_videoParam.GetPalette())
+		delete m_videoParam.GetPalette();
 
-  if (m_unk60) {
-    if (m_pDirectDraw)
-      m_pDirectDraw->Release();
-    if (m_pDDSurface)
-      m_pDDSurface->Release();
-  }
+	if (m_unk60) {
+		if (m_pDirectDraw)
+			m_pDirectDraw->Release();
+		if (m_pDDSurface)
+			m_pDDSurface->Release();
+	}
 
-  Init();
-  m_criticalSection.Leave();
+	Init();
+	m_criticalSection.Leave();
 
-  if (!p_fromDestructor)
-    MxMediaManager::Destroy();
+	if (!p_fromDestructor)
+		MxMediaManager::Destroy();
 }
 
 // OFFSET: LEGO1 0x100be3e0
 void MxVideoManager::UpdateRegion()
 {
-  if (m_region->vtable20() == FALSE) {
-    MxS32 left, top, right, bottom;
-    MxRect32 &regionRect = m_region->GetRect();
+	if (m_region->vtable20() == FALSE) {
+		MxS32 left, top, right, bottom;
+		MxRect32& regionRect = m_region->GetRect();
 
-    left = m_videoParam.GetRect().m_left;
-    if (left <= regionRect.m_left)
-      left = regionRect.m_left;
+		left = m_videoParam.GetRect().m_left;
+		if (left <= regionRect.m_left)
+			left = regionRect.m_left;
 
-    top = regionRect.m_top;
-    if (top <= m_videoParam.GetRect().m_top)
-      top = m_videoParam.GetRect().m_top;
+		top = regionRect.m_top;
+		if (top <= m_videoParam.GetRect().m_top)
+			top = m_videoParam.GetRect().m_top;
 
-    right = regionRect.m_right;
-    if (right >= m_videoParam.GetRect().m_right)
-      right = m_videoParam.GetRect().m_right;
-    
-    bottom = m_videoParam.GetRect().m_bottom;
-    if (bottom >= regionRect.m_bottom)
-      bottom = regionRect.m_bottom;
+		right = regionRect.m_right;
+		if (right >= m_videoParam.GetRect().m_right)
+			right = m_videoParam.GetRect().m_right;
 
-    m_displaySurface->Display(
-      left, top, left, top,
-      right - left + 1, bottom - top + 1
-    );
-  }
+		bottom = m_videoParam.GetRect().m_bottom;
+		if (bottom >= regionRect.m_bottom)
+			bottom = regionRect.m_bottom;
+
+		m_displaySurface->Display(left, top, left, top, right - left + 1, bottom - top + 1);
+	}
 }
 
 // OFFSET: LEGO1 0x100be440
 void MxVideoManager::SortPresenterList()
 {
-  if (this->m_presenters->GetCount() <= 1)
-    return;
+	if (this->m_presenters->GetCount() <= 1)
+		return;
 
-  MxPresenterListCursor a(this->m_presenters);
-  MxPresenterListCursor b(this->m_presenters);
-  MxU32 count = this->m_presenters->GetCount() - 1;
-  MxBool finished;
+	MxPresenterListCursor a(this->m_presenters);
+	MxPresenterListCursor b(this->m_presenters);
+	MxU32 count = this->m_presenters->GetCount() - 1;
+	MxBool finished;
 
-  if (count != 0) {
-    do {
-      a.Reset();
-      b.Head();
+	if (count != 0) {
+		do {
+			a.Reset();
+			b.Head();
 
-      finished = TRUE;
-      for (MxU32 i = count; i != 0; i--) {
-        MxPresenter *p_a, *p_b;
+			finished = TRUE;
+			for (MxU32 i = count; i != 0; i--) {
+				MxPresenter *p_a, *p_b;
 
-        a.Next(p_a);
-        b.Next(p_b);
+				a.Next(p_a);
+				b.Next(p_b);
 
-        if (p_a->GetDisplayZ() < p_b->GetDisplayZ()) {
-          a.SetValue(p_b);
-          b.SetValue(p_a);
-          finished = FALSE;
-        }
-      }
-    } while (!finished && --count != 0);
-  }
+				if (p_a->GetDisplayZ() < p_b->GetDisplayZ()) {
+					a.SetValue(p_b);
+					b.SetValue(p_a);
+					finished = FALSE;
+				}
+			}
+		} while (!finished && --count != 0);
+	}
 }
-
 
 // OFFSET: LEGO1 0x100be600
 MxResult MxVideoManager::vtable0x28(
-    MxVideoParam &p_videoParam,
-    LPDIRECTDRAW p_pDirectDraw,
-    LPDIRECTDRAWSURFACE p_pDDSurface,
-    LPDIRECTDRAWSURFACE p_ddSurface1,
-    LPDIRECTDRAWSURFACE p_ddSurface2,
-    LPDIRECTDRAWCLIPPER p_ddClipper,
-    MxU32 p_frequencyMS,
-    MxBool p_createThread)
+	MxVideoParam& p_videoParam,
+	LPDIRECTDRAW p_pDirectDraw,
+	LPDIRECTDRAWSURFACE p_pDDSurface,
+	LPDIRECTDRAWSURFACE p_ddSurface1,
+	LPDIRECTDRAWSURFACE p_ddSurface2,
+	LPDIRECTDRAWCLIPPER p_ddClipper,
+	MxU32 p_frequencyMS,
+	MxBool p_createThread
+)
 {
-  MxBool locked = FALSE;
-  MxResult status = FAILURE;
+	MxBool locked = FALSE;
+	MxResult status = FAILURE;
 
-  m_unk60 = FALSE;
+	m_unk60 = FALSE;
 
-  if (MxMediaManager::InitPresenters() != SUCCESS)
-    goto done;
+	if (MxMediaManager::InitPresenters() != SUCCESS)
+		goto done;
 
-  m_criticalSection.Enter();
-  locked = TRUE;
+	m_criticalSection.Enter();
+	locked = TRUE;
 
-  m_videoParam = p_videoParam;
-  m_region = new MxRegion();
+	m_videoParam = p_videoParam;
+	m_region = new MxRegion();
 
-  if (!m_region)
-    goto done;
+	if (!m_region)
+		goto done;
 
-  m_pDirectDraw = p_pDirectDraw;
-  m_pDDSurface = p_pDDSurface;
+	m_pDirectDraw = p_pDirectDraw;
+	m_pDDSurface = p_pDDSurface;
 
-  MxPalette *palette;
-  if (p_videoParam.GetPalette() == NULL) {
-    palette = new MxPalette();
-    m_videoParam.SetPalette(palette);
+	MxPalette* palette;
+	if (p_videoParam.GetPalette() == NULL) {
+		palette = new MxPalette();
+		m_videoParam.SetPalette(palette);
 
-    if (!palette)
-      goto done;
-  }
-  else {
-    palette = p_videoParam.GetPalette()->Clone();
-    m_videoParam.SetPalette(palette);
+		if (!palette)
+			goto done;
+	}
+	else {
+		palette = p_videoParam.GetPalette()->Clone();
+		m_videoParam.SetPalette(palette);
 
-    if (!palette)
-      goto done;
-  }
+		if (!palette)
+			goto done;
+	}
 
-  m_displaySurface = new MxDisplaySurface();
-  if (m_displaySurface && m_displaySurface->Init(m_videoParam, p_ddSurface1, p_ddSurface2, p_ddClipper) == SUCCESS) {
-    m_displaySurface->SetPalette(m_videoParam.GetPalette());
+	m_displaySurface = new MxDisplaySurface();
+	if (m_displaySurface && m_displaySurface->Init(m_videoParam, p_ddSurface1, p_ddSurface2, p_ddClipper) == SUCCESS) {
+		m_displaySurface->SetPalette(m_videoParam.GetPalette());
 
-    if (p_createThread) {
-      m_thread = new MxTickleThread(this, p_frequencyMS);
+		if (p_createThread) {
+			m_thread = new MxTickleThread(this, p_frequencyMS);
 
-      if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
-        goto done;
-    }
-    else
-      TickleManager()->RegisterClient(this, p_frequencyMS);
+			if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
+				goto done;
+		}
+		else
+			TickleManager()->RegisterClient(this, p_frequencyMS);
 
-    status = SUCCESS;
-  }
+		status = SUCCESS;
+	}
 
 done:
-  if (status != SUCCESS)
-    Destroy();
+	if (status != SUCCESS)
+		Destroy();
 
-  if (locked)
-    m_criticalSection.Leave();
+	if (locked)
+		m_criticalSection.Leave();
 
-  return status;
+	return status;
 }
 
 // OFFSET: LEGO1 0x100be820
-MxResult MxVideoManager::Create(
-    MxVideoParam &p_videoParam,
-    MxU32 p_frequencyMS,
-    MxBool p_createThread)
+MxResult MxVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread)
 {
-  MxBool locked = FALSE;
-  MxResult status = FAILURE;
+	MxBool locked = FALSE;
+	MxResult status = FAILURE;
 
-  m_unk60 = TRUE;
+	m_unk60 = TRUE;
 
-  if (MxMediaManager::InitPresenters() != SUCCESS)
-    goto done;
+	if (MxMediaManager::InitPresenters() != SUCCESS)
+		goto done;
 
-  m_criticalSection.Enter();
-  locked = TRUE;
+	m_criticalSection.Enter();
+	locked = TRUE;
 
-  m_videoParam = p_videoParam;
-  m_region = new MxRegion();
+	m_videoParam = p_videoParam;
+	m_region = new MxRegion();
 
-  if (!m_region)
-    goto done;
+	if (!m_region)
+		goto done;
 
-  if (DirectDrawCreate(NULL, &m_pDirectDraw, NULL) != DD_OK)
-    goto done;
+	if (DirectDrawCreate(NULL, &m_pDirectDraw, NULL) != DD_OK)
+		goto done;
 
-  if (m_pDirectDraw->SetCooperativeLevel(MxOmni::GetInstance()->GetWindowHandle(), DDSCL_NORMAL) != DD_OK)
-    goto done;
+	if (m_pDirectDraw->SetCooperativeLevel(MxOmni::GetInstance()->GetWindowHandle(), DDSCL_NORMAL) != DD_OK)
+		goto done;
 
-  MxPalette *palette;
-  if (p_videoParam.GetPalette() == NULL) {
-    palette = new MxPalette();
-    m_videoParam.SetPalette(palette);
+	MxPalette* palette;
+	if (p_videoParam.GetPalette() == NULL) {
+		palette = new MxPalette();
+		m_videoParam.SetPalette(palette);
 
-    if (!palette)
-      goto done;
-  }
-  else {
-    palette = p_videoParam.GetPalette()->Clone();
-    m_videoParam.SetPalette(palette);
+		if (!palette)
+			goto done;
+	}
+	else {
+		palette = p_videoParam.GetPalette()->Clone();
+		m_videoParam.SetPalette(palette);
 
-    if (!palette)
-      goto done;
-  }
+		if (!palette)
+			goto done;
+	}
 
-  m_displaySurface = new MxDisplaySurface();
-  if (m_displaySurface && m_displaySurface->Create(m_videoParam) == SUCCESS) {
-    m_displaySurface->SetPalette(m_videoParam.GetPalette());
+	m_displaySurface = new MxDisplaySurface();
+	if (m_displaySurface && m_displaySurface->Create(m_videoParam) == SUCCESS) {
+		m_displaySurface->SetPalette(m_videoParam.GetPalette());
 
-    if (p_createThread) {
-      m_thread = new MxTickleThread(this, p_frequencyMS);
+		if (p_createThread) {
+			m_thread = new MxTickleThread(this, p_frequencyMS);
 
-      if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
-        goto done;
-    }
-    else
-      TickleManager()->RegisterClient(this, p_frequencyMS);
+			if (!m_thread || m_thread->Start(0, 0) != SUCCESS)
+				goto done;
+		}
+		else
+			TickleManager()->RegisterClient(this, p_frequencyMS);
 
-    status = SUCCESS;
-  }
+		status = SUCCESS;
+	}
 
 done:
-  if (status != SUCCESS)
-    Destroy();
+	if (status != SUCCESS)
+		Destroy();
 
-  if (locked)
-    m_criticalSection.Leave();
+	if (locked)
+		m_criticalSection.Leave();
 
-  return status;
+	return status;
 }
 
 // OFFSET: LEGO1 0x100bea50
 void MxVideoManager::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100bea60
-void MxVideoManager::InvalidateRect(MxRect32 &p_rect)
+void MxVideoManager::InvalidateRect(MxRect32& p_rect)
 {
-  m_criticalSection.Enter();
+	m_criticalSection.Enter();
 
-  if (m_region)
-    m_region->vtable18(p_rect);
+	if (m_region)
+		m_region->vtable18(p_rect);
 
-  m_criticalSection.Leave();
+	m_criticalSection.Leave();
 }
 
 // OFFSET: LEGO1 0x100bea90
 MxResult MxVideoManager::Tickle()
 {
-  MxAutoLocker lock(&this->m_criticalSection);
+	MxAutoLocker lock(&this->m_criticalSection);
 
-  SortPresenterList();
+	SortPresenterList();
 
-  MxPresenter *presenter;
-  MxPresenterListCursor cursor(this->m_presenters);
+	MxPresenter* presenter;
+	MxPresenterListCursor cursor(this->m_presenters);
 
-  while (cursor.Next(presenter))
-    presenter->Tickle();
+	while (cursor.Next(presenter))
+		presenter->Tickle();
 
-  cursor.Reset();
+	cursor.Reset();
 
-  while (cursor.Next(presenter))
-    presenter->PutData();
+	while (cursor.Next(presenter))
+		presenter->PutData();
 
-  UpdateRegion();
-  m_region->Reset();
+	UpdateRegion();
+	m_region->Reset();
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100bebe0
-MxResult MxVideoManager::RealizePalette(MxPalette *p_palette)
+MxResult MxVideoManager::RealizePalette(MxPalette* p_palette)
 {
-  PALETTEENTRY paletteEntries[256];
+	PALETTEENTRY paletteEntries[256];
 
-  this->m_criticalSection.Enter();
+	this->m_criticalSection.Enter();
 
-  if (p_palette && this->m_videoParam.GetPalette()) {
-    p_palette->GetEntries(paletteEntries);
-    this->m_videoParam.GetPalette()->SetEntries(paletteEntries);
-    this->m_displaySurface->SetPalette(this->m_videoParam.GetPalette());
-  }
+	if (p_palette && this->m_videoParam.GetPalette()) {
+		p_palette->GetEntries(paletteEntries);
+		this->m_videoParam.GetPalette()->SetEntries(paletteEntries);
+		this->m_displaySurface->SetPalette(this->m_videoParam.GetPalette());
+	}
 
-  this->m_criticalSection.Leave();
-  return SUCCESS;
+	this->m_criticalSection.Leave();
+	return SUCCESS;
 }

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -2,53 +2,53 @@
 #define MXVIDEOMANAGER_H
 
 #include "mxdisplaysurface.h"
-#include "mxregion.h"
 #include "mxmediamanager.h"
-#include "mxvideoparam.h"
 #include "mxrect32.h"
+#include "mxregion.h"
+#include "mxvideoparam.h"
 
 // VTABLE 0x100dc810
 // SIZE 0x64
-class MxVideoManager : public MxMediaManager
-{
+class MxVideoManager : public MxMediaManager {
 public:
-  virtual ~MxVideoManager() override;
+	virtual ~MxVideoManager() override;
 
-  virtual MxResult Tickle() override; // vtable+0x8
-  virtual void Destroy() override; // vtable+0x18
-  virtual MxResult vtable0x28(
-    MxVideoParam& p_videoParam,
-    LPDIRECTDRAW p_pDirectDraw,
-    LPDIRECTDRAWSURFACE p_pDDSurface,
-    LPDIRECTDRAWSURFACE p_ddSurface1,
-    LPDIRECTDRAWSURFACE p_ddSurface2,
-    LPDIRECTDRAWCLIPPER p_ddClipper,
-    MxU32 p_frequencyMS,
-    MxBool p_createThread
-  ); // vtable+0x28
-  virtual MxResult Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x2c
+	virtual MxResult Tickle() override; // vtable+0x8
+	virtual void Destroy() override;    // vtable+0x18
+	virtual MxResult vtable0x28(
+		MxVideoParam& p_videoParam,
+		LPDIRECTDRAW p_pDirectDraw,
+		LPDIRECTDRAWSURFACE p_pDDSurface,
+		LPDIRECTDRAWSURFACE p_ddSurface1,
+		LPDIRECTDRAWSURFACE p_ddSurface2,
+		LPDIRECTDRAWCLIPPER p_ddClipper,
+		MxU32 p_frequencyMS,
+		MxBool p_createThread
+	);                                                                                               // vtable+0x28
+	virtual MxResult Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x2c
 
-  __declspec(dllexport) void InvalidateRect(MxRect32 &);
-  __declspec(dllexport) virtual MxResult RealizePalette(MxPalette *); // vtable+0x30
-  virtual void vtable0x34(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height);
+	__declspec(dllexport) void InvalidateRect(MxRect32&);
+	__declspec(dllexport) virtual MxResult RealizePalette(MxPalette*); // vtable+0x30
+	virtual void vtable0x34(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height);
 
-  MxVideoManager();
+	MxVideoManager();
 
-  MxResult Init();
-  void Destroy(MxBool p_fromDestructor);
-  void SortPresenterList();
-  void UpdateRegion();
+	MxResult Init();
+	void Destroy(MxBool p_fromDestructor);
+	void SortPresenterList();
+	void UpdateRegion();
 
-  inline MxVideoParam& GetVideoParam() { return this->m_videoParam; }
-  inline LPDIRECTDRAW GetDirectDraw() { return this->m_pDirectDraw; }
-  inline MxDisplaySurface *GetDisplaySurface() { return this->m_displaySurface; }
+	inline MxVideoParam& GetVideoParam() { return this->m_videoParam; }
+	inline LPDIRECTDRAW GetDirectDraw() { return this->m_pDirectDraw; }
+	inline MxDisplaySurface* GetDisplaySurface() { return this->m_displaySurface; }
+
 protected:
-  MxVideoParam m_videoParam;
-  LPDIRECTDRAW m_pDirectDraw;
-  LPDIRECTDRAWSURFACE m_pDDSurface;
-  MxDisplaySurface *m_displaySurface;
-  MxRegion *m_region;
-  MxBool m_unk60;
+	MxVideoParam m_videoParam;
+	LPDIRECTDRAW m_pDirectDraw;
+	LPDIRECTDRAWSURFACE m_pDDSurface;
+	MxDisplaySurface* m_displaySurface;
+	MxRegion* m_region;
+	MxBool m_unk60;
 };
 
 #endif // MXVIDEOMANAGER_H

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -6,83 +6,87 @@
 // OFFSET: LEGO1 0x100bec70
 MxVideoParam::MxVideoParam()
 {
-  this->m_rect.m_right = 640;
-  this->m_rect.m_bottom = 480;
-  this->m_rect.m_left = 0;
-  this->m_rect.m_top = 0;
-  this->m_palette = 0;
-  this->m_backBuffers = 0;
-  this->m_unk1c = 0;
-  this->m_deviceId = 0;
+	this->m_rect.m_right = 640;
+	this->m_rect.m_bottom = 480;
+	this->m_rect.m_left = 0;
+	this->m_rect.m_top = 0;
+	this->m_palette = 0;
+	this->m_backBuffers = 0;
+	this->m_unk1c = 0;
+	this->m_deviceId = 0;
 }
 
 // OFFSET: LEGO1 0x100beca0
-MxVideoParam::MxVideoParam(COMPAT_CONST MxRect32 &p_rect, MxPalette *p_pal, MxULong p_backBuffers, COMPAT_CONST MxVideoParamFlags &p_flags)
+MxVideoParam::MxVideoParam(
+	COMPAT_CONST MxRect32& p_rect,
+	MxPalette* p_pal,
+	MxULong p_backBuffers,
+	COMPAT_CONST MxVideoParamFlags& p_flags
+)
 {
-  this->m_rect.m_left = p_rect.m_left;
-  this->m_rect.m_top = p_rect.m_top;
-  this->m_rect.m_right = p_rect.m_right;
-  this->m_rect.m_bottom = p_rect.m_bottom;
-  this->m_palette = p_pal;
-  this->m_backBuffers = p_backBuffers;
-  this->m_flags = p_flags;
-  this->m_unk1c = 0;
-  this->m_deviceId = NULL;
+	this->m_rect.m_left = p_rect.m_left;
+	this->m_rect.m_top = p_rect.m_top;
+	this->m_rect.m_right = p_rect.m_right;
+	this->m_rect.m_bottom = p_rect.m_bottom;
+	this->m_palette = p_pal;
+	this->m_backBuffers = p_backBuffers;
+	this->m_flags = p_flags;
+	this->m_unk1c = 0;
+	this->m_deviceId = NULL;
 }
 
 // OFFSET: LEGO1 0x100becf0
-MxVideoParam::MxVideoParam(MxVideoParam &p_videoParam)
+MxVideoParam::MxVideoParam(MxVideoParam& p_videoParam)
 {
-  this->m_rect.m_left = p_videoParam.m_rect.m_left;
-  this->m_rect.m_top = p_videoParam.m_rect.m_top;
-  this->m_rect.m_right = p_videoParam.m_rect.m_right;
-  this->m_rect.m_bottom = p_videoParam.m_rect.m_bottom;
-  this->m_palette = p_videoParam.m_palette;
-  this->m_backBuffers = p_videoParam.m_backBuffers;
-  this->m_flags = p_videoParam.m_flags;
-  this->m_unk1c = p_videoParam.m_unk1c;
-  this->m_deviceId = NULL;
-  SetDeviceName(p_videoParam.m_deviceId);
+	this->m_rect.m_left = p_videoParam.m_rect.m_left;
+	this->m_rect.m_top = p_videoParam.m_rect.m_top;
+	this->m_rect.m_right = p_videoParam.m_rect.m_right;
+	this->m_rect.m_bottom = p_videoParam.m_rect.m_bottom;
+	this->m_palette = p_videoParam.m_palette;
+	this->m_backBuffers = p_videoParam.m_backBuffers;
+	this->m_flags = p_videoParam.m_flags;
+	this->m_unk1c = p_videoParam.m_unk1c;
+	this->m_deviceId = NULL;
+	SetDeviceName(p_videoParam.m_deviceId);
 }
 
 // OFFSET: LEGO1 0x100bede0
-MxVideoParam &MxVideoParam::operator=(const MxVideoParam &p_videoParam)
+MxVideoParam& MxVideoParam::operator=(const MxVideoParam& p_videoParam)
 {
-  this->m_rect.m_left = p_videoParam.m_rect.m_left;
-  this->m_rect.m_top = p_videoParam.m_rect.m_top;
-  this->m_rect.m_right = p_videoParam.m_rect.m_right;
-  this->m_rect.m_bottom = p_videoParam.m_rect.m_bottom;
-  this->m_palette = p_videoParam.m_palette;
-  this->m_backBuffers = p_videoParam.m_backBuffers;
-  this->m_flags = p_videoParam.m_flags;
-  this->m_unk1c = p_videoParam.m_unk1c;
-  SetDeviceName(p_videoParam.m_deviceId);
+	this->m_rect.m_left = p_videoParam.m_rect.m_left;
+	this->m_rect.m_top = p_videoParam.m_rect.m_top;
+	this->m_rect.m_right = p_videoParam.m_rect.m_right;
+	this->m_rect.m_bottom = p_videoParam.m_rect.m_bottom;
+	this->m_palette = p_videoParam.m_palette;
+	this->m_backBuffers = p_videoParam.m_backBuffers;
+	this->m_flags = p_videoParam.m_flags;
+	this->m_unk1c = p_videoParam.m_unk1c;
+	SetDeviceName(p_videoParam.m_deviceId);
 
-  return *this;
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100bed70
-void MxVideoParam::SetDeviceName(char *id)
+void MxVideoParam::SetDeviceName(char* id)
 {
-  if (this->m_deviceId != 0)
-    delete[] this->m_deviceId;
+	if (this->m_deviceId != 0)
+		delete[] this->m_deviceId;
 
-  if (id != 0)
-  {
-    this->m_deviceId = new char[strlen(id) + 1];
+	if (id != 0) {
+		this->m_deviceId = new char[strlen(id) + 1];
 
-    if (this->m_deviceId != 0) {
-      strcpy(this->m_deviceId, id);
-    }
-  }
-  else {
-    this->m_deviceId = 0;
-  }
+		if (this->m_deviceId != 0) {
+			strcpy(this->m_deviceId, id);
+		}
+	}
+	else {
+		this->m_deviceId = 0;
+	}
 }
 
 // OFFSET: LEGO1 0x100bed50
 MxVideoParam::~MxVideoParam()
 {
-  if (this->m_deviceId != 0)
-    delete[] this->m_deviceId;
+	if (this->m_deviceId != 0)
+		delete[] this->m_deviceId;
 }

--- a/LEGO1/mxvideoparam.h
+++ b/LEGO1/mxvideoparam.h
@@ -1,8 +1,6 @@
 #ifndef MXVIDEOPARAM_H
 #define MXVIDEOPARAM_H
 
-#include <ddraw.h>
-
 #include "compat.h"
 #include "mxpalette.h"
 #include "mxrect32.h"
@@ -10,33 +8,35 @@
 #include "mxvariabletable.h"
 #include "mxvideoparamflags.h"
 
-class MxVideoParam
-{
+#include <ddraw.h>
+
+class MxVideoParam {
 public:
-  __declspec(dllexport) MxVideoParam();
-  __declspec(dllexport) MxVideoParam(MxVideoParam &);
-  __declspec(dllexport) MxVideoParam(COMPAT_CONST MxRect32 &rect, MxPalette *pal, MxULong p3, COMPAT_CONST MxVideoParamFlags &flags);
-  __declspec(dllexport) MxVideoParam &operator=(const MxVideoParam &);
-  __declspec(dllexport) ~MxVideoParam();
+	__declspec(dllexport) MxVideoParam();
+	__declspec(dllexport) MxVideoParam(MxVideoParam&);
+	__declspec(dllexport)
+		MxVideoParam(COMPAT_CONST MxRect32& rect, MxPalette* pal, MxULong p3, COMPAT_CONST MxVideoParamFlags& flags);
+	__declspec(dllexport) MxVideoParam& operator=(const MxVideoParam&);
+	__declspec(dllexport) ~MxVideoParam();
 
-  __declspec(dllexport) void SetDeviceName(char *id);
+	__declspec(dllexport) void SetDeviceName(char* id);
 
-  inline MxVideoParamFlags &flags() { return m_flags; }
+	inline MxVideoParamFlags& flags() { return m_flags; }
 
-  inline void SetPalette(MxPalette *p_palette) { this->m_palette = p_palette; }
-  inline void SetBackBuffers(MxU32 p_backBuffers) { this->m_backBuffers = p_backBuffers; }
+	inline void SetPalette(MxPalette* p_palette) { this->m_palette = p_palette; }
+	inline void SetBackBuffers(MxU32 p_backBuffers) { this->m_backBuffers = p_backBuffers; }
 
-  inline MxRect32 &GetRect() { return this->m_rect; }
-  inline MxPalette *GetPalette() { return this->m_palette; }
-  inline MxU32 GetBackBuffers() { return this->m_backBuffers; }
+	inline MxRect32& GetRect() { return this->m_rect; }
+	inline MxPalette* GetPalette() { return this->m_palette; }
+	inline MxU32 GetBackBuffers() { return this->m_backBuffers; }
 
 private:
-  MxRect32 m_rect;
-  MxPalette *m_palette;
-  MxU32 m_backBuffers;
-  MxVideoParamFlags m_flags;
-  int m_unk1c;
-  char *m_deviceId;
+	MxRect32 m_rect;
+	MxPalette* m_palette;
+	MxU32 m_backBuffers;
+	MxVideoParamFlags m_flags;
+	int m_unk1c;
+	char* m_deviceId;
 };
 
 #endif // MXVIDEOPARAM_H

--- a/LEGO1/mxvideoparamflags.cpp
+++ b/LEGO1/mxvideoparamflags.cpp
@@ -3,13 +3,13 @@
 // OFFSET: LEGO1 0x100bec40
 MxVideoParamFlags::MxVideoParamFlags()
 {
-  this->SetFullScreen(0);
-  this->SetFlipSurfaces(0);
-  this->SetBackBuffers(0);
-  this->Set_f1bit3(0);
-  this->Set_f1bit4(0);
-  this->Set16Bit(0);
-  this->SetWideViewAngle(1);
-  this->Set_f1bit7(1);
-  this->Set_f2bit1(1);
+	this->SetFullScreen(0);
+	this->SetFlipSurfaces(0);
+	this->SetBackBuffers(0);
+	this->Set_f1bit3(0);
+	this->Set_f1bit4(0);
+	this->Set16Bit(0);
+	this->SetWideViewAngle(1);
+	this->Set_f1bit7(1);
+	this->Set_f2bit1(1);
 }

--- a/LEGO1/mxvideoparamflags.h
+++ b/LEGO1/mxvideoparamflags.h
@@ -1,53 +1,51 @@
 #ifndef MXVIDEOPARAMFLAGS_H
 #define MXVIDEOPARAMFLAGS_H
 
-#include <windows.h>
-
 #include "mxtypes.h"
 
-class MxVideoParamFlags
-{
+#include <windows.h>
+
+class MxVideoParamFlags {
 public:
-  __declspec(dllexport) MxVideoParamFlags();
+	__declspec(dllexport) MxVideoParamFlags();
 
-  inline void SetFullScreen(BOOL e)    { m_flags1.bit0 = e; }
-  inline void SetFlipSurfaces(BOOL e)  { m_flags1.bit1 = e; }
-  inline void SetBackBuffers(BOOL e)   { m_flags1.bit2 = e; }
-  inline void Set_f1bit3(BOOL e)       { m_flags1.bit3 = e; }
-  inline void Set_f1bit4(BOOL e)       { m_flags1.bit4 = e; }
-  inline void Set16Bit(BYTE e)         { m_flags1.bit5 = e; }
-  inline void SetWideViewAngle(BOOL e) { m_flags1.bit6 = e; }
-  inline void Set_f1bit7(BOOL e)       { m_flags1.bit7 = e; }
-  inline void Set_f2bit0(BOOL e)       { m_flags2.bit0 = e; }
-  inline void Set_f2bit1(BOOL e)       { m_flags2.bit1 = e; }
-  inline void Set_f2bit2(BOOL e)       { m_flags2.bit2 = e; }
-  inline void Set_f2bit3(BOOL e)       { m_flags2.bit3 = e; }
-  inline void Set_f2bit4(BOOL e)       { m_flags2.bit4 = e; }
-  inline void Set_f2bit5(BOOL e)       { m_flags2.bit5 = e; }
-  inline void Set_f2bit6(BOOL e)       { m_flags2.bit6 = e; }
-  inline void Set_f2bit7(BOOL e)       { m_flags2.bit7 = e; }
+	inline void SetFullScreen(BOOL e) { m_flags1.bit0 = e; }
+	inline void SetFlipSurfaces(BOOL e) { m_flags1.bit1 = e; }
+	inline void SetBackBuffers(BOOL e) { m_flags1.bit2 = e; }
+	inline void Set_f1bit3(BOOL e) { m_flags1.bit3 = e; }
+	inline void Set_f1bit4(BOOL e) { m_flags1.bit4 = e; }
+	inline void Set16Bit(BYTE e) { m_flags1.bit5 = e; }
+	inline void SetWideViewAngle(BOOL e) { m_flags1.bit6 = e; }
+	inline void Set_f1bit7(BOOL e) { m_flags1.bit7 = e; }
+	inline void Set_f2bit0(BOOL e) { m_flags2.bit0 = e; }
+	inline void Set_f2bit1(BOOL e) { m_flags2.bit1 = e; }
+	inline void Set_f2bit2(BOOL e) { m_flags2.bit2 = e; }
+	inline void Set_f2bit3(BOOL e) { m_flags2.bit3 = e; }
+	inline void Set_f2bit4(BOOL e) { m_flags2.bit4 = e; }
+	inline void Set_f2bit5(BOOL e) { m_flags2.bit5 = e; }
+	inline void Set_f2bit6(BOOL e) { m_flags2.bit6 = e; }
+	inline void Set_f2bit7(BOOL e) { m_flags2.bit7 = e; }
 
-  inline BYTE GetFullScreen()    { return m_flags1.bit0; }
-  inline BYTE GetFlipSurfaces()  { return m_flags1.bit1; }
-  inline BYTE GetBackBuffers()   { return m_flags1.bit2; }
-  inline BYTE Get_f1bit3()       { return m_flags1.bit3; }
-  inline BYTE Get_f1bit4()       { return m_flags1.bit4; }
-  inline BYTE Get16Bit()         { return m_flags1.bit5; }
-  inline BYTE GetWideViewAngle() { return m_flags1.bit6; }
-  inline BYTE Get_f1bit7()       { return m_flags1.bit7; }
-  inline BYTE Get_f2bit0()       { return m_flags2.bit0; }
-  inline BYTE Get_f2bit1()       { return m_flags2.bit1; }
-  inline BYTE Get_f2bit2()       { return m_flags2.bit2; }
-  inline BYTE Get_f2bit3()       { return m_flags2.bit3; }
-  inline BYTE Get_f2bit4()       { return m_flags2.bit4; }
-  inline BYTE Get_f2bit5()       { return m_flags2.bit5; }
-  inline BYTE Get_f2bit6()       { return m_flags2.bit6; }
-  inline BYTE Get_f2bit7()       { return m_flags2.bit7; }
+	inline BYTE GetFullScreen() { return m_flags1.bit0; }
+	inline BYTE GetFlipSurfaces() { return m_flags1.bit1; }
+	inline BYTE GetBackBuffers() { return m_flags1.bit2; }
+	inline BYTE Get_f1bit3() { return m_flags1.bit3; }
+	inline BYTE Get_f1bit4() { return m_flags1.bit4; }
+	inline BYTE Get16Bit() { return m_flags1.bit5; }
+	inline BYTE GetWideViewAngle() { return m_flags1.bit6; }
+	inline BYTE Get_f1bit7() { return m_flags1.bit7; }
+	inline BYTE Get_f2bit0() { return m_flags2.bit0; }
+	inline BYTE Get_f2bit1() { return m_flags2.bit1; }
+	inline BYTE Get_f2bit2() { return m_flags2.bit2; }
+	inline BYTE Get_f2bit3() { return m_flags2.bit3; }
+	inline BYTE Get_f2bit4() { return m_flags2.bit4; }
+	inline BYTE Get_f2bit5() { return m_flags2.bit5; }
+	inline BYTE Get_f2bit6() { return m_flags2.bit6; }
+	inline BYTE Get_f2bit7() { return m_flags2.bit7; }
 
 private:
-  flag_bitfield m_flags1;
-  flag_bitfield m_flags2;
-
+	flag_bitfield m_flags1;
+	flag_bitfield m_flags2;
 };
 
 #endif // MXVIDEOPARAMFLAGS_H

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -1,4 +1,5 @@
 #include "mxvideopresenter.h"
+
 #include "mxvideomanager.h"
 
 DECOMP_SIZE_ASSERT(MxVideoPresenter, 0x64);
@@ -7,233 +8,234 @@ DECOMP_SIZE_ASSERT(MxVideoPresenter::AlphaMask, 0xc);
 // OFFSET: LEGO1 0x1000c700
 void MxVideoPresenter::VTable0x5c(undefined4 p_unknown1)
 {
-  // Empty
+	// Empty
 }
 
 // OFFSET: LEGO1 0x1000c710
 void MxVideoPresenter::VTable0x60()
 {
-  // Empty
+	// Empty
 }
 
 // OFFSET: LEGO1 0x1000c720
 void MxVideoPresenter::VTable0x68(undefined4 p_unknown1)
 {
-  // Empty
+	// Empty
 }
 
 // OFFSET: LEGO1 0x1000c730
 void MxVideoPresenter::VTable0x70()
 {
-  // Empty
+	// Empty
 }
 
 // OFFSET: LEGO1 0x1000c740
 MxVideoPresenter::~MxVideoPresenter()
 {
-  Destroy(TRUE);
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x1000c7a0
 void MxVideoPresenter::Destroy()
 {
-  Destroy(FALSE);
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x1000c7b0
 LPDIRECTDRAWSURFACE MxVideoPresenter::VTable0x78()
 {
-  return m_unk58;
+	return m_unk58;
 }
 
 // OFFSET: LEGO1 0x1000c7c0
 MxBool MxVideoPresenter::VTable0x7c()
 {
-  return (m_bitmap != NULL) || (m_alpha != NULL);
+	return (m_bitmap != NULL) || (m_alpha != NULL);
 }
 
 // OFFSET: LEGO1 0x1000c7e0
 MxS32 MxVideoPresenter::GetWidth()
 {
-  return m_alpha ? m_alpha->m_width
-                 : m_bitmap->GetBmiHeader()->biWidth;
+	return m_alpha ? m_alpha->m_width : m_bitmap->GetBmiHeader()->biWidth;
 }
 
 // OFFSET: LEGO1 0x1000c800
 MxS32 MxVideoPresenter::GetHeight()
 {
-  return m_alpha ? m_alpha->m_height
-                 : m_bitmap->GetBmiHeader()->biHeight;
+	return m_alpha ? m_alpha->m_height : m_bitmap->GetBmiHeader()->biHeight;
 }
 
 // OFFSET: LEGO1 0x100b24f0
-MxVideoPresenter::AlphaMask::AlphaMask(const MxBitmap &p_bitmap)
+MxVideoPresenter::AlphaMask::AlphaMask(const MxBitmap& p_bitmap)
 {
-  m_width  = p_bitmap.GetBmiWidth();
-  // DECOMP: ECX becomes word-sized if these are not two separate actions.
-  MxLong _height = p_bitmap.GetBmiHeightAbs();
-  m_height = _height;
+	m_width = p_bitmap.GetBmiWidth();
+	// DECOMP: ECX becomes word-sized if these are not two separate actions.
+	MxLong _height = p_bitmap.GetBmiHeightAbs();
+	m_height = _height;
 
-  MxS32 size = ((m_width * m_height) / 8) + 1;
-  m_bitmask = new MxU8[size];
-  memset(m_bitmask, 0, size);
+	MxS32 size = ((m_width * m_height) / 8) + 1;
+	m_bitmask = new MxU8[size];
+	memset(m_bitmask, 0, size);
 
-  MxU32 biCompression = p_bitmap.GetBmiHeader()->biCompression;
-  MxU32 rows_before_top;
-  MxU8 *bitmap_src_ptr;
+	MxU32 biCompression = p_bitmap.GetBmiHeader()->biCompression;
+	MxU32 rows_before_top;
+	MxU8* bitmap_src_ptr;
 
-  // The goal here is to enable us to walk through the bitmap's rows
-  // in order, regardless of the orientation. We want to end up at the
-  // start of the first row, which is either at position 0, or at
-  // (image_stride * biHeight) - 1.
+	// The goal here is to enable us to walk through the bitmap's rows
+	// in order, regardless of the orientation. We want to end up at the
+	// start of the first row, which is either at position 0, or at
+	// (image_stride * biHeight) - 1.
 
-  // Reminder: Negative biHeight means this is a top-down DIB.
-  // Otherwise it is bottom-up.
+	// Reminder: Negative biHeight means this is a top-down DIB.
+	// Otherwise it is bottom-up.
 
-  if (biCompression == BI_RGB) {
-    // DECOMP: I think this must be an OR. If not, the check for
-    // biCompression == 16 gets optimized away.
-    if (biCompression == BI_RGB_TOPDOWN || p_bitmap.GetBmiHeight() < 0) {
-      rows_before_top = 0;
-    } else {
-      rows_before_top = p_bitmap.GetBmiHeightAbs();
-      rows_before_top--;
-    }
+	if (biCompression == BI_RGB) {
+		// DECOMP: I think this must be an OR. If not, the check for
+		// biCompression == 16 gets optimized away.
+		if (biCompression == BI_RGB_TOPDOWN || p_bitmap.GetBmiHeight() < 0) {
+			rows_before_top = 0;
+		}
+		else {
+			rows_before_top = p_bitmap.GetBmiHeightAbs();
+			rows_before_top--;
+		}
 
-    goto seek_to_last_row;
-  } else if (biCompression == BI_RGB_TOPDOWN) {
-    // DECOMP: This is the only condition where we skip the
-    // calculation below.
-    bitmap_src_ptr = p_bitmap.GetBitmapData();
-  } else {
-    if (p_bitmap.GetBmiHeight() < 0) {
-      rows_before_top = 0;
-    } else {
-      rows_before_top = p_bitmap.GetBmiHeightAbs();
-      rows_before_top--;
-    }
+		goto seek_to_last_row;
+	}
+	else if (biCompression == BI_RGB_TOPDOWN) {
+		// DECOMP: This is the only condition where we skip the
+		// calculation below.
+		bitmap_src_ptr = p_bitmap.GetBitmapData();
+	}
+	else {
+		if (p_bitmap.GetBmiHeight() < 0) {
+			rows_before_top = 0;
+		}
+		else {
+			rows_before_top = p_bitmap.GetBmiHeightAbs();
+			rows_before_top--;
+		}
 
-// TODO: would prefer not to use goto if we can figure this structure out
-seek_to_last_row:
-    bitmap_src_ptr = ((p_bitmap.GetBmiWidth()+3)&-4) * rows_before_top + p_bitmap.GetBitmapData();
-  }
+	// TODO: would prefer not to use goto if we can figure this structure out
+	seek_to_last_row:
+		bitmap_src_ptr = ((p_bitmap.GetBmiWidth() + 3) & -4) * rows_before_top + p_bitmap.GetBitmapData();
+	}
 
-  // How many bytes are there for each row of the bitmap?
-  // (i.e. the image stride)
-  // If this is a bottom-up DIB, we will walk it in reverse.
-  // TODO: Same rounding trick as in MxBitmap
-  MxS32 row_seek = ((m_height+3)&-4);
-  if (p_bitmap.GetBmiHeight() < 0)
-    row_seek = -row_seek;
+	// How many bytes are there for each row of the bitmap?
+	// (i.e. the image stride)
+	// If this is a bottom-up DIB, we will walk it in reverse.
+	// TODO: Same rounding trick as in MxBitmap
+	MxS32 row_seek = ((m_height + 3) & -4);
+	if (p_bitmap.GetBmiHeight() < 0)
+		row_seek = -row_seek;
 
-  // The actual offset into the m_bitmask array. The two for-loops
-  // are just for counting the pixels.
-  MxS32 offset = 0;
+	// The actual offset into the m_bitmask array. The two for-loops
+	// are just for counting the pixels.
+	MxS32 offset = 0;
 
-  MxU8 *t_ptr = bitmap_src_ptr;
-  for (MxS32 j = 0; j < m_height; j++) {
-    for (MxS32 i = 0; i < m_width; i++) {
-      if (*t_ptr) {
-        // TODO: Second CDQ instruction for abs() should not be there.
-        MxU32 shift = abs(offset) & 7;
-        m_bitmask[offset / 8] |= (1 << abs((MxS32)shift));
-      }
-      t_ptr++;
-      offset++;
-    }
-    // Seek to the start of the next row
-    bitmap_src_ptr += row_seek;
-    t_ptr = bitmap_src_ptr;
-  }
+	MxU8* t_ptr = bitmap_src_ptr;
+	for (MxS32 j = 0; j < m_height; j++) {
+		for (MxS32 i = 0; i < m_width; i++) {
+			if (*t_ptr) {
+				// TODO: Second CDQ instruction for abs() should not be there.
+				MxU32 shift = abs(offset) & 7;
+				m_bitmask[offset / 8] |= (1 << abs((MxS32) shift));
+			}
+			t_ptr++;
+			offset++;
+		}
+		// Seek to the start of the next row
+		bitmap_src_ptr += row_seek;
+		t_ptr = bitmap_src_ptr;
+	}
 }
 
 // OFFSET: LEGO1 0x100b2670
-MxVideoPresenter::AlphaMask::AlphaMask(const MxVideoPresenter::AlphaMask &p_alpha)
+MxVideoPresenter::AlphaMask::AlphaMask(const MxVideoPresenter::AlphaMask& p_alpha)
 {
-  m_width  = p_alpha.m_width;
-  m_height = p_alpha.m_height;
+	m_width = p_alpha.m_width;
+	m_height = p_alpha.m_height;
 
-  MxS32 size = ((m_width * m_height) / 8) + 1;
-  m_bitmask = new MxU8[size];
-  memcpy(m_bitmask, p_alpha.m_bitmask, size);
+	MxS32 size = ((m_width * m_height) / 8) + 1;
+	m_bitmask = new MxU8[size];
+	memcpy(m_bitmask, p_alpha.m_bitmask, size);
 }
-
 
 // OFFSET: LEGO1 0x100b26d0
 MxVideoPresenter::AlphaMask::~AlphaMask()
 {
-  if (m_bitmask)
-    delete[] m_bitmask;
+	if (m_bitmask)
+		delete[] m_bitmask;
 }
 
 // OFFSET: LEGO1 0x100b2760
 void MxVideoPresenter::Init()
 {
-  m_bitmap = NULL;
-  m_alpha = NULL;
-  m_unk5c = 1;
-  m_unk58 = NULL;
-  m_unk60 = -1;
-  m_flags = m_flags & 0xfe;
+	m_bitmap = NULL;
+	m_alpha = NULL;
+	m_unk5c = 1;
+	m_unk58 = NULL;
+	m_unk60 = -1;
+	m_flags = m_flags & 0xfe;
 
-  if (MVideoManager() != NULL) {
-    MVideoManager();
-    m_flags = m_flags | 2;
-    m_flags = m_flags & 0xfb;
-  }
+	if (MVideoManager() != NULL) {
+		MVideoManager();
+		m_flags = m_flags | 2;
+		m_flags = m_flags & 0xfb;
+	}
 
-  m_flags = m_flags & 0xf7;
-  m_flags = m_flags & 0xef;
+	m_flags = m_flags & 0xf7;
+	m_flags = m_flags & 0xef;
 }
 
 // OFFSET: LEGO1 0x100b27b0
 void MxVideoPresenter::Destroy(MxBool p_fromDestructor)
 {
-  if (MVideoManager() != NULL)
-    MVideoManager()->RemovePresenter(*this);
+	if (MVideoManager() != NULL)
+		MVideoManager()->RemovePresenter(*this);
 
-  if (m_unk58) {
-    m_unk58->Release();
-    m_unk58 = NULL;
-    m_flags = m_flags & 0xfd;
-    m_flags = m_flags & 0xfb;
-  }
+	if (m_unk58) {
+		m_unk58->Release();
+		m_unk58 = NULL;
+		m_flags = m_flags & 0xfd;
+		m_flags = m_flags & 0xfb;
+	}
 
-  if (MVideoManager() && (m_alpha || m_bitmap)) {
-    MxS32 height = GetHeight();
-    MxS32 width = GetWidth();
+	if (MVideoManager() && (m_alpha || m_bitmap)) {
+		MxS32 height = GetHeight();
+		MxS32 width = GetWidth();
 
-    MxS32 x = GetLocationX();
-    MxS32 y = GetLocationY();
-    MxRect32 rect(x, y, x + width, y + height);
+		MxS32 x = GetLocationX();
+		MxS32 y = GetLocationY();
+		MxRect32 rect(x, y, x + width, y + height);
 
-    MVideoManager()->InvalidateRect(rect);
-    MVideoManager()->vtable0x34(rect.m_left, rect.m_top, rect.GetWidth(), rect.GetHeight());
-  }
+		MVideoManager()->InvalidateRect(rect);
+		MVideoManager()->vtable0x34(rect.m_left, rect.m_top, rect.GetWidth(), rect.GetHeight());
+	}
 
-  delete m_bitmap;
-  delete m_alpha;
+	delete m_bitmap;
+	delete m_alpha;
 
-  Init();
+	Init();
 
-  if (!p_fromDestructor)
-    MxMediaPresenter::Destroy(FALSE);
+	if (!p_fromDestructor)
+		MxMediaPresenter::Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x100b28b0 STUB
 void MxVideoPresenter::VTable0x64()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b2a70 STUB
 void MxVideoPresenter::VTable0x6c()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100b3300
 undefined MxVideoPresenter::VTable0x74()
 {
-  return 0;
+	return 0;
 }

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -1,71 +1,66 @@
 #ifndef MXVIDEOPRESENTER_H
 #define MXVIDEOPRESENTER_H
 
-#include "mxmediapresenter.h"
-#include "mxbitmap.h"
-
 #include "decomp.h"
+#include "mxbitmap.h"
+#include "mxmediapresenter.h"
 
 // VTABLE 0x100d4be8
-class MxVideoPresenter : public MxMediaPresenter
-{
+class MxVideoPresenter : public MxMediaPresenter {
 public:
-  MxVideoPresenter()
-  {
-    Init();
-  }
+	MxVideoPresenter() { Init(); }
 
-  virtual ~MxVideoPresenter() override; // vtable+0x0
+	virtual ~MxVideoPresenter() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x1000c820
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0760
-    return "MxVideoPresenter";
-  }
+	// OFFSET: LEGO1 0x1000c820
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0760
+		return "MxVideoPresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000c830
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxVideoPresenter::ClassName()) || MxMediaPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000c830
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxVideoPresenter::ClassName()) || MxMediaPresenter::IsA(name);
+	}
 
-  void Init();
-  void Destroy(MxBool p_fromDestructor);
+	void Init();
+	void Destroy(MxBool p_fromDestructor);
 
-  virtual void Destroy() override; // vtable+0x38
+	virtual void Destroy() override; // vtable+0x38
 
-  virtual void VTable0x5c(undefined4 p_unknown1); // vtable+0x5c
-  virtual void VTable0x60(); // vtable+0x60
-  virtual void VTable0x64(); // vtable+0x64
-  virtual void VTable0x68(undefined4 p_unknown1); // vtable+0x68
-  virtual void VTable0x6c(); // vtable+0x6c
-  virtual void VTable0x70(); // vtable+0x70
-  virtual undefined VTable0x74(); // vtable+0x74
-  virtual LPDIRECTDRAWSURFACE VTable0x78(); // vtable+0x78
-  virtual MxBool VTable0x7c(); // vtable+0x7c
-  virtual MxS32 GetWidth();  // vtable+0x80
-  virtual MxS32 GetHeight(); // vtable+0x84
+	virtual void VTable0x5c(undefined4 p_unknown1); // vtable+0x5c
+	virtual void VTable0x60();                      // vtable+0x60
+	virtual void VTable0x64();                      // vtable+0x64
+	virtual void VTable0x68(undefined4 p_unknown1); // vtable+0x68
+	virtual void VTable0x6c();                      // vtable+0x6c
+	virtual void VTable0x70();                      // vtable+0x70
+	virtual undefined VTable0x74();                 // vtable+0x74
+	virtual LPDIRECTDRAWSURFACE VTable0x78();       // vtable+0x78
+	virtual MxBool VTable0x7c();                    // vtable+0x7c
+	virtual MxS32 GetWidth();                       // vtable+0x80
+	virtual MxS32 GetHeight();                      // vtable+0x84
 
-  // TODO: Not sure what this is. Seems to have size of 12 bytes
-  // based on 0x100b9e9a. Values are copied from the bitmap header.
-  // SIZE 0xc
-  struct AlphaMask {
-    MxU8 *m_bitmask;
-    MxU16 m_width;
-    MxU16 m_height;
+	// TODO: Not sure what this is. Seems to have size of 12 bytes
+	// based on 0x100b9e9a. Values are copied from the bitmap header.
+	// SIZE 0xc
+	struct AlphaMask {
+		MxU8* m_bitmask;
+		MxU16 m_width;
+		MxU16 m_height;
 
-    AlphaMask(const MxBitmap &);
-    AlphaMask(const AlphaMask &);
-    virtual ~AlphaMask();
-  };
+		AlphaMask(const MxBitmap&);
+		AlphaMask(const AlphaMask&);
+		virtual ~AlphaMask();
+	};
 
-  MxBitmap *m_bitmap;
-  AlphaMask *m_alpha;
-  LPDIRECTDRAWSURFACE m_unk58;
-  undefined2 m_unk5c;
-  unsigned char m_flags; // 0x5e
-  MxLong m_unk60;
+	MxBitmap* m_bitmap;
+	AlphaMask* m_alpha;
+	LPDIRECTDRAWSURFACE m_unk58;
+	undefined2 m_unk5c;
+	unsigned char m_flags; // 0x5e
+	MxLong m_unk60;
 };
 
 #endif // MXVIDEOPRESENTER_H

--- a/LEGO1/mxwavepresenter.cpp
+++ b/LEGO1/mxwavepresenter.cpp
@@ -7,12 +7,12 @@ DECOMP_SIZE_ASSERT(MxWavePresenter, 0x6c);
 // OFFSET: LEGO1 0x100b1ad0
 void MxWavePresenter::Init()
 {
-  m_unk54 = 0;
-  m_unk58 = 0;
-  m_unk5c = 0;
-  m_unk60 = 0;
-  m_unk64 = 0;
-  m_unk65 = 0;
-  m_unk66 = 0;
-  m_unk68 = 0;
+	m_unk54 = 0;
+	m_unk58 = 0;
+	m_unk5c = 0;
+	m_unk60 = 0;
+	m_unk64 = 0;
+	m_unk65 = 0;
+	m_unk66 = 0;
+	m_unk68 = 0;
 }

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -1,44 +1,40 @@
 #ifndef MXWAVEPRESENTER_H
 #define MXWAVEPRESENTER_H
 
-#include "mxsoundpresenter.h"
-
 #include "decomp.h"
+#include "mxsoundpresenter.h"
 
 // VTABLE 0x100d49a8
 // SIZE 0x6c
-class MxWavePresenter : public MxSoundPresenter
-{
+class MxWavePresenter : public MxSoundPresenter {
 private:
-  void Init();
+	void Init();
 
 public:
-  MxWavePresenter() {
-    Init();
-  }
+	MxWavePresenter() { Init(); }
 
-  // OFFSET: LEGO1 0x1000d6c0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f07b4
-    return "MxWavePresenter";
-  }
+	// OFFSET: LEGO1 0x1000d6c0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f07b4
+		return "MxWavePresenter";
+	}
 
-  // OFFSET: LEGO1 0x1000d6d0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, MxWavePresenter::ClassName()) || MxSoundPresenter::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000d6d0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxWavePresenter::ClassName()) || MxSoundPresenter::IsA(name);
+	}
 
-  undefined4 m_unk54;
-  undefined4 m_unk58;
-  undefined4 m_unk5c;
-  undefined4 m_unk60;
-  undefined m_unk64;
-  undefined m_unk65;
-  undefined m_unk66;
-  undefined m_unk67;
-  undefined m_unk68;
+	undefined4 m_unk54;
+	undefined4 m_unk58;
+	undefined4 m_unk5c;
+	undefined4 m_unk60;
+	undefined m_unk64;
+	undefined m_unk65;
+	undefined m_unk66;
+	undefined m_unk67;
+	undefined m_unk68;
 };
 
 #endif // MXWAVEPRESENTER_H

--- a/LEGO1/pizza.cpp
+++ b/LEGO1/pizza.cpp
@@ -5,24 +5,24 @@ DECOMP_SIZE_ASSERT(Pizza, 0x9c);
 // OFFSET: LEGO1 0x10037ef0
 Pizza::Pizza()
 {
-  this->m_unk7c = 0;
-  this->m_unk80 = 0;
-  this->m_unk84 = 0;
-  this->m_unk88 = 0;
-  this->m_unk8c = -1;
-  this->m_unk98 = 0;
-  this->m_unk90 = 0x80000000;
+	this->m_unk7c = 0;
+	this->m_unk80 = 0;
+	this->m_unk84 = 0;
+	this->m_unk88 = 0;
+	this->m_unk8c = -1;
+	this->m_unk98 = 0;
+	this->m_unk90 = 0x80000000;
 }
 
 // OFFSET: LEGO1 0x10038100
 Pizza::~Pizza()
 {
-  TickleManager()->UnregisterClient(this);
+	TickleManager()->UnregisterClient(this);
 }
 
 // OFFSET: LEGO1 0x100388a0
 MxResult Pizza::Tickle()
 {
-  // TODO
-  return SUCCESS;
+	// TODO
+	return SUCCESS;
 }

--- a/LEGO1/pizza.h
+++ b/LEGO1/pizza.h
@@ -2,7 +2,6 @@
 #define PIZZA_H
 
 #include "decomp.h"
-
 #include "isleactor.h"
 #include "mxcore.h"
 #include "mxomni.h"
@@ -11,37 +10,36 @@
 
 // VTABLE 0x100d7380
 // SIZE 0x9c
-class Pizza : public IsleActor
-{
+class Pizza : public IsleActor {
 public:
-  Pizza();
-  virtual ~Pizza() override;
+	Pizza();
+	virtual ~Pizza() override;
 
-  virtual MxResult Tickle() override; // vtable+08
+	virtual MxResult Tickle() override; // vtable+08
 
-  // OFFSET: LEGO1 0x10037f90
-  inline const char *ClassName() const //vtable+0c
-  {
-    // 0x100f038c
-    return "Pizza";
-  }
+	// OFFSET: LEGO1 0x10037f90
+	inline const char* ClassName() const // vtable+0c
+	{
+		// 0x100f038c
+		return "Pizza";
+	}
 
-  // OFFSET: LEGO1 0x10037fa0
-  inline MxBool IsA(const char *name) const override //vtable+10
-  {
-    return !strcmp(name, Pizza::ClassName()) || IsleActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10037fa0
+	inline MxBool IsA(const char* name) const override // vtable+10
+	{
+		return !strcmp(name, Pizza::ClassName()) || IsleActor::IsA(name);
+	}
 
 private:
-  undefined4 m_unk78;
-  undefined4 m_unk7c;
-  undefined4 m_unk80;
-  undefined4 m_unk84;
-  undefined4 m_unk88;
-  undefined4 m_unk8c;
-  undefined4 m_unk90;
-  undefined4 m_unk94;
-  undefined m_unk98;
+	undefined4 m_unk78;
+	undefined4 m_unk7c;
+	undefined4 m_unk80;
+	undefined4 m_unk84;
+	undefined4 m_unk88;
+	undefined4 m_unk8c;
+	undefined4 m_unk90;
+	undefined4 m_unk94;
+	undefined m_unk98;
 };
 
 #endif // PIZZA_H

--- a/LEGO1/pizzamissionstate.cpp
+++ b/LEGO1/pizzamissionstate.cpp
@@ -4,10 +4,10 @@ DECOMP_SIZE_ASSERT(PizzaMissionStateEntry, 0x20)
 DECOMP_SIZE_ASSERT(PizzaMissionState, 0xb0)
 
 // OFFSET: LEGO1 0x10039510
-PizzaMissionStateEntry *PizzaMissionState::GetState(MxU8 id)
+PizzaMissionStateEntry* PizzaMissionState::GetState(MxU8 id)
 {
-  for (MxS16 i = 0; i < 5; i++)
-    if (m_state[i].m_id == id)
-      return m_state + i;
-  return NULL;
+	for (MxS16 i = 0; i < 5; i++)
+		if (m_state[i].m_id == id)
+			return m_state + i;
+	return NULL;
 }

--- a/LEGO1/pizzamissionstate.h
+++ b/LEGO1/pizzamissionstate.h
@@ -3,42 +3,40 @@
 
 #include "legostate.h"
 
-struct PizzaMissionStateEntry
-{
+struct PizzaMissionStateEntry {
 public:
-  undefined2 m_unk0;
-  MxU8 m_id;
-  undefined m_unk3[0x15];
-  MxU16 m_color;
-  undefined m_unk18[6];
+	undefined2 m_unk0;
+	MxU8 m_id;
+	undefined m_unk3[0x15];
+	MxU16 m_color;
+	undefined m_unk18[6];
 };
 
 // VTABLE 0x100d7408
-class PizzaMissionState : public LegoState
-{
+class PizzaMissionState : public LegoState {
 public:
-  // OFFSET: LEGO1 0x10039290
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f00d4
-    return "PizzaMissionState";
-  }
+	// OFFSET: LEGO1 0x10039290
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f00d4
+		return "PizzaMissionState";
+	}
 
-  // OFFSET: LEGO1 0x100392a0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, PizzaMissionState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100392a0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, PizzaMissionState::ClassName()) || LegoState::IsA(name);
+	}
 
-  inline MxU16 GetColor(MxU8 id) { return GetState(id)->m_color; }
+	inline MxU16 GetColor(MxU8 id) { return GetState(id)->m_color; }
 
 private:
-  PizzaMissionStateEntry *GetState(MxU8 id);
+	PizzaMissionStateEntry* GetState(MxU8 id);
 
 protected:
-  undefined4 m_unk8;
-  undefined4 m_unkc;
-  PizzaMissionStateEntry m_state[5];
+	undefined4 m_unk8;
+	undefined4 m_unkc;
+	PizzaMissionStateEntry m_state[5];
 };
 
 #endif // PIZZAMISSIONSTATE_H

--- a/LEGO1/pizzeria.h
+++ b/LEGO1/pizzeria.h
@@ -5,8 +5,7 @@
 
 // VTABLE 0x100d5520
 // SIZE 0x84
-class Pizzeria : public IsleActor
-{
+class Pizzeria : public IsleActor {
 public:
 };
 

--- a/LEGO1/pizzeriastate.cpp
+++ b/LEGO1/pizzeriastate.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x10017af0 STUB
 PizzeriaState::PizzeriaState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/pizzeriastate.h
+++ b/LEGO1/pizzeriastate.h
@@ -5,11 +5,9 @@
 
 // VTABLE 0x100d5ee8
 // SIZE 0xb4
-class PizzeriaState : public LegoState
-{
+class PizzeriaState : public LegoState {
 public:
-  PizzeriaState();
-
+	PizzeriaState();
 };
 
 #endif // PIZZERIASTATE_H

--- a/LEGO1/police.cpp
+++ b/LEGO1/police.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x1005e130 STUB
 Police::Police()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005e320 STUB
 Police::~Police()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1005e480 STUB
-MxLong Police::Notify(MxParam &p)
+MxLong Police::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/police.h
+++ b/LEGO1/police.h
@@ -6,26 +6,25 @@
 // VTABLE 0x100d8a80
 // SIZE 0x110
 // Radio at 0xf8
-class Police : public LegoWorld
-{
+class Police : public LegoWorld {
 public:
-  Police();
-  virtual ~Police() override; // vtable+0x0
-  
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
+	Police();
+	virtual ~Police() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x1005e1e0
-  inline virtual const char *ClassName() const override // vtable+0xc
-  { 
-    // 0x100f0450
-    return "Police";
-  }
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x1005e1f0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Police::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1005e1e0
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0450
+		return "Police";
+	}
+
+	// OFFSET: LEGO1 0x1005e1f0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Police::ClassName()) || LegoWorld::IsA(name);
+	}
 };
 
 #endif // POLICE_H

--- a/LEGO1/policeentity.h
+++ b/LEGO1/policeentity.h
@@ -5,21 +5,20 @@
 
 // VTABLE 0x100d4ab0
 // SIZE 0x68
-class PoliceEntity : public BuildingEntity
-{
+class PoliceEntity : public BuildingEntity {
 public:
-  // OFFSET: LEGO1 0x1000ed60
-  inline virtual const char *ClassName() const override // vtable+0xc
-  { 
-    // 0x100f0328
-    return "PoliceEntity";
-  }
+	// OFFSET: LEGO1 0x1000ed60
+	inline virtual const char* ClassName() const override // vtable+0xc
+	{
+		// 0x100f0328
+		return "PoliceEntity";
+	}
 
-  // OFFSET: LEGO1 0x1000ed70
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, PoliceEntity::ClassName()) || BuildingEntity::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000ed70
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, PoliceEntity::ClassName()) || BuildingEntity::IsA(name);
+	}
 };
 
 #endif // POLICEENTITY_H

--- a/LEGO1/policestate.cpp
+++ b/LEGO1/policestate.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1005e7c0 STUB
 PoliceState::PoliceState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/policestate.h
+++ b/LEGO1/policestate.h
@@ -5,23 +5,22 @@
 
 // VTABLE 0x100d8af0
 // SIZE 0x10
-class PoliceState : public LegoState
-{
+class PoliceState : public LegoState {
 public:
-  PoliceState();
+	PoliceState();
 
-  // OFFSET: LEGO1 0x1005e860
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0444
-    return "PoliceState";
-  }
+	// OFFSET: LEGO1 0x1005e860
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0444
+		return "PoliceState";
+	}
 
-  // OFFSET: LEGO1 0x1005e870
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, PoliceState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1005e870
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, PoliceState::ClassName()) || LegoState::IsA(name);
+	}
 };
 
 #endif // POLICESTATE_H

--- a/LEGO1/racecar.cpp
+++ b/LEGO1/racecar.cpp
@@ -5,11 +5,11 @@ DECOMP_SIZE_ASSERT(RaceCar, 0x164);
 // OFFSET: LEGO1 0x10028200
 RaceCar::RaceCar()
 {
-  this->m_unk13c = 40.0;
+	this->m_unk13c = 40.0;
 }
 
 // OFFSET: LEGO1 0x10028420 STUB
 RaceCar::~RaceCar()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/racecar.h
+++ b/LEGO1/racecar.h
@@ -6,27 +6,27 @@
 
 // VTABLE 0x100d6918
 // SIZE 0x164
-class RaceCar : public IslePathActor
-{
+class RaceCar : public IslePathActor {
 public:
-  RaceCar();
-  virtual ~RaceCar() override; // vtable+0x0
+	RaceCar();
+	virtual ~RaceCar() override; // vtable+0x0
 
-  // OFFSET: LEGO1 0x10028270
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03e0
-    return "RaceCar";
-  }
+	// OFFSET: LEGO1 0x10028270
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03e0
+		return "RaceCar";
+	}
 
-  // OFFSET: LEGO1 0x10028280
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, RaceCar::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10028280
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, RaceCar::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  // TODO: RaceCar fields
-  undefined m_unk160[4];
+	// TODO: RaceCar fields
+	undefined m_unk160[4];
 };
 
 #endif // RACECAR_H

--- a/LEGO1/racestandsentity.h
+++ b/LEGO1/racestandsentity.h
@@ -5,8 +5,6 @@
 
 // VTABLE 0x100d48a8
 // SIZE 0x68
-class RaceStandsEntity : public BuildingEntity
-{
-};
+class RaceStandsEntity : public BuildingEntity {};
 
 #endif // RACESTANDSENTITY_H

--- a/LEGO1/racestate.cpp
+++ b/LEGO1/racestate.cpp
@@ -8,16 +8,16 @@ DECOMP_SIZE_ASSERT(RaceStateEntry, 0x06)
 // OFFSET: LEGO1 0x10015f30 STUB
 RaceState::RaceState()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10016280
-RaceStateEntry *RaceState::GetState(MxU8 id)
+RaceStateEntry* RaceState::GetState(MxU8 id)
 {
-  for (MxS16 i = 0;; i++) {
-    if (i >= 5)
-      return NULL;
-    if (m_state[i].m_id == id) 
-      return m_state + i;
-  }
+	for (MxS16 i = 0;; i++) {
+		if (i >= 5)
+			return NULL;
+		if (m_state[i].m_id == id)
+			return m_state + i;
+	}
 }

--- a/LEGO1/racestate.h
+++ b/LEGO1/racestate.h
@@ -3,44 +3,42 @@
 
 #include "legostate.h"
 
-struct RaceStateEntry
-{
+struct RaceStateEntry {
 public:
-  MxU8 m_id;
-  undefined m_unk1[1];
-  MxU16 m_unk2;
-  MxU16 m_color;
+	MxU8 m_id;
+	undefined m_unk1[1];
+	MxU16 m_unk2;
+	MxU16 m_color;
 };
 
 // VTABLE 0x100d5e30
 // SIZE 0x2c
-class RaceState : public LegoState
-{
+class RaceState : public LegoState {
 public:
-  RaceState();
+	RaceState();
 
-  // OFFSET: LEGO1 0x10016010
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f07d0
-    return "RaceState";
-  }
+	// OFFSET: LEGO1 0x10016010
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f07d0
+		return "RaceState";
+	}
 
-  // OFFSET: LEGO1 0x10016020
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, RaceState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x10016020
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, RaceState::ClassName()) || LegoState::IsA(name);
+	}
 
-  inline MxU16 GetColor(MxU8 id) { return GetState(id)->m_color; }
+	inline MxU16 GetColor(MxU8 id) { return GetState(id)->m_color; }
 
 private:
-  RaceStateEntry *GetState(MxU8 id);
+	RaceStateEntry* GetState(MxU8 id);
 
 protected:
-  RaceStateEntry m_state[5];
-  undefined2 m_unk26[2];
-  undefined4 m_unk28;
+	RaceStateEntry m_state[5];
+	undefined2 m_unk26[2];
+	undefined4 m_unk28;
 };
 
 #endif // RACESTATE_H

--- a/LEGO1/radio.cpp
+++ b/LEGO1/radio.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1002c990 STUB
 Radio::~Radio()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/radio.h
+++ b/LEGO1/radio.h
@@ -4,11 +4,9 @@
 #include "mxcore.h"
 
 // VTABLE 0x100d6d10
-class Radio : public MxCore
-{
+class Radio : public MxCore {
 public:
-  virtual ~Radio() override;
-
+	virtual ~Radio() override;
 };
 
 #endif // RADIO_H

--- a/LEGO1/radiostate.cpp
+++ b/LEGO1/radiostate.cpp
@@ -3,5 +3,5 @@
 // OFFSET: LEGO1 0x1002ce10 STUB
 RadioState::RadioState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/radiostate.h
+++ b/LEGO1/radiostate.h
@@ -5,24 +5,22 @@
 
 // VTABLE 0x100d6d28
 // SIZE 0x30
-class RadioState : public LegoState
-{
+class RadioState : public LegoState {
 public:
-  RadioState();
+	RadioState();
 
-  // OFFSET: LEGO1 0x1002cf60
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f04f8
-    return "RadioState";
-  }
+	// OFFSET: LEGO1 0x1002cf60
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f04f8
+		return "RadioState";
+	}
 
-  // OFFSET: LEGO1 0x1002cf70
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, RadioState::ClassName()) || LegoState::IsA(name);
-  }
-
+	// OFFSET: LEGO1 0x1002cf70
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, RadioState::ClassName()) || LegoState::IsA(name);
+	}
 };
 
 #endif // RADIOSTATE_H

--- a/LEGO1/realtime/realtime.cpp
+++ b/LEGO1/realtime/realtime.cpp
@@ -1,41 +1,45 @@
 #include "realtime.h"
 
 // OFFSET: LEGO1 0x100a5b40
-void CalcLocalTransform(const MxVector3 &p_posVec, const MxVector3 &p_dirVec,
-                        const MxVector3 &p_upVec, MxMatrix &p_outMatrix)
+void CalcLocalTransform(
+	const MxVector3& p_posVec,
+	const MxVector3& p_dirVec,
+	const MxVector3& p_upVec,
+	MxMatrix& p_outMatrix
+)
 {
-  MxFloat x_axis[3], y_axis[3], z_axis[3];
+	MxFloat x_axis[3], y_axis[3], z_axis[3];
 
-  // This is an unrolled version of the "NORMVEC3" macro,
-  // used here to apply a silly hack to get a 100% match
-  {
-    const MxFloat dirVec1Operation = (p_dirVec)[1] * (p_dirVec)[1];
-    MxDouble len = sqrt(((p_dirVec)[0] * (p_dirVec)[0] + dirVec1Operation + (p_dirVec)[2] * (p_dirVec)[2]));
-    ((z_axis)[0] = (p_dirVec)[0] / (len), (z_axis)[1] = (p_dirVec)[1] / (len), (z_axis)[2] = (p_dirVec)[2] / (len));
-  }
+	// This is an unrolled version of the "NORMVEC3" macro,
+	// used here to apply a silly hack to get a 100% match
+	{
+		const MxFloat dirVec1Operation = (p_dirVec)[1] * (p_dirVec)[1];
+		MxDouble len = sqrt(((p_dirVec)[0] * (p_dirVec)[0] + dirVec1Operation + (p_dirVec)[2] * (p_dirVec)[2]));
+		((z_axis)[0] = (p_dirVec)[0] / (len), (z_axis)[1] = (p_dirVec)[1] / (len), (z_axis)[2] = (p_dirVec)[2] / (len));
+	}
 
-  NORMVEC3(y_axis, p_upVec)
+	NORMVEC3(y_axis, p_upVec)
 
-  VXV3(x_axis, y_axis, z_axis);
+	VXV3(x_axis, y_axis, z_axis);
 
-  // Exact same thing as pointed out by the above comment
-  {
-    const MxFloat axis2Operation = (x_axis)[2] * (x_axis)[2];
-    MxDouble len = sqrt(((x_axis)[0] * (x_axis)[0] + axis2Operation + (x_axis)[1] * (x_axis)[1]));
-    ((x_axis)[0] = (x_axis)[0] / (len), (x_axis)[1] = (x_axis)[1] / (len), (x_axis)[2] = (x_axis)[2] / (len));
-  }
+	// Exact same thing as pointed out by the above comment
+	{
+		const MxFloat axis2Operation = (x_axis)[2] * (x_axis)[2];
+		MxDouble len = sqrt(((x_axis)[0] * (x_axis)[0] + axis2Operation + (x_axis)[1] * (x_axis)[1]));
+		((x_axis)[0] = (x_axis)[0] / (len), (x_axis)[1] = (x_axis)[1] / (len), (x_axis)[2] = (x_axis)[2] / (len));
+	}
 
-  VXV3(y_axis, z_axis, x_axis);
+	VXV3(y_axis, z_axis, x_axis);
 
-  // Again, the same thing
-  {
-    const MxFloat axis2Operation = (y_axis)[2] * (y_axis)[2];
-    MxDouble len = sqrt(((y_axis)[0] * (y_axis)[0] + axis2Operation + (y_axis)[1] * (y_axis)[1]));
-    ((y_axis)[0] = (y_axis)[0] / (len), (y_axis)[1] = (y_axis)[1] / (len), (y_axis)[2] = (y_axis)[2] / (len));
-  }
+	// Again, the same thing
+	{
+		const MxFloat axis2Operation = (y_axis)[2] * (y_axis)[2];
+		MxDouble len = sqrt(((y_axis)[0] * (y_axis)[0] + axis2Operation + (y_axis)[1] * (y_axis)[1]));
+		((y_axis)[0] = (y_axis)[0] / (len), (y_axis)[1] = (y_axis)[1] / (len), (y_axis)[2] = (y_axis)[2] / (len));
+	}
 
-  SET4from3(&p_outMatrix[0], x_axis,    0);
-  SET4from3(&p_outMatrix[4], y_axis,    0);
-  SET4from3(&p_outMatrix[8], z_axis,    0);
-  SET4from3(&p_outMatrix[12], p_posVec, 1);
+	SET4from3(&p_outMatrix[0], x_axis, 0);
+	SET4from3(&p_outMatrix[4], y_axis, 0);
+	SET4from3(&p_outMatrix[8], z_axis, 0);
+	SET4from3(&p_outMatrix[12], p_posVec, 1);
 }

--- a/LEGO1/realtime/realtime.h
+++ b/LEGO1/realtime/realtime.h
@@ -3,11 +3,17 @@
 
 #include "../mxmatrix.h"
 
-#define NORMVEC3(dst, src) { \
-	MxDouble len = sqrt(NORMSQRD3(src)); \
-	VDS3(dst, src, len); }
+#define NORMVEC3(dst, src)                                                                                             \
+	{                                                                                                                  \
+		MxDouble len = sqrt(NORMSQRD3(src));                                                                           \
+		VDS3(dst, src, len);                                                                                           \
+	}
 
-void CalcLocalTransform(const MxVector3 &p_posVec, const MxVector3 &p_dirVec,
-                        const MxVector3 &p_upVec, MxMatrix &p_outMatrix);
+void CalcLocalTransform(
+	const MxVector3& p_posVec,
+	const MxVector3& p_dirVec,
+	const MxVector3& p_upVec,
+	MxMatrix& p_outMatrix
+);
 
 #endif // REALTIME_H

--- a/LEGO1/realtime/realtimeview.cpp
+++ b/LEGO1/realtime/realtimeview.cpp
@@ -1,4 +1,5 @@
 #include "realtimeview.h"
+
 #include <math.h>
 
 // 0x10109598
@@ -16,31 +17,31 @@ float g_partsThreshold = 1000.0f;
 // OFFSET: LEGO1 0x100a5e00
 float RealtimeView::GetUserMaxLOD()
 {
-  // TODO
-  return 0;
+	// TODO
+	return 0;
 }
 
 // OFFSET: LEGO1 0x100a5e10
 float RealtimeView::GetPartsThreshold()
 {
-  return g_partsThreshold;
+	return g_partsThreshold;
 }
 
 // OFFSET: LEGO1 100a5e20
 void RealtimeView::UpdateMaxLOD()
 {
-  g_userMaxLodPower = pow(g_userMaxBase, -g_userMaxLod);
+	g_userMaxLodPower = pow(g_userMaxBase, -g_userMaxLod);
 }
 
 // OFFSET: LEGO1 0x100a5de0
 void RealtimeView::SetUserMaxLOD(float p_lod)
 {
-  g_userMaxLod = p_lod;
-  UpdateMaxLOD();
+	g_userMaxLod = p_lod;
+	UpdateMaxLOD();
 }
 
 // OFFSET: LEGO1 0x100a5df0
 void RealtimeView::SetPartsThreshold(float p_threshold)
 {
-  g_partsThreshold = p_threshold;
+	g_partsThreshold = p_threshold;
 }

--- a/LEGO1/realtime/realtimeview.h
+++ b/LEGO1/realtime/realtimeview.h
@@ -1,14 +1,13 @@
 #ifndef REALTIMEVIEW_H
 #define REALTIMEVIEW_H
 
-class RealtimeView
-{
+class RealtimeView {
 public:
-  __declspec(dllexport) static float GetPartsThreshold();
-  __declspec(dllexport) static float GetUserMaxLOD();
-  __declspec(dllexport) static void SetPartsThreshold(float);
-  static void UpdateMaxLOD();
-  __declspec(dllexport) static void SetUserMaxLOD(float);
+	__declspec(dllexport) static float GetPartsThreshold();
+	__declspec(dllexport) static float GetUserMaxLOD();
+	__declspec(dllexport) static void SetPartsThreshold(float);
+	static void UpdateMaxLOD();
+	__declspec(dllexport) static void SetUserMaxLOD(float);
 };
 
 #endif // REALTIMEVIEW_H

--- a/LEGO1/registrationbook.cpp
+++ b/LEGO1/registrationbook.cpp
@@ -3,19 +3,19 @@
 // OFFSET: LEGO1 0x10076d20 STUB
 RegistrationBook::RegistrationBook()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x10076f50 STUB
 RegistrationBook::~RegistrationBook()
 {
-  // TODO
+	// TODO
 }
 
 // OFFSET: LEGO1 0x100770e0 STUB
-MxLong RegistrationBook::Notify(MxParam &p)
+MxLong RegistrationBook::Notify(MxParam& p)
 {
-  // TODO
+	// TODO
 
-  return 0;
+	return 0;
 }

--- a/LEGO1/registrationbook.h
+++ b/LEGO1/registrationbook.h
@@ -5,14 +5,12 @@
 
 // VTABLE 0x100d9928
 // SIZE 0x2d0
-class RegistrationBook : public LegoWorld
-{
+class RegistrationBook : public LegoWorld {
 public:
-  RegistrationBook();
-  virtual ~RegistrationBook() override; // vtable+0x0
+	RegistrationBook();
+	virtual ~RegistrationBook() override; // vtable+0x0
 
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 };
 
 #endif // REGISTRATIONBOOK_H

--- a/LEGO1/score.cpp
+++ b/LEGO1/score.cpp
@@ -1,333 +1,327 @@
 #include "score.h"
-#include "gifmanager.h"
+
 #include "ambulancemissionstate.h"
-#include "mxnotificationmanager.h"
-#include "mxnotificationparam.h"
-#include "mxtransitionmanager.h"
+#include "gifmanager.h"
 #include "legocontrolmanager.h"
 #include "legogamestate.h"
 #include "legoinputmanager.h"
 #include "legoomni.h"
+#include "mxnotificationmanager.h"
+#include "mxnotificationparam.h"
+#include "mxtransitionmanager.h"
 #include "pizzamissionstate.h"
 #include "racestate.h"
 #include "towtrackmissionstate.h"
 
 DECOMP_SIZE_ASSERT(Score, 0x104)
 
-MxAtomId *g_infoscorScript;
+MxAtomId* g_infoscorScript;
 
 // OFFSET: LEGO1 0x10001000
 Score::Score()
 {
-  m_unkf8 = 0;
-  NotificationManager()->Register(this);
+	m_unkf8 = 0;
+	NotificationManager()->Register(this);
 }
 
 // OFFSET: LEGO1 0x10001200
 Score::~Score()
 {
-  if (InputManager()->GetWorld() == this)
-    InputManager()->ClearWorld();
-  InputManager()->UnRegister(this);
-  ControlManager()->Unregister(this);
-  NotificationManager()->Unregister(this);
+	if (InputManager()->GetWorld() == this)
+		InputManager()->ClearWorld();
+	InputManager()->UnRegister(this);
+	ControlManager()->Unregister(this);
+	NotificationManager()->Unregister(this);
 }
 
 // OFFSET: LEGO1 0x10001410
-MxLong Score::Notify(MxParam &p)
+MxLong Score::Notify(MxParam& p)
 {
-  MxLong ret = 0;
-  LegoWorld::Notify(p);
-  if (m_unkf6) {
-    switch (((MxNotificationParam &)p).GetType())
-    {
-    case PAINT:
-      ret = 1;
-      Paint();
-      break;
-    case MXSTREAMER_UNKNOWN:
-      ret = FUN_10001510((MxEndActionNotificationParam &)p);
-      break;
-    case APP_MESSAGE:
-      if (((MxAppNotificationParam &)p).GetUnknown18() == 0x20)
-        DeleteScript(); // Shutting down
-      ret = 1;
-      break;
-    case TYPE17:
-      ret = FUN_100016d0((MxType17NotificationParam &)p);
-      break;
-    case MXTRANSITIONMANAGER_TRANSITIONENDED:
-      DeleteObjects(g_infoscorScript, 7, 9);
-      if (m_unkf8)
-        GameState()->HandleAction(m_unkf8);
-      ret = 1;
-      break;
-    default:
-      break;
-    }
-  }
-  return ret;
+	MxLong ret = 0;
+	LegoWorld::Notify(p);
+	if (m_unkf6) {
+		switch (((MxNotificationParam&) p).GetType()) {
+		case PAINT:
+			ret = 1;
+			Paint();
+			break;
+		case MXSTREAMER_UNKNOWN:
+			ret = FUN_10001510((MxEndActionNotificationParam&) p);
+			break;
+		case APP_MESSAGE:
+			if (((MxAppNotificationParam&) p).GetUnknown18() == 0x20)
+				DeleteScript(); // Shutting down
+			ret = 1;
+			break;
+		case TYPE17:
+			ret = FUN_100016d0((MxType17NotificationParam&) p);
+			break;
+		case MXTRANSITIONMANAGER_TRANSITIONENDED:
+			DeleteObjects(g_infoscorScript, 7, 9);
+			if (m_unkf8)
+				GameState()->HandleAction(m_unkf8);
+			ret = 1;
+			break;
+		default:
+			break;
+		}
+	}
+	return ret;
 }
 
 // OFFSET: LEGO1 0x100010b0
 MxBool Score::VTable0x5c()
 {
-  return TRUE; 
+	return TRUE;
 }
 
 // OFFSET: LEGO1 0x100012a0
-MxResult Score::InitFromMxDSObject(MxDSObject &p_dsObject)
+MxResult Score::InitFromMxDSObject(MxDSObject& p_dsObject)
 {
-  MxResult result = SetAsCurrentWorld(p_dsObject);
+	MxResult result = SetAsCurrentWorld(p_dsObject);
 
-  if (result == SUCCESS) {
-    InputManager()->SetWorld(this);
-    ControlManager()->Register(this);
-    InputManager()->Register(this);
-    SetIsWorldActive(FALSE);
-    LegoGameState *gs = GameState();
-    ScoreState *state = (ScoreState *)gs->GetState("ScoreState");
-    m_state = state ? state : (ScoreState *)gs->CreateState("ScoreState");
-    GameState()->SetUnknown424(0xd);
-    GameState()->FUN_1003a720(0);
-  }
+	if (result == SUCCESS) {
+		InputManager()->SetWorld(this);
+		ControlManager()->Register(this);
+		InputManager()->Register(this);
+		SetIsWorldActive(FALSE);
+		LegoGameState* gs = GameState();
+		ScoreState* state = (ScoreState*) gs->GetState("ScoreState");
+		m_state = state ? state : (ScoreState*) gs->CreateState("ScoreState");
+		GameState()->SetUnknown424(0xd);
+		GameState()->FUN_1003a720(0);
+	}
 
-  return result;
+	return result;
 }
 
 // OFFSET: LEGO1 0x10001340
 void Score::DeleteScript()
 {
-  if (m_state->GetTutorialFlag()) {
-    MxDSAction action;
-    action.SetObjectId(0x1f5);
-    action.SetAtomId(*g_infoscorScript);
-    action.SetUnknown24(-2);
-    DeleteObject(action);
-    m_state->SetTutorialFlag(FALSE);
-  }
+	if (m_state->GetTutorialFlag()) {
+		MxDSAction action;
+		action.SetObjectId(0x1f5);
+		action.SetAtomId(*g_infoscorScript);
+		action.SetUnknown24(-2);
+		DeleteObject(action);
+		m_state->SetTutorialFlag(FALSE);
+	}
 }
 
 // OFFSET: LEGO1 0x10001510
-MxLong Score::FUN_10001510(MxEndActionNotificationParam &p)
+MxLong Score::FUN_10001510(MxEndActionNotificationParam& p)
 {
-  MxDSAction *action = p.GetAction();
+	MxDSAction* action = p.GetAction();
 
-  if (m_atom == action->GetAtomId()) {
-    MxU32 id = action->GetObjectId();
-    switch (action->GetObjectId()) {
-    case 10:
-      m_unkf8 = 0x38;
-      TransitionManager()->StartTransition(MxTransitionManager::PIXELATION, 0x32, 0, 0);
-      break;
-    case 0x1f5:
-      FUN_10015910(0xb);
-      m_state->SetTutorialFlag(FALSE);
-    }
-  }
+	if (m_atom == action->GetAtomId()) {
+		MxU32 id = action->GetObjectId();
+		switch (action->GetObjectId()) {
+		case 10:
+			m_unkf8 = 0x38;
+			TransitionManager()->StartTransition(MxTransitionManager::PIXELATION, 0x32, 0, 0);
+			break;
+		case 0x1f5:
+			FUN_10015910(0xb);
+			m_state->SetTutorialFlag(FALSE);
+		}
+	}
 
-  return 1;
+	return 1;
 }
 
 // OFFSET: LEGO1 0x10001580
 void Score::Stop()
 {
-  LegoWorld::Stop();
+	LegoWorld::Stop();
 
-  MxDSAction action;
-  action.SetObjectId(0x1f4);
-  action.SetAtomId(m_atom);
-  action.SetUnknown84(this);
-  Start(&action);
+	MxDSAction action;
+	action.SetObjectId(0x1f4);
+	action.SetAtomId(m_atom);
+	action.SetUnknown84(this);
+	Start(&action);
 
-  if (m_state->GetTutorialFlag()) {
-    MxDSAction action2;
-    action.SetObjectId(0x1f5);
-    action.SetAtomId(*g_infoscorScript);
-    Start(&action);
-  }
-  else
-    FUN_10015910(0xb);
+	if (m_state->GetTutorialFlag()) {
+		MxDSAction action2;
+		action.SetObjectId(0x1f5);
+		action.SetAtomId(*g_infoscorScript);
+		Start(&action);
+	}
+	else
+		FUN_10015910(0xb);
 
-  FUN_10015820(0, 7);
+	FUN_10015820(0, 7);
 }
 
 // OFFSET: LEGO1 0x100016d0
-MxLong Score::FUN_100016d0(MxType17NotificationParam &p)
+MxLong Score::FUN_100016d0(MxType17NotificationParam& p)
 {
-  MxS16 l = p.GetUnknown28();
+	MxS16 l = p.GetUnknown28();
 
-  if (l == 1 || p.GetUnknown20() == 4) {
-    switch (p.GetUnknown20())
-    {
-    case 1:
-      m_unkf8 = 2;
-      DeleteScript();
-      TransitionManager()->StartTransition(MxTransitionManager::PIXELATION, 0x32, 0, 0);
-      break;
-    case 2:
-      m_unkf8 = 3;
-      DeleteScript();
-      TransitionManager()->StartTransition(MxTransitionManager::PIXELATION, 0x32, 0, 0);
-      break;
-    case 3:
-    {
-      LegoInputManager *im = InputManager();
-      im->SetUnknown88(TRUE);
-      im->SetUnknown336(FALSE);
-      DeleteScript();
+	if (l == 1 || p.GetUnknown20() == 4) {
+		switch (p.GetUnknown20()) {
+		case 1:
+			m_unkf8 = 2;
+			DeleteScript();
+			TransitionManager()->StartTransition(MxTransitionManager::PIXELATION, 0x32, 0, 0);
+			break;
+		case 2:
+			m_unkf8 = 3;
+			DeleteScript();
+			TransitionManager()->StartTransition(MxTransitionManager::PIXELATION, 0x32, 0, 0);
+			break;
+		case 3: {
+			LegoInputManager* im = InputManager();
+			im->SetUnknown88(TRUE);
+			im->SetUnknown336(FALSE);
+			DeleteScript();
 
-      MxDSAction action;
-      action.SetObjectId(10);
-      action.SetAtomId(*g_infoscorScript);
-      Start(&action);
-      break;
-    }
-    case 4:
-    {
-      switch (l) {
-        case 1:
-        {
-          MxDSAction action;
-          action.SetObjectId(7);
-          action.SetAtomId(*g_infoscorScript);
-          Start(&action);
-          break;
-        }
-        case 2:
-        {
-          MxDSAction action;
-          action.SetObjectId(8);
-          action.SetAtomId(*g_infoscorScript);
-          Start(&action);
-          break;
-        }
-        case 3:
-        {
-          MxDSAction action;
-          action.SetObjectId(9);
-          action.SetAtomId(*g_infoscorScript);
-          Start(&action);
-          break;
-        }
-      }
-      break;
-    }
-    }
-  }
+			MxDSAction action;
+			action.SetObjectId(10);
+			action.SetAtomId(*g_infoscorScript);
+			Start(&action);
+			break;
+		}
+		case 4: {
+			switch (l) {
+			case 1: {
+				MxDSAction action;
+				action.SetObjectId(7);
+				action.SetAtomId(*g_infoscorScript);
+				Start(&action);
+				break;
+			}
+			case 2: {
+				MxDSAction action;
+				action.SetObjectId(8);
+				action.SetAtomId(*g_infoscorScript);
+				Start(&action);
+				break;
+			}
+			case 3: {
+				MxDSAction action;
+				action.SetObjectId(9);
+				action.SetAtomId(*g_infoscorScript);
+				Start(&action);
+				break;
+			}
+			}
+			break;
+		}
+		}
+	}
 
-  return 1;
+	return 1;
 }
 
 // OFFSET: LEGO1 0x10001980
 void Score::VTable0x68(MxBool p_add)
 {
-  LegoWorld::VTable0x68(p_add);
+	LegoWorld::VTable0x68(p_add);
 
-  if (p_add) {
-    InputManager()->SetWorld(this);
-    SetIsWorldActive(FALSE);
-  }
-  else if (InputManager()->GetWorld() == this)
-    InputManager()->ClearWorld();
+	if (p_add) {
+		InputManager()->SetWorld(this);
+		SetIsWorldActive(FALSE);
+	}
+	else if (InputManager()->GetWorld() == this)
+		InputManager()->ClearWorld();
 }
 
 // OFFSET: LEGO1 0x100019d0
 void Score::Paint()
 {
-  GifManager *gm = GetGifManager();
-  GifData *gd = gm->Get("bigcube.gif");
+	GifManager* gm = GetGifManager();
+	GifData* gd = gm->Get("bigcube.gif");
 
-  if (gd) {
-    RaceState *l78 = (RaceState *)GameState()->GetState("JetskiRaceState");
-    RaceState *l70 = (RaceState *)GameState()->GetState("CarRaceState");
-    TowTrackMissionState *lesi = (TowTrackMissionState *)GameState()->GetState("TowTrackMissionState");
-    PizzaMissionState *l74 = (PizzaMissionState *)GameState()->GetState("PizzaMissionState");
-    AmbulanceMissionState *lebp = (AmbulanceMissionState *)GameState()->GetState("AmbulanceMissionState");
+	if (gd) {
+		RaceState* l78 = (RaceState*) GameState()->GetState("JetskiRaceState");
+		RaceState* l70 = (RaceState*) GameState()->GetState("CarRaceState");
+		TowTrackMissionState* lesi = (TowTrackMissionState*) GameState()->GetState("TowTrackMissionState");
+		PizzaMissionState* l74 = (PizzaMissionState*) GameState()->GetState("PizzaMissionState");
+		AmbulanceMissionState* lebp = (AmbulanceMissionState*) GameState()->GetState("AmbulanceMissionState");
 
-    DDSURFACEDESC desc;
-    memset(&desc, 0, 0x6c);
-    desc.dwSize = 0x6c;
-    if (gd->m_surface->Lock(NULL, &desc, 0, NULL) == DD_OK) {
-      if (desc.lPitch != desc.dwWidth) {
-        gd->m_surface->Unlock(desc.lpSurface);
-        return;
-      }
+		DDSURFACEDESC desc;
+		memset(&desc, 0, 0x6c);
+		desc.dwSize = 0x6c;
+		if (gd->m_surface->Lock(NULL, &desc, 0, NULL) == DD_OK) {
+			if (desc.lPitch != desc.dwWidth) {
+				gd->m_surface->Unlock(desc.lpSurface);
+				return;
+			}
 
-      for (MxU8 id = 1; id <= 5; id++) {
-        m_surface = (MxU8 *)desc.lpSurface;
-        MxU16 color = 0;
-        if (l70)
-          color = l70->GetColor(id);
-        MxU32 row = id - 1;
-        FillArea(0, row, color);
-        color = 0;
-        if (l78)
-          color = l78->GetColor(id);
-        FillArea(1, row, color);
-        color = 0;
-        if (l74)
-          color = l74->GetColor(id);
-        FillArea(2, row, color);
-        color = 0;
-        if (lesi)
-          color = lesi->GetColor(id);
-        FillArea(3, row, color);
-        color = 0;
-        if (lebp)
-          color = lebp->GetColor(id);
-        FillArea(4, row, color);
-      }
+			for (MxU8 id = 1; id <= 5; id++) {
+				m_surface = (MxU8*) desc.lpSurface;
+				MxU16 color = 0;
+				if (l70)
+					color = l70->GetColor(id);
+				MxU32 row = id - 1;
+				FillArea(0, row, color);
+				color = 0;
+				if (l78)
+					color = l78->GetColor(id);
+				FillArea(1, row, color);
+				color = 0;
+				if (l74)
+					color = l74->GetColor(id);
+				FillArea(2, row, color);
+				color = 0;
+				if (lesi)
+					color = lesi->GetColor(id);
+				FillArea(3, row, color);
+				color = 0;
+				if (lebp)
+					color = lebp->GetColor(id);
+				FillArea(4, row, color);
+			}
 
-      gd->m_surface->Unlock(desc.lpSurface);
-      gd->m_texture->Changed(TRUE, FALSE);
-      m_surface = NULL;
-    }
-  }
+			gd->m_surface->Unlock(desc.lpSurface);
+			gd->m_texture->Changed(TRUE, FALSE);
+			m_surface = NULL;
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x10001d20
 void Score::FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color)
 {
-  MxU32 data[24];
-  data[9] = 0x2b00;
-  data[10] = 0x5700;
-  data[11] = 0x8000;
-  data[19] = 0x2a;
-  data[12] = 0xab00;
-  data[13] = 0xd600;
-  data[20] = 0x27;
-  data[21] = 0x29;
-  data[22] = 0x29;
-  data[23] = 0x2a;
-  data[4] = 0x2f;
-  data[5] = 0x56;
-  data[6] = 0x81;
-  data[15] = 0x29;
-  data[16] = 0x27;
-  data[7] = 0xaa;
-  data[8] = 0xd4;
-  data[14] = 0x25;
-  data[0] = 0x11;
-  data[17] = 0x28;
-  data[18] = 0x28;
-  data[1] = 0xf;
-  MxU32 size = data[p_x + 14];
-  MxU8 *ptr = data[p_x + 4] + data[p_y + 9] + m_surface;
-  MxS32 count = data[p_y + 19];
-  data[2] = 0x8;
-  data[3] = 0x5;
-  MxU32 value = data[p_color];
-  for (; count > 0; count--) {
-    memset(ptr++, value, size);
-    ptr += 0x100;
-  }
+	MxU32 data[24];
+	data[9] = 0x2b00;
+	data[10] = 0x5700;
+	data[11] = 0x8000;
+	data[19] = 0x2a;
+	data[12] = 0xab00;
+	data[13] = 0xd600;
+	data[20] = 0x27;
+	data[21] = 0x29;
+	data[22] = 0x29;
+	data[23] = 0x2a;
+	data[4] = 0x2f;
+	data[5] = 0x56;
+	data[6] = 0x81;
+	data[15] = 0x29;
+	data[16] = 0x27;
+	data[7] = 0xaa;
+	data[8] = 0xd4;
+	data[14] = 0x25;
+	data[0] = 0x11;
+	data[17] = 0x28;
+	data[18] = 0x28;
+	data[1] = 0xf;
+	MxU32 size = data[p_x + 14];
+	MxU8* ptr = data[p_x + 4] + data[p_y + 9] + m_surface;
+	MxS32 count = data[p_y + 19];
+	data[2] = 0x8;
+	data[3] = 0x5;
+	MxU32 value = data[p_color];
+	for (; count > 0; count--) {
+		memset(ptr++, value, size);
+		ptr += 0x100;
+	}
 }
 
 // OFFSET: LEGO1 0x10001e40
-MxBool Score::VTable0x64() 
+MxBool Score::VTable0x64()
 {
-  DeleteScript();
-  m_unkf8 = 2;
-  return TRUE;
+	DeleteScript();
+	m_unkf8 = 2;
+	return TRUE;
 }

--- a/LEGO1/score.h
+++ b/LEGO1/score.h
@@ -2,51 +2,50 @@
 #define SCORE_H
 
 #include "legoworld.h"
-#include "scorestate.h"
 #include "mxactionnotificationparam.h"
 #include "mxappnotificationparam.h"
 #include "mxtype17notificationparam.h"
+#include "scorestate.h"
 
 // VTABLE 0x100d4018
 // SIZE 0x104
-class Score : public LegoWorld
-{
+class Score : public LegoWorld {
 public:
-  Score();
-  virtual ~Score() override; // vtable+0x0
-  virtual MxLong Notify(MxParam &p) override; // vtable+0x4
-  
-  // OFFSET: LEGO1 0x100010c0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f0058
-    return "Score";
-  }
+	Score();
+	virtual ~Score() override;                  // vtable+0x0
+	virtual MxLong Notify(MxParam& p) override; // vtable+0x4
 
-  // OFFSET: LEGO1 0x100010d0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, Score::ClassName()) || LegoWorld::IsA(name);
-  }
+	// OFFSET: LEGO1 0x100010c0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0058
+		return "Score";
+	}
 
-  virtual MxResult InitFromMxDSObject(MxDSObject &p_dsObject) override; // vtable+18
-  virtual void Stop() override; // vtable+50
-  virtual MxBool VTable0x5c() override; // vtable+5c
-  virtual MxBool VTable0x64() override; // vtable+64
-  virtual void VTable0x68(MxBool p_add) override; // vtable+68
+	// OFFSET: LEGO1 0x100010d0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, Score::ClassName()) || LegoWorld::IsA(name);
+	}
 
-  void Paint();
-  MxLong FUN_10001510(MxEndActionNotificationParam &p);
-  MxLong FUN_100016d0(MxType17NotificationParam &p);
-  void FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color);
+	virtual MxResult InitFromMxDSObject(MxDSObject& p_dsObject) override; // vtable+18
+	virtual void Stop() override;                                         // vtable+50
+	virtual MxBool VTable0x5c() override;                                 // vtable+5c
+	virtual MxBool VTable0x64() override;                                 // vtable+64
+	virtual void VTable0x68(MxBool p_add) override;                       // vtable+68
+
+	void Paint();
+	MxLong FUN_10001510(MxEndActionNotificationParam& p);
+	MxLong FUN_100016d0(MxType17NotificationParam& p);
+	void FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color);
 
 protected:
-  undefined4 m_unkf8;
-  ScoreState *m_state;
-  MxU8 *m_surface;
+	undefined4 m_unkf8;
+	ScoreState* m_state;
+	MxU8* m_surface;
 
 private:
-  void DeleteScript();
+	void DeleteScript();
 };
 
 #endif // SCORE_H

--- a/LEGO1/scorestate.cpp
+++ b/LEGO1/scorestate.cpp
@@ -3,13 +3,14 @@
 DECOMP_SIZE_ASSERT(ScoreState, 0x0C);
 
 // OFFSET: LEGO1 0x1000de20
-MxBool ScoreState::VTable0x14() {
-  return FALSE;
+MxBool ScoreState::VTable0x14()
+{
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x1000de30
 MxBool ScoreState::SetFlag()
 {
-  m_playCubeTutorial = TRUE;
-  return TRUE;
+	m_playCubeTutorial = TRUE;
+	return TRUE;
 }

--- a/LEGO1/scorestate.h
+++ b/LEGO1/scorestate.h
@@ -5,30 +5,29 @@
 
 // VTABLE 0x100d53f8
 // SIZE 0xc
-class ScoreState : public LegoState
-{
+class ScoreState : public LegoState {
 public:
-  // OFFSET: LEGO1 0x1000de40
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  { 
-    // 0x100f0084
-    return "ScoreState";
-  }; 
+	// OFFSET: LEGO1 0x1000de40
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f0084
+		return "ScoreState";
+	};
 
-  // OFFSET: LEGO1 0x1000de50
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, ScoreState::ClassName()) || LegoState::IsA(name);
-  };
+	// OFFSET: LEGO1 0x1000de50
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, ScoreState::ClassName()) || LegoState::IsA(name);
+	};
 
-  virtual MxBool VTable0x14() override; // vtable+0x14
-  virtual MxBool SetFlag() override; // vtable+0x18
+	virtual MxBool VTable0x14() override; // vtable+0x14
+	virtual MxBool SetFlag() override;    // vtable+0x18
 
-  inline MxBool GetTutorialFlag() { return m_playCubeTutorial; }
-  inline void SetTutorialFlag(MxBool p_playCubeTutorial) { m_playCubeTutorial = p_playCubeTutorial; }
+	inline MxBool GetTutorialFlag() { return m_playCubeTutorial; }
+	inline void SetTutorialFlag(MxBool p_playCubeTutorial) { m_playCubeTutorial = p_playCubeTutorial; }
 
 private:
-  MxBool m_playCubeTutorial;
+	MxBool m_playCubeTutorial;
 };
 
 #endif // SCORESTATE_H

--- a/LEGO1/skateboard.cpp
+++ b/LEGO1/skateboard.cpp
@@ -1,19 +1,18 @@
 #include "skateboard.h"
 
-#include "mxomni.h"
-#include "mxnotificationmanager.h"
-
 #include "decomp.h"
+#include "mxnotificationmanager.h"
+#include "mxomni.h"
 
 DECOMP_SIZE_ASSERT(SkateBoard, 0x168);
 
 // OFFSET: LEGO1 0x1000fd40
 SkateBoard::SkateBoard()
 {
-  this->m_unk160 = 0;
-  this->m_unk13c = 15.0;
-  this->m_unk150 = 3.5;
-  this->m_unk148 = 1;
+	this->m_unk160 = 0;
+	this->m_unk13c = 15.0;
+	this->m_unk150 = 3.5;
+	this->m_unk148 = 1;
 
-  NotificationManager()->Register(this);
+	NotificationManager()->Register(this);
 }

--- a/LEGO1/skateboard.h
+++ b/LEGO1/skateboard.h
@@ -6,27 +6,27 @@
 
 // VTABLE 0x100d55f0
 // SIZE 0x168
-class SkateBoard : public IslePathActor
-{
+class SkateBoard : public IslePathActor {
 public:
-  SkateBoard();
+	SkateBoard();
 
-  // OFFSET: LEGO1 0x1000fdd0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f041c
-    return "SkateBoard";
-  }
+	// OFFSET: LEGO1 0x1000fdd0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f041c
+		return "SkateBoard";
+	}
 
-  // OFFSET: LEGO1 0x1000fde0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, SkateBoard::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1000fde0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, SkateBoard::ClassName()) || IslePathActor::IsA(name);
+	}
+
 private:
-  // TODO: SkateBoard types
-  undefined m_unk160;
-  undefined m_unk161[0x7];
+	// TODO: SkateBoard types
+	undefined m_unk160;
+	undefined m_unk161[0x7];
 };
 
 #endif // SKATEBOARD_H

--- a/LEGO1/towtrack.cpp
+++ b/LEGO1/towtrack.cpp
@@ -5,13 +5,13 @@ DECOMP_SIZE_ASSERT(TowTrack, 0x180);
 // OFFSET: LEGO1 0x1004c720
 TowTrack::TowTrack()
 {
-  this->m_unk168 = 0;
-  this->m_unk16a = -1;
-  this->m_unk164 = 0;
-  this->m_unk16c = 0;
-  this->m_unk170 = -1;
-  this->m_unk16e = 0;
-  this->m_unk174 = -1;
-  this->m_unk13c = 40.0;
-  this->m_unk178 = 1.0;
+	this->m_unk168 = 0;
+	this->m_unk16a = -1;
+	this->m_unk164 = 0;
+	this->m_unk16c = 0;
+	this->m_unk170 = -1;
+	this->m_unk16e = 0;
+	this->m_unk174 = -1;
+	this->m_unk13c = 40.0;
+	this->m_unk178 = 1.0;
 }

--- a/LEGO1/towtrack.h
+++ b/LEGO1/towtrack.h
@@ -6,37 +6,35 @@
 
 // VTABLE 0x100d7ee0
 // SIZE 0x180
-class TowTrack : public IslePathActor
-{
+class TowTrack : public IslePathActor {
 public:
-  TowTrack();
+	TowTrack();
 
-  // OFFSET: LEGO1 0x1004c7c0
-  inline virtual const char *ClassName() const override // vtable+0x0c
-  {
-    // 0x100f03b8
-    return "TowTrack";
-  }
+	// OFFSET: LEGO1 0x1004c7c0
+	inline virtual const char* ClassName() const override // vtable+0x0c
+	{
+		// 0x100f03b8
+		return "TowTrack";
+	}
 
-  // OFFSET: LEGO1 0x1004c7d0
-  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
-  {
-    return !strcmp(name, TowTrack::ClassName()) || IslePathActor::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1004c7d0
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, TowTrack::ClassName()) || IslePathActor::IsA(name);
+	}
 
 private:
-  // TODO: TowTrack field types
-  undefined m_unk154[4];
-  MxS32 m_unk164;
-  MxS16 m_unk168;
-  MxS16 m_unk16a;
-  MxS16 m_unk16c;
-  MxS16 m_unk16e;
-  MxS32 m_unk170;
-  MxS32 m_unk174;
-  MxFloat m_unk178;
-  undefined4 m_unk17c;
+	// TODO: TowTrack field types
+	undefined m_unk154[4];
+	MxS32 m_unk164;
+	MxS16 m_unk168;
+	MxS16 m_unk16a;
+	MxS16 m_unk16c;
+	MxS16 m_unk16e;
+	MxS32 m_unk170;
+	MxS32 m_unk174;
+	MxFloat m_unk178;
+	undefined4 m_unk17c;
 };
-
 
 #endif // TOWTRACK_H

--- a/LEGO1/towtrackmissionstate.cpp
+++ b/LEGO1/towtrackmissionstate.cpp
@@ -5,5 +5,5 @@ DECOMP_SIZE_ASSERT(TowTrackMissionState, 0x28)
 // OFFSET: LEGO1 0x1004dd30 STUB
 TowTrackMissionState::TowTrackMissionState()
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/towtrackmissionstate.h
+++ b/LEGO1/towtrackmissionstate.h
@@ -5,44 +5,48 @@
 
 // VTABLE 0x100d7fd8
 // SIZE 0x28
-class TowTrackMissionState : public LegoState
-{
+class TowTrackMissionState : public LegoState {
 public:
-  TowTrackMissionState();
+	TowTrackMissionState();
 
-  // OFFSET: LEGO1 0x1004dfa0
-  inline virtual const char *ClassName() const // vtable+0x0c
-  { 
-    // 0x100f00bc
-    return "TowTrackMissionState";
-  } 
+	// OFFSET: LEGO1 0x1004dfa0
+	inline virtual const char* ClassName() const // vtable+0x0c
+	{
+		// 0x100f00bc
+		return "TowTrackMissionState";
+	}
 
-  // OFFSET: LEGO1 0x1004dfb0
-  inline virtual MxBool IsA(const char *name) const // vtable+0x10
-  {
-    return !strcmp(name, TowTrackMissionState::ClassName()) || LegoState::IsA(name);
-  }
+	// OFFSET: LEGO1 0x1004dfb0
+	inline virtual MxBool IsA(const char* name) const // vtable+0x10
+	{
+		return !strcmp(name, TowTrackMissionState::ClassName()) || LegoState::IsA(name);
+	}
 
-  inline MxU16 GetColor(MxU8 id)
-  {
-    switch (id)
-    {
-    case 1: return m_color1;
-    case 2: return m_color2;
-    case 3: return m_color3;
-    case 4: return m_color4;
-    case 5: return m_color5;
-    default: return 0;
-    }
-  }
+	inline MxU16 GetColor(MxU8 id)
+	{
+		switch (id) {
+		case 1:
+			return m_color1;
+		case 2:
+			return m_color2;
+		case 3:
+			return m_color3;
+		case 4:
+			return m_color4;
+		case 5:
+			return m_color5;
+		default:
+			return 0;
+		}
+	}
 
 protected:
-  undefined m_unk8[0x14];
-  MxU16 m_color1;
-  MxU16 m_color2;
-  MxU16 m_color3;
-  MxU16 m_color4;
-  MxU16 m_color5;
+	undefined m_unk8[0x14];
+	MxU16 m_color1;
+	MxU16 m_color2;
+	MxU16 m_color3;
+	MxU16 m_color4;
+	MxU16 m_color5;
 };
 
 #endif // TOWTRACKMISSIONSTATE_H

--- a/LEGO1/viewmanager.cpp
+++ b/LEGO1/viewmanager.cpp
@@ -1,7 +1,7 @@
 #include "viewmanager.h"
 
 // OFFSET: LEGO1 0x100a64d0 STUB
-void ViewManager::RemoveAll(ViewROI *)
+void ViewManager::RemoveAll(ViewROI*)
 {
-  // TODO
+	// TODO
 }

--- a/LEGO1/viewmanager.h
+++ b/LEGO1/viewmanager.h
@@ -3,10 +3,9 @@
 
 class ViewROI;
 
-class ViewManager
-{
+class ViewManager {
 public:
-  __declspec(dllexport) void RemoveAll(ViewROI *);
+	__declspec(dllexport) void RemoveAll(ViewROI*);
 };
 
 #endif // VIEWMANAGER_H


### PR DESCRIPTION
Since we've gained several contributors over the last few weeks (which is great), the issue regarding code style is coming up more and more often - so far we've been manually verifying that all contributions are more or less in line with the (implicit) style rules we've been adhering to so far.

However, this becomes increasingly unfeasible since the current manual process requires spending a considerable amount of extra time, not to mention that the lack of explicit guidelines adds to the workload of every contributor.

Personally, I believe we have to introduce the following scripts/checks to enhance the collaboration process:

* Verify formatting of the code - addressed by this PR using `clang-format`
* Verify our decomp declarations - (partially) addressed by https://github.com/isledecomp/isle/pull/228
* Verify naming conventions (i.e. `m_unk0x00` and https://github.com/isledecomp/isle/blob/master/CONTRIBUTING.md#code-style )

This PR introduces the `clang-format` tool, a `.clang-format` file that specifies the rules and a GitHub action that verifies that the code is formatted according to the rules (and fails if there are any issues).

`clang-format` has many integrations with popular editors and IDEs, so adoption should be relatively straightforward for everyone.

The set of rules is based on the `Microsoft` preset, since it comes closest to the style we've been using so far. On top of that, `.clang-format` specifies rules that are custom to this project. These are based on how we have written code ~80-90% of the time so far, since the goal is to solidify the existing, implicitly used style instead of introducing a new one.

So far the output looks pretty good to me. Let me know what you think. Here's a list of all options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html - feel free to suggest changes.