### PR TITLE
MxVideoPresenter::IsHit

### DIFF
--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -51,6 +51,7 @@ public:
 
   inline BITMAPINFOHEADER *GetBmiHeader() const { return m_bmiHeader; }
   inline MxLong GetBmiWidth() const { return m_bmiHeader->biWidth; }
+  inline MxLong GetBmiStride() const { return ((m_bmiHeader->biWidth + 3) & -4); }
   inline MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
   inline MxLong GetBmiHeightAbs() const { return m_bmiHeader->biHeight > 0 ? m_bmiHeader->biHeight : -m_bmiHeader->biHeight; }
   inline MxU8 *GetBitmapData() const { return m_data; }

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -16,10 +16,12 @@ public:
   {
     Flag_Looping = 0x01,
     Flag_Bit3 = 0x04,
+    Flag_Bit4 = 0x08,
     Flag_Bit5 = 0x10,
     Flag_Enabled = 0x20,
     Flag_Parsed = 0x80,
     Flag_Bit9 = 0x200,
+    Flag_Bit10 = 0x400,
   };
 
   __declspec(dllexport) MxDSAction();

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -35,6 +35,7 @@ public:
 
   virtual void Destroy() override; // vtable+0x38
 
+  virtual MxBool IsHit(MxS32 p_x, MxS32 p_y) override; //vtable+0x50
   virtual void VTable0x5c(undefined4 p_unknown1); // vtable+0x5c
   virtual void VTable0x60(); // vtable+0x60
   virtual void VTable0x64(); // vtable+0x64
@@ -47,8 +48,6 @@ public:
   virtual MxS32 GetWidth();  // vtable+0x80
   virtual MxS32 GetHeight(); // vtable+0x84
 
-  // TODO: Not sure what this is. Seems to have size of 12 bytes
-  // based on 0x100b9e9a. Values are copied from the bitmap header.
   // SIZE 0xc
   struct AlphaMask {
     MxU8 *m_bitmask;
@@ -58,6 +57,8 @@ public:
     AlphaMask(const MxBitmap &);
     AlphaMask(const AlphaMask &);
     virtual ~AlphaMask();
+
+    MxS32 IsHit(MxU32 p_x, MxU32 p_y);
   };
 
   MxBitmap *m_bitmap;


### PR DESCRIPTION
(This is ready, but I'll keep it as a draft for now until we get the clang-format pull request done.)

Implements IsHit() for MxVideoPresenter. If available, the code will use the AlphaMask from #226 as a memoization for this check.

The match percentage here isn't great. I don't know why the original uses so many stack variables. Any ideas are welcome.