### PR TITLE
MxStillPresenter::ParseExtra

### DIFF
--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -8,3 +8,6 @@ const char* g_strWORLD = "WORLD";
 
 // 0x10102040
 const char* g_strACTION = "ACTION";
+
+// 0x101020cc
+const char* g_strVISIBILITY = "VISIBILITY";

--- a/LEGO1/define.h
+++ b/LEGO1/define.h
@@ -4,5 +4,6 @@
 extern const char* g_parseExtraTokens;
 extern const char* g_strWORLD;
 extern const char* g_strACTION;
+extern const char* g_strVISIBILITY;
 
 #endif // DEFINE_H

--- a/LEGO1/mxstillpresenter.cpp
+++ b/LEGO1/mxstillpresenter.cpp
@@ -1,5 +1,43 @@
 #include "mxstillpresenter.h"
 
 #include "decomp.h"
+#include "define.h"
+#include "legoomni.h"
 
 DECOMP_SIZE_ASSERT(MxStillPresenter, 0x6c);
+
+// 0x10101eb0
+const char* g_strBMP_ISMAP = "BMP_ISMAP";
+
+// OFFSET: LEGO1 0x100ba1e0
+void MxStillPresenter::ParseExtra()
+{
+	MxPresenter::ParseExtra();
+
+	if (m_action->GetFlags() & MxDSAction::Flag_Bit5)
+		m_flags |= 0x8;
+
+	MxU32 len = m_action->GetExtraLength();
+
+	if (len == 0)
+		return;
+
+  len &= MAXWORD;
+
+	char buf[512];
+	memcpy(buf, m_action->GetExtraData(), len);
+	buf[len] = '\0';
+
+	char output[512];
+	if (KeyValueStringParse(output, g_strVISIBILITY, buf)) {
+		if (strcmpi(output, "FALSE") == 0) {
+			Enable(FALSE);
+		}
+	}
+
+	if (KeyValueStringParse(output, g_strBMP_ISMAP, buf)) {
+		m_flags |= 0x10;
+		m_flags &= ~0x2;
+		m_flags &= ~0x4;
+	}
+}

--- a/LEGO1/mxstillpresenter.cpp
+++ b/LEGO1/mxstillpresenter.cpp
@@ -22,7 +22,7 @@ void MxStillPresenter::ParseExtra()
 	if (len == 0)
 		return;
 
-  len &= MAXWORD;
+	len &= MAXWORD;
 
 	char buf[512];
 	memcpy(buf, m_action->GetExtraData(), len);

--- a/LEGO1/mxstillpresenter.h
+++ b/LEGO1/mxstillpresenter.h
@@ -8,6 +8,8 @@
 // SIZE 0x6c
 class MxStillPresenter : public MxVideoPresenter {
 public:
+  virtual void ParseExtra() override; // vtable+0x30
+
 	MxStillPresenter() { m_unk68 = 0; }
 	undefined4 m_unk64;
 	undefined4 m_unk68;

--- a/LEGO1/mxstillpresenter.h
+++ b/LEGO1/mxstillpresenter.h
@@ -8,7 +8,7 @@
 // SIZE 0x6c
 class MxStillPresenter : public MxVideoPresenter {
 public:
-  virtual void ParseExtra() override; // vtable+0x30
+	virtual void ParseExtra() override; // vtable+0x30
 
 	MxStillPresenter() { m_unk68 = 0; }
 	undefined4 m_unk64;


### PR DESCRIPTION
Not an exact match, but wrong for all the usual reasons.

This function does an odd thing with the "extra" string length that also happens in the main `MxPresenter::ParseExtra`. The variable is word-sized, but then we mask out the more significant other bits with an `AND EAX, 0xffff`. I doubt my literal interpretation of that matches the original, but it at least gets the instruction in there.

Is this extra length + char* another structure? Why `memcpy` the data versus the more logical `strcpy`?