### PR TITLE
implement/match several mxsmkpresenter functions

### DIFF
--- a/3rdparty/smk/smk.h
+++ b/3rdparty/smk/smk.h
@@ -1,0 +1,54 @@
+#ifndef SMK_H
+#define SMK_H
+
+struct SmackSum {
+	unsigned long m_totalTime;
+	unsigned long m_ms100PerFrame;
+	unsigned long m_totalOpenTime;
+	unsigned long m_totalFrames;
+  	unsigned long m_skippedFrames;
+	unsigned long m_totalBlitTime;
+	unsigned long m_totalReadTime;
+	unsigned long m_totalDecompressTime;
+	unsigned long m_totalBackReadTime;
+	unsigned long m_totalReadSpeed;
+	unsigned long m_slowestFrameTime;
+	unsigned long m_slowestTwoFrameTime;
+	unsigned long m_slowestFrameNum;
+	unsigned long m_slowestTwoFrameNum;
+	unsigned long m_averageFrameSize;
+	unsigned long m_highestOneSecRate;
+	unsigned long m_highestOneSecFrame;
+	unsigned long m_highestMemAmount;
+	unsigned long m_totalExtraMemory;
+	unsigned long m_highestExtraUsed;
+};
+
+struct Smack {
+	unsigned long m_version;
+	unsigned long m_width;
+	unsigned long m_height;
+	unsigned long m_frames;
+	unsigned long m_msInAFrame;
+	unsigned long m_smkType;
+	unsigned long m_audioTrackSize[7];
+	unsigned long m_treeSize;
+	unsigned long m_codeSize;
+	unsigned long m_abSize;
+	unsigned long m_detailSize;
+	unsigned long m_typeSize;
+	unsigned long m_trackType[7];
+	unsigned long m_extra;
+	unsigned long m_newPalette;
+	unsigned char m_palette[772];
+	unsigned long m_frameNum;
+	unsigned long m_lastRectX;
+	unsigned long m_lastRectY;
+	unsigned long m_lastRectW;
+	unsigned long m_lastRectH;
+	unsigned long m_openFlags;
+	unsigned long m_leftOfs;
+	unsigned long m_topOfs;
+};
+
+#endif // SMK_H

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,8 +213,9 @@ if (MINGW)
   target_compile_definitions(lego1 PRIVATE DIRECTINPUT_VERSION=0x0500)
 endif()
 
-# Additional include directories for both targets
+# Additional include directories
 include_directories("${CMAKE_SOURCE_DIR}/3rdparty/vec")
+include_directories("${CMAKE_SOURCE_DIR}/3rdparty/smk")
 
 if (ISLE_USE_SMARTHEAP)
   add_library(SmartHeap::SmartHeap STATIC IMPORTED)
@@ -231,9 +232,6 @@ if (ISLE_USE_DX5)
   target_include_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/dx5/inc")
   target_link_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/dx5/lib")
 endif()
-
-# Additional include directories
-include_directories("${CMAKE_SOURCE_DIR}/3rdparty/smk")
 
 # Link libraries
 target_link_libraries(lego1 PRIVATE ddraw dsound dxguid dinput winmm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,9 @@ if (ISLE_USE_DX5)
   target_link_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/dx5/lib")
 endif()
 
+# Additional include directories
+include_directories("${CMAKE_SOURCE_DIR}/3rdparty/smk")
+
 # Link libraries
 target_link_libraries(lego1 PRIVATE ddraw dsound dxguid dinput winmm)
 

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -13,19 +13,7 @@ MxSmkPresenter::MxSmkPresenter()
 // OFFSET: LEGO1 0x100b3870
 MxSmkPresenter::~MxSmkPresenter()
 {
-	FUN_100b3900(TRUE);
-}
-
-// OFFSET: LEGO1 0x100b3900
-void MxSmkPresenter::FUN_100b3900(MxBool p_fromDestructor)
-{
-	m_criticalSection.Enter();
-	FUN_100c5d40(&m_mxSmack);
-	Init();
-	m_criticalSection.Leave();
-	if (!p_fromDestructor) {
-		MxVideoPresenter::Destroy(FALSE);
-	}
+	Destroy(TRUE);
 }
 
 // OFFSET: LEGO1 0x100b38d0
@@ -35,6 +23,21 @@ void MxSmkPresenter::Init()
 	memset(&m_mxSmack, 0, sizeof(m_mxSmack));
 	m_flags &= 0xfd;
 	m_flags &= 0xfb;
+}
+
+// OFFSET: LEGO1 0x100b3900
+void MxSmkPresenter::Destroy(MxBool p_fromDestructor)
+{
+	m_criticalSection.Enter();
+
+	FUN_100c5d40(&m_mxSmack);
+	Init();
+
+	m_criticalSection.Leave();
+
+	if (!p_fromDestructor) {
+		MxVideoPresenter::Destroy(FALSE);
+	}
 }
 
 // OFFSET: LEGO1 0x100b3960

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -4,16 +4,37 @@
 
 DECOMP_SIZE_ASSERT(MxSmkPresenter, 0x720);
 
-// OFFSET: LEGO1 0x100b3650 STUB
+// OFFSET: LEGO1 0x100b3650
 MxSmkPresenter::MxSmkPresenter()
 {
-	// TODO
+	Init();
 }
 
-// OFFSET: LEGO1 0x100b38d0 STUB
+// OFFSET: LEGO1 0x100b3870
+MxSmkPresenter::~MxSmkPresenter()
+{
+	FUN_100b3900(TRUE);
+}
+
+// OFFSET: LEGO1 0x100b3900
+void MxSmkPresenter::FUN_100b3900(MxBool p_fromDestructor)
+{
+	m_criticalSection.Enter();
+	FUN_100c5d40(&m_mxSmack);
+	Init();
+	m_criticalSection.Leave();
+	if (!p_fromDestructor) {
+		MxVideoPresenter::Destroy(FALSE);
+	}
+}
+
+// OFFSET: LEGO1 0x100b38d0
 void MxSmkPresenter::Init()
 {
-	// TODO
+	m_unk0x71c = 0;
+	memset(&m_mxSmack, 0, sizeof(m_mxSmack));
+	m_flags &= 0xfd;
+	m_flags &= 0xfb;
 }
 
 // OFFSET: LEGO1 0x100b3960
@@ -24,5 +45,20 @@ void MxSmkPresenter::VTable0x60()
 	}
 
 	m_bitmap = new MxBitmap();
-	m_bitmap->SetSize(m_smkWidth, m_smkHeight, NULL, FALSE);
+	m_bitmap->SetSize(m_mxSmack.m_smack.m_width, m_mxSmack.m_smack.m_height, NULL, FALSE);
+}
+
+// OFFSET: LEGO1 0x100c5d40
+void MxSmkPresenter::FUN_100c5d40(MxSmack* p_mxSmack)
+{
+	if (p_mxSmack->m_unk0x6a0)
+		delete p_mxSmack->m_unk0x6a0;
+	if (p_mxSmack->m_unk0x6a4)
+		delete p_mxSmack->m_unk0x6a4;
+	if (p_mxSmack->m_unk0x6a8)
+		delete p_mxSmack->m_unk0x6a8;
+	if (p_mxSmack->m_unk0x6ac)
+		delete p_mxSmack->m_unk0x6ac;
+	if (p_mxSmack->m_unk0x6b4)
+		delete p_mxSmack->m_unk0x6b4;
 }

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -11,7 +11,7 @@
 class MxSmkPresenter : public MxVideoPresenter {
 public:
 	MxSmkPresenter();
-	~MxSmkPresenter();
+	virtual ~MxSmkPresenter() override;
 
 	virtual void VTable0x60() override;
 
@@ -35,8 +35,10 @@ public:
 
 private:
 	void Init();
-	void FUN_100b3900(MxBool p_fromDestructor);
-	void FUN_100c5d40(MxSmack* p_mxSmack);
+	void Destroy(MxBool p_fromDestructor);
+
+	// This should most likely be in a separate translation unit
+	static void FUN_100c5d40(MxSmack* p_mxSmack);
 };
 
 #endif // MXSMKPRESENTER_H

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -2,7 +2,6 @@
 #define MXSMKPRESENTER_H
 
 #include <smk.h>
-
 #include "decomp.h"
 #include "mxvideopresenter.h"
 
@@ -15,8 +14,7 @@ public:
 
 	virtual void VTable0x60() override;
 
-	struct MxSmack
-	{
+	struct MxSmack {
 		Smack m_smack;
 
 		// Unknown for the time being. Not an immediately

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -1,9 +1,10 @@
 #ifndef MXSMKPRESENTER_H
 #define MXSMKPRESENTER_H
 
-#include <smk.h>
 #include "decomp.h"
 #include "mxvideopresenter.h"
+
+#include <smk.h>
 
 // VTABLE 0x100dc348
 // SIZE 0x720

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -1,6 +1,8 @@
 #ifndef MXSMKPRESENTER_H
 #define MXSMKPRESENTER_H
 
+#include <smk.h>
+
 #include "decomp.h"
 #include "mxvideopresenter.h"
 
@@ -9,17 +11,33 @@
 class MxSmkPresenter : public MxVideoPresenter {
 public:
 	MxSmkPresenter();
+	~MxSmkPresenter();
 
 	virtual void VTable0x60() override;
 
-	undefined4 m_unk64;
-	MxS32 m_smkWidth;  // 0x68
-	MxS32 m_smkHeight; // 0x6c
-	undefined4 m_unk70[427];
-	undefined4 m_unk71c;
+	struct MxSmack
+	{
+		Smack m_smack;
+
+		// Unknown for the time being. Not an immediately
+		// recognizable part of the SMK standard...
+
+		undefined m_unk0x3f4[784];
+		undefined4* m_unk0x6a0;
+		undefined4* m_unk0x6a4;
+		undefined4* m_unk0x6a8;
+		undefined4* m_unk0x6ac;
+		undefined4* m_unk0x6b0;
+		undefined4* m_unk0x6b4;
+	};
+
+	MxSmack m_mxSmack;
+	undefined4 m_unk0x71c;
 
 private:
 	void Init();
+	void FUN_100b3900(MxBool p_fromDestructor);
+	void FUN_100c5d40(MxSmack* p_mxSmack);
 };
 
 #endif // MXSMKPRESENTER_H


### PR DESCRIPTION
This PR implements and matches several MxSmkPresenter functions. MxSmkPresenter's constructor and deconstructor are both matching. `MxSmkPresenter::Init()` is also 100% matching. `MxSmkPresenter::FUN_100b3900` was 100% matching when I first completed the implementation, but it unfortunately seems to have de-matched at some point in my work and I haven't experimented with correcting it. `MxSmkPresenter::FUN_100c5d40` never matched, but it looks like it is barely off. `MxSmkPresenter::VTable0x60` was also adjusted to accommodate for the new member changes, and it currently retains its match.

To prepare to start filling out the class, I implemented a minimal version of a Smacker header, which you can find located at `3rdparty/smk/smk.h`. Originally, I had put this struct directly in MxSmkPresenter. However, throughout my research, it has become apparent to me that Mindscape had implemented their own stuff on top of the provided Smacker standard. I've given this the name of `MxSmack`, and it embeds a standard `Smack` inside of it.

Additional side note, the manual null-checks in `MxSmkPresenter::FUN_100c5d40` are intentional and seem to be required to get proper code generation.