### PR TITLE
MxSmkPresenter vtables

### DIFF
--- a/3rdparty/smk/smk.h
+++ b/3rdparty/smk/smk.h
@@ -40,7 +40,7 @@ struct Smack {
 	unsigned long m_trackType[7];
 	unsigned long m_extra;
 	unsigned long m_newPalette;
-	unsigned int m_palette[193];
+	unsigned char m_palette[772];
 	unsigned long m_frameNum;
 	unsigned long m_lastRectX;
 	unsigned long m_lastRectY;

--- a/3rdparty/smk/smk.h
+++ b/3rdparty/smk/smk.h
@@ -40,7 +40,7 @@ struct Smack {
 	unsigned long m_trackType[7];
 	unsigned long m_extra;
 	unsigned long m_newPalette;
-	unsigned char m_palette[772];
+	unsigned int m_palette[193];
 	unsigned long m_frameNum;
 	unsigned long m_lastRectX;
 	unsigned long m_lastRectY;

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -1,6 +1,7 @@
 #include "mxsmkpresenter.h"
 
 #include "decomp.h"
+#include "mxvideomanager.h"
 
 DECOMP_SIZE_ASSERT(MxSmkPresenter, 0x720);
 
@@ -64,4 +65,49 @@ void MxSmkPresenter::FUN_100c5d40(MxSmack* p_mxSmack)
 		delete p_mxSmack->m_unk0x6ac;
 	if (p_mxSmack->m_unk0x6b4)
 		delete p_mxSmack->m_unk0x6b4;
+}
+
+// OFFSET: LEGO1 0x100b4300
+void MxSmkPresenter::Destroy()
+{
+	Destroy(FALSE);
+}
+
+// OFFSET: LEGO1 0x100b3940 STUB
+void MxSmkPresenter::VTable0x5c(undefined4 p_unknown1)
+{
+}
+
+// OFFSET: LEGO1 0x100b3a00 STUB
+void MxSmkPresenter::VTable0x68(undefined4 p_unknown1)
+{
+}
+
+// OFFSET: LEGO1 0x100b42c0
+void MxSmkPresenter::VTable0x70()
+{
+	MxPalette* palette = m_bitmap->CreatePalette();
+	MVideoManager()->RealizePalette(palette);
+	delete palette;
+}
+
+// OFFSET: LEGO1 0x100b4260
+MxU32 MxSmkPresenter::VTable0x88()
+{
+	MxU32 result = m_unk0x71c;
+	if ((m_mxSmack.m_smack.m_smkType & 1) != 0) {
+		result = m_unk0x71c / m_mxSmack.m_smack.m_frames;
+		if (1 < m_unk0x71c && (m_unk0x71c % m_mxSmack.m_smack.m_frames) == 1) {
+			m_unk0x71c = 1;
+		}
+		return result;
+	}
+	else {
+		if (m_mxSmack.m_smack.m_frames == result) {
+			m_unk0x71c = 0;
+			result = 0;
+			memset(m_mxSmack.m_smack.m_palette, 0, sizeof(m_mxSmack.m_smack.m_palette));
+		}
+		return result;
+	}
 }

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -13,7 +13,12 @@ public:
 	MxSmkPresenter();
 	virtual ~MxSmkPresenter() override;
 
+	virtual void Destroy() override;
+	virtual void VTable0x5c(undefined4 p_unknown1) override;
 	virtual void VTable0x60() override;
+	virtual void VTable0x68(undefined4 p_unknown1) override; // vtable+0x68
+	virtual void VTable0x70() override;
+	virtual MxU32 VTable0x88();
 
 	struct MxSmack {
 		Smack m_smack;


### PR DESCRIPTION
I couldn't figure out how to fully match MxSmkPresenter::VTable0x88 (or what it even does)