### PR TITLE
[Proposal] Add virtual table verification to reccmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ISLE.EXE
 LEGO1.DLL
 build/
 *.swp
+__pycache__/

--- a/LEGO1/act1state.h
+++ b/LEGO1/act1state.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d7028
+// VTABLEADDR 0x100d7028
 // SIZE 0x26c
 class Act1State : public LegoState {
 public:

--- a/LEGO1/act2brick.h
+++ b/LEGO1/act2brick.h
@@ -3,7 +3,7 @@
 
 #include "legopathactor.h"
 
-// VTABLE 0x100d9b60
+// VTABLEADDR 0x100d9b60
 // SIZE 0x194
 class Act2Brick : public LegoPathActor {
 public:

--- a/LEGO1/act2policestation.h
+++ b/LEGO1/act2policestation.h
@@ -3,7 +3,7 @@
 
 #include "legoentity.h"
 
-// VTABLE 0x100d53a8
+// VTABLEADDR 0x100d53a8
 // SIZE 0x68
 class Act2PoliceStation : public LegoEntity {
 public:

--- a/LEGO1/act3.h
+++ b/LEGO1/act3.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d9628
+// VTABLEADDR 0x100d9628
 // SIZE 0x4274
 class Act3 : public LegoWorld {
 public:

--- a/LEGO1/act3shark.h
+++ b/LEGO1/act3shark.h
@@ -3,7 +3,7 @@
 
 #include "legoanimactor.h"
 
-// VTABLE 0x100d7920
+// VTABLEADDR 0x100d7920
 class Act3Shark : public LegoAnimActor {
 public:
 	// OFFSET: LEGO1 0x100430c0

--- a/LEGO1/act3state.h
+++ b/LEGO1/act3state.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d4fc8
+// VTABLEADDR 0x100d4fc8
 // SIZE 0xc
 class Act3State : public LegoState {
 public:

--- a/LEGO1/ambulance.h
+++ b/LEGO1/ambulance.h
@@ -3,7 +3,7 @@
 
 #include "islepathactor.h"
 
-// VTABLE 0x100d71a8
+// VTABLEADDR 0x100d71a8
 // SIZE 0x184
 class Ambulance : public IslePathActor {
 public:

--- a/LEGO1/ambulancemissionstate.h
+++ b/LEGO1/ambulancemissionstate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d72a0
+// VTABLEADDR 0x100d72a0
 // SIZE 0x24
 class AmbulanceMissionState : public LegoState {
 public:

--- a/LEGO1/animstate.h
+++ b/LEGO1/animstate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d8d80
+// VTABLEADDR 0x100d8d80
 // SIZE 0x1c
 class AnimState : public LegoState {
 public:

--- a/LEGO1/beachhouseentity.h
+++ b/LEGO1/beachhouseentity.h
@@ -3,7 +3,7 @@
 
 #include "buildingentity.h"
 
-// VTABLE 0x100d4a18
+// VTABLEADDR 0x100d4a18
 // SIZE 0x68
 class BeachHouseEntity : public BuildingEntity {
 public:

--- a/LEGO1/bike.h
+++ b/LEGO1/bike.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d9808
+// VTABLEADDR 0x100d9808
 // SIZE 0x164
 class Bike : public IslePathActor {
 public:

--- a/LEGO1/buildingentity.h
+++ b/LEGO1/buildingentity.h
@@ -3,7 +3,7 @@
 
 #include "legoentity.h"
 
-// VTABLE 0x100d5c88
+// VTABLEADDR 0x100d5c88
 // SIZE <= 0x68, hard to tell because it's always constructed as a derivative
 class BuildingEntity : public LegoEntity {
 public:

--- a/LEGO1/bumpbouy.h
+++ b/LEGO1/bumpbouy.h
@@ -4,7 +4,7 @@
 #include "legoanimactor.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d6790
+// VTABLEADDR 0x100d6790
 class BumpBouy : public LegoAnimActor {
 public:
 	// OFFSET: LEGO1 0x100274e0

--- a/LEGO1/carrace.h
+++ b/LEGO1/carrace.h
@@ -3,7 +3,7 @@
 
 #include "legorace.h"
 
-// VTABLE 0x100d5e50
+// VTABLEADDR 0x100d5e50
 // SIZE 0x154
 class CarRace : public LegoRace {
 public:

--- a/LEGO1/carracestate.h
+++ b/LEGO1/carracestate.h
@@ -3,7 +3,7 @@
 
 #include "racestate.h"
 
-// VTABLE 0x100d4b70
+// VTABLEADDR 0x100d4b70
 // SIZE 0x2c
 class CarRaceState : public RaceState {
 public:

--- a/LEGO1/doors.h
+++ b/LEGO1/doors.h
@@ -3,7 +3,7 @@
 
 #include "legopathactor.h"
 
-// VTABLE 0x100d4788
+// VTABLEADDR 0x100d4788
 // SIZE 0x1f8
 class Doors : public LegoPathActor {
 public:

--- a/LEGO1/dunebuggy.h
+++ b/LEGO1/dunebuggy.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d8f98
+// VTABLEADDR 0x100d8f98
 // SIZE 0x16c
 class DuneBuggy : public IslePathActor {
 public:

--- a/LEGO1/elevatorbottom.h
+++ b/LEGO1/elevatorbottom.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d5f20
+// VTABLEADDR 0x100d5f20
 class ElevatorBottom : public LegoWorld {
 public:
 	ElevatorBottom();

--- a/LEGO1/gasstation.h
+++ b/LEGO1/gasstation.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d4650
+// VTABLEADDR 0x100d4650
 // SIZE 0x128
 // Radio variable at 0x46, in constructor
 class GasStation : public LegoWorld {

--- a/LEGO1/gasstationentity.h
+++ b/LEGO1/gasstationentity.h
@@ -3,7 +3,7 @@
 
 #include "buildingentity.h"
 
-// VTABLE 0x100d5258
+// VTABLEADDR 0x100d5258
 // SIZE 0x68
 class GasStationEntity : public BuildingEntity {
 public:

--- a/LEGO1/gasstationstate.h
+++ b/LEGO1/gasstationstate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d46e0
+// VTABLEADDR 0x100d46e0
 // SIZE 0x24
 class GasStationState : public LegoState {
 public:

--- a/LEGO1/gifmanager.h
+++ b/LEGO1/gifmanager.h
@@ -42,7 +42,7 @@ public:
 	GifMapEntry* m_unk4;
 };
 
-// VTABLE 0x100d86d4
+// VTABLEADDR 0x100d86d4
 class GifManagerBase {
 public:
 	// OFFSET: LEGO1 0x1005a310 STUB
@@ -56,7 +56,7 @@ protected:
 	GifMap m_unk8;
 };
 
-// VTABLE 0x100d86fc
+// VTABLEADDR 0x100d86fc
 class GifManager : public GifManagerBase {
 public:
 	// OFFSET: LEGO1 0x1005a580 STUB

--- a/LEGO1/helicopter.h
+++ b/LEGO1/helicopter.h
@@ -5,7 +5,7 @@
 #include "islepathactor.h"
 #include "mxmatrix.h"
 
-// VTABLE 0x100d40f8
+// VTABLEADDR 0x100d40f8
 // SIZE 0x230
 class Helicopter : public IslePathActor {
 public:

--- a/LEGO1/helicopterstate.h
+++ b/LEGO1/helicopterstate.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "legostate.h"
 
-// VTABLE 0x100d5418
+// VTABLEADDR 0x100d5418
 // SIZE 0xc
 class HelicopterState : public LegoState {
 public:

--- a/LEGO1/historybook.h
+++ b/LEGO1/historybook.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100da328
+// VTABLEADDR 0x100da328
 // SIZE 0x3e4
 class HistoryBook : public LegoWorld {
 public:

--- a/LEGO1/hospital.h
+++ b/LEGO1/hospital.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d9730
+// VTABLEADDR 0x100d9730
 // SIZE 0x12c
 class Hospital : public LegoWorld {
 public:

--- a/LEGO1/hospitalentity.h
+++ b/LEGO1/hospitalentity.h
@@ -3,7 +3,7 @@
 
 #include "buildingentity.h"
 
-// VTABLE 0x100d5068
+// VTABLEADDR 0x100d5068
 // SIZE 0x68
 class HospitalEntity : public BuildingEntity {
 public:

--- a/LEGO1/hospitalstate.h
+++ b/LEGO1/hospitalstate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d97a0
+// VTABLEADDR 0x100d97a0
 // SIZE 0x18
 class HospitalState : public LegoState {
 public:

--- a/LEGO1/infocenter.h
+++ b/LEGO1/infocenter.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d9338
+// VTABLEADDR 0x100d9338
 // SIZE 0x1d8
 class Infocenter : public LegoWorld {
 public:

--- a/LEGO1/infocenterdoor.h
+++ b/LEGO1/infocenterdoor.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d72d8
+// VTABLEADDR 0x100d72d8
 // SIZE 0xfc
 class InfocenterDoor : public LegoWorld {
 public:

--- a/LEGO1/infocenterentity.h
+++ b/LEGO1/infocenterentity.h
@@ -3,7 +3,7 @@
 
 #include "buildingentity.h"
 
-// VTABLE 0x100d4b90
+// VTABLEADDR 0x100d4b90
 // SIZE 0x68
 class InfoCenterEntity : public BuildingEntity {
 public:

--- a/LEGO1/infocenterstate.h
+++ b/LEGO1/infocenterstate.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "legostate.h"
 
-// VTABLE 0x100d93a8
+// VTABLEADDR 0x100d93a8
 // SIZE 0x94
 class InfocenterState : public LegoState {
 public:

--- a/LEGO1/isle.h
+++ b/LEGO1/isle.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d6fb8
+// VTABLEADDR 0x100d6fb8
 // SIZE 0x140
 // Radio at 0x12c
 class Isle : public LegoWorld {

--- a/LEGO1/isleactor.h
+++ b/LEGO1/isleactor.h
@@ -3,7 +3,7 @@
 
 #include "legoactor.h"
 
-// VTABLE 0x100d5178
+// VTABLEADDR 0x100d5178
 class IsleActor : public LegoActor {
 public:
 	// OFFSET: LEGO1 0x1000e660

--- a/LEGO1/islepathactor.h
+++ b/LEGO1/islepathactor.h
@@ -5,7 +5,7 @@
 #include "legoworld.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d4398
+// VTABLEADDR 0x100d4398
 // SIZE 0x160
 class IslePathActor : public LegoPathActor {
 public:

--- a/LEGO1/jetski.h
+++ b/LEGO1/jetski.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d9ec8
+// VTABLEADDR 0x100d9ec8
 // SIZE 0x164
 class Jetski : public IslePathActor {
 public:

--- a/LEGO1/jetskirace.h
+++ b/LEGO1/jetskirace.h
@@ -3,7 +3,7 @@
 
 #include "legorace.h"
 
-// VTABLE 0x100d4fe8
+// VTABLEADDR 0x100d4fe8
 // SIZE 0x144
 class JetskiRace : public LegoRace {
 public:

--- a/LEGO1/jetskiracestate.h
+++ b/LEGO1/jetskiracestate.h
@@ -3,7 +3,7 @@
 
 #include "racestate.h"
 
-// VTABLE 0x100d4fa8
+// VTABLEADDR 0x100d4fa8
 // SIZE 0x2c
 class JetskiRaceState : public RaceState {
 public:

--- a/LEGO1/jukebox.h
+++ b/LEGO1/jukebox.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d8958
+// VTABLEADDR 0x100d8958
 // SIZE 0x104
 class JukeBox : public LegoWorld {
 public:

--- a/LEGO1/jukeboxentity.h
+++ b/LEGO1/jukeboxentity.h
@@ -3,7 +3,7 @@
 
 #include "legoentity.h"
 
-// VTABLE 0x100da8a0
+// VTABLEADDR 0x100da8a0
 // SIZE 0x6c
 class JukeBoxEntity : public LegoEntity {
 public:

--- a/LEGO1/jukeboxstate.h
+++ b/LEGO1/jukeboxstate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d4a90
+// VTABLEADDR 0x100d4a90
 // SIZE 0x10
 class JukeBoxState : public LegoState {
 public:

--- a/LEGO1/lego3dwavepresenter.h
+++ b/LEGO1/lego3dwavepresenter.h
@@ -3,7 +3,7 @@
 
 #include "legowavepresenter.h"
 
-// VTABLE 0x100d52b0
+// VTABLEADDR 0x100d52b0
 // SIZE 0xa0
 class Lego3DWavePresenter : public LegoWavePresenter {
 public:

--- a/LEGO1/legoact2state.h
+++ b/LEGO1/legoact2state.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d4a70
+// VTABLEADDR 0x100d4a70
 // SIZE 0x10
 class LegoAct2State : public LegoState {
 public:

--- a/LEGO1/legoactioncontrolpresenter.h
+++ b/LEGO1/legoactioncontrolpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100d5118
+// VTABLEADDR 0x100d5118
 // SIZE 0x68
 class LegoActionControlPresenter : public MxMediaPresenter {
 public:

--- a/LEGO1/legoactor.h
+++ b/LEGO1/legoactor.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "legoentity.h"
 
-// VTABLE 0x100d6d68
+// VTABLEADDR 0x100d6d68
 // SIZE 0x78
 class LegoActor : public LegoEntity {
 public:

--- a/LEGO1/legoactorpresenter.h
+++ b/LEGO1/legoactorpresenter.h
@@ -3,7 +3,7 @@
 
 #include "legoentitypresenter.h"
 
-// VTABLE 0x100d5320
+// VTABLEADDR 0x100d5320
 // SIZE 0x50
 class LegoActorPresenter : public LegoEntityPresenter {
 public:

--- a/LEGO1/legoanimationmanager.h
+++ b/LEGO1/legoanimationmanager.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d8c18
+// VTABLEADDR 0x100d8c18
 // SIZE 0x500
 class LegoAnimationManager : public MxCore {
 public:

--- a/LEGO1/legoanimmmpresenter.h
+++ b/LEGO1/legoanimmmpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxcompositepresenter.h"
 
-// VTABLE 0x100d7de8
+// VTABLEADDR 0x100d7de8
 // SIZE 0x74
 class LegoAnimMMPresenter : public MxCompositePresenter {
 public:

--- a/LEGO1/legoanimpresenter.h
+++ b/LEGO1/legoanimpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxvideopresenter.h"
 
-// VTABLE 0x100d90c8
+// VTABLEADDR 0x100d90c8
 class LegoAnimPresenter : public MxVideoPresenter {
 public:
 	LegoAnimPresenter();

--- a/LEGO1/legobackgroundcolor.h
+++ b/LEGO1/legobackgroundcolor.h
@@ -3,7 +3,7 @@
 
 #include "mxvariable.h"
 
-// VTABLE 0x100d74a8
+// VTABLEADDR 0x100d74a8
 // SIZE 0x30
 class LegoBackgroundColor : public MxVariable {
 public:

--- a/LEGO1/legobuildingmanager.h
+++ b/LEGO1/legobuildingmanager.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d6f50
+// VTABLEADDR 0x100d6f50
 // SIZE 0x30
 class LegoBuildingManager : public MxCore {
 public:

--- a/LEGO1/legocachesound.h
+++ b/LEGO1/legocachesound.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d4718
+// VTABLEADDR 0x100d4718
 // SIZE 0x88
 class LegoCacheSound : public MxCore {
 public:

--- a/LEGO1/legocameracontroller.h
+++ b/LEGO1/legocameracontroller.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d57b0
+// VTABLEADDR 0x100d57b0
 // SIZE 0xc8
 class LegoCameraController : public MxCore {
 public:

--- a/LEGO1/legocarbuild.h
+++ b/LEGO1/legocarbuild.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d6658
+// VTABLEADDR 0x100d6658
 // SIZE 0x34c
 class LegoCarBuild : public LegoWorld {
 public:

--- a/LEGO1/legocarbuildanimpresenter.h
+++ b/LEGO1/legocarbuildanimpresenter.h
@@ -3,7 +3,7 @@
 
 #include "legoanimpresenter.h"
 
-// VTABLE 0x100d99e0
+// VTABLEADDR 0x100d99e0
 // SIZE 0x150
 class LegoCarBuildAnimPresenter : public LegoAnimPresenter {
 public:

--- a/LEGO1/legocarraceactor.h
+++ b/LEGO1/legocarraceactor.h
@@ -3,7 +3,7 @@
 
 #include "legoraceactor.h"
 
-// VTABLE 0x100da0d8
+// VTABLEADDR 0x100da0d8
 class LegoCarRaceActor : public LegoRaceActor {
 public:
 	// OFFSET: LEGO1 0x10081650

--- a/LEGO1/legocontrolmanager.h
+++ b/LEGO1/legocontrolmanager.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d6a80
+// VTABLEADDR 0x100d6a80
 class LegoControlManager : public MxCore {
 public:
 	LegoControlManager();

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -8,7 +8,7 @@
 #include "mxentity.h"
 #include "mxvector.h"
 
-// VTABLE 0x100d4858
+// VTABLEADDR 0x100d4858
 // SIZE 0x68 (probably)
 class LegoEntity : public MxEntity {
 public:

--- a/LEGO1/legoentitypresenter.h
+++ b/LEGO1/legoentitypresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxcompositepresenter.h"
 
-// VTABLE 0x100d8398
+// VTABLEADDR 0x100d8398
 class LegoEntityPresenter : public MxCompositePresenter {
 public:
 	LegoEntityPresenter();

--- a/LEGO1/legoeventnotificationparam.h
+++ b/LEGO1/legoeventnotificationparam.h
@@ -4,7 +4,7 @@
 #include "mxnotificationparam.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d6aa0
+// VTABLEADDR 0x100d6aa0
 class LegoEventNotificationParam : public MxNotificationParam {
 public:
 	inline LegoEventNotificationParam() : MxNotificationParam((MxParamType) 0, NULL) {}

--- a/LEGO1/legoextraactor.h
+++ b/LEGO1/legoextraactor.h
@@ -3,7 +3,7 @@
 
 #include "legoanimactor.h"
 
-// VTABLE 0x100d6c10
+// VTABLEADDR 0x100d6c10
 class LegoExtraActor : public LegoAnimActor {
 public:
 	// OFFSET: LEGO1 0x1002b7a0

--- a/LEGO1/legoflctexturepresenter.h
+++ b/LEGO1/legoflctexturepresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxflcpresenter.h"
 
-// VTABLE 0x100d89e0
+// VTABLEADDR 0x100d89e0
 // SIZE 0x70
 class LegoFlcTexturePresenter : public MxFlcPresenter {
 public:

--- a/LEGO1/legofullscreenmovie.h
+++ b/LEGO1/legofullscreenmovie.h
@@ -3,7 +3,7 @@
 
 #include "mxvariable.h"
 
-// VTABLE 0x100d74b8
+// VTABLEADDR 0x100d74b8
 // SIZE 0x24
 class LegoFullScreenMovie : public MxVariable {
 public:

--- a/LEGO1/legohideanimpresenter.h
+++ b/LEGO1/legohideanimpresenter.h
@@ -3,7 +3,7 @@
 
 #include "legoloopinganimpresenter.h"
 
-// VTABLE 0x100d9278
+// VTABLEADDR 0x100d9278
 // SIZE 0xc4
 class LegoHideAnimPresenter : public LegoLoopingAnimPresenter {
 public:

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -22,7 +22,7 @@ class LegoControlManager;
 // TODO Really a MxQueue, but we don't have one of those
 class LegoEventQueue : public MxList<LegoEventNotificationParam> {};
 
-// VTABLE 0x100d8760
+// VTABLEADDR 0x100d8760
 // SIZE 0x338
 class LegoInputManager : public MxPresenter {
 public:

--- a/LEGO1/legojetski.h
+++ b/LEGO1/legojetski.h
@@ -3,7 +3,7 @@
 
 #include "legojetskiraceactor.h"
 
-// VTABLE 0x100d5a40
+// VTABLEADDR 0x100d5a40
 class LegoJetski : public LegoJetskiRaceActor {
 public:
 	// OFFSET: LEGO1 0x10013e80

--- a/LEGO1/legojetskiraceactor.h
+++ b/LEGO1/legojetskiraceactor.h
@@ -3,7 +3,7 @@
 
 #include "legocarraceactor.h"
 
-// VTABLE 0x100da240
+// VTABLEADDR 0x100da240
 class LegoJetskiRaceActor : public LegoCarRaceActor {
 public:
 	// OFFSET: LEGO1 0x10081d80

--- a/LEGO1/legoloadcachesoundpresenter.h
+++ b/LEGO1/legoloadcachesoundpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxwavepresenter.h"
 
-// VTABLE 0x100d5fa8
+// VTABLEADDR 0x100d5fa8
 // SIZE 0x90
 class LegoLoadCacheSoundPresenter : public MxWavePresenter {
 public:

--- a/LEGO1/legolocomotionanimpresenter.h
+++ b/LEGO1/legolocomotionanimpresenter.h
@@ -3,7 +3,7 @@
 
 #include "legoloopinganimpresenter.h"
 
-// VTABLE 0x100d9170
+// VTABLEADDR 0x100d9170
 class LegoLocomotionAnimPresenter : public LegoLoopingAnimPresenter {
 public:
 	LegoLocomotionAnimPresenter();

--- a/LEGO1/legoloopinganimpresenter.h
+++ b/LEGO1/legoloopinganimpresenter.h
@@ -3,7 +3,7 @@
 
 #include "legoanimpresenter.h"
 
-// VTABLE 0x100d4900
+// VTABLEADDR 0x100d4900
 // SIZE 0xc0 (discovered through inlined constructor at 0x10009ecd)
 class LegoLoopingAnimPresenter : public LegoAnimPresenter {
 public:

--- a/LEGO1/legometerpresenter.h
+++ b/LEGO1/legometerpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxstillpresenter.h"
 
-// VTABLE 0x100d7ac8
+// VTABLEADDR 0x100d7ac8
 // SIZE 0x94 (from 0x1000a163)
 class LegoMeterPresenter : public MxStillPresenter {
 public:

--- a/LEGO1/legomodelpresenter.h
+++ b/LEGO1/legomodelpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxvideopresenter.h"
 
-// VTABLE 0x100d4e50
+// VTABLEADDR 0x100d4e50
 // SIZE 0x6c (discovered through inline constructor at 0x10009ae6)
 class LegoModelPresenter : public MxVideoPresenter {
 public:

--- a/LEGO1/legonavcontroller.h
+++ b/LEGO1/legonavcontroller.h
@@ -5,7 +5,7 @@
 #include "mxtimer.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d85b8
+// VTABLEADDR 0x100d85b8
 // SIZE 0x70
 class LegoNavController : public MxCore {
 public:

--- a/LEGO1/legoobjectfactory.h
+++ b/LEGO1/legoobjectfactory.h
@@ -5,7 +5,7 @@
 
 #define FOR_LEGOOBJECTFACTORY_OBJECTS(X) X(InfocenterState)
 
-// VTABLE 0x100d4768
+// VTABLEADDR 0x100d4768
 class LegoObjectFactory : public MxObjectFactory {
 public:
 	LegoObjectFactory();

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -26,7 +26,7 @@ class MxBackgroundAudioManager;
 class MxDSFile;
 class MxTransitionManager;
 
-// VTABLE 0x100d8638
+// VTABLEADDR 0x100d8638
 // SIZE: 0x140
 class LegoOmni : public MxOmni {
 public:

--- a/LEGO1/legopalettepresenter.h
+++ b/LEGO1/legopalettepresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxvideopresenter.h"
 
-// VTABLE 0x100d9aa0
+// VTABLEADDR 0x100d9aa0
 // SIZE 0x68
 class LegoPalettePresenter : public MxVideoPresenter {
 public:

--- a/LEGO1/legopartpresenter.h
+++ b/LEGO1/legopartpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100d4df0
+// VTABLEADDR 0x100d4df0
 // SIZE 0x54 (from inlined construction at 0x10009fac)
 class LegoPartPresenter : public MxMediaPresenter {
 public:

--- a/LEGO1/legopathactor.h
+++ b/LEGO1/legopathactor.h
@@ -4,7 +4,7 @@
 #include "legoactor.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d6e28
+// VTABLEADDR 0x100d6e28
 // SIZE 0x154 (from inlined construction at 0x1000a346)
 class LegoPathActor : public LegoActor {
 public:

--- a/LEGO1/legopathcontroller.h
+++ b/LEGO1/legopathcontroller.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d7d60
+// VTABLEADDR 0x100d7d60
 // SIZE 0x40
 class LegoPathController : public MxCore {
 public:

--- a/LEGO1/legopathpresenter.h
+++ b/LEGO1/legopathpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100d7c10
+// VTABLEADDR 0x100d7c10
 // SIZE 0x54
 class LegoPathPresenter : public MxMediaPresenter {
 public:

--- a/LEGO1/legophonemepresenter.h
+++ b/LEGO1/legophonemepresenter.h
@@ -6,7 +6,7 @@
 #include "mxstring.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d8040
+// VTABLEADDR 0x100d8040
 // SIZE 0x88
 class LegoPhonemePresenter : public MxFlcPresenter {
 public:

--- a/LEGO1/legoplantmanager.h
+++ b/LEGO1/legoplantmanager.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d6758
+// VTABLEADDR 0x100d6758
 // SIZE 0x2c
 class LegoPlantManager : public MxCore {
 public:

--- a/LEGO1/legorace.h
+++ b/LEGO1/legorace.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d5db0
+// VTABLEADDR 0x100d5db0
 class LegoRace : public LegoWorld {
 public:
 	LegoRace();

--- a/LEGO1/legoraceactor.h
+++ b/LEGO1/legoraceactor.h
@@ -3,7 +3,7 @@
 
 #include "legoanimactor.h"
 
-// VTABLE 0x100d5b88
+// VTABLEADDR 0x100d5b88
 class LegoRaceActor : public LegoAnimActor {
 public:
 	// OFFSET: LEGO1 0x10014af0

--- a/LEGO1/legosoundmanager.h
+++ b/LEGO1/legosoundmanager.h
@@ -3,7 +3,7 @@
 
 #include "mxsoundmanager.h"
 
-// VTABLE 0x100d6b10
+// VTABLEADDR 0x100d6b10
 // SIZE 0x44
 class LegoSoundManager : public MxSoundManager {
 public:

--- a/LEGO1/legostate.h
+++ b/LEGO1/legostate.h
@@ -6,7 +6,7 @@
 #include "mxcore.h"
 #include "mxstring.h"
 
-// VTABLE 0x100d46c0
+// VTABLEADDR 0x100d46c0
 class LegoState : public MxCore {
 public:
 	virtual ~LegoState() override; // vtable+0x00

--- a/LEGO1/legostream.h
+++ b/LEGO1/legostream.h
@@ -13,7 +13,7 @@
 
 class MxVariableTable;
 
-// VTABLE 0x100d7d80
+// VTABLEADDR 0x100d7d80
 class LegoStream {
 public:
 	LegoStream() : m_mode(0) {}
@@ -40,7 +40,7 @@ protected:
 	MxU8 m_mode;
 };
 
-// VTABLE 0x100db730
+// VTABLEADDR 0x100db730
 class LegoFileStream : public LegoStream {
 public:
 	LegoFileStream();
@@ -59,7 +59,7 @@ private:
 	FILE* m_hFile;
 };
 
-// VTABLE 0x100db710
+// VTABLEADDR 0x100db710
 class LegoMemoryStream : public LegoStream {
 public:
 	LegoMemoryStream(char* p_buffer);

--- a/LEGO1/legotexturepresenter.h
+++ b/LEGO1/legotexturepresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100d4d90
+// VTABLEADDR 0x100d4d90
 // SIZE 0x54 (from inlined construction at 0x10009bb5)
 class LegoTexturePresenter : public MxMediaPresenter {
 public:

--- a/LEGO1/legovehiclebuildstate.h
+++ b/LEGO1/legovehiclebuildstate.h
@@ -5,7 +5,7 @@
 #include "legostate.h"
 #include "mxstring.h"
 
-// VTABLE 0x100d66e0
+// VTABLEADDR 0x100d66e0
 // SIZE 0x50 (from 1000acd7)
 class LegoVehicleBuildState : public LegoState {
 public:

--- a/LEGO1/legovideomanager.h
+++ b/LEGO1/legovideomanager.h
@@ -8,7 +8,7 @@
 
 #include <ddraw.h>
 
-// VTABLE 0x100d9c88
+// VTABLEADDR 0x100d9c88
 // SIZE 0x590
 class LegoVideoManager : public MxVideoManager {
 public:

--- a/LEGO1/legoworld.h
+++ b/LEGO1/legoworld.h
@@ -5,7 +5,7 @@
 #include "legoentity.h"
 #include "mxpresenter.h"
 
-// VTABLE 0x100d6280
+// VTABLEADDR 0x100d6280
 // SIZE 0xf8
 class LegoWorld : public LegoEntity {
 public:

--- a/LEGO1/legoworldpresenter.h
+++ b/LEGO1/legoworldpresenter.h
@@ -3,7 +3,7 @@
 
 #include "legoentitypresenter.h"
 
-// VTABLE 0x100d8ee0
+// VTABLEADDR 0x100d8ee0
 // SIZE 0x54
 class LegoWorldPresenter : public LegoEntityPresenter {
 public:

--- a/LEGO1/motorcycle.h
+++ b/LEGO1/motorcycle.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d7090
+// VTABLEADDR 0x100d7090
 // SIZE 0x16c
 class Motorcycle : public IslePathActor {
 public:

--- a/LEGO1/mxactionnotificationparam.h
+++ b/LEGO1/mxactionnotificationparam.h
@@ -4,7 +4,7 @@
 #include "mxdsaction.h"
 #include "mxnotificationparam.h"
 
-// VTABLE 0x100d8350
+// VTABLEADDR 0x100d8350
 // SIZE 0x14
 class MxActionNotificationParam : public MxNotificationParam {
 public:
@@ -45,7 +45,7 @@ protected:
 	MxBool m_realloc;     // 0x10
 };
 
-// VTABLE 0x100d8358
+// VTABLEADDR 0x100d8358
 // SIZE 0x14
 class MxEndActionNotificationParam : public MxActionNotificationParam {
 public:

--- a/LEGO1/mxaudiomanager.h
+++ b/LEGO1/mxaudiomanager.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxmediamanager.h"
 
-// VTABLE 0x100dc6e0
+// VTABLEADDR 0x100dc6e0
 class MxAudioManager : public MxMediaManager {
 public:
 	MxAudioManager();

--- a/LEGO1/mxaudiopresenter.h
+++ b/LEGO1/mxaudiopresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100d4c70
+// VTABLEADDR 0x100d4c70
 class MxAudioPresenter : public MxMediaPresenter {
 public:
 	MxAudioPresenter() { m_unk50 = 100; }

--- a/LEGO1/mxbackgroundaudiomanager.h
+++ b/LEGO1/mxbackgroundaudiomanager.h
@@ -6,7 +6,7 @@
 #include "mxnotificationmanager.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d9fe8
+// VTABLEADDR 0x100d9fe8
 // SIZE 0x150
 class MxBackgroundAudioManager : public MxCore {
 public:

--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -29,7 +29,7 @@ struct MxBITMAPINFO {
 #define BI_RGB_TOPDOWN 0x10
 
 // SIZE 0x20
-// VTABLE 0x100dc7b0
+// VTABLEADDR 0x100dc7b0
 class MxBitmap : public MxCore {
 public:
 	__declspec(dllexport) MxBitmap();

--- a/LEGO1/mxcompositemediapresenter.h
+++ b/LEGO1/mxcompositemediapresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxcompositepresenter.h"
 
-// VTABLE 0x100dc618
+// VTABLEADDR 0x100dc618
 // SIZE 0x50
 class MxCompositeMediaPresenter : public MxCompositePresenter {
 public:

--- a/LEGO1/mxcompositepresenter.h
+++ b/LEGO1/mxcompositepresenter.h
@@ -4,7 +4,7 @@
 #include "mxpresenter.h"
 #include "mxunklist.h"
 
-// VTABLE 0x100dc618
+// VTABLEADDR 0x100dc618
 // SIZE 0x4c
 class MxCompositePresenter : public MxPresenter {
 public:

--- a/LEGO1/mxcontrolpresenter.h
+++ b/LEGO1/mxcontrolpresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxcompositepresenter.h"
 
-// VTABLE 0x100d7b88
+// VTABLEADDR 0x100d7b88
 // SIZE 0x5c
 class MxControlPresenter : public MxCompositePresenter {
 public:

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -8,14 +8,20 @@
 
 class MxParam;
 
-// VTABLE 0x100dc0f8
+// VTABLEADDR 0x100dc0f8
 // SIZE 0x8
 class MxCore {
 public:
 	__declspec(dllexport) MxCore();
-	__declspec(dllexport) virtual ~MxCore();                   // vtable+00
-	__declspec(dllexport) virtual MxResult Notify(MxParam& p); // vtable+04
-	virtual MxResult Tickle();                                 // vtable+08
+
+	// VTABLE 0x0
+	__declspec(dllexport) virtual ~MxCore();
+
+	// VTABLE 0x4
+	__declspec(dllexport) virtual MxResult Notify(MxParam& p);
+
+	// VTABLE 0x8
+	virtual MxResult Tickle();
 
 	// OFFSET: LEGO1 0x100144c0
 	inline virtual const char* ClassName() const // vtable+0c

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -17,7 +17,7 @@ public:
 	MxDirectDraw::DeviceModesInfo* m_deviceInfo; // +0xe0
 };
 
-// VTABLE 0x100db814 (or 0x100d9cc8?)
+// VTABLEADDR 0x100db814 (or 0x100d9cc8?)
 // SIZE 0x198
 class MxDeviceEnumerate {
 public:
@@ -35,7 +35,7 @@ public:
 	undefined4 m_unknown[97];
 };
 
-// VTABLE 0x100db800
+// VTABLEADDR 0x100db800
 // SIZE 0x894
 class MxDirect3D : public MxDirectDraw {
 public:

--- a/LEGO1/mxdirectdraw.h
+++ b/LEGO1/mxdirectdraw.h
@@ -6,7 +6,7 @@
 
 extern BOOL g_is_PALETTEINDEXED8;
 
-// VTABLE 0x100db818
+// VTABLEADDR 0x100db818
 // SIZE 0x880
 class MxDirectDraw {
 public:

--- a/LEGO1/mxdiskstreamcontroller.h
+++ b/LEGO1/mxdiskstreamcontroller.h
@@ -6,7 +6,7 @@
 
 #include <string.h>
 
-// VTABLE 0x100dccb8
+// VTABLEADDR 0x100dccb8
 // SIZE 0xc8
 class MxDiskStreamController : public MxStreamController {
 public:

--- a/LEGO1/mxdiskstreamprovider.h
+++ b/LEGO1/mxdiskstreamprovider.h
@@ -9,7 +9,7 @@
 
 class MxDiskStreamProvider;
 
-// VTABLE 0x100dd130
+// VTABLEADDR 0x100dd130
 class MxDiskStreamProviderThread : public MxThread {
 public:
 	// Only inlined, no offset
@@ -21,7 +21,7 @@ private:
 	MxDiskStreamProvider* m_target;
 };
 
-// VTABLE 0x100dd138
+// VTABLEADDR 0x100dd138
 class MxDiskStreamProvider : public MxStreamProvider {
 public:
 	MxDiskStreamProvider();

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -9,7 +9,7 @@
 
 #include <ddraw.h>
 
-// VTABLE 0x100dc768
+// VTABLEADDR 0x100dc768
 // SIZE 0xac
 class MxDisplaySurface : public MxCore {
 public:

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -7,7 +7,7 @@
 
 class MxOmni;
 
-// VTABLE 0x100dc098
+// VTABLEADDR 0x100dc098
 // SIZE 0x94
 class MxDSAction : public MxDSObject {
 public:

--- a/LEGO1/mxdsactionlist.h
+++ b/LEGO1/mxdsactionlist.h
@@ -6,7 +6,7 @@
 
 class MxDSAction;
 
-// VTABLE 0x100dced8
+// VTABLEADDR 0x100dced8
 // SIZE 0x1c
 class MxDSActionList : public MxList<MxDSAction*> {
 public:

--- a/LEGO1/mxdsanim.h
+++ b/LEGO1/mxdsanim.h
@@ -3,7 +3,7 @@
 
 #include "mxdsmediaaction.h"
 
-// VTABLE 0x100dcd88
+// VTABLEADDR 0x100dcd88
 // SIZE 0xb8
 class MxDSAnim : public MxDSMediaAction {
 public:

--- a/LEGO1/mxdsbuffer.h
+++ b/LEGO1/mxdsbuffer.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxcore.h"
 
-// VTABLE 0x100dcca0
+// VTABLEADDR 0x100dcca0
 // SIZE 0x34
 class MxDSBuffer : public MxCore {
 public:

--- a/LEGO1/mxdschunk.h
+++ b/LEGO1/mxdschunk.h
@@ -4,7 +4,7 @@
 #include "mxcore.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100dc7f8
+// VTABLEADDR 0x100dc7f8
 class MxDSChunk : public MxCore {
 public:
 	MxDSChunk();

--- a/LEGO1/mxdsfile.h
+++ b/LEGO1/mxdsfile.h
@@ -6,7 +6,7 @@
 #include "mxstring.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100dc890
+// VTABLEADDR 0x100dc890
 class MxDSFile : public MxDSSource {
 public:
 	__declspec(dllexport) MxDSFile(const char* filename, MxULong skipReadingChunks);

--- a/LEGO1/mxdsmediaaction.h
+++ b/LEGO1/mxdsmediaaction.h
@@ -5,7 +5,7 @@
 #include "mxdsaction.h"
 #include "mxpoint32.h"
 
-// VTABLE 0x100dcd40
+// VTABLEADDR 0x100dcd40
 // SIZE 0xb8
 class MxDSMediaAction : public MxDSAction {
 public:

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -4,7 +4,7 @@
 #include "mxdsaction.h"
 #include "mxdsactionlist.h"
 
-// VTABLE 0x100dcef0
+// VTABLEADDR 0x100dcef0
 // SIZE 0x9c
 class MxDSMultiAction : public MxDSAction {
 public:

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -6,7 +6,7 @@
 #include "mxcore.h"
 #include "mxdstypes.h"
 
-// VTABLE 0x100dc868
+// VTABLEADDR 0x100dc868
 // SIZE 0x2c
 class MxDSObject : public MxCore {
 public:

--- a/LEGO1/mxdsobjectaction.h
+++ b/LEGO1/mxdsobjectaction.h
@@ -3,7 +3,7 @@
 
 #include "mxdsmediaaction.h"
 
-// VTABLE 0x100dccf8
+// VTABLEADDR 0x100dccf8
 // SIZE 0xb8
 class MxDSObjectAction : public MxDSMediaAction {
 public:

--- a/LEGO1/mxdsparallelaction.h
+++ b/LEGO1/mxdsparallelaction.h
@@ -3,7 +3,7 @@
 
 #include "mxdsmultiaction.h"
 
-// VTABLE 0x100dcf80
+// VTABLEADDR 0x100dcf80
 // SIZE 0x9c
 class MxDSParallelAction : public MxDSMultiAction {
 public:

--- a/LEGO1/mxdsselectaction.h
+++ b/LEGO1/mxdsselectaction.h
@@ -5,7 +5,7 @@
 #include "mxdsparallelaction.h"
 #include "mxstringlist.h"
 
-// VTABLE 0x100dcfc8
+// VTABLEADDR 0x100dcfc8
 // SIZE 0xb0
 class MxDSSelectAction : public MxDSParallelAction {
 public:

--- a/LEGO1/mxdsserialaction.h
+++ b/LEGO1/mxdsserialaction.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxdsmultiaction.h"
 
-// VTABLE 0x100dcf38
+// VTABLEADDR 0x100dcf38
 // SIZE 0xa8
 class MxDSSerialAction : public MxDSMultiAction {
 public:

--- a/LEGO1/mxdssound.h
+++ b/LEGO1/mxdssound.h
@@ -3,7 +3,7 @@
 
 #include "mxdsmediaaction.h"
 
-// VTABLE 0x100dcdd0
+// VTABLEADDR 0x100dcdd0
 // SIZE 0xc0
 class MxDSSound : public MxDSMediaAction {
 public:

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -5,7 +5,7 @@
 
 class MxDSBuffer;
 
-// VTABLE 0x100dc8c8
+// VTABLEADDR 0x100dc8c8
 class MxDSSource : public MxCore {
 public:
 	MxDSSource() : m_lengthInDWords(0), m_pBuffer(NULL), m_position(-1) {}

--- a/LEGO1/mxdsstill.h
+++ b/LEGO1/mxdsstill.h
@@ -3,7 +3,7 @@
 
 #include "mxdsmediaaction.h"
 
-// VTABLE 0x100dce60
+// VTABLEADDR 0x100dce60
 // SIZE 0xb8
 class MxDSStill : public MxDSMediaAction {
 public:

--- a/LEGO1/mxdsstreamingaction.h
+++ b/LEGO1/mxdsstreamingaction.h
@@ -5,7 +5,7 @@
 
 class MxDSBuffer;
 
-// VTABLE 0x100dd088
+// VTABLEADDR 0x100dd088
 // SIZE 0xb4
 class MxDSStreamingAction : public MxDSAction {
 public:

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100dc698
+// VTABLEADDR 0x100dc698
 // SIZE 0x4c
 class MxDSSubscriber : public MxCore {
 public:

--- a/LEGO1/mxentity.h
+++ b/LEGO1/mxentity.h
@@ -7,7 +7,7 @@
 #include "mxdsobject.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d5390
+// VTABLEADDR 0x100d5390
 // SIZE 0x10
 class MxEntity : public MxCore {
 public:

--- a/LEGO1/mxeventmanager.h
+++ b/LEGO1/mxeventmanager.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxmediamanager.h"
 
-// VTABLE 0x100dc900
+// VTABLEADDR 0x100dc900
 // SIZE 0x2c
 class MxEventManager : public MxMediaManager {
 public:

--- a/LEGO1/mxeventpresenter.h
+++ b/LEGO1/mxeventpresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100dca88
+// VTABLEADDR 0x100dca88
 // SIZE 0x54
 class MxEventPresenter : public MxMediaPresenter {
 public:

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxvideopresenter.h"
 
-// VTABLE 0x100dc2c0
+// VTABLEADDR 0x100dc2c0
 // SIZE 0x68
 class MxFlcPresenter : public MxVideoPresenter {
 public:

--- a/LEGO1/mxhashtable.h
+++ b/LEGO1/mxhashtable.h
@@ -32,7 +32,7 @@ public:
 };
 
 // See MxOmni::Create
-// VTABLE 0x100dc1b0
+// VTABLEADDR 0x100dc1b0
 template <class T>
 class HashTableParent : public MxCore {
 public:
@@ -51,7 +51,7 @@ protected:
 	void (*m_customDestructor)(T*); // +0xc
 };
 
-// VTABLE 0x100dc1e8
+// VTABLEADDR 0x100dc1e8
 template <class T>
 class MxHashTable : protected HashTableParent<T> {
 public:

--- a/LEGO1/mxloopingflcpresenter.h
+++ b/LEGO1/mxloopingflcpresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxflcpresenter.h"
 
-// VTABLE 0x100dc480
+// VTABLEADDR 0x100dc480
 // SIZE 0x6c
 class MxLoopingFlcPresenter : public MxFlcPresenter {
 public:

--- a/LEGO1/mxloopingmidipresenter.h
+++ b/LEGO1/mxloopingmidipresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxmidipresenter.h"
 
-// VTABLE 0x100dc240
+// VTABLEADDR 0x100dc240
 // SIZE 0x58
 class MxLoopingMIDIPresenter : public MxMIDIPresenter {
 public:

--- a/LEGO1/mxloopingsmkpresenter.h
+++ b/LEGO1/mxloopingsmkpresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxsmkpresenter.h"
 
-// VTABLE 0x100dc540
+// VTABLEADDR 0x100dc540
 // SIZE 0x724
 class MxLoopingSmkPresenter : public MxSmkPresenter {
 public:

--- a/LEGO1/mxmatrix.h
+++ b/LEGO1/mxmatrix.h
@@ -3,7 +3,7 @@
 
 #include "mxvector.h"
 
-// VTABLE 0x100d4350
+// VTABLEADDR 0x100d4350
 // SIZE 0x8
 class MxMatrix {
 public:
@@ -43,7 +43,7 @@ private:
 	float* m_data;
 };
 
-// VTABLE 0x100d4300
+// VTABLEADDR 0x100d4300
 // SIZE 0x48
 class MxMatrixData : public MxMatrix {
 public:

--- a/LEGO1/mxmediamanager.h
+++ b/LEGO1/mxmediamanager.h
@@ -7,7 +7,7 @@
 #include "mxthread.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100dc6b0
+// VTABLEADDR 0x100dc6b0
 // SIZE 0x2c
 class MxMediaManager : public MxCore {
 public:

--- a/LEGO1/mxmediapresenter.h
+++ b/LEGO1/mxmediapresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxpresenter.h"
 
-// VTABLE 0x100d4cd8
+// VTABLEADDR 0x100d4cd8
 class MxMediaPresenter : public MxPresenter {
 public:
 	inline MxMediaPresenter() { Init(); }

--- a/LEGO1/mxmidipresenter.h
+++ b/LEGO1/mxmidipresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxmusicpresenter.h"
 
-// VTABLE 0x100dca20
+// VTABLEADDR 0x100dca20
 class MxMIDIPresenter : public MxMusicPresenter {
 public:
 	MxMIDIPresenter();

--- a/LEGO1/mxmusicmanager.h
+++ b/LEGO1/mxmusicmanager.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxaudiomanager.h"
 
-// VTABLE 0x100dc930
+// VTABLEADDR 0x100dc930
 // SIZE 0x58
 class MxMusicManager : public MxAudioManager {
 public:

--- a/LEGO1/mxmusicpresenter.h
+++ b/LEGO1/mxmusicpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxaudiopresenter.h"
 
-// VTABLE 0x100dc9b8
+// VTABLEADDR 0x100dc9b8
 // SIZE 0x54
 class MxMusicPresenter : public MxAudioPresenter {
 public:

--- a/LEGO1/mxnextactiondatastart.h
+++ b/LEGO1/mxnextactiondatastart.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100dc9a0
+// VTABLEADDR 0x100dc9a0
 class MxNextActionDataStart : public MxCore {};
 
 #endif // MXNEXTACTIONDATASTART_H

--- a/LEGO1/mxnotificationmanager.h
+++ b/LEGO1/mxnotificationmanager.h
@@ -24,7 +24,7 @@ class MxIdList : public list<MxU32> {};
 
 class MxNotificationPtrList : public list<MxNotification*> {};
 
-// VTABLE 0x100dc078
+// VTABLEADDR 0x100dc078
 class MxNotificationManager : public MxCore {
 private:
 	MxNotificationPtrList* m_queue;    // 0x8

--- a/LEGO1/mxnotificationparam.h
+++ b/LEGO1/mxnotificationparam.h
@@ -33,7 +33,7 @@ enum MxParamType {
 	MXTRANSITIONMANAGER_TRANSITIONENDED = 24
 };
 
-// VTABLE 0x100d56e0
+// VTABLEADDR 0x100d56e0
 class MxNotificationParam : public MxParam {
 public:
 	inline MxNotificationParam(MxParamType p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender) {}

--- a/LEGO1/mxobjectfactory.h
+++ b/LEGO1/mxobjectfactory.h
@@ -18,7 +18,7 @@
 	X(MxLoopingSmkPresenter)                                                                                           \
 	X(MxLoopingMIDIPresenter)
 
-// VTABLE 0x100dc220
+// VTABLEADDR 0x100dc220
 class MxObjectFactory : public MxCore {
 public:
 	MxObjectFactory();

--- a/LEGO1/mxomni.h
+++ b/LEGO1/mxomni.h
@@ -21,7 +21,7 @@ class MxTimer;
 class MxVariableTable;
 class MxVideoManager;
 
-// VTABLE 0x100dc168
+// VTABLEADDR 0x100dc168
 // SIZE 0x68
 class MxOmni : public MxCore {
 public:

--- a/LEGO1/mxpalette.h
+++ b/LEGO1/mxpalette.h
@@ -6,7 +6,7 @@
 
 #include <ddraw.h>
 
-// VTABLE 0x100dc848
+// VTABLEADDR 0x100dc848
 // SIZE 0x414
 class MxPalette : public MxCore {
 public:

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -10,7 +10,7 @@
 
 class MxStreamController;
 
-// VTABLE 0x100d4d38
+// VTABLEADDR 0x100d4d38
 class MxPresenter : public MxCore {
 public:
 	enum TickleState {

--- a/LEGO1/mxpresenterlist.h
+++ b/LEGO1/mxpresenterlist.h
@@ -6,14 +6,14 @@
 class MxPresenter;
 
 // Unclear what the purpose of this class is
-// VTABLE 0x100d62f0
+// VTABLEADDR 0x100d62f0
 // SIZE 0x18
 class MxPresenterListParent : public MxList<MxPresenter*> {
 public:
 	MxPresenterListParent() { m_customDestructor = Destroy; }
 };
 
-// VTABLE 0x100d6308
+// VTABLEADDR 0x100d6308
 // SIZE 0x18
 class MxPresenterList : public MxPresenterListParent {
 public:

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -4,7 +4,7 @@
 #include "mxdsbuffer.h"
 #include "mxstreamcontroller.h"
 
-// VTABLE 0x100dc728
+// VTABLEADDR 0x100dc728
 // SIZE 0x98
 class MxRAMStreamController : public MxStreamController {
 public:

--- a/LEGO1/mxramstreamprovider.h
+++ b/LEGO1/mxramstreamprovider.h
@@ -3,7 +3,7 @@
 
 #include "mxstreamprovider.h"
 
-// VTABLE 0x100dd0d0
+// VTABLEADDR 0x100dd0d0
 class MxRAMStreamProvider : public MxStreamProvider {
 public:
 	MxRAMStreamProvider();

--- a/LEGO1/mxregion.h
+++ b/LEGO1/mxregion.h
@@ -5,7 +5,7 @@
 #include "mxcore.h"
 #include "mxrect32.h"
 
-// VTABLE 0x100dcae8
+// VTABLEADDR 0x100dcae8
 // SIZE 0x1c
 class MxRegion : public MxCore {
 public:

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -6,7 +6,7 @@
 
 #include <smk.h>
 
-// VTABLE 0x100dc348
+// VTABLEADDR 0x100dc348
 // SIZE 0x720
 class MxSmkPresenter : public MxVideoPresenter {
 public:

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -6,7 +6,7 @@
 
 #include <dsound.h>
 
-// VTABLE 0x100dc128
+// VTABLEADDR 0x100dc128
 // SIZE 0x3c
 class MxSoundManager : public MxAudioManager {
 public:

--- a/LEGO1/mxsoundpresenter.h
+++ b/LEGO1/mxsoundpresenter.h
@@ -4,7 +4,7 @@
 #include "mxaudiopresenter.h"
 #include "mxomni.h"
 
-// VTABLE 0x100d4b08
+// VTABLEADDR 0x100d4b08
 class MxSoundPresenter : public MxAudioPresenter {
 public:
 	virtual ~MxSoundPresenter() override;

--- a/LEGO1/mxstillpresenter.h
+++ b/LEGO1/mxstillpresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxvideopresenter.h"
 
-// VTABLE 0x100d7a38
+// VTABLEADDR 0x100d7a38
 // SIZE 0x6c
 class MxStillPresenter : public MxVideoPresenter {
 public:

--- a/LEGO1/mxstreamchunk.h
+++ b/LEGO1/mxstreamchunk.h
@@ -3,7 +3,7 @@
 
 #include "mxdschunk.h"
 
-// VTABLE 0x100dc2a8
+// VTABLEADDR 0x100dc2a8
 class MxStreamChunk : public MxDSChunk {};
 
 #endif // MXSTREAMCHUNK_H

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -9,7 +9,7 @@
 #include "mxdsobject.h"
 #include "mxstreamprovider.h"
 
-// VTABLE 0x100dc968
+// VTABLEADDR 0x100dc968
 // SIZE 0x64
 class MxStreamController : public MxCore {
 public:

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -56,7 +56,7 @@ private:
 	MxStreamController* m_controller;
 };
 
-// VTABLE 0x100dc710
+// VTABLEADDR 0x100dc710
 // SIZE 0x2c
 class MxStreamer : public MxCore {
 public:

--- a/LEGO1/mxstreamprovider.h
+++ b/LEGO1/mxstreamprovider.h
@@ -5,7 +5,7 @@
 #include "mxcore.h"
 #include "mxdsfile.h"
 
-// VTABLE 0x100dd100
+// VTABLEADDR 0x100dd100
 // SIZE 0x10
 class MxStreamProvider : public MxCore {
 public:

--- a/LEGO1/mxstring.h
+++ b/LEGO1/mxstring.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100dc110
+// VTABLEADDR 0x100dc110
 class MxString : public MxCore {
 public:
 	__declspec(dllexport) MxString(const MxString&);

--- a/LEGO1/mxstringlist.h
+++ b/LEGO1/mxstringlist.h
@@ -4,11 +4,11 @@
 #include "mxlist.h"
 #include "mxstring.h"
 
-// VTABLE 0x100dd040
+// VTABLEADDR 0x100dd040
 // SIZE 0x18
 class MxStringList : public MxList<MxString> {};
 
-// VTABLE 0x100dd058
+// VTABLEADDR 0x100dd058
 typedef MxListCursorChild<MxString> MxStringListCursor;
 
 // OFFSET: LEGO1 0x100cb3c0 TEMPLATE

--- a/LEGO1/mxticklemanager.h
+++ b/LEGO1/mxticklemanager.h
@@ -32,7 +32,7 @@ private:
 
 typedef list<MxTickleClient*> MxTickleClientPtrList;
 
-// VTABLE 0x100d86d8
+// VTABLEADDR 0x100d86d8
 class MxTickleManager : public MxCore {
 public:
 	inline MxTickleManager() {}

--- a/LEGO1/mxtimer.h
+++ b/LEGO1/mxtimer.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100dc0e0
+// VTABLEADDR 0x100dc0e0
 // SIZE 0x10
 class MxTimer : public MxCore {
 public:

--- a/LEGO1/mxtransitionmanager.h
+++ b/LEGO1/mxtransitionmanager.h
@@ -7,7 +7,7 @@
 
 #include <ddraw.h>
 
-// VTABLE 0x100d7ea0
+// VTABLEADDR 0x100d7ea0
 class MxTransitionManager : public MxCore {
 public:
 	MxTransitionManager();

--- a/LEGO1/mxvariable.h
+++ b/LEGO1/mxvariable.h
@@ -4,7 +4,7 @@
 #include "mxcore.h"
 #include "mxstring.h"
 
-// VTABLE 0x100d7498
+// VTABLEADDR 0x100d7498
 // SIZE 0x24
 class MxVariable {
 public:

--- a/LEGO1/mxvariabletable.h
+++ b/LEGO1/mxvariabletable.h
@@ -5,7 +5,7 @@
 #include "mxtypes.h"
 #include "mxvariable.h"
 
-// VTABLE 0x100dc1c8
+// VTABLEADDR 0x100dc1c8
 // SIZE 0x28
 class MxVariableTable : public MxHashTable<MxVariable> {
 public:

--- a/LEGO1/mxvector.h
+++ b/LEGO1/mxvector.h
@@ -5,7 +5,7 @@
 
 #include <vec.h>
 
-// VTABLE 0x100d4288
+// VTABLEADDR 0x100d4288
 // SIZE 0x8
 class MxVector2 {
 public:
@@ -68,7 +68,7 @@ protected:
 	float* m_data;
 };
 
-// VTABLE 0x100d4518
+// VTABLEADDR 0x100d4518
 // SIZE 0x8
 class MxVector3 : public MxVector2 {
 public:
@@ -100,7 +100,7 @@ public:
 	inline void Fill(float p_value) { EqualsScalar(&p_value); }
 };
 
-// VTABLE 0x100d45a0
+// VTABLEADDR 0x100d45a0
 // SIZE 0x8
 class MxVector4 : public MxVector3 {
 public:
@@ -131,7 +131,7 @@ public:
 	virtual void UnknownQuaternionOp(MxVector4* p_a, MxVector4* p_b);
 };
 
-// VTABLE 0x100d4488
+// VTABLEADDR 0x100d4488
 // SIZE 0x14
 class MxVector3Data : public MxVector3 {
 public:
@@ -158,7 +158,7 @@ public:
 	}
 };
 
-// VTABLE 0x100d41e8
+// VTABLEADDR 0x100d41e8
 // SIZE 0x18
 class MxVector4Data : public MxVector4 {
 public:

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -7,7 +7,7 @@
 #include "mxregion.h"
 #include "mxvideoparam.h"
 
-// VTABLE 0x100dc810
+// VTABLEADDR 0x100dc810
 // SIZE 0x64
 class MxVideoManager : public MxMediaManager {
 public:

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -5,7 +5,7 @@
 #include "mxbitmap.h"
 #include "mxmediapresenter.h"
 
-// VTABLE 0x100d4be8
+// VTABLEADDR 0x100d4be8
 class MxVideoPresenter : public MxMediaPresenter {
 public:
 	MxVideoPresenter() { Init(); }

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "mxsoundpresenter.h"
 
-// VTABLE 0x100d49a8
+// VTABLEADDR 0x100d49a8
 // SIZE 0x6c
 class MxWavePresenter : public MxSoundPresenter {
 private:

--- a/LEGO1/pizza.h
+++ b/LEGO1/pizza.h
@@ -8,7 +8,7 @@
 #include "mxticklemanager.h"
 #include "mxtypes.h"
 
-// VTABLE 0x100d7380
+// VTABLEADDR 0x100d7380
 // SIZE 0x9c
 class Pizza : public IsleActor {
 public:

--- a/LEGO1/pizzamissionstate.h
+++ b/LEGO1/pizzamissionstate.h
@@ -12,7 +12,7 @@ public:
 	undefined m_unk18[6];
 };
 
-// VTABLE 0x100d7408
+// VTABLEADDR 0x100d7408
 class PizzaMissionState : public LegoState {
 public:
 	// OFFSET: LEGO1 0x10039290

--- a/LEGO1/pizzeria.h
+++ b/LEGO1/pizzeria.h
@@ -3,7 +3,7 @@
 
 #include "isleactor.h"
 
-// VTABLE 0x100d5520
+// VTABLEADDR 0x100d5520
 // SIZE 0x84
 class Pizzeria : public IsleActor {
 public:

--- a/LEGO1/pizzeriastate.h
+++ b/LEGO1/pizzeriastate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d5ee8
+// VTABLEADDR 0x100d5ee8
 // SIZE 0xb4
 class PizzeriaState : public LegoState {
 public:

--- a/LEGO1/police.h
+++ b/LEGO1/police.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d8a80
+// VTABLEADDR 0x100d8a80
 // SIZE 0x110
 // Radio at 0xf8
 class Police : public LegoWorld {

--- a/LEGO1/policeentity.h
+++ b/LEGO1/policeentity.h
@@ -3,7 +3,7 @@
 
 #include "buildingentity.h"
 
-// VTABLE 0x100d4ab0
+// VTABLEADDR 0x100d4ab0
 // SIZE 0x68
 class PoliceEntity : public BuildingEntity {
 public:

--- a/LEGO1/policestate.h
+++ b/LEGO1/policestate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d8af0
+// VTABLEADDR 0x100d8af0
 // SIZE 0x10
 class PoliceState : public LegoState {
 public:

--- a/LEGO1/racecar.h
+++ b/LEGO1/racecar.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d6918
+// VTABLEADDR 0x100d6918
 // SIZE 0x164
 class RaceCar : public IslePathActor {
 public:

--- a/LEGO1/racestandsentity.h
+++ b/LEGO1/racestandsentity.h
@@ -3,7 +3,7 @@
 
 #include "buildingentity.h"
 
-// VTABLE 0x100d48a8
+// VTABLEADDR 0x100d48a8
 // SIZE 0x68
 class RaceStandsEntity : public BuildingEntity {};
 

--- a/LEGO1/racestate.h
+++ b/LEGO1/racestate.h
@@ -11,7 +11,7 @@ public:
 	MxU16 m_color;
 };
 
-// VTABLE 0x100d5e30
+// VTABLEADDR 0x100d5e30
 // SIZE 0x2c
 class RaceState : public LegoState {
 public:

--- a/LEGO1/radio.h
+++ b/LEGO1/radio.h
@@ -3,7 +3,7 @@
 
 #include "mxcore.h"
 
-// VTABLE 0x100d6d10
+// VTABLEADDR 0x100d6d10
 class Radio : public MxCore {
 public:
 	virtual ~Radio() override;

--- a/LEGO1/radiostate.h
+++ b/LEGO1/radiostate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d6d28
+// VTABLEADDR 0x100d6d28
 // SIZE 0x30
 class RadioState : public LegoState {
 public:

--- a/LEGO1/registrationbook.h
+++ b/LEGO1/registrationbook.h
@@ -3,7 +3,7 @@
 
 #include "legoworld.h"
 
-// VTABLE 0x100d9928
+// VTABLEADDR 0x100d9928
 // SIZE 0x2d0
 class RegistrationBook : public LegoWorld {
 public:

--- a/LEGO1/score.h
+++ b/LEGO1/score.h
@@ -7,7 +7,7 @@
 #include "mxtype17notificationparam.h"
 #include "scorestate.h"
 
-// VTABLE 0x100d4018
+// VTABLEADDR 0x100d4018
 // SIZE 0x104
 class Score : public LegoWorld {
 public:

--- a/LEGO1/scorestate.h
+++ b/LEGO1/scorestate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d53f8
+// VTABLEADDR 0x100d53f8
 // SIZE 0xc
 class ScoreState : public LegoState {
 public:

--- a/LEGO1/skateboard.h
+++ b/LEGO1/skateboard.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d55f0
+// VTABLEADDR 0x100d55f0
 // SIZE 0x168
 class SkateBoard : public IslePathActor {
 public:

--- a/LEGO1/towtrack.h
+++ b/LEGO1/towtrack.h
@@ -4,7 +4,7 @@
 #include "decomp.h"
 #include "islepathactor.h"
 
-// VTABLE 0x100d7ee0
+// VTABLEADDR 0x100d7ee0
 // SIZE 0x180
 class TowTrack : public IslePathActor {
 public:

--- a/LEGO1/towtrackmissionstate.h
+++ b/LEGO1/towtrackmissionstate.h
@@ -3,7 +3,7 @@
 
 #include "legostate.h"
 
-// VTABLE 0x100d7fd8
+// VTABLEADDR 0x100d7fd8
 // SIZE 0x28
 class TowTrackMissionState : public LegoState {
 public:

--- a/tools/reccmp/modules/bin.py
+++ b/tools/reccmp/modules/bin.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+from modules.logger import logger
+import struct
+
+# Declare a class that can automatically convert virtual executable addresses
+# to file addresses
+class Bin:
+  file = None
+
+  def __init__(self, filename):
+    logger.debug('Parsing headers of "%s"... ', filename)
+    self.file = open(filename, 'rb')
+
+    #HACK: Strictly, we should be parsing the header, but we know where
+    #      everything is in these two files so we just jump straight there
+
+    # Read ImageBase
+    self.file.seek(0xB4)
+    self.imagebase, = struct.unpack('<i', self.file.read(4))
+
+    # Read .text VirtualAddress
+    self.file.seek(0x184)
+    self.textvirt, = struct.unpack('<i', self.file.read(4))
+
+    # Read .text PointerToRawData
+    self.file.seek(0x18C)
+    self.textraw, = struct.unpack('<i', self.file.read(4))
+    logger.debug('... Parsing finished')
+
+  def __del__(self):
+    if self.file:
+      self.file.close()
+
+  def get_addr(self, virt):
+    return virt - self.imagebase - self.textvirt + self.textraw
+
+  def read(self, offset, size):
+    self.file.seek(self.get_addr(offset))
+    return self.file.read(size)

--- a/tools/reccmp/modules/logger.py
+++ b/tools/reccmp/modules/logger.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger(__name__)

--- a/tools/reccmp/modules/syminfo.py
+++ b/tools/reccmp/modules/syminfo.py
@@ -246,3 +246,12 @@ class SymInfo:
         return self.names[name]
     else:
         logger.error('Failed to find function symbol with name: %s', name)
+
+  def verify_vtable(self, class_name, func_name, offset):
+    for class_id, c in classes.items():
+      if c.name == class_name and c.field_list:
+        fl = fieldlists[c.field_list]
+        for v in fl.vtable:
+          if v.name == func_name and v.offset == offset:
+            return True
+    return False

--- a/tools/reccmp/modules/syminfo.py
+++ b/tools/reccmp/modules/syminfo.py
@@ -1,0 +1,248 @@
+from modules.logger import logger
+import modules.util as util
+import subprocess
+import os
+
+fieldlists = dict()
+classes = dict()
+
+class VTableEntry:
+  def __init__(self):
+    self.name = None
+    self.offset = -1
+
+class Class:
+  def __init__(self):
+    self.name = None
+    self.id = None
+    self.field_list = None
+    self.size = None
+
+class FieldList:
+  def __init__(self):
+    self.id = None
+    self.baseclass = None
+    self.vtable = []
+    self.members = []
+
+class RecompiledInfo:
+  def __init__(self):
+    self.addr = None
+    self.size = None
+    self.name = None
+    self.start = None
+
+def remove_quotes(l):
+  while l[0] == '\'':
+    l = l[1:]
+
+  while l[len(l)-1] == '\'':
+    l = l[0:len(l)-1]
+
+  return l
+
+# Declare a class that parses the output of cvdump for fast access later
+class SymInfo:
+  funcs = {}
+  lines = {}
+  names = {}
+
+  def __init__(self, pdb, file, wine_path_converter):
+    call = [util.get_file_in_script_dir('cvdump.exe'), '-l', '-s', '-t']
+
+    if wine_path_converter:
+      # Run cvdump through wine and convert path to Windows-friendly wine path
+      call.insert(0, 'wine')
+      call.append(wine_path_converter.get_wine_path(pdb))
+    else:
+      call.append(pdb)
+
+    logger.info('Parsing %s ...', pdb)
+    logger.debug('Command = %r', call)
+    line_dump = subprocess.check_output(call).decode('utf-8').split('\r\n')
+
+    current_section = None
+
+    logger.debug('Parsing output of cvdump.exe ...')
+
+    for i, line in enumerate(line_dump):
+      if line.startswith('***'):
+        current_section = line[4:]
+
+      if current_section == 'SYMBOLS' and 'S_GPROC32' in line:
+        addr = int(line[26:34], 16)
+
+        info = RecompiledInfo()
+        info.addr = addr + file.imagebase + file.textvirt
+
+        use_dbg_offs = False
+        if use_dbg_offs:
+          debug_offs = line_dump[i + 2]
+          debug_start = int(debug_offs[22:30], 16)
+          debug_end = int(debug_offs[43:], 16)
+
+          info.start = debug_start
+          info.size = debug_end - debug_start
+        else:
+          info.start = 0
+          info.size = int(line[41:49], 16)
+
+        info.name = line[77:]
+
+        self.names[info.name] = info
+        self.funcs[addr] = info
+      elif current_section == 'LINES' and line.startswith('  ') and not line.startswith('   '):
+        sourcepath = line.split()[0]
+
+        if wine_path_converter:
+          # Convert filename to Unix path for file compare
+          sourcepath = wine_path_converter.get_unix_path(sourcepath)
+
+        if sourcepath not in self.lines:
+          self.lines[sourcepath] = {}
+
+        j = i + 2
+        while True:
+          ll = line_dump[j].split()
+          if len(ll) == 0:
+            break
+
+          k = 0
+          while k < len(ll):
+            linenum = int(ll[k + 0])
+            address = int(ll[k + 1], 16)
+            if linenum not in self.lines[sourcepath]:
+              self.lines[sourcepath][linenum] = address
+            k += 2
+
+          j += 1
+      elif 'LF_CLASS' in line or 'LF_STRUCTURE' in line:
+        c = Class()
+
+        c.id = int(line.split()[0], 16)
+
+        flt_str = 'field list type '
+        nextline = line_dump[i+1]
+        flt_start = nextline.index(flt_str)+len(flt_str)
+        flt_end = nextline.index(',', flt_start)
+        c.field_list = int(nextline[flt_start:flt_end], 16)
+
+        info = line_dump[i+3].split(',')
+        for i in info:
+          kv = i.split('=')
+          if len(kv) == 2:
+            k = kv[0].strip()
+            v = kv[1].strip()
+            if k == 'Size':
+              c.size = int(v)
+            elif k == 'class name':
+              c.name = v
+
+        classes[c.id] = c
+
+      elif 'LF_FIELDLIST' in line:
+        def parse_line(lines, index):
+          def space_count(s):
+            spaces = 0
+            for c in s:
+              if c == '\t':
+                spaces += 1
+            return spaces
+
+          l = lines[index].rstrip()
+          spaces = space_count(l)
+
+          while True:
+            index += 1
+            nextline = lines[index]
+            nextspaces = space_count(nextline)
+            if nextspaces > spaces:
+              l += nextline[nextspaces:].rstrip()
+            else:
+              break
+
+          l = l.strip()
+
+          return l
+
+        def get_vtable_func_info(l):
+          info = VTableEntry()
+          csv = l.split(',')
+          for c in csv:
+            kv = c.split('=')
+            if len(kv) == 2:
+              k = kv[0].strip()
+              v = kv[1].strip()
+              if k == 'name':
+                info.name = remove_quotes(v)
+              elif k == 'vfptr offset':
+                info.offset = int(v)
+
+          return info
+
+        fl = FieldList()
+
+        fl.id = int(line_dump[i].split()[0], 16)
+
+        while True:
+          i += 1
+          if not line_dump[i].strip():
+            break
+
+          if 'BCLASS' in line_dump[i]:
+            dp = line_dump[i].split(',')
+            for d in dp:
+              kv = d.split('=')
+              if len(kv) == 2:
+                k = kv[0].strip()
+                v = kv[1].strip()
+                if k == 'type':
+                  fl.baseclass = int(v, 16)
+          elif 'VIRTUAL' in line_dump[i]:
+            info = get_vtable_func_info(parse_line(line_dump, i))
+            fl.vtable.append(info)
+          elif 'LF_MEMBER' in line_dump[i]:
+            member = VTableEntry()
+            l = line_dump[i]
+            offset_str = 'offset = '
+            member.offset = int(l[l.index(offset_str) + len(offset_str):])
+            member.name = remove_quotes(line_dump[i+1][16:].rstrip())
+            fl.members.append(member)
+
+        fieldlists[fl.id] = fl
+
+    logger.debug('... Parsing output of cvdump.exe finished')
+
+  def get_recompiled_address(self, filename, line):
+    addr = None
+    found = False
+
+    logger.debug('Looking for %s:%d', filename, line)
+
+    for fn in self.lines:
+      # Sometimes a PDB is compiled with a relative path while we always have
+      # an absolute path. Therefore we must
+      try:
+        if os.path.samefile(fn, filename):
+          filename = fn
+          break
+      except FileNotFoundError as e:
+        continue
+
+    if filename in self.lines and line in self.lines[fn]:
+      addr = self.lines[fn][line]
+
+      if addr in self.funcs:
+        return self.funcs[addr]
+      else:
+        logger.error('Failed to find function symbol with address: 0x%x', addr)
+    else:
+      logger.error('Failed to find function symbol with filename and line: %s:%d', filename, line)
+
+  def get_recompiled_address_from_name(self, name):
+    logger.debug('Looking for %s', name)
+
+    if name in self.names:
+        return self.names[name]
+    else:
+        logger.error('Failed to find function symbol with name: %s', name)

--- a/tools/reccmp/modules/util.py
+++ b/tools/reccmp/modules/util.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+def get_file_in_script_dir(fn):
+  return os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), fn)

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -400,16 +400,17 @@ for subdir, dirs, files in os.walk(source):
                 break
 
               try:
-                start_brkt = line.index('(')
+                start_brkt = line.rindex('(')
                 name_discovery = line[0:start_brkt].split()
                 vtbl_name = name_discovery[len(name_discovery) - 1]
                 break
               except ValueError:
                 continue
           except ValueError:
-            pass
+            continue
 
-          print('Found vtable function %s::%s offset %s' % (in_class, vtbl_name, hex(address)))
+          if not syminfo.verify_vtable(in_class, vtbl_name, address):
+            raise Exception('Function %s::%s is not at %s' % (in_class, vtbl_name, hex(address)))
         else:
           # NOTE: Naive implementation, won't support vtable functions after a nested class
           class_discovery = line.split()

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -247,7 +247,7 @@ htmlinsert = []
 # Generate basename of original file, used in locating OFFSET lines
 basename = os.path.basename(os.path.splitext(original)[0])
 funcpattern = '// OFFSET:'
-vtblpattern = '// VTABLE'
+vtblpattern = '// VTABLE '
 in_class = None
 
 for subdir, dirs, files in os.walk(source):


### PR DESCRIPTION
This is a proposed addition to reccmp that would verify the position of each vtable function using the PDB. It also breaks up some reccmp functionality into modules for easier maintenance.

The reason I'm leaving it as a draft for now is because we will need to agree on a format for the vtable comments that the script will read.

In this draft, I've copied the `// OFFSET` formatting by having `// VTABLE` in a line above vtable functions:

```
// VTABLE 0x8
virtual MxResult Tickle();
```

There's an example of this in `mxcore.h`.

To do this the `// VTABLE` comments above each class defining the address of the original vtable has had to be renamed to prevent confusion. I've chosen to rename them to `// VTABLEADDR`, but am open to other suggestions.

Formatting it this way makes things consistent and explicit, but might be a little cumbersome to write and might force each class to take up a lot of lines. Alternatively, we could make the script check for a comment at the _end_ of the line, which more closely matches our current formatting, e.g.

```
virtual MxResult Tickle(); // vtable 0x8
```

This has a benefit of being easier to write and less obtrusive, and should be equally doable, though it also may be easier to miss as a reader.

This addition also has the capability to verify the offsets of members or the size of each class (though we already have the latter as a compile step). That may be useful too, and I figure whatever formatting we use for the vtable functions we can re-use for the member offsets if we decide to add that too.