### PR TITLE
LegoGameState destructor and related

### DIFF
--- a/LEGO1/legogamestate.cpp
+++ b/LEGO1/legogamestate.cpp
@@ -2,6 +2,7 @@
 
 #include "infocenterstate.h"
 #include "legoomni.h"
+#include "legoroi.h"
 #include "legostate.h"
 #include "legostream.h"
 #include "mxobjectfactory.h"
@@ -43,6 +44,8 @@ extern const char* s_endOfVariables;
 LegoGameState::LegoGameState()
 {
 	// TODO
+	SetROIHandlerFunction();
+
 	m_stateCount = 0;
 	m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
 	VariableTable()->SetVariable(m_backgroundColor);
@@ -57,10 +60,22 @@ LegoGameState::LegoGameState()
 	SerializeScoreHistory(1);
 }
 
-// OFFSET: LEGO1 0x10039720 STUB
+// OFFSET: LEGO1 0x10039720
 LegoGameState::~LegoGameState()
 {
-	// TODO
+	LegoROI::SetSomeHandlerFunction(NULL);
+
+	if (m_stateCount) {
+		for (MxS16 i = 0; i < m_stateCount; i++) {
+			LegoState* state = m_stateArray[i];
+			if (state)
+				delete state;
+		}
+
+		delete[] m_stateArray;
+	}
+
+	delete[] m_savePath;
 }
 
 // OFFSET: LEGO1 0x10039c60 STUB
@@ -161,6 +176,33 @@ void LegoGameState::SetSavePath(char* p_savePath)
 	}
 	else
 		m_savePath = NULL;
+}
+
+// OFFSET: LEGO1 0x1003bac0
+void LegoGameState::SetROIHandlerFunction()
+{
+	LegoROI::SetSomeHandlerFunction(&ROIHandlerFunction);
+}
+
+// OFFSET: LEGO1 0x1003bad0
+MxBool ROIHandlerFunction(char* p_input, char* p_output, MxU32 p_copyLen)
+{
+	if (p_output != NULL && p_copyLen != 0 &&
+		(strnicmp(p_input, "INDIR-F-", strlen("INDIR-F-")) == 0 ||
+		 strnicmp(p_input, "INDIR-G-", strlen("INDIR-F-")) == 0)) {
+
+		char buf[256];
+		sprintf(buf, "c_%s", &p_input[strlen("INDIR-F-")]);
+
+		const char* value = VariableTable()->GetVariable(buf);
+		if (value != NULL) {
+			strncpy(p_output, value, p_copyLen);
+			p_output[p_copyLen - 1] = '\0';
+			return TRUE;
+		}
+	}
+
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x1003bbb0

--- a/LEGO1/legogamestate.h
+++ b/LEGO1/legogamestate.h
@@ -40,6 +40,7 @@ public:
 private:
 	void RegisterState(LegoState* p_state);
 	MxResult WriteEndOfVariables(LegoStream* p_stream);
+	void SetROIHandlerFunction();
 
 private:
 	char* m_savePath; // 0x0
@@ -57,5 +58,7 @@ private:
 	undefined4 m_unk428;
 	undefined4 m_unk42c;
 };
+
+MxBool ROIHandlerFunction(char* p_0, char* p_output, MxU32 p_copyLen);
 
 #endif // LEGOGAMESTATE_H

--- a/LEGO1/legoroi.cpp
+++ b/LEGO1/legoroi.cpp
@@ -1,16 +1,90 @@
 #include "legoroi.h"
 
-// 0x10101368
-int g_roiConfig = 100;
+#include <string.h>
 
-// OFFSET: LEGO1 0x100a9e10
-void LegoROI::SetDisplayBB(int p_displayBB)
-{
-	// Intentionally empty function
-}
+// SIZE 0x14
+typedef struct {
+	const char* name;
+	MxS32 red;
+	MxS32 green;
+	MxS32 blue;
+	MxS32 unk10;
+} roi_color_alias;
+
+// 0x100dbe28
+double g_unk_roiConstant = 0.00392156862745098;
+
+// 0x101011b0
+roi_color_alias g_roiColorAliases[22] = {
+	{"lego black", 0x21, 0x21, 0x21, 0},       {"lego black f", 0x21, 0x21, 0x21, 0},
+	{"lego black flat", 0x21, 0x21, 0x21, 0},  {"lego blue", 0x00, 0x54, 0x8c, 0},
+	{"lego blue flat", 0x00, 0x54, 0x8c, 0},   {"lego brown", 0x4a, 0x23, 0x1a, 0},
+	{"lego brown flt", 0x4a, 0x23, 0x1a, 0},   {"lego brown flat", 0x4a, 0x23, 0x1a, 0},
+	{"lego drk grey", 0x40, 0x40, 0x40, 0},    {"lego drk grey flt", 0x40, 0x40, 0x40, 0},
+	{"lego dk grey flt", 0x40, 0x40, 0x40, 0}, {"lego green", 0x00, 0x78, 0x2d, 0},
+	{"lego green flat", 0x00, 0x78, 0x2d, 0},  {"lego lt grey", 0x82, 0x82, 0x82, 0},
+	{"lego lt grey flt", 0x82, 0x82, 0x82, 0}, {"lego lt grey fla", 0x82, 0x82, 0x82, 0},
+	{"lego red", 0xcb, 0x12, 0x20, 0},         {"lego red flat", 0xcb, 0x12, 0x20, 0},
+	{"lego white", 0xfa, 0xfa, 0xfa, 0},       {"lego white flat", 0xfa, 0xfa, 0xfa, 0},
+	{"lego yellow", 0xff, 0xb9, 0x00, 0},      {"lego yellow flat", 0xff, 0xb9, 0x00, 0},
+};
+
+// 0x10101368
+MxS32 g_roiConfig = 100;
+
+// 0x101013ac
+ROI_Handler g_someHandlerFunction = NULL;
 
 // OFFSET: LEGO1 0x100a81c0
-void LegoROI::configureLegoROI(int p_roi)
+void LegoROI::configureLegoROI(MxS32 p_roi)
 {
 	g_roiConfig = p_roi;
+}
+
+// OFFSET: LEGO1 0x100a9bf0
+MxBool LegoROI::CallTheHandlerFunction(char* p_param, float& p_red, float& p_green, float& p_blue, float& p_other)
+{
+	// TODO
+	if (p_param == NULL)
+		return FALSE;
+
+	if (g_someHandlerFunction) {
+		char buf[32];
+		if (g_someHandlerFunction(p_param, buf, 32))
+			p_param = buf;
+	}
+
+	return LegoROI::ColorAliasLookup(p_param, p_red, p_green, p_blue, p_other);
+}
+
+// OFFSET: LEGO1 0x100a9c50
+MxBool LegoROI::ColorAliasLookup(char* p_param, float& p_red, float& p_green, float& p_blue, float& p_other)
+{
+	// TODO: this seems awfully hacky for these devs. is there a dynamic way
+	// to represent `the end of this array` that would improve this?
+	MxU32 i = 0;
+	do {
+		if (strcmpi(g_roiColorAliases[i].name, p_param) == 0) {
+			p_red = g_roiColorAliases[i].red * g_unk_roiConstant;
+			p_green = g_roiColorAliases[i].green * g_unk_roiConstant;
+			p_blue = g_roiColorAliases[i].blue * g_unk_roiConstant;
+			p_other = g_roiColorAliases[i].unk10 * g_unk_roiConstant;
+			return TRUE;
+		}
+		i++;
+	} while ((MxS32*) &g_roiColorAliases[i] < &g_roiConfig);
+
+	return FALSE;
+}
+
+// OFFSET: LEGO1 0x100a9d30
+void LegoROI::SetSomeHandlerFunction(ROI_Handler p_func)
+{
+	g_someHandlerFunction = p_func;
+}
+
+// OFFSET: LEGO1 0x100a9e10
+void LegoROI::SetDisplayBB(MxS32 p_displayBB)
+{
+	// Intentionally empty function
 }

--- a/LEGO1/legoroi.h
+++ b/LEGO1/legoroi.h
@@ -1,10 +1,18 @@
 #ifndef LEGOROI_H
 #define LEGOROI_H
 
+#include "mxtypes.h"
+
+typedef MxBool (*ROI_Handler)(char*, char*, MxU32);
+
 class LegoROI {
 public:
-	__declspec(dllexport) void SetDisplayBB(int p_displayBB);
-	__declspec(dllexport) static void configureLegoROI(int p_roi);
+	__declspec(dllexport) void SetDisplayBB(MxS32 p_displayBB);
+	__declspec(dllexport) static void configureLegoROI(MxS32 p_roi);
+
+	static void SetSomeHandlerFunction(ROI_Handler p_func);
+	static MxBool CallTheHandlerFunction(char* p_param, float& p_red, float& p_green, float& p_blue, float& p_other);
+	static MxBool ColorAliasLookup(char* p_param, float& p_red, float& p_green, float& p_blue, float& p_other);
 };
 
 #endif // LEGOROI_H


### PR DESCRIPTION
Implements `~LegoGameState()`, one of the public symbols, along with these related functions:

- `LegoGameState::SetROIHandlerFunction`
- `LegoROI::SetSomeHandlerFunction` (called by above)
- `ROIHandlerFunction` (from LegoGameState. set as the handler by the above two)
- `LegoROI::CallTheHandlerFunction` (calls the above)
- `LegoROI::ColorAliasLookup` (called by above)

I'm sure we could come up with better names for these functions. Good match for all, most are 100%. There is an array of structs with color aliases (as I'm calling them) that map to MxS32 for RGB values and a fourth MxS32 that is always zero. The aliases are strings like "lego black", some of which already appear in `LegoGameState`.

The main point of interest is `ColorAliasLookup`. We multiply the RGB values by a constant `double` variable and I'm not sure what that's doing. The array `g_roiColorAliases` has 22 entries, and the loop that checks for a match on the string is doing the range check against the address of the following variable `g_roiConfig` rather than a fixed array size. The match percentage is good here but I doubt the devs did it this way. What am I missing? This does seem to be a do/while because we don't check the condition before starting like we do in a for-loop.

Bonus: used MxTypes for some values in `LegoROI` and reordered the functions.