### PR TITLE
Match MxRegionTopBottom::FUN_100c5280

### DIFF
--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -30,7 +30,7 @@ void MxDSSelectAction::CopyFrom(MxDSSelectAction& p_dsSelectAction)
 	MxStringListCursor cursor(p_dsSelectAction.m_unk0xac);
 	MxString string;
 	while (cursor.Next(string))
-		this->m_unk0xac->OtherAppend(string);
+		this->m_unk0xac->Append(string);
 }
 
 // OFFSET: LEGO1 0x100cbd50
@@ -109,7 +109,7 @@ void MxDSSelectAction::Deserialize(char** p_source, MxS16 p_unk24)
 			if (!strcmp(string.GetData(), *p_source))
 				index = i;
 
-			this->m_unk0xac->OtherAppend(*p_source);
+			this->m_unk0xac->Append(*p_source);
 			*p_source += strlen(*p_source) + 1;
 		}
 

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -153,21 +153,6 @@ inline void MxList<T>::DeleteAll()
 }
 
 template <class T>
-inline void MxList<T>::Append(T p_newobj)
-{
-	MxListEntry<T>* currentLast = this->m_last;
-	MxListEntry<T>* newEntry = new MxListEntry<T>(p_newobj, currentLast);
-
-	if (currentLast)
-		currentLast->SetNext(newEntry);
-	else
-		this->m_first = newEntry;
-
-	this->m_last = newEntry;
-	this->m_count++;
-}
-
-template <class T>
 inline MxListEntry<T>* MxList<T>::_InsertEntry(T p_newobj, MxListEntry<T>* p_prev, MxListEntry<T>* p_next)
 {
 	MxListEntry<T>* newEntry = new MxListEntry<T>(p_newobj, p_prev, p_next);

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -72,8 +72,7 @@ public:
 
 	virtual ~MxList();
 
-	void Append(T);
-	void OtherAppend(T p_obj) { _InsertEntry(p_obj, this->m_last, NULL); };
+	void Append(T p_obj) { _InsertEntry(p_obj, this->m_last, NULL); };
 	void DeleteAll();
 	MxU32 GetCount() { return this->m_count; }
 	void SetDestroy(void (*p_customDestructor)(T)) { this->m_customDestructor = p_customDestructor; }

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -157,14 +157,9 @@ void MxRegionTopBottom::FUN_100c5280(MxS32 p_left, MxS32 p_right)
 			if (p_right < leftRight->m_right)
 				p_right = leftRight->m_right;
 
-			// TODO: Currently inlined, shouldn't be
 			b = a;
 			b.Advance();
-
-			if (a.HasMatch()) {
-				a.Destroy();
-				a.Detach();
-			}
+			a.Destroy();
 
 			if (!b.Current(leftRight))
 				break;

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -87,7 +87,7 @@ void MxRegion::vtable18(MxRect32& p_rect)
 
 	if (rectCopy.m_left < rectCopy.m_right && rectCopy.m_top < rectCopy.m_bottom) {
 		MxRegionTopBottom* newTopBottom = new MxRegionTopBottom(rectCopy);
-		m_list->OtherAppend(newTopBottom);
+		m_list->Append(newTopBottom);
 	}
 
 	m_rect.m_left = m_rect.m_left <= p_rect.m_left ? m_rect.m_left : p_rect.m_left;
@@ -147,7 +147,7 @@ void MxRegionTopBottom::FUN_100c5280(MxS32 p_left, MxS32 p_right)
 
 	if (!a.HasMatch()) {
 		MxRegionLeftRight* copy = new MxRegionLeftRight(p_left, p_right);
-		m_leftRightList->OtherAppend(copy);
+		m_leftRightList->Append(copy);
 	}
 	else {
 		if (p_left > leftRight->m_left)
@@ -173,7 +173,7 @@ void MxRegionTopBottom::FUN_100c5280(MxS32 p_left, MxS32 p_right)
 		}
 		else {
 			MxRegionLeftRight* copy = new MxRegionLeftRight(p_left, p_right);
-			m_leftRightList->OtherAppend(copy);
+			m_leftRightList->Append(copy);
 		}
 	}
 }

--- a/LEGO1/mxstringlist.h
+++ b/LEGO1/mxstringlist.h
@@ -21,7 +21,7 @@ typedef MxListCursorChild<MxString> MxStringListCursor;
 // MxList<MxString>::~MxList<MxString>
 
 // OFFSET: LEGO1 0x100cbb40 TEMPLATE
-// MxList<MxString>::OtherAppend
+// MxList<MxString>::Append
 
 // OFFSET: LEGO1 0x100cc2d0 TEMPLATE
 // MxList<MxString>::_InsertEntry


### PR DESCRIPTION
The recent leak of the alpha version and its `LEGO1D.DLL` file help a fair bit with resolving the inlining patterns the developers have used (even though a lot of the code is outdated), especially in classes like `MxList`. The reason is that in the debug version, no functions are inlined at all as far as I can tell.

Using this information I was able to match `MxRegionTopBottom::FUN_100c5280` and probably a few more in the future. The key insight is that the members of the `MxListEntry` class are accessed through getters/setters and not directly.

~The regressions are due to compiler randomness (can be shown by relocating them elsewhere in the compilation units), but I'm still investigating to see if it's fixable, thus draft/WIP.~

Figured out that `Append` and `OtherAppend` are actually the same function, but in some cases it gets partially optimized away by the compiler, which lead to the impression they are distinct. The 1996 alpha debug build revealed this as well.