### PR TITLE
MxQueue and parts of LegoInputManager

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -95,7 +95,7 @@ void IsleApp::Close()
 	if (Lego()) {
 		GameState()->Save(0);
 		if (InputManager()) {
-			InputManager()->QueueEvent(KEYDOWN, 0, 0, 0, 0x20);
+			InputManager()->QueueEvent(c_notificationKeyPress, 0, 0, 0, 0x20);
 		}
 
 		VideoManager()->Get3DManager()->GetLego3DView()->GetViewManager()->RemoveAll(NULL);
@@ -431,22 +431,22 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			return DefWindowProcA(hWnd, uMsg, wParam, lParam);
 		}
 		keyCode = wParam;
-		type = KEYDOWN;
+		type = c_notificationKeyPress;
 		break;
 	case WM_MOUSEMOVE:
 		g_mousemoved = 1;
-		type = MOUSEMOVE;
+		type = c_notificationMouseMove;
 		break;
 	case WM_TIMER:
-		type = TIMER;
+		type = c_notificationTimer;
 		break;
 	case WM_LBUTTONDOWN:
 		g_mousedown = 1;
-		type = MOUSEDOWN;
+		type = c_notificationButtonDown;
 		break;
 	case WM_LBUTTONUP:
 		g_mousedown = 0;
-		type = MOUSEUP;
+		type = c_notificationButtonUp;
 		break;
 	case 0x5400:
 		if (g_isle) {
@@ -462,7 +462,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		if (InputManager()) {
 			InputManager()->QueueEvent(type, wParam, LOWORD(lParam), HIWORD(lParam), keyCode);
 		}
-		if (g_isle && g_isle->m_drawCursor && type == MOUSEMOVE) {
+		if (g_isle && g_isle->m_drawCursor && type == c_notificationMouseMove) {
 			int x = LOWORD(lParam);
 			int y = HIWORD(lParam);
 			if (x >= 640) {

--- a/LEGO1/legoeventnotificationparam.cpp
+++ b/LEGO1/legoeventnotificationparam.cpp
@@ -2,4 +2,4 @@
 
 #include "decomp.h"
 
-DECOMP_SIZE_ASSERT(LegoEventNotificationParam, 0x1c);
+DECOMP_SIZE_ASSERT(LegoEventNotificationParam, 0x20);

--- a/LEGO1/legoeventnotificationparam.h
+++ b/LEGO1/legoeventnotificationparam.h
@@ -8,15 +8,27 @@
 class LegoEventNotificationParam : public MxNotificationParam {
 public:
 	inline LegoEventNotificationParam() : MxNotificationParam((MxParamType) 0, NULL) {}
+	inline LegoEventNotificationParam(
+		MxParamType p_type,
+		MxCore* p_sender,
+		MxU8 p_modifier,
+		MxS32 p_x,
+		MxS32 p_y,
+		MxU8 p_key
+	)
+		: MxNotificationParam(p_type, p_sender), m_modifier(p_modifier), m_x(p_x), m_y(p_y), m_key(p_key), m_unk1c(0)
+	{
+	}
 
 	virtual ~LegoEventNotificationParam() override {} // vtable+0x0 (scalar deleting destructor)
-	inline MxU8 GetKey() { return m_key; }
+	inline MxU8 GetKey() const { return m_key; }
 
 protected:
 	MxU8 m_modifier; // 0x0c
 	MxS32 m_x;       // 0x10
 	MxS32 m_y;       // 0x14
 	MxU8 m_key;      // 0x18
+	MxU32 m_unk1c;   // 0x1c
 };
 
 #endif // LEGOEVENTNOTIFICATIONPARAM_H

--- a/LEGO1/legoeventnotificationparam.h
+++ b/LEGO1/legoeventnotificationparam.h
@@ -7,9 +7,9 @@
 // VTABLE 0x100d6aa0
 class LegoEventNotificationParam : public MxNotificationParam {
 public:
-	inline LegoEventNotificationParam() : MxNotificationParam((MxParamType) 0, NULL) {}
+	inline LegoEventNotificationParam() : MxNotificationParam(PARAM_NONE, NULL) {}
 	inline LegoEventNotificationParam(
-		MxParamType p_type,
+		NotificationId p_type,
 		MxCore* p_sender,
 		MxU8 p_modifier,
 		MxS32 p_x,

--- a/LEGO1/legoinputmanager.cpp
+++ b/LEGO1/legoinputmanager.cpp
@@ -9,10 +9,10 @@ DECOMP_SIZE_ASSERT(LegoInputManager, 0x338);
 // OFFSET: LEGO1 0x1005b790
 LegoInputManager::LegoInputManager()
 {
-	m_eventQueue = NULL;
+	m_unk0x5c = NULL;
 	m_world = NULL;
 	m_camera = NULL;
-	m_unk0x68 = NULL;
+	m_eventQueue = NULL;
 	m_unk0x80 = 0;
 	m_timer = 0;
 	m_unk0x6c = 0;
@@ -36,7 +36,7 @@ LegoInputManager::LegoInputManager()
 // OFFSET: LEGO1 0x1005b8b0 STUB
 MxResult LegoInputManager::Tickle()
 {
-	// TODO
+	ProcessEvents();
 	return SUCCESS;
 }
 
@@ -46,18 +46,26 @@ LegoInputManager::~LegoInputManager()
 	Destroy();
 }
 
+// OFFSET: LEGO1 0x1005b960
+void LegoInputManager::Create()
+{
+	// TODO
+	if (m_eventQueue == NULL)
+		m_eventQueue = new LegoEventQueue();
+}
+
 // OFFSET: LEGO1 0x1005bfe0
 void LegoInputManager::Destroy()
 {
 	ReleaseDX();
 
+	if (m_unk0x5c)
+		delete m_unk0x5c;
+	m_unk0x5c = NULL;
+
 	if (m_eventQueue)
 		delete m_eventQueue;
 	m_eventQueue = NULL;
-
-	if (m_unk0x68)
-		delete m_unk0x68;
-	m_unk0x68 = NULL;
 
 	if (m_controlManager)
 		delete m_controlManager;
@@ -215,10 +223,35 @@ void LegoInputManager::ClearWorld()
 	m_world = NULL;
 }
 
-// OFFSET: LEGO1 0x1005c740 STUB
-void LegoInputManager::QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5)
+// OFFSET: LEGO1 0x1005c740
+void LegoInputManager::QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p_x, MxLong p_y, MxU8 p_key)
+{
+	// TODO: param type wrong?
+	LegoEventNotificationParam param =
+		LegoEventNotificationParam((MxParamType) p_id, NULL, p_modifier, p_x, p_y, p_key);
+
+	if (((!m_unk0x88) || ((m_unk0x335 && (param.GetType() == MOUSEDOWN)))) || ((m_unk0x336 && (p_key == ' ')))) {
+		ProcessOneEvent(param);
+	}
+}
+
+// OFFSET: LEGO1 0x1005c820
+void LegoInputManager::ProcessEvents()
+{
+	MxAutoLocker lock(&m_criticalSection);
+
+	LegoEventNotificationParam event;
+	while (m_eventQueue->Dequeue(event)) {
+		if (ProcessOneEvent(event))
+			break;
+	}
+}
+
+// OFFSET: LEGO1 0x1005c9c0 STUB
+MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 {
 	// TODO
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x1005cfb0

--- a/LEGO1/legoinputmanager.cpp
+++ b/LEGO1/legoinputmanager.cpp
@@ -227,11 +227,10 @@ void LegoInputManager::ClearWorld()
 // OFFSET: LEGO1 0x1005c740
 void LegoInputManager::QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p_x, MxLong p_y, MxU8 p_key)
 {
-	// TODO: param type wrong?
-	LegoEventNotificationParam param =
-		LegoEventNotificationParam((MxParamType) p_id, NULL, p_modifier, p_x, p_y, p_key);
+	LegoEventNotificationParam param = LegoEventNotificationParam(p_id, NULL, p_modifier, p_x, p_y, p_key);
 
-	if (((!m_unk0x88) || ((m_unk0x335 && (param.GetType() == MOUSEDOWN)))) || ((m_unk0x336 && (p_key == ' ')))) {
+	if (((!m_unk0x88) || ((m_unk0x335 && (param.GetType() == c_notificationButtonDown)))) ||
+		((m_unk0x336 && (p_key == ' ')))) {
 		ProcessOneEvent(param);
 	}
 }

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -10,15 +10,6 @@
 
 #include <dinput.h>
 
-enum NotificationId {
-	NONE = 0,
-	KEYDOWN = 7,
-	MOUSEUP = 8,
-	MOUSEDOWN = 9,
-	MOUSEMOVE = 10,
-	TIMER = 15
-};
-
 class LegoControlManager;
 
 // VTABLE 0x100d8800
@@ -113,13 +104,13 @@ public:
 // OFFSET: LEGO1 0x1005d010 TEMPLATE
 // MxListEntry<LegoEventNotificationParam>::GetValue
 
-// VTABLE 0x100d87e8
+// VTABLE 0x100d87e8 TEMPLATE
 // class MxQueue<LegoEventNotificationParam>
 
-// VTABLE 0x100d87d0
+// VTABLE 0x100d87d0 TEMPLATE
 // class MxList<LegoEventNotificationParam>
 
-// VTABLE 0x100d87b8
+// VTABLE 0x100d87b8 TEMPLATE
 // class MxListParent<LegoEventNotificationParam>
 
 #endif // LEGOINPUTMANAGER_H

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -38,7 +38,6 @@ public:
 	virtual MxResult Tickle() override; // vtable+0x8
 
 	MxResult Create(HWND p_hwnd);
-	void Create();
 	void Destroy();
 	void CreateAndAcquireKeyboard(HWND hwnd);
 	void ReleaseDX();

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -6,6 +6,7 @@
 #include "legoworld.h"
 #include "mxlist.h"
 #include "mxpresenter.h"
+#include "mxqueue.h"
 
 #include <dinput.h>
 
@@ -19,8 +20,9 @@ enum NotificationId {
 };
 
 class LegoControlManager;
-// TODO Really a MxQueue, but we don't have one of those
-class LegoEventQueue : public MxList<LegoEventNotificationParam> {};
+
+// VTABLE 0x100d8800
+class LegoEventQueue : public MxQueue<LegoEventNotificationParam> {};
 
 // VTABLE 0x100d8760
 // SIZE 0x338
@@ -29,12 +31,13 @@ public:
 	LegoInputManager();
 	virtual ~LegoInputManager() override;
 
-	__declspec(dllexport) void QueueEvent(NotificationId id, unsigned char p2, MxLong p3, MxLong p4, unsigned char p5);
+	__declspec(dllexport) void QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p_x, MxLong p_y, MxU8 p_key);
 	__declspec(dllexport) void Register(MxCore*);
 	__declspec(dllexport) void UnRegister(MxCore*);
 
 	virtual MxResult Tickle() override; // vtable+0x8
 
+	void Create();
 	void Destroy();
 	void CreateAndAcquireKeyboard(HWND hwnd);
 	void ReleaseDX();
@@ -53,12 +56,15 @@ public:
 	inline LegoControlManager* GetControlManager() { return m_controlManager; }
 	inline LegoWorld* GetWorld() { return m_world; }
 
+	void ProcessEvents();
+	MxBool ProcessOneEvent(LegoEventNotificationParam& p_param);
+
 	// private:
 	MxCriticalSection m_criticalSection;
-	LegoEventQueue* m_eventQueue; // list or hash table
+	MxList<undefined4>* m_unk0x5c; // list or hash table
 	LegoCameraController* m_camera;
 	LegoWorld* m_world;
-	MxList<undefined4>* m_unk0x68; // list or hash table
+	LegoEventQueue* m_eventQueue; // +0x68
 	undefined4 m_unk0x6c;
 	undefined4 m_unk0x70;
 	undefined4 m_unk0x74;
@@ -82,5 +88,38 @@ public:
 	MxBool m_unk0x335;
 	MxBool m_unk0x336;
 };
+
+// OFFSET: LEGO1 0x1005bb80 TEMPLATE
+// MxListParent<LegoEventNotificationParam>::Compare
+
+// OFFSET: LEGO1 0x1005bc30 TEMPLATE
+// MxListParent<LegoEventNotificationParam>::Destroy
+
+// OFFSET: LEGO1 0x1005bc80 TEMPLATE
+// MxList<LegoEventNotificationParam>::~MxList<LegoEventNotificationParam>
+
+// OFFSET: LEGO1 0x1005bd50 TEMPLATE
+// MxListParent<LegoEventNotificationParam>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005bdc0 TEMPLATE
+// MxList<LegoEventNotificationParam>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005beb0 TEMPLATE
+// LegoEventQueue::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005bf70 TEMPLATE
+// MxQueue<LegoEventNotificationParam>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005d010 TEMPLATE
+// MxListEntry<LegoEventNotificationParam>::GetValue
+
+// VTABLE 0x100d87e8
+// class MxQueue<LegoEventNotificationParam>
+
+// VTABLE 0x100d87d0
+// class MxList<LegoEventNotificationParam>
+
+// VTABLE 0x100d87b8
+// class MxListParent<LegoEventNotificationParam>
 
 #endif // LEGOINPUTMANAGER_H

--- a/LEGO1/mxactionnotificationparam.h
+++ b/LEGO1/mxactionnotificationparam.h
@@ -8,7 +8,12 @@
 // SIZE 0x14
 class MxActionNotificationParam : public MxNotificationParam {
 public:
-	inline MxActionNotificationParam(MxParamType p_type, MxCore* p_sender, MxDSAction* p_action, MxBool p_reallocAction)
+	inline MxActionNotificationParam(
+		NotificationId p_type,
+		MxCore* p_sender,
+		MxDSAction* p_action,
+		MxBool p_reallocAction
+	)
 		: MxNotificationParam(p_type, p_sender)
 	{
 		MxDSAction* oldAction = p_action;
@@ -50,7 +55,7 @@ protected:
 class MxEndActionNotificationParam : public MxActionNotificationParam {
 public:
 	inline MxEndActionNotificationParam(
-		MxParamType p_type,
+		NotificationId p_type,
 		MxCore* p_sender,
 		MxDSAction* p_action,
 		MxBool p_reallocAction

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -27,6 +27,10 @@ public:
 	}
 
 	T GetValue() { return this->m_obj; }
+	inline MxListEntry* GetPrev() const { return m_prev; };
+	inline MxListEntry* GetNext() const { return m_next; };
+	inline void SetPrev(MxListEntry* p_node) { m_prev = p_node; };
+	inline void SetNext(MxListEntry* p_node) { m_next = p_node; };
 
 	friend class MxList<T>;
 	friend class MxListCursor<T>;
@@ -81,7 +85,6 @@ protected:
 	MxListEntry<T>* m_first; // +0x10
 	MxListEntry<T>* m_last;  // +0x14
 
-private:
 	void _DeleteEntry(MxListEntry<T>* match);
 	MxListEntry<T>* _InsertEntry(T, MxListEntry<T>*, MxListEntry<T>*);
 };

--- a/LEGO1/mxnotificationparam.h
+++ b/LEGO1/mxnotificationparam.h
@@ -7,7 +7,7 @@
 
 class MxCore;
 
-enum MxParamType {
+enum NotificationId {
 	PARAM_NONE = 0,
 	c_notificationStartAction = 1, // 100dc210:100d8350
 	c_notificationEndAction = 2,   // 100d8358:100d8350
@@ -36,18 +36,20 @@ enum MxParamType {
 // VTABLE 0x100d56e0
 class MxNotificationParam : public MxParam {
 public:
-	inline MxNotificationParam(MxParamType p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender) {}
+	inline MxNotificationParam(NotificationId p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender)
+	{
+	}
 
 	virtual ~MxNotificationParam() override {} // vtable+0x0 (scalar deleting destructor)
 	virtual MxNotificationParam* Clone();      // vtable+0x4
 
-	inline MxParamType GetNotification() const { return m_type; }
+	inline NotificationId GetNotification() const { return m_type; }
 	inline MxCore* GetSender() const { return m_sender; }
-	inline MxParamType GetType() const { return m_type; }
+	inline NotificationId GetType() const { return m_type; }
 
 protected:
-	MxParamType m_type; // 0x4
-	MxCore* m_sender;   // 0x8
+	NotificationId m_type; // 0x4
+	MxCore* m_sender;      // 0x8
 };
 
 #endif // MXNOTIFICATIONPARAM_H

--- a/LEGO1/mxnotificationparam.h
+++ b/LEGO1/mxnotificationparam.h
@@ -43,6 +43,7 @@ public:
 
 	inline MxParamType GetNotification() const { return m_type; }
 	inline MxCore* GetSender() const { return m_sender; }
+	inline MxParamType GetType() const { return m_type; }
 
 protected:
 	MxParamType m_type; // 0x4

--- a/LEGO1/mxqueue.h
+++ b/LEGO1/mxqueue.h
@@ -6,22 +6,21 @@
 template <class T>
 class MxQueue : public MxList<T> {
 public:
-  void Enqueue(T& p_obj)
-  {
-    // TODO
-  }
+	void Enqueue(T& p_obj)
+	{
+		// TODO
+	}
 
-  MxBool Dequeue(T& p_obj)
-  {
-    MxBool has_next = (m_first != NULL);
-    if (m_first) {
-      p_obj = m_first->GetValue();
-      _DeleteEntry(m_first);
-    }
+	MxBool Dequeue(T& p_obj)
+	{
+		MxBool has_next = (m_first != NULL);
+		if (m_first) {
+			p_obj = m_first->GetValue();
+			_DeleteEntry(m_first);
+		}
 
-    return has_next;
-  }
+		return has_next;
+	}
 };
-
 
 #endif // MXQUEUE_H

--- a/LEGO1/mxqueue.h
+++ b/LEGO1/mxqueue.h
@@ -1,0 +1,27 @@
+#ifndef MXQUEUE_H
+#define MXQUEUE_H
+
+#include "mxlist.h"
+
+template <class T>
+class MxQueue : public MxList<T> {
+public:
+  void Enqueue(T& p_obj)
+  {
+    // TODO
+  }
+
+  MxBool Dequeue(T& p_obj)
+  {
+    MxBool has_next = (m_first != NULL);
+    if (m_first) {
+      p_obj = m_first->GetValue();
+      _DeleteEntry(m_first);
+    }
+
+    return has_next;
+  }
+};
+
+
+#endif // MXQUEUE_H

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -42,7 +42,7 @@ public:
 
 class MxStreamerNotification : public MxNotificationParam {
 public:
-	inline MxStreamerNotification(MxParamType p_type, MxCore* p_sender, MxStreamController* p_ctrlr)
+	inline MxStreamerNotification(NotificationId p_type, MxCore* p_sender, MxStreamController* p_ctrlr)
 		: MxNotificationParam(p_type, p_sender)
 	{
 		m_controller = p_ctrlr;


### PR DESCRIPTION
Implements the `MxQueue` datatype that we need for `LegoInputManager`. It is a subclass of `MxList`, adding only the Enqueue and Dequeue methods. I had to open up the scope from private to protected in `MxList` to make this work. Only Dequeue is implemented right now because I don't think Enqueue is ever called. If you go off the 96 source (and I did) then it seems the `QUEUE_EVENTS` macro is not defined, and so Enqueue is not called in `QueueEvent()`.

Sidebar while on the topic of these complex datatypes: we have a few now, and all seem to require superclasses like `MxHashTableParent` that don't make much sense. I think what's happening here is that all collection datatypes have a common ancestor, say: `MxCollection`. With that, you get an `m_count` variable and a `m_customDestructor` method to clean up the template type. Each subclass builds on top of that to add whatever it needs for that datatype. For example: an `MxQueue` is just a linked list with a special API, so it extends `MxList`.

The vtables that you get in the binary are specific to whatever class was provided in the template; they are not generic vtables. I added a bunch of template defs to legoinputmanager.h to illustrate what I mean. I'm going to look into this a little more because it's too big of a change to jam into this pull request, but it should simplify a lot of what we have now.

`LegoEventNotificationParam` got an extra parameter to round out its size. The constructor used in `QueueEvent()` (as in the 96 source, and added here) leaves off this parameter, though. We will also have to address whether the type of `MxNotificationParam::m_type` should be the enum `NotificationId`. Most likely yes, because the exposed symbol for `QueueEvent` uses it. I can change this after review if we feel strongly about doing it now.