### PR TITLE
Improved source file path comparison in reccmp

### DIFF
--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -220,12 +220,14 @@ class SymInfo:
     found = False
 
     logger.debug('Looking for %s:%d', filename, line)
+    filename_basename = os.path.basename(filename).lower()
 
     for fn in self.lines:
       # Sometimes a PDB is compiled with a relative path while we always have
       # an absolute path. Therefore we must
       try:
-        if os.path.samefile(fn, filename):
+        if (os.path.basename(fn).lower() == filename_basename and
+            os.path.samefile(fn, filename)):
           filename = fn
           break
       except FileNotFoundError as e:


### PR DESCRIPTION
The `cvdump` tool reads our recompiled PDB and lists each source file and function, with pairs of source line numbers and offsets into the binary where the instructions for that compiled line begin. You can reasonably assume (and we do) that the first line number given is the start of the function, regardless of formatting in the source file.

The main loop of `reccmp` scans each file for the `// OFFSET` marker, then finds the line number of the next opening curly brace, which is the start of code for that function.

These two pieces of information come together in `get_recompiled_address` where we look for a match to begin comparing the assembly. However, as the code comment points out, we are not guaranteed an absolute path in the PDB, so we have to use the `os.path.samefile` function to make sure it's the correct file.

We can make this process faster by eliminating obvious mismatches. To do this, I take the path from the PDB and the path to the source file we are checking, get just the filename using `os.path.basename`, then string compare the lower case version of both.

On my system, this takes the runtime from 21 seconds down to 5 seconds.