### PR TITLE
Bootstrap MxMediaPresenter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(lego1 SHARED
   LEGO1/mxsoundmanager.cpp
   LEGO1/mxsoundpresenter.cpp
   LEGO1/mxstillpresenter.cpp
+  LEGO1/mxstreamchunklist.cpp
   LEGO1/mxstreamcontroller.cpp
   LEGO1/mxstreamer.cpp
   LEGO1/mxstreamprovider.cpp

--- a/LEGO1/mxdsactionlist.cpp
+++ b/LEGO1/mxdsactionlist.cpp
@@ -6,13 +6,9 @@ DECOMP_SIZE_ASSERT(MxDSActionList, 0x1c);
 DECOMP_SIZE_ASSERT(MxDSActionListCursor, 0x10);
 
 // OFFSET: LEGO1 0x100c9c90
-MxS8 MxDSActionList::Compare(MxDSAction* p_var0, MxDSAction* p_var1)
+MxS8 MxDSActionList::Compare(MxDSAction* p_a, MxDSAction* p_b)
 {
-	if (p_var1 == p_var0)
-		return 0;
-	if (p_var1 <= p_var0)
-		return 1;
-	return -1;
+	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 }
 
 // OFFSET: LEGO1 0x100c9cb0

--- a/LEGO1/mxdschunk.h
+++ b/LEGO1/mxdschunk.h
@@ -23,7 +23,7 @@ public:
 		return !strcmp(name, MxDSChunk::ClassName()) || MxCore::IsA(name);
 	}
 
-private:
+	// private:
 	MxS16 m_length;  // 0x8
 	MxLong m_buffer; // 0xc
 	MxLong m_unk10;  // 0x10

--- a/LEGO1/mxdssubscriber.cpp
+++ b/LEGO1/mxdssubscriber.cpp
@@ -1,13 +1,28 @@
 #include "mxdssubscriber.h"
 
-// OFFSET: LEGO1 0x100b7bb0
+DECOMP_SIZE_ASSERT(MxDSSubscriber, 0x4c);
+
+// OFFSET: LEGO1 0x100b7bb0 STUB
 MxDSSubscriber::MxDSSubscriber()
 {
 	// TODO
 }
 
-// OFFSET: LEGO1 0x100b7e00
+// OFFSET: LEGO1 0x100b7e00 STUB
 MxDSSubscriber::~MxDSSubscriber()
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x100b7ed0 STUB
+MxResult MxDSSubscriber::FUN_100b7ed0(MxStreamController*, MxU32, MxS16)
+{
+	// TODO
+	return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x100b8390 STUB
+void MxDSSubscriber::FUN_100b8390(MxDSChunk*)
 {
 	// TODO
 }

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -1,7 +1,10 @@
 #ifndef MXDSSUBSCRIBER_H
 #define MXDSSUBSCRIBER_H
 
+#include "decomp.h"
 #include "mxcore.h"
+#include "mxdschunk.h"
+#include "mxstreamcontroller.h"
 
 // VTABLE 0x100dc698
 // SIZE 0x4c
@@ -22,6 +25,12 @@ public:
 	{
 		return !strcmp(name, MxDSSubscriber::ClassName()) || MxCore::IsA(name);
 	}
+
+	MxResult FUN_100b7ed0(MxStreamController*, MxU32, MxS16);
+	void FUN_100b8390(MxDSChunk*);
+
+private:
+	undefined m_pad[0x44]; // 0x8
 };
 
 #endif // MXDSSUBSCRIBER_H

--- a/LEGO1/mxmediapresenter.h
+++ b/LEGO1/mxmediapresenter.h
@@ -2,15 +2,18 @@
 #define MXMEDIAPRESENTER_H
 
 #include "decomp.h"
+#include "mxdssubscriber.h"
 #include "mxpresenter.h"
+#include "mxstreamchunklist.h"
 
 // VTABLE 0x100d4cd8
+// SIZE 0x50
 class MxMediaPresenter : public MxPresenter {
 public:
 	inline MxMediaPresenter() { Init(); }
 	virtual ~MxMediaPresenter() override;
 
-	virtual MxResult Tickle() override;
+	virtual MxResult Tickle() override; // vtable+0x8
 
 	// OFFSET: LEGO1 0x1000c5c0
 	inline virtual const char* ClassName() const override // vtable+0xc
@@ -29,17 +32,17 @@ public:
 	virtual void RepeatingTickle() override;
 	virtual void DoneTickle() override;
 	virtual void Destroy() override;
-	virtual MxLong StartAction(MxStreamController*, MxDSAction*) override;
+	virtual MxResult StartAction(MxStreamController*, MxDSAction*) override;
 	virtual void EndAction() override;
 	virtual void Enable(MxBool p_enable) override;
 	virtual void VTable0x58();
 
-	undefined4 m_unk40;
-	undefined4 m_unk44;
-	undefined4 m_unk48;
-	undefined4 m_unk4c;
-
 protected:
+	MxDSSubscriber* m_subscriber;      // 0x40
+	MxStreamChunkList* m_chunks;       // 0x44
+	MxStreamChunkListCursor* m_cursor; // 0x48
+	MxStreamChunk* m_currentChunk;     // 0x4c
+
 	void Init();
 	void Destroy(MxBool p_fromDestructor);
 };

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -116,7 +116,7 @@ MxResult MxPresenter::Tickle()
 }
 
 // OFFSET: LEGO1 0x100b4d80
-MxLong MxPresenter::StartAction(MxStreamController*, MxDSAction* p_action)
+MxResult MxPresenter::StartAction(MxStreamController*, MxDSAction* p_action)
 {
 	MxAutoLocker lock(&this->m_criticalSection);
 

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -54,15 +54,15 @@ protected:
 	__declspec(dllexport) virtual void ParseExtra(); // vtable+0x30
 
 public:
-	virtual MxResult AddToManager();                                                    // vtable+0x34
-	virtual void Destroy();                                                             // vtable+0x38
-	__declspec(dllexport) virtual MxLong StartAction(MxStreamController*, MxDSAction*); // vtable+0x3c
-	__declspec(dllexport) virtual void EndAction();                                     // vtable+0x40
-	virtual void SetTickleState(TickleState p_tickleState);                             // vtable+0x44
-	virtual MxBool HasTickleStatePassed(TickleState p_tickleState);                     // vtable+0x48
-	virtual undefined4 PutData();                                                       // vtable+0x4c
-	virtual MxBool IsHit(MxS32 p_x, MxS32 p_y);                                         // vtable+0x50
-	__declspec(dllexport) virtual void Enable(MxBool p_enable);                         // vtable+0x54
+	virtual MxResult AddToManager();                                                      // vtable+0x34
+	virtual void Destroy();                                                               // vtable+0x38
+	__declspec(dllexport) virtual MxResult StartAction(MxStreamController*, MxDSAction*); // vtable+0x3c
+	__declspec(dllexport) virtual void EndAction();                                       // vtable+0x40
+	virtual void SetTickleState(TickleState p_tickleState);                               // vtable+0x44
+	virtual MxBool HasTickleStatePassed(TickleState p_tickleState);                       // vtable+0x48
+	virtual undefined4 PutData();                                                         // vtable+0x4c
+	virtual MxBool IsHit(MxS32 p_x, MxS32 p_y);                                           // vtable+0x50
+	__declspec(dllexport) virtual void Enable(MxBool p_enable);                           // vtable+0x54
 
 	MxBool IsEnabled();
 

--- a/LEGO1/mxpresenterlist.cpp
+++ b/LEGO1/mxpresenterlist.cpp
@@ -6,11 +6,7 @@ DECOMP_SIZE_ASSERT(MxPresenterList, 0x18);
 DECOMP_SIZE_ASSERT(MxPresenterListCursor, 0x10);
 
 // OFFSET: LEGO1 0x1001cd00
-MxS8 MxPresenterList::Compare(MxPresenter* p_var0, MxPresenter* p_var1)
+MxS8 MxPresenterList::Compare(MxPresenter* p_a, MxPresenter* p_b)
 {
-	if (p_var1 == p_var0)
-		return 0;
-	if (p_var1 <= p_var0)
-		return 1;
-	return -1;
+	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 }

--- a/LEGO1/mxstreamchunklist.cpp
+++ b/LEGO1/mxstreamchunklist.cpp
@@ -1,0 +1,19 @@
+#include "mxstreamchunklist.h"
+
+#include "mxstreamchunk.h"
+
+DECOMP_SIZE_ASSERT(MxStreamChunkList, 0x18);
+DECOMP_SIZE_ASSERT(MxStreamChunkListCursor, 0x10);
+
+// OFFSET: LEGO1 0x100b5900
+MxS8 MxStreamChunkList::Compare(MxStreamChunk* p_a, MxStreamChunk* p_b)
+{
+	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
+}
+
+// OFFSET: LEGO1 0x100b5920
+void MxStreamChunkList::Destroy(MxStreamChunk* p_chunk)
+{
+	if (p_chunk)
+		delete p_chunk;
+}

--- a/LEGO1/mxstreamchunklist.h
+++ b/LEGO1/mxstreamchunklist.h
@@ -12,7 +12,7 @@ class MxStreamChunkList : public MxList<MxStreamChunk*> {
 public:
 	MxStreamChunkList() { m_customDestructor = Destroy; }
 
-	virtual MxS8 Compare(MxStreamChunk*, MxStreamChunk*); // +0x14
+	virtual MxS8 Compare(MxStreamChunk*, MxStreamChunk*) override; // +0x14
 
 	static void Destroy(MxStreamChunk* p_chunk);
 };

--- a/LEGO1/mxstreamchunklist.h
+++ b/LEGO1/mxstreamchunklist.h
@@ -1,0 +1,34 @@
+#ifndef MXSTREAMCHUNKLIST_H
+#define MXSTREAMCHUNKLIST_H
+
+#include "decomp.h"
+#include "mxlist.h"
+
+class MxStreamChunk;
+
+// VTABLE 0x100dc600
+// SIZE 0x18
+class MxStreamChunkList : public MxList<MxStreamChunk*> {
+public:
+	MxStreamChunkList() { m_customDestructor = Destroy; }
+
+	virtual MxS8 Compare(MxStreamChunk*, MxStreamChunk*); // +0x14
+
+	static void Destroy(MxStreamChunk* p_chunk);
+};
+
+typedef MxListCursorChild<MxStreamChunk*> MxStreamChunkListCursor;
+
+// OFFSET: LEGO1 0x100b5930 TEMPLATE
+// MxListParent<MxStreamChunk *>::Compare
+
+// OFFSET: LEGO1 0x100b5990 TEMPLATE
+// MxListParent<MxStreamChunk *>::Destroy
+
+// OFFSET: LEGO1 0x100b59a0 TEMPLATE
+// MxList<MxStreamChunk *>::~MxList<MxStreamChunk *>
+
+// OFFSET: LEGO1 0x100b5b10 TEMPLATE
+// MxList<MxStreamChunk *>::`scalar deleting destructor'
+
+#endif // MXSTREAMCHUNKLIST_H


### PR DESCRIPTION
* Adds the members to `MxMediaPresenter`. What we have here is a list of stream chunks, a current chunk, and a cursor into the stream chunk list, as well as an instance of `MxDSSubscriber`.
* Implements `Destroy` and `StartAction` and the list w/ annotations, 100% matches

For the list, I've re-used the same implementation pattern as before. @disinvite - the refactoring of the list stuff you mentioned in https://github.com/isledecomp/isle/pull/268 would be great indeed going forward since it feels like more boilerplate than it should be.