### PR TITLE
Implement/match MxEventPresenter

### DIFF
--- a/LEGO1/mxeventpresenter.cpp
+++ b/LEGO1/mxeventpresenter.cpp
@@ -1,8 +1,10 @@
 #include "mxeventpresenter.h"
 
 #include "decomp.h"
+#include "mxautolocker.h"
 #include "mxeventmanager.h"
 #include "mxomni.h"
+#include "mxvariabletable.h"
 
 DECOMP_SIZE_ASSERT(MxEventPresenter, 0x54);
 
@@ -21,13 +23,14 @@ MxEventPresenter::~MxEventPresenter()
 // OFFSET: LEGO1 0x100c2da0
 void MxEventPresenter::Init()
 {
-	m_unk50 = NULL;
+	m_data = NULL;
 }
 
 // OFFSET: LEGO1 0x100c2db0
 MxResult MxEventPresenter::AddToManager()
 {
 	MxResult ret = FAILURE;
+
 	if (EventManager()) {
 		ret = SUCCESS;
 		EventManager()->AddPresenter(*this);
@@ -44,10 +47,71 @@ void MxEventPresenter::Destroy()
 
 	m_criticalSection.Enter();
 
-	if (m_unk50)
-		delete m_unk50;
+	if (m_data)
+		delete[] m_data;
 
 	Init();
 
 	m_criticalSection.Leave();
+}
+
+// OFFSET: LEGO1 0x100c2e30
+void MxEventPresenter::CopyData(MxStreamChunk* p_chunk)
+{
+	m_data = new MxU8[p_chunk->GetLength()];
+	memcpy(m_data, p_chunk->GetData(), p_chunk->GetLength());
+}
+
+// OFFSET: LEGO1 0x100c2e70
+void MxEventPresenter::ReadyTickle()
+{
+	MxStreamChunk* chunk = NextChunk();
+
+	if (chunk) {
+		CopyData(chunk);
+		m_subscriber->FUN_100b8390(chunk);
+		ParseExtra();
+		m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+		m_currentTickleState = TickleState_Starting;
+	}
+}
+
+// OFFSET: LEGO1 0x100c2eb0
+void MxEventPresenter::StartingTickle()
+{
+	MxStreamChunk* chunk = NextChunk();
+
+	if (chunk && m_action->GetElapsedTime() >= chunk->GetTime()) {
+		m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+		m_currentTickleState = TickleState_Streaming;
+	}
+}
+
+// OFFSET: LEGO1 0x100c2ef0
+undefined4 MxEventPresenter::PutData()
+{
+	MxAutoLocker lock(&m_criticalSection);
+
+	if (IsEnabled()) {
+		if (m_currentTickleState >= TickleState_Streaming &&
+			(m_currentTickleState <= TickleState_Repeating || m_currentTickleState == TickleState_Done)) {
+			if (m_currentChunk && m_currentChunk->GetLength()) {
+				if (m_data[12] == 2) {
+					const char* data = (const char*) m_currentChunk->GetData();
+					MxVariableTable* variableTable = VariableTable();
+
+					const char* key = data;
+					const char* value = &data[strlen(data) + 1];
+					strlen(value);
+					variableTable->SetVariable(key, value);
+				}
+
+				if (m_currentTickleState == TickleState_Streaming)
+					m_subscriber->FUN_100b8390(m_currentChunk);
+				m_currentChunk = NULL;
+			}
+		}
+	}
+
+	return 0;
 }

--- a/LEGO1/mxeventpresenter.h
+++ b/LEGO1/mxeventpresenter.h
@@ -24,13 +24,17 @@ public:
 		return !strcmp(name, MxEventPresenter::ClassName()) || MxMediaPresenter::IsA(name);
 	}
 
-	virtual MxResult AddToManager() override; // vtable+0x34
-	virtual void Destroy() override;          // vtable+0x38
+	virtual void ReadyTickle() override;           // vtable+0x18
+	virtual void StartingTickle() override;        // vtable+0x1c
+	virtual MxResult AddToManager() override;      // vtable+0x34
+	virtual void Destroy() override;               // vtable+0x38
+	virtual undefined4 PutData() override;         // vtable+0x4c
+	virtual void CopyData(MxStreamChunk* p_chunk); // vtable+0x5c
 
 private:
 	void Init();
 
-	undefined4* m_unk50;
+	MxU8* m_data; // 0x50
 };
 
 #endif // MXEVENTPRESENTER_H


### PR DESCRIPTION
* Implements `CopyData`, `ReadyTickle`, `StartingTickle` and `PutData`
* `m_data` is obviously some sort of structure but I don't have enough information yet on what it is. It can most likely be extracted from `libweaver`
* All 100% except `PutData`, which does something odd with an extra `strlen` that I can't get to match.