### PR TITLE
MxList refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(lego1 SHARED
   LEGO1/legopartpresenter.cpp
   LEGO1/legopathactor.cpp
   LEGO1/legopathcontroller.cpp
+  LEGO1/legopathcontrollerlist.cpp
   LEGO1/legopathpresenter.cpp
   LEGO1/legophonemepresenter.cpp
   LEGO1/legoplantmanager.cpp

--- a/LEGO1/legoinputmanager.cpp
+++ b/LEGO1/legoinputmanager.cpp
@@ -5,6 +5,7 @@
 #include "mxautolocker.h"
 
 DECOMP_SIZE_ASSERT(LegoInputManager, 0x338);
+DECOMP_SIZE_ASSERT(LegoEventQueue, 0x18);
 
 // OFFSET: LEGO1 0x1005b790
 LegoInputManager::LegoInputManager()
@@ -54,6 +55,27 @@ MxResult LegoInputManager::Create(HWND p_hwnd)
 		m_eventQueue = new LegoEventQueue();
 	return SUCCESS;
 }
+
+// OFFSET: LEGO1 0x1005bb80 TEMPLATE
+// MxCollection<LegoEventNotificationParam>::Compare
+
+// OFFSET: LEGO1 0x1005bc30 TEMPLATE
+// MxCollection<LegoEventNotificationParam>::Destroy
+
+// OFFSET: LEGO1 0x1005bc80 TEMPLATE
+// MxList<LegoEventNotificationParam>::~MxList<LegoEventNotificationParam>
+
+// OFFSET: LEGO1 0x1005bd50 TEMPLATE
+// MxCollection<LegoEventNotificationParam>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005bdc0 TEMPLATE
+// MxList<LegoEventNotificationParam>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005beb0 TEMPLATE
+// LegoEventQueue::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1005bf70 TEMPLATE
+// MxQueue<LegoEventNotificationParam>::`scalar deleting destructor'
 
 // OFFSET: LEGO1 0x1005bfe0
 void LegoInputManager::Destroy()
@@ -270,3 +292,6 @@ void LegoInputManager::KillTimer()
 		::KillTimer(omni->GetWindowHandle(), m_timer);
 	}
 }
+
+// OFFSET: LEGO1 0x1005d010 TEMPLATE
+// MxListEntry<LegoEventNotificationParam>::GetValue

--- a/LEGO1/legoinputmanager.h
+++ b/LEGO1/legoinputmanager.h
@@ -12,7 +12,17 @@
 
 class LegoControlManager;
 
+// VTABLE 0x100d87b8 TEMPLATE
+// class MxCollection<LegoEventNotificationParam>
+
+// VTABLE 0x100d87d0 TEMPLATE
+// class MxList<LegoEventNotificationParam>
+
+// VTABLE 0x100d87e8 TEMPLATE
+// class MxQueue<LegoEventNotificationParam>
+
 // VTABLE 0x100d8800
+// SIZE 0x18
 class LegoEventQueue : public MxQueue<LegoEventNotificationParam> {};
 
 // VTABLE 0x100d8760
@@ -79,38 +89,5 @@ public:
 	MxBool m_unk0x335;
 	MxBool m_unk0x336;
 };
-
-// OFFSET: LEGO1 0x1005bb80 TEMPLATE
-// MxListParent<LegoEventNotificationParam>::Compare
-
-// OFFSET: LEGO1 0x1005bc30 TEMPLATE
-// MxListParent<LegoEventNotificationParam>::Destroy
-
-// OFFSET: LEGO1 0x1005bc80 TEMPLATE
-// MxList<LegoEventNotificationParam>::~MxList<LegoEventNotificationParam>
-
-// OFFSET: LEGO1 0x1005bd50 TEMPLATE
-// MxListParent<LegoEventNotificationParam>::`scalar deleting destructor'
-
-// OFFSET: LEGO1 0x1005bdc0 TEMPLATE
-// MxList<LegoEventNotificationParam>::`scalar deleting destructor'
-
-// OFFSET: LEGO1 0x1005beb0 TEMPLATE
-// LegoEventQueue::`scalar deleting destructor'
-
-// OFFSET: LEGO1 0x1005bf70 TEMPLATE
-// MxQueue<LegoEventNotificationParam>::`scalar deleting destructor'
-
-// OFFSET: LEGO1 0x1005d010 TEMPLATE
-// MxListEntry<LegoEventNotificationParam>::GetValue
-
-// VTABLE 0x100d87e8 TEMPLATE
-// class MxQueue<LegoEventNotificationParam>
-
-// VTABLE 0x100d87d0 TEMPLATE
-// class MxList<LegoEventNotificationParam>
-
-// VTABLE 0x100d87b8 TEMPLATE
-// class MxListParent<LegoEventNotificationParam>
 
 #endif // LEGOINPUTMANAGER_H

--- a/LEGO1/legopathcontrollerlist.cpp
+++ b/LEGO1/legopathcontrollerlist.cpp
@@ -11,12 +11,6 @@ MxS8 LegoPathControllerList::Compare(LegoPathController* p_a, LegoPathController
 	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 }
 
-// OFFSET: LEGO1 0x1001d3c0
-void LegoPathControllerList::Destroy(LegoPathController* p_controller)
-{
-	delete p_controller;
-}
-
 // OFFSET: LEGO1 0x1001d230 TEMPLATE
 // MxCollection<LegoPathController *>::Compare
 
@@ -31,6 +25,12 @@ void LegoPathControllerList::Destroy(LegoPathController* p_controller)
 
 // OFFSET: LEGO1 0x1001d330 TEMPLATE
 // MxList<LegoPathController *>::~MxList<LegoPathController *>
+
+// OFFSET: LEGO1 0x1001d3c0
+void LegoPathControllerList::Destroy(LegoPathController* p_controller)
+{
+	delete p_controller;
+}
 
 // OFFSET: LEGO1 0x1001d490 TEMPLATE
 // MxCollection<LegoPathController *>::`scalar deleting destructor'

--- a/LEGO1/legopathcontrollerlist.cpp
+++ b/LEGO1/legopathcontrollerlist.cpp
@@ -1,0 +1,42 @@
+#include "legopathcontrollerlist.h"
+
+#include "decomp.h"
+#include "legopathcontroller.h"
+
+DECOMP_SIZE_ASSERT(LegoPathControllerList, 0x18);
+
+// OFFSET: LEGO1 0x1001d210
+MxS8 LegoPathControllerList::Compare(LegoPathController* p_a, LegoPathController* p_b)
+{
+	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
+}
+
+// OFFSET: LEGO1 0x1001d3c0
+void LegoPathControllerList::Destroy(LegoPathController* p_controller)
+{
+	delete p_controller;
+}
+
+// OFFSET: LEGO1 0x1001d230 TEMPLATE
+// MxCollection<LegoPathController *>::Compare
+
+// OFFSET: LEGO1 0x1001d240 TEMPLATE
+// MxList<LegoPathController *>::MxList<LegoPathController *>
+
+// OFFSET: LEGO1 0x1001d2d0 TEMPLATE
+// MxCollection<LegoPathController *>::~MxCollection<LegoPathController *>
+
+// OFFSET: LEGO1 0x1001d320 TEMPLATE
+// MxCollection<LegoPathController *>::Destroy
+
+// OFFSET: LEGO1 0x1001d330 TEMPLATE
+// MxList<LegoPathController *>::~MxList<LegoPathController *>
+
+// OFFSET: LEGO1 0x1001d490 TEMPLATE
+// MxCollection<LegoPathController *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1001d500 TEMPLATE
+// MxList<LegoPathController *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1001d5b0 TEMPLATE
+// MxPtrList<LegoPathController>::`scalar deleting destructor'

--- a/LEGO1/legopathcontrollerlist.h
+++ b/LEGO1/legopathcontrollerlist.h
@@ -11,6 +11,8 @@
 // VTABLE 0x100d6338
 // SIZE 0x18
 class LegoPathControllerList : public MxPtrList<LegoPathController> {
+public:
+	LegoPathControllerList() : MxPtrList<LegoPathController>(Destroy) {}
 	virtual MxS8 Compare(LegoPathController*, LegoPathController*) override; // vtable+0x14
 	static void Destroy(LegoPathController*);
 };

--- a/LEGO1/legopathcontrollerlist.h
+++ b/LEGO1/legopathcontrollerlist.h
@@ -1,0 +1,24 @@
+#ifndef LEGOPATHCONTROLLERLIST_H
+#define LEGOPATHCONTROLLERLIST_H
+
+#include "legopathcontroller.h"
+#include "mxlist.h"
+#include "mxtypes.h"
+
+// VTABLE 0x100d6320 TEMPLATE
+// class MxPtrList<LegoPathController>
+
+// VTABLE 0x100d6338
+// SIZE 0x18
+class LegoPathControllerList : public MxPtrList<LegoPathController> {
+	virtual MxS8 Compare(LegoPathController*, LegoPathController*) override; // vtable+0x14
+	static void Destroy(LegoPathController*);
+};
+
+// VTABLE 0x100d6380 TEMPLATE
+// class MxCollection<LegoPathController *>
+
+// VTABLE 0x100d6398 TEMPLATE
+// class MxList<LegoPathController *>
+
+#endif // LEGOPATHCONTROLLERLIST_H

--- a/LEGO1/legoworld.h
+++ b/LEGO1/legoworld.h
@@ -41,11 +41,11 @@ public:
 	void EndAction(MxPresenter* p_presenter);
 
 protected:
-	LegoPathControllerList m_list0x68; // +0x68
-	MxPresenterList m_list0x80;        // +0x80
-	LegoCameraController* m_camera;    // +0x98
+	LegoPathControllerList m_list0x68; // 0x68
+	MxPresenterList m_list0x80;        // 0x80
+	LegoCameraController* m_camera;    // 0x98
 	undefined m_unk9c[0x1c];
-	MxPresenterList m_list0xb8; // +0xb8
+	MxPresenterList m_list0xb8; // 0xb8
 	undefined m_unkd0[0x26];
 	undefined m_unkf6;
 	undefined m_unkf7;

--- a/LEGO1/legoworld.h
+++ b/LEGO1/legoworld.h
@@ -3,7 +3,9 @@
 
 #include "legocameracontroller.h"
 #include "legoentity.h"
+#include "legopathcontrollerlist.h"
 #include "mxpresenter.h"
+#include "mxpresenterlist.h"
 
 // VTABLE 0x100d6280
 // SIZE 0xf8
@@ -39,9 +41,12 @@ public:
 	void EndAction(MxPresenter* p_presenter);
 
 protected:
-	undefined m_unk68[0x30];
-	LegoCameraController* m_camera;
-	undefined m_unk9c[0x5a];
+	LegoPathControllerList m_list0x68; // +0x68
+	MxPresenterList m_list0x80;        // +0x80
+	LegoCameraController* m_camera;    // +0x98
+	undefined m_unk9c[0x1c];
+	MxPresenterList m_list0xb8; // +0xb8
+	undefined m_unkd0[0x26];
 	undefined m_unkf6;
 	undefined m_unkf7;
 };

--- a/LEGO1/mxcollection.h
+++ b/LEGO1/mxcollection.h
@@ -18,8 +18,8 @@ public:
 	virtual MxS8 Compare(T, T) { return 0; }
 
 protected:
-	MxU32 m_count;                 // +0x8
-	void (*m_customDestructor)(T); // +0xc
+	MxU32 m_count;                 // 0x8
+	void (*m_customDestructor)(T); // 0xc
 };
 
 #endif // MXCOLLECTION_H

--- a/LEGO1/mxdsactionlist.cpp
+++ b/LEGO1/mxdsactionlist.cpp
@@ -17,3 +17,18 @@ void MxDSActionList::Destroy(MxDSAction* p_action)
 	if (p_action)
 		delete p_action;
 }
+
+// OFFSET: LEGO1 0x100c9cc0 TEMPLATE
+// MxCollection<MxDSAction *>::Compare
+
+// OFFSET: LEGO1 0x100c9d20 TEMPLATE
+// MxCollection<MxDSAction *>::Destroy
+
+// OFFSET: LEGO1 0x100c9d30 TEMPLATE
+// MxList<MxDSAction *>::~MxList<MxDSAction *>
+
+// OFFSET: LEGO1 0x100c9e30 TEMPLATE
+// MxCollection<MxDSAction *>::~MxCollection<MxDSAction *>
+
+// OFFSET: LEGO1 0x100c9ea0 TEMPLATE
+// MxList<MxDSAction *>::~MxList<MxDSAction *>

--- a/LEGO1/mxdsactionlist.cpp
+++ b/LEGO1/mxdsactionlist.cpp
@@ -28,7 +28,7 @@ void MxDSActionList::Destroy(MxDSAction* p_action)
 // MxList<MxDSAction *>::~MxList<MxDSAction *>
 
 // OFFSET: LEGO1 0x100c9e30 TEMPLATE
-// MxCollection<MxDSAction *>::~MxCollection<MxDSAction *>
+// MxCollection<MxDSAction *>::`scalar deleting destructor'
 
 // OFFSET: LEGO1 0x100c9ea0 TEMPLATE
-// MxList<MxDSAction *>::~MxList<MxDSAction *>
+// MxList<MxDSAction *>::`scalar deleting destructor'

--- a/LEGO1/mxdsactionlist.h
+++ b/LEGO1/mxdsactionlist.h
@@ -6,13 +6,19 @@
 
 class MxDSAction;
 
+// VTABLE 0x100dcea8 TEMPLATE
+// class MxCollection<MxDSAction *>
+
+// VTABLE 0x100dcec0 TEMPLATE
+// class MxList<MxDSAction *>
+
 // VTABLE 0x100dced8
 // SIZE 0x1c
 class MxDSActionList : public MxList<MxDSAction*> {
 public:
 	MxDSActionList() { this->m_unk18 = 0; }
 
-	virtual MxS8 Compare(MxDSAction*, MxDSAction*) override; // +0x14
+	virtual MxS8 Compare(MxDSAction*, MxDSAction*) override; // vtable+0x14
 
 	static void Destroy(MxDSAction* p_action);
 
@@ -21,14 +27,5 @@ private:
 };
 
 typedef MxListCursorChild<MxDSAction*> MxDSActionListCursor;
-
-// OFFSET: LEGO1 0x100c9cc0 TEMPLATE
-// MxListParent<MxDSAction *>::Compare
-
-// OFFSET: LEGO1 0x100c9d20 TEMPLATE
-// MxListParent<MxDSAction *>::Destroy
-
-// OFFSET: LEGO1 0x100c9d30 TEMPLATE
-// MxList<MxDSAction *>::~MxList<MxDSAction *>
 
 #endif // MXDSACTIONLIST_H

--- a/LEGO1/mxhashtable.h
+++ b/LEGO1/mxhashtable.h
@@ -59,16 +59,16 @@ public:
 protected:
 	void _NodeInsert(MxHashTableNode<T>*);
 
-	MxHashTableNode<T>** m_slots; // +0x10
-	MxU32 m_numSlots;             // +0x14
-	MxU32 m_autoResizeRatio;      // +0x18
-	HashTableOpt m_resizeOption;  // +0x1c
+	MxHashTableNode<T>** m_slots; // 0x10
+	MxU32 m_numSlots;             // 0x14
+	MxU32 m_autoResizeRatio;      // 0x18
+	HashTableOpt m_resizeOption;  // 0x1c
 	// FIXME: or FIXME? This qword is used as an integer or double depending
 	// on the value of m_resizeOption. Hard to say whether this is how the devs
 	// did it, but a simple cast in either direction doesn't match.
 	union {
-		MxU32 m_increaseAmount;  // +0x20
-		double m_increaseFactor; // +0x20
+		MxU32 m_increaseAmount;  // 0x20
+		double m_increaseFactor; // 0x20
 	};
 };
 

--- a/LEGO1/mxhashtable.h
+++ b/LEGO1/mxhashtable.h
@@ -156,13 +156,13 @@ void MxHashTable<T>::DeleteAll()
 
 		while (t) {
 			MxHashTableNode<T>* next = t->m_next;
-			m_customDestructor(t->m_obj);
+			this->m_customDestructor(t->m_obj);
 			delete t;
 			t = next;
 		}
 	}
 
-	m_count = 0;
+	this->m_count = 0;
 	memset(m_slots, 0, sizeof(MxHashTableNode<T>*) * m_numSlots);
 
 	delete[] m_slots;
@@ -188,7 +188,7 @@ inline void MxHashTable<T>::Resize()
 	MxHashTableNode<T>** new_table = new MxHashTableNode<T>*[m_numSlots];
 	m_slots = new_table;
 	memset(m_slots, 0, sizeof(MxHashTableNode<T>*) * m_numSlots);
-	m_count = 0;
+	this->m_count = 0;
 
 	for (MxS32 i = 0; i != old_size; i++) {
 		MxHashTableNode<T>* t = old_table[i];
@@ -214,13 +214,13 @@ inline void MxHashTable<T>::_NodeInsert(MxHashTableNode<T>* p_node)
 		m_slots[bucket]->m_prev = p_node;
 
 	m_slots[bucket] = p_node;
-	m_count++;
+	this->m_count++;
 }
 
 template <class T>
 inline void MxHashTable<T>::Add(T p_newobj)
 {
-	if (m_resizeOption && ((m_count + 1) / m_numSlots) > m_autoResizeRatio)
+	if (m_resizeOption && ((this->m_count + 1) / m_numSlots) > m_autoResizeRatio)
 		MxHashTable<T>::Resize();
 
 	MxU32 hash = Hash(p_newobj);

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -13,7 +13,7 @@ class MxListCursor;
 template <class T>
 class MxPtrList : public MxList<T*> {
 public:
-	MxPtrList() { m_customDestructor = Destroy; }
+	MxPtrList(void (*p_destroy)(T*) = Destroy) { m_customDestructor = p_destroy; }
 };
 
 template <class T>

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -1,6 +1,7 @@
 #ifndef MXLIST_H
 #define MXLIST_H
 
+#include "mxcollection.h"
 #include "mxcore.h"
 #include "mxtypes.h"
 
@@ -8,6 +9,12 @@ template <class T>
 class MxList;
 template <class T>
 class MxListCursor;
+
+template <class T>
+class MxPtrList : public MxList<T*> {
+public:
+	MxPtrList() { m_customDestructor = Destroy; }
+};
 
 template <class T>
 class MxListEntry {
@@ -40,29 +47,9 @@ private:
 	MxListEntry* m_next;
 };
 
-// SIZE 0x10
-template <class T>
-class MxListParent : public MxCore {
-public:
-	MxListParent()
-	{
-		m_count = 0;
-		m_customDestructor = Destroy;
-	}
-
-	virtual ~MxListParent() {}
-	virtual MxS8 Compare(T, T) { return 0; };
-
-	static void Destroy(T){};
-
-protected:
-	MxU32 m_count;                 // +0x8
-	void (*m_customDestructor)(T); // +0xc
-};
-
 // SIZE 0x18
 template <class T>
-class MxList : protected MxListParent<T> {
+class MxList : protected MxCollection<T> {
 public:
 	MxList()
 	{

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -67,8 +67,8 @@ public:
 	friend class MxListCursor<T>;
 
 protected:
-	MxListEntry<T>* m_first; // +0x10
-	MxListEntry<T>* m_last;  // +0x14
+	MxListEntry<T>* m_first; // 0x10
+	MxListEntry<T>* m_last;  // 0x14
 
 	void _DeleteEntry(MxListEntry<T>* match);
 	MxListEntry<T>* _InsertEntry(T, MxListEntry<T>*, MxListEntry<T>*);

--- a/LEGO1/mxpresenterlist.cpp
+++ b/LEGO1/mxpresenterlist.cpp
@@ -10,3 +10,27 @@ MxS8 MxPresenterList::Compare(MxPresenter* p_a, MxPresenter* p_b)
 {
 	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 }
+
+// OFFSET: LEGO1 0x1001cd20 TEMPLATE
+// MxCollection<MxPresenter *>::Compare
+
+// OFFSET: LEGO1 0x1001cd30 TEMPLATE
+// MxCollection<MxPresenter *>::Destroy
+
+// OFFSET: LEGO1 0x1001cd40 TEMPLATE
+// MxList<MxPresenter *>::MxList<MxPresenter *>
+
+// OFFSET: LEGO1 0x1001cdd0 TEMPLATE
+// MxCollection<MxPresenter *>::~MxCollection<MxPresenter *>
+
+// OFFSET: LEGO1 0x1001ce20 TEMPLATE
+// MxList<MxPresenter *>::~MxList<MxPresenter *>
+
+// OFFSET: LEGO1 0x1001cf70 TEMPLATE
+// MxCollection<MxPresenter *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1001cfe0 TEMPLATE
+// MxList<MxPresenter *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x1001d090 TEMPLATE
+// MxPtrList<MxPresenter>::`scalar deleting destructor'

--- a/LEGO1/mxpresenterlist.h
+++ b/LEGO1/mxpresenterlist.h
@@ -5,30 +5,22 @@
 
 class MxPresenter;
 
-// Unclear what the purpose of this class is
-// VTABLE 0x100d62f0
-// SIZE 0x18
-class MxPresenterListParent : public MxList<MxPresenter*> {
-public:
-	MxPresenterListParent() { m_customDestructor = Destroy; }
-};
+// VTABLE 0x100d62f0 TEMPLATE
+// class MxPtrList<MxPresenter>
 
 // VTABLE 0x100d6308
 // SIZE 0x18
-class MxPresenterList : public MxPresenterListParent {
+class MxPresenterList : public MxPtrList<MxPresenter> {
 public:
-	virtual MxS8 Compare(MxPresenter*, MxPresenter*) override; // +0x14
+	virtual MxS8 Compare(MxPresenter*, MxPresenter*) override; // vtable+0x14
 };
 
 typedef MxListCursorChildChild<MxPresenter*> MxPresenterListCursor;
 
-// OFFSET: LEGO1 0x1001cd20 TEMPLATE
-// MxListParent<MxPresenter *>::Compare
+// VTABLE 0x100d6350 TEMPLATE
+// class MxCollection<MxPresenter *>
 
-// OFFSET: LEGO1 0x1001cd30 TEMPLATE
-// MxListParent<MxPresenter *>::Destroy
-
-// OFFSET: LEGO1 0x1001ce20 TEMPLATE
-// MxList<MxPresenter *>::~MxList<MxPresenter *>
+// VTABLE 0x100d6368 TEMPLATE
+// class MxList<MxPresenter *>
 
 #endif // MXPRESENTERLIST_H

--- a/LEGO1/mxregion.h
+++ b/LEGO1/mxregion.h
@@ -21,7 +21,7 @@ struct MxRegionTopBottom {
 	inline void SetTop(MxS32 p_top) { m_top = p_top; }
 	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
-	friend class MxRegionListParent;
+	friend class MxRegionList;
 
 private:
 	MxS32 m_top;

--- a/LEGO1/mxregionlist.cpp
+++ b/LEGO1/mxregionlist.cpp
@@ -3,7 +3,7 @@
 #include "mxregion.h"
 
 // OFFSET: LEGO1 0x100c33e0
-void MxRegionListParent::Destroy(MxRegionTopBottom* p_topBottom)
+void MxRegionList::Destroy(MxRegionTopBottom* p_topBottom)
 {
 	if (p_topBottom) {
 		if (p_topBottom->m_leftRightList)
@@ -13,7 +13,22 @@ void MxRegionListParent::Destroy(MxRegionTopBottom* p_topBottom)
 }
 
 // OFFSET: LEGO1 0x100c4e80
-void MxRegionLeftRightListParent::Destroy(MxRegionLeftRight* p_leftRight)
+void MxRegionLeftRightList::Destroy(MxRegionLeftRight* p_leftRight)
 {
 	delete p_leftRight;
 }
+
+// OFFSET: LEGO1 0x100c54f0 TEMPLATE
+// MxListCursor<MxRegionLeftRight *>::MxListCursor<MxRegionLeftRight *>
+
+// OFFSET: LEGO1 0x100c58c0 TEMPLATE
+// MxList<MxRegionLeftRight *>::_InsertEntry
+
+// OFFSET: LEGO1 0x100c5970 TEMPLATE
+// MxList<MxRegionTopBottom *>::_InsertEntry
+
+// OFFSET: LEGO1 0x100c5a20 TEMPLATE
+// MxListEntry<MxRegionTopBottom *>::MxListEntry<MxRegionTopBottom *>
+
+// OFFSET: LEGO1 0x100c5a40 TEMPLATE
+// MxList<MxRegionLeftRight *>::_DeleteEntry

--- a/LEGO1/mxregionlist.cpp
+++ b/LEGO1/mxregionlist.cpp
@@ -18,6 +18,36 @@ void MxRegionLeftRightList::Destroy(MxRegionLeftRight* p_leftRight)
 	delete p_leftRight;
 }
 
+// OFFSET: LEGO1 0x100c32e0 TEMPLATE
+// MxCollection<MxRegionTopBottom *>::Compare
+
+// OFFSET: LEGO1 0x100c3340 TEMPLATE
+// MxCollection<MxRegionTopBottom *>::Destroy
+
+// OFFSET: LEGO1 0x100c34d0 TEMPLATE
+// MxCollection<MxRegionTopBottom *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100c3540 TEMPLATE
+// MxList<MxRegionTopBottom *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100c35f0 TEMPLATE
+// MxPtrList<MxRegionTopBottom>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100c4d80 TEMPLATE
+// MxCollection<MxRegionLeftRight *>::Compare
+
+// OFFSET: LEGO1 0x100c4de0 TEMPLATE
+// MxCollection<MxRegionLeftRight *>::Destroy
+
+// OFFSET: LEGO1 0x100c4f50 TEMPLATE
+// MxCollection<MxRegionLeftRight *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100c4fc0 TEMPLATE
+// MxList<MxRegionLeftRight *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100c5070 TEMPLATE
+// MxPtrList<MxRegionLeftRight>::`scalar deleting destructor'
+
 // OFFSET: LEGO1 0x100c54f0 TEMPLATE
 // MxListCursor<MxRegionLeftRight *>::MxListCursor<MxRegionLeftRight *>
 

--- a/LEGO1/mxregionlist.h
+++ b/LEGO1/mxregionlist.h
@@ -6,51 +6,30 @@
 struct MxRegionTopBottom;
 struct MxRegionLeftRight;
 
-// VTABLE 0x100dcb40
-// SIZE 0x18
-class MxRegionListParent : public MxList<MxRegionTopBottom*> {
-public:
-	static void Destroy(MxRegionTopBottom* p_topBottom);
-
-	MxRegionListParent() { m_customDestructor = Destroy; }
-};
+// VTABLE 0x100dcb40 TEMPLATE
+// class MxPtrList<MxRegionTopBottom>
 
 // VTABLE 0x100dcb58
 // SIZE 0x18
-class MxRegionList : public MxRegionListParent {};
+class MxRegionList : public MxPtrList<MxRegionTopBottom> {
+public:
+	static void Destroy(MxRegionTopBottom*);
+};
 
 // VTABLE 0x100dcb88
 typedef MxListCursorChildChild<MxRegionTopBottom*> MxRegionListCursor;
 
-// OFFSET: LEGO1 0x100c5970 TEMPLATE
-// MxList<MxRegionTopBottom *>::_InsertEntry
-
-// OFFSET: LEGO1 0x100c5a20 TEMPLATE
-// MxListEntry<MxRegionTopBottom *>::MxListEntry<MxRegionTopBottom *>
-
-// VTABLE 0x100dcc70
-// SIZE 0x18
-class MxRegionLeftRightListParent : public MxList<MxRegionLeftRight*> {
-public:
-	static void Destroy(MxRegionLeftRight* p_leftRight);
-
-	MxRegionLeftRightListParent() { m_customDestructor = Destroy; }
-};
-
-// VTABLE 0x100dcc88
-// SIZE 0x18
-class MxRegionLeftRightList : public MxRegionLeftRightListParent {};
-
 // VTABLE 0x100dcc10
 typedef MxListCursorChildChild<MxRegionLeftRight*> MxRegionLeftRightListCursor;
 
-// OFFSET: LEGO1 0x100c54f0 TEMPLATE
-// MxListCursor<MxRegionLeftRight *>::MxListCursor<MxRegionLeftRight *>
+// VTABLE 0x100dcc70 TEMPLATE
+// class MxPtrList<MxRegionLeftRight>
 
-// OFFSET: LEGO1 0x100c58c0 TEMPLATE
-// MxList<MxRegionLeftRight *>::_InsertEntry
-
-// OFFSET: LEGO1 0x100c5a40 TEMPLATE
-// MxList<MxRegionLeftRight *>::_DeleteEntry
+// VTABLE 0x100dcc88
+// SIZE 0x18
+class MxRegionLeftRightList : public MxPtrList<MxRegionLeftRight> {
+public:
+	static void Destroy(MxRegionLeftRight*);
+};
 
 #endif // MXREGIONLIST_H

--- a/LEGO1/mxregionlist.h
+++ b/LEGO1/mxregionlist.h
@@ -6,6 +6,12 @@
 struct MxRegionTopBottom;
 struct MxRegionLeftRight;
 
+// VTABLE 0x100dcb10 TEMPLATE
+// class MxCollection<MxRegionTopBottom *>
+
+// VTABLE 0x100dcb28 TEMPLATE
+// class MxList<MxRegionTopBottom *>
+
 // VTABLE 0x100dcb40 TEMPLATE
 // class MxPtrList<MxRegionTopBottom>
 
@@ -13,6 +19,7 @@ struct MxRegionLeftRight;
 // SIZE 0x18
 class MxRegionList : public MxPtrList<MxRegionTopBottom> {
 public:
+	MxRegionList() : MxPtrList<MxRegionTopBottom>(Destroy) {}
 	static void Destroy(MxRegionTopBottom*);
 };
 
@@ -22,6 +29,12 @@ typedef MxListCursorChildChild<MxRegionTopBottom*> MxRegionListCursor;
 // VTABLE 0x100dcc10
 typedef MxListCursorChildChild<MxRegionLeftRight*> MxRegionLeftRightListCursor;
 
+// VTABLE 0x100dcc40 TEMPLATE
+// class MxCollection<MxRegionLeftRight *>
+
+// VTABLE 0x100dcc58 TEMPLATE
+// class MxList<MxRegionLeftRight *>
+
 // VTABLE 0x100dcc70 TEMPLATE
 // class MxPtrList<MxRegionLeftRight>
 
@@ -29,6 +42,7 @@ typedef MxListCursorChildChild<MxRegionLeftRight*> MxRegionLeftRightListCursor;
 // SIZE 0x18
 class MxRegionLeftRightList : public MxPtrList<MxRegionLeftRight> {
 public:
+	MxRegionLeftRightList() : MxPtrList<MxRegionLeftRight>(Destroy) {}
 	static void Destroy(MxRegionLeftRight*);
 };
 

--- a/LEGO1/mxstreamchunklist.cpp
+++ b/LEGO1/mxstreamchunklist.cpp
@@ -17,3 +17,18 @@ void MxStreamChunkList::Destroy(MxStreamChunk* p_chunk)
 	if (p_chunk)
 		delete p_chunk;
 }
+
+// OFFSET: LEGO1 0x100b5930 TEMPLATE
+// MxCollection<MxStreamChunk *>::Compare
+
+// OFFSET: LEGO1 0x100b5990 TEMPLATE
+// MxCollection<MxStreamChunk *>::Destroy
+
+// OFFSET: LEGO1 0x100b59a0 TEMPLATE
+// MxList<MxStreamChunk *>::~MxList<MxStreamChunk *>
+
+// OFFSET: LEGO1 0x100b5aa0 TEMPLATE
+// MxCollection<MxStreamChunk *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100b5b10 TEMPLATE
+// MxList<MxStreamChunk *>::`scalar deleting destructor'

--- a/LEGO1/mxstreamchunklist.h
+++ b/LEGO1/mxstreamchunklist.h
@@ -6,29 +6,23 @@
 
 class MxStreamChunk;
 
+// VTABLE 0x100dc5d0 TEMPLATE
+// class MxCollection<MxStreamChunk *>
+
+// VTABLE 0x100dc5e8 TEMPLATE
+// class MxList<MxStreamChunk *>
+
 // VTABLE 0x100dc600
 // SIZE 0x18
 class MxStreamChunkList : public MxList<MxStreamChunk*> {
 public:
 	MxStreamChunkList() { m_customDestructor = Destroy; }
 
-	virtual MxS8 Compare(MxStreamChunk*, MxStreamChunk*) override; // +0x14
+	virtual MxS8 Compare(MxStreamChunk*, MxStreamChunk*) override; // vtable+0x14
 
 	static void Destroy(MxStreamChunk* p_chunk);
 };
 
 typedef MxListCursorChild<MxStreamChunk*> MxStreamChunkListCursor;
-
-// OFFSET: LEGO1 0x100b5930 TEMPLATE
-// MxListParent<MxStreamChunk *>::Compare
-
-// OFFSET: LEGO1 0x100b5990 TEMPLATE
-// MxListParent<MxStreamChunk *>::Destroy
-
-// OFFSET: LEGO1 0x100b59a0 TEMPLATE
-// MxList<MxStreamChunk *>::~MxList<MxStreamChunk *>
-
-// OFFSET: LEGO1 0x100b5b10 TEMPLATE
-// MxList<MxStreamChunk *>::`scalar deleting destructor'
 
 #endif // MXSTREAMCHUNKLIST_H

--- a/LEGO1/mxstringlist.cpp
+++ b/LEGO1/mxstringlist.cpp
@@ -3,3 +3,24 @@
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxListEntry<MxString>, 0x18)
+
+// OFFSET: LEGO1 0x100cb3c0 TEMPLATE
+// MxCollection<MxString>::Compare
+
+// OFFSET: LEGO1 0x100cb470 TEMPLATE
+// MxCollection<MxString>::Destroy
+
+// OFFSET: LEGO1 0x100cb4c0 TEMPLATE
+// MxList<MxString>::~MxList<MxString>
+
+// OFFSET: LEGO1 0x100cbb40 TEMPLATE
+// MxList<MxString>::Append
+
+// OFFSET: LEGO1 0x100cc2d0 TEMPLATE
+// MxList<MxString>::_InsertEntry
+
+// OFFSET: LEGO1 0x100cc3c0 TEMPLATE
+// MxListEntry<MxString>::MxListEntry<MxString>
+
+// OFFSET: LEGO1 0x100cc450 TEMPLATE
+// MxListEntry<MxString>::GetValue

--- a/LEGO1/mxstringlist.h
+++ b/LEGO1/mxstringlist.h
@@ -11,25 +11,4 @@ class MxStringList : public MxList<MxString> {};
 // VTABLE 0x100dd058
 typedef MxListCursorChild<MxString> MxStringListCursor;
 
-// OFFSET: LEGO1 0x100cb3c0 TEMPLATE
-// MxListParent<MxString>::Compare
-
-// OFFSET: LEGO1 0x100cb470 TEMPLATE
-// MxListParent<MxString>::Destroy
-
-// OFFSET: LEGO1 0x100cb4c0 TEMPLATE
-// MxList<MxString>::~MxList<MxString>
-
-// OFFSET: LEGO1 0x100cbb40 TEMPLATE
-// MxList<MxString>::Append
-
-// OFFSET: LEGO1 0x100cc2d0 TEMPLATE
-// MxList<MxString>::_InsertEntry
-
-// OFFSET: LEGO1 0x100cc3c0 TEMPLATE
-// MxListEntry<MxString>::MxListEntry<MxString>
-
-// OFFSET: LEGO1 0x100cc450 TEMPLATE
-// MxListEntry<MxString>::GetValue
-
 #endif // MXSTRINGLIST_H

--- a/LEGO1/mxvariabletable.h
+++ b/LEGO1/mxvariabletable.h
@@ -17,8 +17,8 @@ public:
 	// OFFSET: LEGO1 0x100afdb0
 	static void Destroy(MxVariable* p_obj) { p_obj->Destroy(); }
 
-	virtual MxS8 Compare(MxVariable*, MxVariable*) override; // +0x14
-	virtual MxU32 Hash(MxVariable*) override;                // +0x18
+	virtual MxS8 Compare(MxVariable*, MxVariable*) override; // vtable+0x14
+	virtual MxU32 Hash(MxVariable*) override;                // vtable+0x18
 };
 
 // OFFSET: LEGO1 0x100afcd0 TEMPLATE


### PR DESCRIPTION
Continued from #283. `MxList` template classes now extend from `MxCollection`. We also have `MxPtrList`, which is the same as `MxList` but you can omit the `*` when declaring the template. It is not used consistently as you'll see from the code changed here, but it does conveniently explain the missing link between `MxList` and the most-derived class in a few places.

I left the cursor classes alone for now. Converting the list classes is probably enough for a single PR review.

- Restored the `this` reference in places where I had mistakenly removed it in #283. This was added in #245 to support two-phase compilation. (See also: https://stackoverflow.com/questions/4643074/why-do-i-have-to-access-template-base-class-members-through-the-this-pointer/4643295#4643295)
- We did get a slight reduction in boilerplate code: `MxPtrList` sets the `m_customDestructor` member, which means we don't have to do this again manually in each subclass. There is still the case of many identical `Compare` methods, but the vtables tell us that they do not come from the superclass. A tricky `typedef` could possibly eliminate this redundancy, but the 96 source shows that the devs were happy to just reimplement this wherever it was needed.
- Moved the `// OFFSET: LEGO1 <addr> TEMPLATE` marks to .cpp files where they had been in .h files. This will assist the `checkorder` tool in #228.
- I have been adding `// VTABLE <addr> TEMPLATE` marks for template classes such as `MxList` or `MxCollection`. My thought is that @itsmattkc's proposed enhancement to `reccmp` in #256 may be able to use these, and also that it provides a reference for us to see in the code. If these aren't needed or should be moved, let me know what you think.
- One new collection class: `LegoPathControllerList` used by `LegoWorld`. I added this and two `MxPresenterList` members to `LegoWorld`. It looks like the `MxList` of each collection type gets its own constructor, but right now our generated code inlines all the vtable setups. I marked them as `// OFFSET`s for documentation purposes and in the event that it just fixes itself later.