### PR TITLE
Implement/match remaining MxWavePresenter functions

### DIFF
--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -16,6 +16,9 @@ const char* g_parseExtraTokens = ":;";
 // 0x10101edc
 const char* g_strWORLD = "WORLD";
 
+// 0x10101f20
+const char* g_strSOUND = "SOUND";
+
 // 0x10102040
 const char* g_strACTION = "ACTION";
 

--- a/LEGO1/define.h
+++ b/LEGO1/define.h
@@ -6,6 +6,7 @@
 extern MxU32 g_mxcoreCount[101];
 extern const char* g_parseExtraTokens;
 extern const char* g_strWORLD;
+extern const char* g_strSOUND;
 extern const char* g_strACTION;
 extern const char* g_strVISIBILITY;
 

--- a/LEGO1/mxaudiopresenter.cpp
+++ b/LEGO1/mxaudiopresenter.cpp
@@ -5,13 +5,13 @@
 DECOMP_SIZE_ASSERT(MxAudioPresenter, 0x54);
 
 // OFFSET: LEGO1 0x1000d260
-MxU32 MxAudioPresenter::GetVolume()
+MxS32 MxAudioPresenter::GetVolume()
 {
 	return m_volume;
 }
 
 // OFFSET: LEGO1 0x1000d270
-void MxAudioPresenter::SetVolume(MxU32 p_volume)
+void MxAudioPresenter::SetVolume(MxS32 p_volume)
 {
 	m_volume = p_volume;
 }

--- a/LEGO1/mxaudiopresenter.h
+++ b/LEGO1/mxaudiopresenter.h
@@ -23,11 +23,11 @@ public:
 		return !strcmp(name, MxAudioPresenter::ClassName()) || MxMediaPresenter::IsA(name);
 	}
 
-	virtual MxU32 GetVolume();              // vtable+0x5c
-	virtual void SetVolume(MxU32 p_volume); // vtable+0x60
+	virtual MxS32 GetVolume();              // vtable+0x5c
+	virtual void SetVolume(MxS32 p_volume); // vtable+0x60
 
-private:
-	MxU32 m_volume;
+protected:
+	MxS32 m_volume;
 };
 
 #endif // MXAUDIOPRESENTER_H

--- a/LEGO1/mxdschunk.h
+++ b/LEGO1/mxdschunk.h
@@ -13,6 +13,8 @@ public:
 		Flag_Bit1 = 0x01,
 		Flag_Bit2 = 0x02,
 		Flag_Bit3 = 0x04,
+		Flag_Bit8 = 0x80,
+		Flag_Bit16 = 0x8000
 	};
 
 	MxDSChunk();
@@ -31,6 +33,7 @@ public:
 		return !strcmp(name, MxDSChunk::ClassName()) || MxCore::IsA(name);
 	}
 
+	inline void SetFlags(MxU16 flags) { m_flags = flags; }
 	inline void SetTime(MxLong p_time) { m_time = p_time; }
 	inline void SetLength(MxU32 p_length) { m_length = p_length; }
 	inline void SetData(MxU8* p_data) { m_data = p_data; }

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -409,7 +409,7 @@ void MxOmni::StartTimer()
 {
 	if (m_timerRunning == FALSE && m_timer != NULL && m_soundManager != NULL) {
 		m_timer->Start();
-		m_soundManager->vtable0x34();
+		m_soundManager->Pause();
 		m_timerRunning = TRUE;
 	}
 }
@@ -419,7 +419,7 @@ void MxOmni::StopTimer()
 {
 	if (m_timerRunning != FALSE && m_timer != NULL && m_soundManager != NULL) {
 		m_timer->Stop();
-		m_soundManager->vtable0x38();
+		m_soundManager->Resume();
 		m_timerRunning = FALSE;
 	}
 }

--- a/LEGO1/mxsoundmanager.cpp
+++ b/LEGO1/mxsoundmanager.cpp
@@ -15,6 +15,9 @@ MxSoundManager::MxSoundManager()
 	Init();
 }
 
+// OFFSET: LEGO1 0x100ae7b0 TEMPLATE
+// MxSoundManager::`scalar deleting destructor'
+
 // OFFSET: LEGO1 0x100ae7d0
 MxSoundManager::~MxSoundManager()
 {
@@ -176,7 +179,7 @@ MxS32 MxSoundManager::FUN_100aecf0(MxU32 p_unk)
 }
 
 // OFFSET: LEGO1 0x100aed10
-void MxSoundManager::vtable0x34()
+void MxSoundManager::Pause()
 {
 	MxAutoLocker lock(&m_criticalSection);
 
@@ -185,11 +188,11 @@ void MxSoundManager::vtable0x34()
 
 	while (cursor.Next(presenter))
 		if (presenter->IsA("MxWavePresenter"))
-			((MxWavePresenter*) presenter)->VTable0x64();
+			((MxWavePresenter*) presenter)->Pause();
 }
 
 // OFFSET: LEGO1 0x100aee10
-void MxSoundManager::vtable0x38()
+void MxSoundManager::Resume()
 {
 	MxAutoLocker lock(&m_criticalSection);
 
@@ -198,5 +201,5 @@ void MxSoundManager::vtable0x38()
 
 	while (cursor.Next(presenter))
 		if (presenter->IsA("MxWavePresenter"))
-			((MxWavePresenter*) presenter)->VTable0x68();
+			((MxWavePresenter*) presenter)->Resume();
 }

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -25,11 +25,12 @@ public:
 
 	inline LPDIRECTSOUND GetDirectSound() { return m_directSound; }
 
+	MxS32 FUN_100aecf0(MxU32 p_unk);
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);
 	MxPresenter* FUN_100aebd0(const MxAtomId& p_atomId, MxU32 p_objectId);
-	MxS32 FUN_100aecf0(MxU32 p_unk);
 
 	LPDIRECTSOUND m_directSound;    // 0x30
 	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x34

--- a/LEGO1/mxsoundmanager.h
+++ b/LEGO1/mxsoundmanager.h
@@ -12,16 +12,13 @@
 class MxSoundManager : public MxAudioManager {
 public:
 	MxSoundManager();
-
-	// OFFSET: LEGO1 0x100ae7b0 TEMPLATE
-	// MxSoundManager::`scalar deleting destructor'
 	virtual ~MxSoundManager() override; // vtable+0x0
 
-	virtual void Destroy() override;                                     // vtable+18
-	virtual void SetVolume(MxS32 p_volume) override;                     // vtable+2c
+	virtual void Destroy() override;                                     // vtable+0x18
+	virtual void SetVolume(MxS32 p_volume) override;                     // vtable+0x2c
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x30
-	virtual void vtable0x34();                                           // vtable+0x34
-	virtual void vtable0x38();                                           // vtable+0x38
+	virtual void Pause();                                                // vtable+0x34
+	virtual void Resume();                                               // vtable+0x38
 
 	inline LPDIRECTSOUND GetDirectSound() { return m_directSound; }
 

--- a/LEGO1/mxwavepresenter.cpp
+++ b/LEGO1/mxwavepresenter.cpp
@@ -8,8 +8,6 @@
 #include "mxomni.h"
 #include "mxsoundmanager.h"
 
-#include <limits.h>
-
 DECOMP_SIZE_ASSERT(MxWavePresenter, 0x6c);
 DECOMP_SIZE_ASSERT(MxWavePresenter::WaveFormat, 0x1c);
 

--- a/LEGO1/mxwavepresenter.cpp
+++ b/LEGO1/mxwavepresenter.cpp
@@ -24,9 +24,9 @@ void MxWavePresenter::Destroy()
 }
 
 // OFFSET: LEGO1 0x1000d6b0
-MxBool MxWavePresenter::VTable0x6c()
+MxBool MxWavePresenter::IsPaused()
 {
-	return m_unk68;
+	return m_paused;
 }
 
 // OFFSET: LEGO1 0x100b1ad0
@@ -37,9 +37,9 @@ void MxWavePresenter::Init()
 	m_chunkLength = 0;
 	m_lockSize = 0;
 	m_writtenChunks = 0;
-	m_playing = FALSE;
+	m_started = FALSE;
 	m_unk66 = FALSE;
-	m_unk68 = FALSE;
+	m_paused = FALSE;
 }
 
 // OFFSET: LEGO1 0x100b1af0
@@ -82,7 +82,7 @@ MxS8 MxWavePresenter::GetPlayedChunks()
 // OFFSET: LEGO1 0x100b1ba0
 MxBool MxWavePresenter::FUN_100b1ba0()
 {
-	return !m_playing || GetPlayedChunks() != m_writtenChunks;
+	return !m_started || GetPlayedChunks() != m_writtenChunks;
 }
 
 // OFFSET: LEGO1 0x100b1bd0
@@ -258,21 +258,21 @@ undefined4 MxWavePresenter::PutData()
 				m_currentChunk = NULL;
 			}
 
-			if (!m_playing) {
+			if (!m_started) {
 				m_dsBuffer->SetCurrentPosition(0);
 
 				if (m_dsBuffer->Play(0, 0, DSBPLAY_LOOPING) == DS_OK)
-					m_playing = TRUE;
+					m_started = TRUE;
 			}
 			break;
 		case TickleState_Repeating:
-			if (m_playing)
+			if (m_started)
 				break;
 
 			m_dsBuffer->SetCurrentPosition(0);
 
 			if (m_dsBuffer->Play(0, 0, m_action->GetLoopCount() > 1) == DS_OK)
-				m_playing = TRUE;
+				m_started = TRUE;
 		}
 	}
 
@@ -314,7 +314,7 @@ void MxWavePresenter::Enable(MxBool p_enable)
 
 		if (p_enable) {
 			m_writtenChunks = 0;
-			m_playing = FALSE;
+			m_started = FALSE;
 		}
 		else if (m_dsBuffer)
 			m_dsBuffer->Stop();
@@ -344,20 +344,20 @@ void MxWavePresenter::ParseExtra()
 }
 
 // OFFSET: LEGO1 0x100b2440
-void MxWavePresenter::VTable0x64()
+void MxWavePresenter::Pause()
 {
-	if (!m_unk68 && m_playing) {
+	if (!m_paused && m_started) {
 		if (m_dsBuffer)
 			m_dsBuffer->Stop();
-		m_unk68 = TRUE;
+		m_paused = TRUE;
 	}
 }
 
 // OFFSET: LEGO1 0x100b2470
-void MxWavePresenter::VTable0x68()
+void MxWavePresenter::Resume()
 {
-	if (m_unk68) {
-		if (m_dsBuffer && m_playing) {
+	if (m_paused) {
+		if (m_dsBuffer && m_started) {
 			switch (m_currentTickleState) {
 			case TickleState_Streaming:
 				m_dsBuffer->Play(0, 0, DSBPLAY_LOOPING);
@@ -370,6 +370,6 @@ void MxWavePresenter::VTable0x68()
 			}
 		}
 
-		m_unk68 = FALSE;
+		m_paused = FALSE;
 	}
 }

--- a/LEGO1/mxwavepresenter.cpp
+++ b/LEGO1/mxwavepresenter.cpp
@@ -39,7 +39,7 @@ void MxWavePresenter::Init()
 	m_length = 0;
 	m_bytes = 0;
 	m_unk64 = 0;
-	m_unk65 = FALSE;
+	m_playing = FALSE;
 	m_unk66 = FALSE;
 	m_unk68 = FALSE;
 }
@@ -84,7 +84,7 @@ MxS8 MxWavePresenter::FUN_100b1b60()
 // OFFSET: LEGO1 0x100b1ba0
 MxBool MxWavePresenter::FUN_100b1ba0()
 {
-	return !m_unk65 || FUN_100b1b60() != m_unk64;
+	return !m_playing || FUN_100b1b60() != m_unk64;
 }
 
 // OFFSET: LEGO1 0x100b1bd0
@@ -261,21 +261,21 @@ undefined4 MxWavePresenter::PutData()
 				m_currentChunk = NULL;
 			}
 
-			if (!m_unk65) {
+			if (!m_playing) {
 				m_dsBuffer->SetCurrentPosition(0);
 
 				if (m_dsBuffer->Play(0, 0, DSBPLAY_LOOPING) == DS_OK)
-					m_unk65 = TRUE;
+					m_playing = TRUE;
 			}
 			break;
 		case TickleState_Repeating:
-			if (m_unk65)
+			if (m_playing)
 				break;
 
 			m_dsBuffer->SetCurrentPosition(0);
 
 			if (m_dsBuffer->Play(0, 0, m_action->GetLoopCount() > 1) == DS_OK)
-				m_unk65 = TRUE;
+				m_playing = TRUE;
 		}
 	}
 
@@ -317,7 +317,7 @@ void MxWavePresenter::Enable(MxBool p_enable)
 
 		if (p_enable) {
 			m_unk64 = 0;
-			m_unk65 = FALSE;
+			m_playing = FALSE;
 		}
 		else if (m_dsBuffer)
 			m_dsBuffer->Stop();
@@ -349,7 +349,7 @@ void MxWavePresenter::ParseExtra()
 // OFFSET: LEGO1 0x100b2440
 void MxWavePresenter::VTable0x64()
 {
-	if (!m_unk68 && m_unk65) {
+	if (!m_unk68 && m_playing) {
 		if (m_dsBuffer)
 			m_dsBuffer->Stop();
 		m_unk68 = TRUE;
@@ -360,7 +360,7 @@ void MxWavePresenter::VTable0x64()
 void MxWavePresenter::VTable0x68()
 {
 	if (m_unk68) {
-		if (m_dsBuffer && m_unk65) {
+		if (m_dsBuffer && m_playing) {
 			switch (m_currentTickleState) {
 			case TickleState_Streaming:
 				m_dsBuffer->Play(0, 0, DSBPLAY_LOOPING);

--- a/LEGO1/mxwavepresenter.cpp
+++ b/LEGO1/mxwavepresenter.cpp
@@ -202,12 +202,12 @@ void MxWavePresenter::StreamingTickle()
 			MxStreamChunk* chunk = FUN_100b5650();
 
 			if (chunk && chunk->GetFlags() & MxDSChunk::Flag_Bit2 && !(chunk->GetFlags() & MxDSChunk::Flag_Bit16)) {
-				chunk->SetFlags(chunk->GetFlags() | MxDSChunk::Flag_Bit8);
+				chunk->SetFlags(chunk->GetFlags() | MxDSChunk::Flag_Bit16);
 
 				m_currentChunk = new MxStreamChunk;
 				MxU8* data = new MxU8[m_length];
 
-				// TODO
+				memset(data, m_silenceData, m_length);
 
 				m_currentChunk->SetLength(m_length);
 				m_currentChunk->SetData(data);

--- a/LEGO1/mxwavepresenter.cpp
+++ b/LEGO1/mxwavepresenter.cpp
@@ -1,6 +1,9 @@
 #include "mxwavepresenter.h"
 
 #include "decomp.h"
+#include "define.h"
+#include "legoomni.h"
+#include "mxautolocker.h"
 #include "mxdssound.h"
 #include "mxomni.h"
 #include "mxsoundmanager.h"
@@ -23,7 +26,7 @@ void MxWavePresenter::Destroy()
 }
 
 // OFFSET: LEGO1 0x1000d6b0
-undefined MxWavePresenter::VTable0x6c()
+MxBool MxWavePresenter::VTable0x6c()
 {
 	return m_unk68;
 }
@@ -34,11 +37,11 @@ void MxWavePresenter::Init()
 	m_waveFormat = NULL;
 	m_dsBuffer = NULL;
 	m_length = 0;
-	m_unk60 = 0;
+	m_bytes = 0;
 	m_unk64 = 0;
 	m_unk65 = FALSE;
 	m_unk66 = FALSE;
-	m_unk68 = 0;
+	m_unk68 = FALSE;
 }
 
 // OFFSET: LEGO1 0x100b1af0
@@ -84,11 +87,46 @@ MxBool MxWavePresenter::FUN_100b1ba0()
 	return !m_unk65 || FUN_100b1b60() != m_unk64;
 }
 
-// OFFSET: LEGO1 0x100b1bd0 STUB
+// OFFSET: LEGO1 0x100b1bd0
 void MxWavePresenter::FUN_100b1bd0(void* p_audioPtr, MxU32 p_length)
 {
-	// Lock/Unlock on m_dsBuffer
-	// TODO
+	DWORD dwStatus;
+	LPVOID pvAudioPtr1;
+	DWORD dwOffset;
+	LPVOID pvAudioPtr2;
+	DWORD dwAudioBytes1;
+	DWORD dwAudioBytes2;
+
+	dwOffset = m_length * m_unk64;
+	m_dsBuffer->GetStatus(&dwStatus);
+
+	if (dwStatus == DSBSTATUS_BUFFERLOST) {
+		m_dsBuffer->Restore();
+		m_dsBuffer->GetStatus(&dwStatus);
+	}
+
+	if (dwStatus != DSBSTATUS_BUFFERLOST) {
+		if (m_action->GetFlags() & MxDSAction::Flag_Looping) {
+			m_unk64++;
+			m_bytes = p_length;
+		}
+		else {
+			m_unk64 = 1 - m_unk64;
+			m_bytes = m_length;
+		}
+
+		if (m_dsBuffer->Lock(dwOffset, m_bytes, &pvAudioPtr1, &dwAudioBytes1, &pvAudioPtr2, &dwAudioBytes2, 0) ==
+			DS_OK) {
+			memcpy(pvAudioPtr1, p_audioPtr, p_length);
+
+			// TODO
+
+			if (m_bytes > p_length && !(m_action->GetFlags() & MxDSAction::Flag_Looping)) {
+			}
+
+			m_dsBuffer->Unlock(pvAudioPtr1, m_bytes, pvAudioPtr2, 0);
+		}
+	}
 }
 
 // OFFSET: LEGO1 0x100b1cf0
@@ -136,7 +174,7 @@ void MxWavePresenter::StartingTickle()
 		desc.dwSize = sizeof(desc);
 
 		if (m_unk66)
-			desc.dwFlags = DSBCAPS_CTRL3D | DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRLVOLUME;
+			desc.dwFlags = DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRL3D | DSBCAPS_CTRLVOLUME;
 		else
 			desc.dwFlags = DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME;
 
@@ -159,63 +197,182 @@ void MxWavePresenter::StartingTickle()
 	}
 }
 
-// OFFSET: LEGO1 0x100b1ea0 STUB
+// OFFSET: LEGO1 0x100b1ea0
 void MxWavePresenter::StreamingTickle()
 {
-	// TODO
+	if (!m_currentChunk) {
+		if (!(m_action->GetFlags() & MxDSAction::Flag_Looping)) {
+			MxStreamChunk* chunk = FUN_100b5650();
+
+			if (chunk && chunk->GetFlags() & MxDSChunk::Flag_Bit2 && !(chunk->GetFlags() & MxDSChunk::Flag_Bit16)) {
+				chunk->SetFlags(chunk->GetFlags() | MxDSChunk::Flag_Bit8);
+
+				m_currentChunk = new MxStreamChunk;
+				MxU8* data = new MxU8[m_length];
+
+				// TODO
+
+				m_currentChunk->SetLength(m_length);
+				m_currentChunk->SetData(data);
+				m_currentChunk->SetTime(chunk->GetTime() + 1000);
+				m_currentChunk->SetFlags(MxDSChunk::Flag_Bit1);
+			}
+		}
+
+		MxMediaPresenter::StreamingTickle();
+	}
 }
 
-// OFFSET: LEGO1 0x100b20c0 STUB
+// OFFSET: LEGO1 0x100b20c0
 void MxWavePresenter::DoneTickle()
 {
-	// TODO
+	if (m_dsBuffer) {
+		DWORD dwCurrentPlayCursor, dwCurrentWriteCursor;
+		m_dsBuffer->GetCurrentPosition(&dwCurrentPlayCursor, &dwCurrentWriteCursor);
+
+		MxS8 result = dwCurrentPlayCursor / m_length;
+		if (m_action->GetFlags() & MxDSAction::Flag_Bit7 || m_action->GetFlags() & MxDSAction::Flag_Looping ||
+			m_unk64 != result || m_bytes + (m_length * result) <= dwCurrentPlayCursor)
+			MxMediaPresenter::DoneTickle();
+	}
+	else
+		MxMediaPresenter::DoneTickle();
 }
 
-// OFFSET: LEGO1 0x100b2130 STUB
+// OFFSET: LEGO1 0x100b2130
 void MxWavePresenter::AppendChunk(MxStreamChunk* p_chunk)
 {
-	// TODO
+	FUN_100b1bd0(p_chunk->GetData(), p_chunk->GetLength());
+	if (IsEnabled())
+		m_subscriber->FUN_100b8390(p_chunk);
 }
 
-// OFFSET: LEGO1 0x100b2160 STUB
+// OFFSET: LEGO1 0x100b2160
 undefined4 MxWavePresenter::PutData()
 {
-	// TODO
+	MxAutoLocker lock(&m_criticalSection);
+
+	if (IsEnabled()) {
+		switch (m_currentTickleState) {
+		case TickleState_Streaming:
+			if (m_currentChunk && FUN_100b1ba0()) {
+				FUN_100b1bd0(m_currentChunk->GetData(), m_currentChunk->GetLength());
+				m_subscriber->FUN_100b8390(m_currentChunk);
+				m_currentChunk = NULL;
+			}
+
+			if (!m_unk65) {
+				m_dsBuffer->SetCurrentPosition(0);
+
+				if (m_dsBuffer->Play(0, 0, DSBPLAY_LOOPING) == DS_OK)
+					m_unk65 = TRUE;
+			}
+			break;
+		case TickleState_Repeating:
+			if (m_unk65)
+				break;
+
+			m_dsBuffer->SetCurrentPosition(0);
+
+			if (m_dsBuffer->Play(0, 0, m_action->GetLoopCount() > 1) == DS_OK)
+				m_unk65 = TRUE;
+		}
+	}
+
 	return 0;
 }
 
-// OFFSET: LEGO1 0x100b2280 STUB
+// OFFSET: LEGO1 0x100b2280
 void MxWavePresenter::EndAction()
 {
-	// TODO
+	if (m_action) {
+		MxAutoLocker lock(&m_criticalSection);
+		MxMediaPresenter::EndAction();
+
+		if (m_dsBuffer)
+			m_dsBuffer->Stop();
+	}
 }
 
-// OFFSET: LEGO1 0x100b2300 STUB
-void MxWavePresenter::SetVolume(MxU32 p_volume)
+// OFFSET: LEGO1 0x100b2300
+void MxWavePresenter::SetVolume(MxS32 p_volume)
 {
-	// TODO
+	m_criticalSection.Enter();
+
+	m_volume = p_volume;
+	if (m_dsBuffer != NULL) {
+		MxS32 volume = p_volume * MxOmni::GetInstance()->GetSoundManager()->GetVolume() / 100;
+		MxS32 otherVolume = MxOmni::GetInstance()->GetSoundManager()->FUN_100aecf0(volume);
+		m_dsBuffer->SetVolume(otherVolume);
+	}
+
+	m_criticalSection.Leave();
 }
 
-// OFFSET: LEGO1 0x100b2360 STUB
+// OFFSET: LEGO1 0x100b2360
 void MxWavePresenter::Enable(MxBool p_enable)
 {
-	// TODO
+	if (IsEnabled() != p_enable) {
+		MxSoundPresenter::Enable(p_enable);
+
+		if (p_enable) {
+			m_unk64 = 0;
+			m_unk65 = FALSE;
+		}
+		else if (m_dsBuffer)
+			m_dsBuffer->Stop();
+	}
 }
 
-// OFFSET: LEGO1 0x100b23a0 STUB
+// OFFSET: LEGO1 0x100b23a0
 void MxWavePresenter::ParseExtra()
 {
-	// TODO
+	char extraCopy[512];
+
+	MxSoundPresenter::ParseExtra();
+	*((MxU16*) &extraCopy[0]) = m_action->GetExtraLength();
+	char* extraData = m_action->GetExtraData();
+
+	if (*((MxU16*) &extraCopy[0])) {
+		MxU16 len = *((MxU16*) &extraCopy[0]);
+		memcpy(extraCopy, extraData, len);
+		extraCopy[len] = '\0';
+
+		char t_soundValue[512];
+		if (KeyValueStringParse(t_soundValue, g_strSOUND, extraCopy)) {
+			if (!strcmpi(t_soundValue, "FALSE"))
+				Enable(FALSE);
+		}
+	}
 }
 
-// OFFSET: LEGO1 0x100b2440 STUB
+// OFFSET: LEGO1 0x100b2440
 void MxWavePresenter::VTable0x64()
 {
-	// TODO
+	if (!m_unk68 && m_unk65) {
+		if (m_dsBuffer)
+			m_dsBuffer->Stop();
+		m_unk68 = TRUE;
+	}
 }
 
-// OFFSET: LEGO1 0x100b2470 STUB
+// OFFSET: LEGO1 0x100b2470
 void MxWavePresenter::VTable0x68()
 {
-	// TODO
+	if (m_unk68) {
+		if (m_dsBuffer && m_unk65) {
+			switch (m_currentTickleState) {
+			case TickleState_Streaming:
+				m_dsBuffer->Play(0, 0, DSBPLAY_LOOPING);
+				break;
+			case TickleState_Repeating:
+				m_dsBuffer->Play(0, 0, m_action->GetLoopCount() > 1);
+				break;
+			case TickleState_Done:
+				m_dsBuffer->Play(0, 0, 0);
+			}
+		}
+
+		m_unk68 = FALSE;
+	}
 }

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -37,10 +37,10 @@ public:
 	virtual undefined4 PutData() override;                     // vtable+0x4c
 	virtual void Enable(MxBool p_enable) override;             // vtable+0x54
 	virtual void AppendChunk(MxStreamChunk* p_chunk) override; // vtable+0x58
-	virtual void SetVolume(MxU32 p_volume) override;           // vtable+0x60
+	virtual void SetVolume(MxS32 p_volume) override;           // vtable+0x60
 	virtual void VTable0x64();                                 // vtable+0x64
 	virtual void VTable0x68();                                 // vtable+0x68
-	virtual undefined VTable0x6c();                            // vtable+0x6c
+	virtual MxBool VTable0x6c();                               // vtable+0x6c
 
 	// Reference: https://github.com/itsmattkc/SIEdit/blob/master/lib/othertypes.h
 	// SIZE 0x1c
@@ -57,15 +57,15 @@ private:
 	MxBool FUN_100b1ba0();
 	void FUN_100b1bd0(void* p_audioPtr, MxU32 p_length);
 
-	WaveFormat* m_waveFormat;
-	LPDIRECTSOUNDBUFFER m_dsBuffer;
-	MxU32 m_length;
-	undefined4 m_unk60;
-	MxU8 m_unk64;
-	MxBool m_unk65;
-	MxBool m_unk66;
-	MxS8 m_unk67;
-	undefined m_unk68;
+	WaveFormat* m_waveFormat;       // 0x54
+	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x58
+	MxU32 m_length;                 // 0x5c
+	MxU32 m_bytes;                  // 0x60
+	MxU8 m_unk64;                   // 0x64
+	MxBool m_unk65;                 // 0x65
+	MxBool m_unk66;                 // 0x66
+	MxS8 m_unk67;                   // 0x67
+	MxBool m_unk68;                 // 0x68
 };
 
 #endif // MXWAVEPRESENTER_H

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -62,7 +62,7 @@ private:
 	MxU32 m_length;                 // 0x5c
 	MxU32 m_bytes;                  // 0x60
 	MxU8 m_unk64;                   // 0x64
-	MxBool m_unk65;                 // 0x65
+	MxBool m_playing;               // 0x65
 	MxBool m_unk66;                 // 0x66
 	MxS8 m_unk67;                   // 0x67
 	MxBool m_unk68;                 // 0x68

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -53,15 +53,15 @@ public:
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);
-	MxS8 FUN_100b1b60();
+	MxS8 GetPlayedChunks();
 	MxBool FUN_100b1ba0();
 	void WriteToSoundBuffer(void* p_audioPtr, MxU32 p_length);
 
 	WaveFormat* m_waveFormat;       // 0x54
 	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x58
-	MxU32 m_length;                 // 0x5c
+	MxU32 m_chunkLength;            // 0x5c
 	MxU32 m_lockSize;               // 0x60
-	MxU8 m_unk64;                   // 0x64
+	MxU8 m_writtenChunks;           // 0x64
 	MxBool m_playing;               // 0x65
 	MxBool m_unk66;                 // 0x66
 	MxS8 m_silenceData;             // 0x67

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -38,9 +38,9 @@ public:
 	virtual void Enable(MxBool p_enable) override;             // vtable+0x54
 	virtual void AppendChunk(MxStreamChunk* p_chunk) override; // vtable+0x58
 	virtual void SetVolume(MxS32 p_volume) override;           // vtable+0x60
-	virtual void VTable0x64();                                 // vtable+0x64
-	virtual void VTable0x68();                                 // vtable+0x68
-	virtual MxBool VTable0x6c();                               // vtable+0x6c
+	virtual void Pause();                                      // vtable+0x64
+	virtual void Resume();                                     // vtable+0x68
+	virtual MxBool IsPaused();                                 // vtable+0x6c
 
 	// Reference: https://github.com/itsmattkc/SIEdit/blob/master/lib/othertypes.h
 	// SIZE 0x1c
@@ -62,10 +62,10 @@ private:
 	MxU32 m_chunkLength;            // 0x5c
 	MxU32 m_lockSize;               // 0x60
 	MxU8 m_writtenChunks;           // 0x64
-	MxBool m_playing;               // 0x65
+	MxBool m_started;               // 0x65
 	MxBool m_unk66;                 // 0x66
 	MxS8 m_silenceData;             // 0x67
-	MxBool m_unk68;                 // 0x68
+	MxBool m_paused;                // 0x68
 };
 
 #endif // MXWAVEPRESENTER_H

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -55,16 +55,16 @@ private:
 	void Destroy(MxBool p_fromDestructor);
 	MxS8 FUN_100b1b60();
 	MxBool FUN_100b1ba0();
-	void FUN_100b1bd0(void* p_audioPtr, MxU32 p_length);
+	void WriteToSoundBuffer(void* p_audioPtr, MxU32 p_length);
 
 	WaveFormat* m_waveFormat;       // 0x54
 	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x58
 	MxU32 m_length;                 // 0x5c
-	MxU32 m_bytes;                  // 0x60
+	MxU32 m_lockSize;               // 0x60
 	MxU8 m_unk64;                   // 0x64
 	MxBool m_playing;               // 0x65
 	MxBool m_unk66;                 // 0x66
-	MxS8 m_unk67;                   // 0x67
+	MxS8 m_silenceData;             // 0x67
 	MxBool m_unk68;                 // 0x68
 };
 


### PR DESCRIPTION
Implements the remaining functions in `MxWavePresenter`.

```
+  MxWavePresenter::WriteToSoundBuffer (0x100b1bd0) is 100.00% similar to the original
+  MxWavePresenter::StreamingTickle (0x100b1ea0) is 100.00% similar to the original
+  MxWavePresenter::DoneTickle (0x100b20c0) is 82.35% similar to the original
+  MxWavePresenter::AppendChunk (0x100b2130) is 100.00% similar to the original
+  MxWavePresenter::PutData (0x100b2160) is 100.00% similar to the original
+  MxWavePresenter::EndAction (0x100b2280) is 100.00% similar to the original
+  MxWavePresenter::SetVolume (0x100b2300) is 100.00% similar to the original
+  MxWavePresenter::Enable (0x100b2360) is 100.00% similar to the original
+  MxWavePresenter::ParseExtra (0x100b23a0) is 86.32% similar to the original
+  MxWavePresenter::VTable0x64 (0x100b2440) is 100.00% similar to the original
+  MxWavePresenter::VTable0x68 (0x100b2470) is 100.00% similar to the original
```