### PR TITLE
LegoRace initial layout

### DIFF
--- a/LEGO1/legorace.cpp
+++ b/LEGO1/legorace.cpp
@@ -1,25 +1,23 @@
 #include "legorace.h"
 
+#include "mxnotificationmanager.h"
+
 DECOMP_SIZE_ASSERT(LegoRace, 0x144)
 
-#include "mxnotificationmanager.h"
-#include "mxomni.h"
-
 // OFFSET: LEGO1 0x1000dab0
-undefined4 LegoRace::vtable0x78(void)
+undefined4 LegoRace::VTable0x78(undefined4)
 {
 	return 0;
 }
 
 // OFFSET: LEGO1 0x1000dac0 STUB
-void LegoRace::vtable0x7c()
+void LegoRace::VTable0x7c(undefined4, undefined4)
 {
 	// TODO
-	return;
 }
 
 // OFFSET: LEGO1 0x1000dae0
-MxBool LegoRace::vtable0x5c()
+MxBool LegoRace::VTable0x5c()
 {
 	return TRUE;
 }
@@ -46,21 +44,28 @@ LegoRace::LegoRace()
 }
 
 // OFFSET: LEGO1 0x10015b70
-undefined4 LegoRace::vtable0x70()
+undefined4 LegoRace::VTable0x70(undefined4)
 {
 	return 0;
 }
 
 // OFFSET: LEGO1 0x10015b80
-undefined4 LegoRace::vtable0x74()
+undefined4 LegoRace::VTable0x74(undefined4)
 {
 	return 0;
 }
 
 // OFFSET: LEGO1 0x10015b90
-MxBool LegoRace::vtable0x64()
+MxBool LegoRace::VTable0x64()
 {
 	return FALSE;
+}
+
+// OFFSET: LEGO1 0x10015ce0 STUB
+MxResult LegoRace::Create(MxDSObject& p_dsObject)
+{
+	// TODO
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x10015d40 STUB
@@ -73,13 +78,11 @@ LegoRace::~LegoRace()
 MxLong LegoRace::Notify(MxParam& p)
 {
 	// TODO
-
 	return 0;
 }
 
 // OFFSET: LEGO1 0x10015ed0 STUB
-void LegoRace::vtable0x68(MxBool p_add)
+void LegoRace::VTable0x68(MxBool p_add)
 {
 	// TODO
-	return;
 }

--- a/LEGO1/legorace.cpp
+++ b/LEGO1/legorace.cpp
@@ -1,9 +1,48 @@
 #include "legorace.h"
 
-// OFFSET: LEGO1 0x10015aa0 STUB
-LegoRace::LegoRace()
+DECOMP_SIZE_ASSERT(LegoRace, 0x144)
+
+#include "mxnotificationmanager.h"
+#include "mxomni.h"
+
+// OFFSET: LEGO1 0x1000dab0
+undefined4 LegoRace::vtable0x78(void)
+{
+	return 0;
+}
+
+// OFFSET: LEGO1 0x1000dac0 STUB
+void LegoRace::vtable0x7c()
 {
 	// TODO
+	return;
+}
+
+// OFFSET: LEGO1 0x1000dae0
+MxBool LegoRace::vtable0x5c()
+{
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x10015aa0
+LegoRace::LegoRace()
+{
+	this->m_unkf8 = 0;
+	this->m_unkfc = 0;
+	this->m_unk100 = 0;
+	this->m_unk104 = 0;
+	this->m_unk108 = 0;
+	this->m_unk10c = 0;
+	this->m_unk140 = 0;
+	this->m_unk110 = 0;
+	this->m_unk114 = 0;
+	this->m_unk118 = 0;
+	this->m_unk128 = 0;
+	this->m_unk12c = 0;
+	this->m_unk120 = 0;
+	this->m_unk124 = 0;
+	this->m_unk11c = 0;
+	NotificationManager()->Register(this);
 }
 
 // OFFSET: LEGO1 0x10015d40 STUB
@@ -18,4 +57,29 @@ MxLong LegoRace::Notify(MxParam& p)
 	// TODO
 
 	return 0;
+}
+
+// OFFSET: LEGO1 0x10015b70
+undefined4 LegoRace::vtable0x70()
+{
+	return 0;
+}
+
+// OFFSET: LEGO1 0x10015b80
+undefined4 LegoRace::vtable0x74()
+{
+	return 0;
+}
+
+// OFFSET: LEGO1 0x10015b90
+MxBool LegoRace::vtable0x64()
+{
+	return FALSE;
+}
+
+// OFFSET: LEGO1 0x10015ed0 STUB
+void LegoRace::vtable0x68(MxBool p_add)
+{
+	// TODO
+	return;
 }

--- a/LEGO1/legorace.cpp
+++ b/LEGO1/legorace.cpp
@@ -45,20 +45,6 @@ LegoRace::LegoRace()
 	NotificationManager()->Register(this);
 }
 
-// OFFSET: LEGO1 0x10015d40 STUB
-LegoRace::~LegoRace()
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x10015e00 STUB
-MxLong LegoRace::Notify(MxParam& p)
-{
-	// TODO
-
-	return 0;
-}
-
 // OFFSET: LEGO1 0x10015b70
 undefined4 LegoRace::vtable0x70()
 {
@@ -75,6 +61,20 @@ undefined4 LegoRace::vtable0x74()
 MxBool LegoRace::vtable0x64()
 {
 	return FALSE;
+}
+
+// OFFSET: LEGO1 0x10015d40 STUB
+LegoRace::~LegoRace()
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x10015e00 STUB
+MxLong LegoRace::Notify(MxParam& p)
+{
+	// TODO
+
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10015ed0 STUB

--- a/LEGO1/legorace.h
+++ b/LEGO1/legorace.h
@@ -6,6 +6,7 @@
 #include "mxtypes.h"
 
 // VTABLE 0x100d5db0
+// SIZE 0x144
 class LegoRace : public LegoWorld {
 public:
 	LegoRace();
@@ -26,18 +27,16 @@ public:
 		return !strcmp(name, LegoRace::ClassName()) || LegoWorld::IsA(name);
 	}
 
-	// FIXME: Something is wrong here that is breaking the linking
-	// virtual MxS32 vtable0x18(int) override; // vtable+0x18  // FIXME: should be  virtual MxResult Create(MxDSObject&
-	// p_dsObject) override;  // vtable+0x18
+	virtual MxResult Create(MxDSObject& p_dsObject) override; // vtable+0x18
+	virtual MxBool VTable0x5c() override;                     // vtable+0x5c
+	virtual MxBool VTable0x64() override;                     // vtable+0x64
+	virtual void VTable0x68(MxBool p_add) override;           // vtable+0x68
+	virtual undefined4 VTable0x6c(undefined4) = 0;            // vtable+0x6c
+	virtual undefined4 VTable0x70(undefined4);                // vtable+0x70
+	virtual undefined4 VTable0x74(undefined4);                // vtable+0x74
+	virtual undefined4 VTable0x78(undefined4);                // vtable+0x78
+	virtual void VTable0x7c(undefined4, undefined4);          // vtable+0x7c
 
-	virtual MxBool vtable0x5c() override;           // vtable+0x5c
-	virtual MxBool vtable0x64() override;           // vtable+0x64
-	virtual void vtable0x68(MxBool p_add) override; // vtable+0x68
-
-	virtual undefined4 vtable0x70(); // vtable+0x70
-	virtual undefined4 vtable0x74(); // vtable+0x74
-	virtual undefined4 vtable0x78(); // vtable+0x78
-	virtual void vtable0x7c();       // vtable+0x7c
 private:
 	undefined4 m_unkf8;     // 0xf8
 	undefined4 m_unkfc;     // 0xfc

--- a/LEGO1/legorace.h
+++ b/LEGO1/legorace.h
@@ -1,7 +1,9 @@
 #ifndef LEGORACE_H
 #define LEGORACE_H
 
+#include "decomp.h"
 #include "legoworld.h"
+#include "mxtypes.h"
 
 // VTABLE 0x100d5db0
 class LegoRace : public LegoWorld {
@@ -23,6 +25,36 @@ public:
 	{
 		return !strcmp(name, LegoRace::ClassName()) || LegoWorld::IsA(name);
 	}
+
+	// FIXME: Something is wrong here that is breaking the linking
+	// virtual MxS32 vtable0x18(int) override; // vtable+0x18  // FIXME: should be  virtual MxResult Create(MxDSObject&
+	// p_dsObject) override;  // vtable+0x18
+
+	virtual MxBool vtable0x5c() override;           // vtable+0x5c
+	virtual MxBool vtable0x64() override;           // vtable+0x64
+	virtual void vtable0x68(MxBool p_add) override; // vtable+0x68
+
+	virtual undefined4 vtable0x70(); // vtable+0x70
+	virtual undefined4 vtable0x74(); // vtable+0x74
+	virtual undefined4 vtable0x78(); // vtable+0x78
+	virtual void vtable0x7c();       // vtable+0x7c
+private:
+	undefined4 m_unkf8;     // 0xf8
+	undefined4 m_unkfc;     // 0xfc
+	undefined4 m_unk100;    // 0x100
+	undefined4 m_unk104;    // 0x104
+	undefined4 m_unk108;    // 0x108
+	undefined4 m_unk10c;    // 0x10c
+	undefined4 m_unk110;    // 0x110
+	undefined4 m_unk114;    // 0x114
+	undefined4 m_unk118;    // 0x118
+	undefined4 m_unk11c;    // 0x11c
+	undefined4 m_unk120;    // 0x120 - this may be the current vehcle (function at 0x10015880)
+	undefined4 m_unk124;    // 0x124 - something game state
+	undefined4 m_unk128;    // 0x128
+	undefined4 m_unk12c;    // 0x12c
+	undefined4 m_unk130[4]; // unconfirmed bytes, ghidra claims these are integers
+	undefined4 m_unk140;
 };
 
 #endif // LEGORACE_H


### PR DESCRIPTION
The base class for other race classes. There are these vtable entries that are just empty, but the outcome of the asm doesnt include the `ret 0x4`, just `ret`, which is weird.

And the vtable0x18 override, I need help, adding it in causes the linker to complain