### PR TITLE
(clang-format) Add EmptyLineBeforeAccessModifier

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,6 +16,7 @@ BraceWrapping:
   AfterStruct: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
+EmptyLineBeforeAccessModifier: Always
 IncludeBlocks: Regroup
 IndentAccessModifiers: false
 IndentWidth: 4

--- a/LEGO1/legoobjectfactory.h
+++ b/LEGO1/legoobjectfactory.h
@@ -11,6 +11,7 @@ public:
 	LegoObjectFactory();
 	virtual MxCore* Create(const char* p_name) override; // vtable 0x14
 	virtual void Destroy(MxCore* p_object) override;     // vtable 0x18
+
 private:
 #define X(V) MxAtomId m_id##V;
 	FOR_LEGOOBJECTFACTORY_OBJECTS(X)

--- a/LEGO1/legopalettepresenter.h
+++ b/LEGO1/legopalettepresenter.h
@@ -26,6 +26,7 @@ public:
 	}
 
 	virtual void Destroy() override; // vtable+0x38
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/mxobjectfactory.h
+++ b/LEGO1/mxobjectfactory.h
@@ -38,6 +38,7 @@ public:
 
 	virtual MxCore* Create(const char* p_name); // vtable 0x14
 	virtual void Destroy(MxCore* p_object);     // vtable 0x18
+
 private:
 #define X(V) MxAtomId m_id##V;
 	FOR_MXOBJECTFACTORY_OBJECTS(X)


### PR DESCRIPTION
This rule ensures that there is an empty line before each access modifier (except at the beginning of the struct/class). We have already been writing code using this rule so this just formalizes it (and fixes a few instances).