### PR TITLE
MxFlcPresenter vtable70, m_unk64

### DIFF
--- a/3rdparty/flic/flic.h
+++ b/3rdparty/flic/flic.h
@@ -1,0 +1,36 @@
+#ifndef FLIC_H
+#define FLIC_H
+
+#include <windows.h>
+
+// A basic FLIC header structure from the "EGI" documentation. Source: https://www.compuphase.com/flic.htm#FLICHEADER
+// This also goes over the FLIC structures: https://github.com/thinkbeforecoding/nomemalloc.handson/blob/master/flic.txt
+typedef struct {
+  DWORD size;          /* Size of FLIC including this header */
+  WORD  type;          /* File type 0xAF11, 0xAF12, 0xAF30, 0xAF44, ... */
+  WORD  frames;        /* Number of frames in first segment */
+  WORD  width;         /* FLIC width in pixels */
+  WORD  height;        /* FLIC height in pixels */
+  WORD  depth;         /* Bits per pixel (usually 8) */
+  WORD  flags;         /* Set to zero or to three */
+  DWORD speed;         /* Delay between frames */
+  WORD  reserved1;     /* Set to zero */
+  DWORD created;       /* Date of FLIC creation (FLC only) */
+  DWORD creator;       /* Serial number or compiler id (FLC only) */
+  DWORD updated;       /* Date of FLIC update (FLC only) */
+  DWORD updater;       /* Serial number (FLC only), see creator */
+  WORD  aspect_dx;     /* Width of square rectangle (FLC only) */
+  WORD  aspect_dy;     /* Height of square rectangle (FLC only) */
+  WORD  ext_flags;     /* EGI: flags for specific EGI extensions */
+  WORD  keyframes;     /* EGI: key-image frequency */
+  WORD  totalframes;   /* EGI: total number of frames (segments) */
+  DWORD req_memory;    /* EGI: maximum chunk size (uncompressed) */
+  WORD  max_regions;   /* EGI: max. number of regions in a CHK_REGION chunk */
+  WORD  transp_num;    /* EGI: number of transparent levels */
+  BYTE  reserved2[24]; /* Set to zero */
+  DWORD oframe1;       /* Offset to frame 1 (FLC only) */
+  DWORD oframe2;       /* Offset to frame 2 (FLC only) */
+  BYTE  reserved3[40]; /* Set to zero */
+} FLIC_HEADER;
+
+#endif FLIC_H // FLIC_H

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,6 @@ endif()
 
 # Additional include directories
 target_include_directories(lego1 PUBLIC "${CMAKE_SOURCE_DIR}/3rdparty/vec")
-
 target_include_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/flic")
 target_include_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/smk")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,8 @@ endif()
 
 # Additional include directories
 target_include_directories(lego1 PUBLIC "${CMAKE_SOURCE_DIR}/3rdparty/vec")
+
+target_include_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/flic")
 target_include_directories(lego1 PRIVATE "${CMAKE_SOURCE_DIR}/3rdparty/smk")
 
 if (ISLE_USE_SMARTHEAP)

--- a/LEGO1/mxflcpresenter.cpp
+++ b/LEGO1/mxflcpresenter.cpp
@@ -11,7 +11,7 @@ DECOMP_SIZE_ASSERT(MxFlcPresenter, 0x68);
 // OFFSET: LEGO1 0x100b3310
 MxFlcPresenter::MxFlcPresenter()
 {
-	this->m_unk64 = 0;
+	this->m_flicHeader = NULL;
 	this->m_flags &= 0xfd;
 	this->m_flags &= 0xfb;
 }
@@ -19,20 +19,26 @@ MxFlcPresenter::MxFlcPresenter()
 // OFFSET: LEGO1 0x100b3420
 MxFlcPresenter::~MxFlcPresenter()
 {
-	if (this->m_unk64) {
-		delete this->m_unk64;
+	if (this->m_flicHeader) {
+		delete this->m_flicHeader;
 	}
 }
 
-// OFFSET: LEGO1 0x100b34d0
-void MxFlcPresenter::vtable60()
+// OFFSET: LEGO1 0x100b3490
+void MxFlcPresenter::LoadHeader(MxStreamChunk* p_chunk)
 {
-	if(m_bitmap)
+	m_flicHeader = (FLIC_HEADER*) new MxU8[p_chunk->GetLength()];
+	memcpy(m_flicHeader, p_chunk->GetData(), p_chunk->GetLength());
+}
+
+// OFFSET: LEGO1 0x100b34d0
+void MxFlcPresenter::CreateBitmap()
+{
+	if (m_bitmap)
 		delete m_bitmap;
 
 	m_bitmap = new MxBitmap;
-
-	m_bitmap->SetSize(m_unk64->width, m_unk64->height, NULL, FALSE);
+	m_bitmap->SetSize(m_flicHeader->width, m_flicHeader->height, NULL, FALSE);
 }
 
 // OFFSET: LEGO1 0x100b3620

--- a/LEGO1/mxflcpresenter.cpp
+++ b/LEGO1/mxflcpresenter.cpp
@@ -23,7 +23,17 @@ MxFlcPresenter::~MxFlcPresenter()
 		delete this->m_unk64;
 	}
 }
-<<<<<<< HEAD
+
+// OFFSET: LEGO1 0x100b34d0
+void MxFlcPresenter::vtable60()
+{
+	if(m_bitmap)
+		delete m_bitmap;
+
+	m_bitmap = new MxBitmap;
+
+	m_bitmap->SetSize(m_unk64->width, m_unk64->height, NULL, FALSE);
+}
 
 // OFFSET: LEGO1 0x100b3620
 void MxFlcPresenter::VTable0x70()
@@ -34,16 +44,3 @@ void MxFlcPresenter::VTable0x70()
 	if (pal)
 		delete pal;
 }
-||||||| parent of 679bbcf (MxFlcPresenter: vtable70)
-=======
-
-// OFFSET: LEGO1 0x100b3620
-void MxFlcPresenter::vtable70()
-{
-	MxPalette* pal = m_bitmap->CreatePalette();
-	MVideoManager()->RealizePalette(pal);
-	if (pal) {
-		delete pal;
-	}
-}
->>>>>>> 679bbcf (MxFlcPresenter: vtable70)

--- a/LEGO1/mxflcpresenter.cpp
+++ b/LEGO1/mxflcpresenter.cpp
@@ -23,6 +23,7 @@ MxFlcPresenter::~MxFlcPresenter()
 		delete this->m_unk64;
 	}
 }
+<<<<<<< HEAD
 
 // OFFSET: LEGO1 0x100b3620
 void MxFlcPresenter::VTable0x70()
@@ -33,3 +34,16 @@ void MxFlcPresenter::VTable0x70()
 	if (pal)
 		delete pal;
 }
+||||||| parent of 679bbcf (MxFlcPresenter: vtable70)
+=======
+
+// OFFSET: LEGO1 0x100b3620
+void MxFlcPresenter::vtable70()
+{
+	MxPalette* pal = m_bitmap->CreatePalette();
+	MVideoManager()->RealizePalette(pal);
+	if (pal) {
+		delete pal;
+	}
+}
+>>>>>>> 679bbcf (MxFlcPresenter: vtable70)

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -2,10 +2,9 @@
 #define MXFLCPRESENTER_H
 
 #include "decomp.h"
+#include "mxvideopresenter.h"
 
 #include <flic.h>
-
-#include "mxvideopresenter.h"
 
 // VTABLE 0x100dc2c0
 // SIZE 0x68
@@ -27,10 +26,12 @@ public:
 		return "MxFlcPresenter";
 	}
 
-	virtual void vtable60() override; // vtable+0x60
-	virtual void VTable0x70() override; // vtable+0x70
+	virtual void LoadHeader(MxStreamChunk* p_chunk) override; // vtable+0x5c
+	virtual void CreateBitmap() override;                     // vtable+0x60
+	virtual void VTable0x70() override;                       // vtable+0x70
 
-	FLIC_HEADER* m_unk64; // 0x64 - what we believe so far. Could be another custom structure like MxSmack.
+protected:
+	FLIC_HEADER* m_flicHeader;
 };
 
 #endif // MXFLCPRESENTER_H

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -26,6 +26,8 @@ public:
 
 	virtual void VTable0x70() override; // vtable+0x70
 
+	virtual void vtable70() override; // vtable+0x74
+
 	undefined4* m_unk64;
 };
 

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -2,6 +2,9 @@
 #define MXFLCPRESENTER_H
 
 #include "decomp.h"
+
+#include <flic.h>
+
 #include "mxvideopresenter.h"
 
 // VTABLE 0x100dc2c0
@@ -24,11 +27,10 @@ public:
 		return "MxFlcPresenter";
 	}
 
+	virtual void vtable60() override; // vtable+0x60
 	virtual void VTable0x70() override; // vtable+0x70
 
-	virtual void vtable70() override; // vtable+0x74
-
-	undefined4* m_unk64;
+	FLIC_HEADER* m_unk64; // 0x64 - what we believe so far. Could be another custom structure like MxSmack.
 };
 
 #endif // MXFLCPRESENTER_H

--- a/LEGO1/mxloopingflcpresenter.cpp
+++ b/LEGO1/mxloopingflcpresenter.cpp
@@ -29,3 +29,21 @@ void MxLoopingFlcPresenter::Destroy(MxBool p_fromDestructor)
 {
 	// TODO
 }
+
+// OFFSET: LEGO1 0x100b4470
+void MxLoopingFlcPresenter::NextFrame()
+{
+	MxStreamChunk* chunk = NextChunk();
+
+	if (chunk->GetFlags() & MxStreamChunk::Flag_Bit2) {
+		m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
+		m_currentTickleState = TickleState_Repeating;
+	}
+	else {
+		LoadFrame(chunk);
+		AppendChunk(chunk);
+		m_unk68 += m_flicHeader->speed;
+	}
+
+	m_subscriber->FUN_100b8390(chunk);
+}

--- a/LEGO1/mxloopingflcpresenter.h
+++ b/LEGO1/mxloopingflcpresenter.h
@@ -18,6 +18,8 @@ public:
 		return "MxLoopingFlcPresenter";
 	}
 
+	virtual void NextFrame() override; // vtable+0x64
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);


### PR DESCRIPTION
vtable70 is basically creating a bitmap; doing this needs m_unk64, which is the main point of interest.

It *appears* that just like MxSmkPresenter, there is a general structure of a "FLIC", at least what appears to be a FLIC header. All that matters currently with m_unk64 is that +0x8 is the width and +0xa is the height.

This PR is just a test for now, we'll have to see whether this is what m_unk64 is or isn't.