### PR TITLE
Implement/match MxStillPresenter::LoadFrame

### DIFF
--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -233,9 +233,9 @@ void MxDisplaySurface::ReleaseDC(HDC p_hdc)
 }
 
 // OFFSET: LEGO1 0x100bbc60 STUB
-undefined4 MxDisplaySurface::vtable44(undefined4, undefined4*, undefined4, undefined4)
+LPDIRECTDRAWSURFACE MxDisplaySurface::vtable44(MxBitmap*, undefined4*, undefined4, undefined4)
 {
-	return 0;
+	return NULL;
 }
 
 // OFFSET: LEGO1 0x100bc200 STUB

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -56,7 +56,7 @@ public:
 	virtual void Display(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
 	virtual void GetDC(HDC* p_hdc);
 	virtual void ReleaseDC(HDC p_hdc);
-	virtual undefined4 vtable44(undefined4, undefined4*, undefined4, undefined4);
+	virtual LPDIRECTDRAWSURFACE vtable44(MxBitmap*, undefined4*, undefined4, undefined4);
 
 	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return this->m_ddSurface1; }
 	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }

--- a/LEGO1/mxstillpresenter.cpp
+++ b/LEGO1/mxstillpresenter.cpp
@@ -3,6 +3,8 @@
 #include "decomp.h"
 #include "define.h"
 #include "legoomni.h"
+#include "mxomni.h"
+#include "mxvideomanager.h"
 
 DECOMP_SIZE_ASSERT(MxStillPresenter, 0x6c);
 
@@ -74,10 +76,41 @@ void MxStillPresenter::NextFrame()
 	m_subscriber->FUN_100b8390(chunk);
 }
 
-// OFFSET: LEGO1 0x100b9dd0 STUB
+// OFFSET: LEGO1 0x100b9dd0
 void MxStillPresenter::LoadFrame(MxStreamChunk* p_chunk)
 {
-	// TODO
+	memcpy(m_bitmap->GetBitmapData(), p_chunk->GetData(), p_chunk->GetLength());
+
+	MxS32 height = GetHeight() - 1;
+	MxS32 width = GetWidth() - 1;
+	MxS32 x = GetLocationX();
+	MxS32 y = GetLocationY();
+
+	MxRect32 rect(x, y, width + x, height + y);
+	MVideoManager()->InvalidateRect(rect);
+
+	if (m_flags & Flag_Bit2) {
+		undefined4 unk = 0;
+		m_unk58 = MxOmni::GetInstance()->GetVideoManager()->GetDisplaySurface()->vtable44(
+			m_bitmap,
+			&unk,
+			(m_flags & Flag_Bit4) / 8,
+			m_action->GetFlags() & MxDSAction::Flag_Bit4
+		);
+
+		if (m_alpha)
+			delete m_alpha;
+		m_alpha = new AlphaMask(*m_bitmap);
+
+		if (m_bitmap)
+			delete m_bitmap;
+		m_bitmap = NULL;
+
+		if (m_unk58 && unk)
+			m_flags |= Flag_Bit3;
+		else
+			m_flags &= ~Flag_Bit3;
+	}
 }
 
 // OFFSET: LEGO1 0x100b9f30 STUB

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -11,6 +11,7 @@
 // SIZE 0x64
 class MxVideoManager : public MxMediaManager {
 public:
+	MxVideoManager();
 	virtual ~MxVideoManager() override;
 
 	virtual MxResult Tickle() override; // vtable+0x8
@@ -30,8 +31,6 @@ public:
 	__declspec(dllexport) void InvalidateRect(MxRect32&);
 	__declspec(dllexport) virtual MxResult RealizePalette(MxPalette*); // vtable+0x30
 	virtual void vtable0x34(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height);
-
-	MxVideoManager();
 
 	MxResult Init();
 	void Destroy(MxBool p_fromDestructor);


### PR DESCRIPTION
Match is at ~97%, there's a few instructions that are moved around a little bit, similar to other places where we initialize `MxRect32`.