### PR TITLE
STL lists for stream classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(lego1 SHARED
   LEGO1/mxstreamchunklist.cpp
   LEGO1/mxstreamcontroller.cpp
   LEGO1/mxstreamer.cpp
+  LEGO1/mxstreamlist.cpp
   LEGO1/mxstreamprovider.cpp
   LEGO1/mxstring.cpp
   LEGO1/mxstringlist.cpp

--- a/LEGO1/mxcriticalsection.cpp
+++ b/LEGO1/mxcriticalsection.cpp
@@ -1,6 +1,10 @@
 #include "mxcriticalsection.h"
 
+#include "decomp.h"
+
 #include <stdio.h>
+
+DECOMP_SIZE_ASSERT(MxCriticalSection, 0x1c);
 
 // 0x10101e78
 int g_useMutex = 0;

--- a/LEGO1/mxcriticalsection.h
+++ b/LEGO1/mxcriticalsection.h
@@ -3,6 +3,7 @@
 
 #include <windows.h>
 
+// SIZE 0x1c
 class MxCriticalSection {
 public:
 	__declspec(dllexport) MxCriticalSection();

--- a/LEGO1/mxdiskstreamcontroller.cpp
+++ b/LEGO1/mxdiskstreamcontroller.cpp
@@ -5,11 +5,25 @@
 #include "mxomni.h"
 #include "mxticklemanager.h"
 
-// OFFSET: LEGO1 0x100c7120 STUB
+DECOMP_SIZE_ASSERT(MxDiskStreamController, 0xc8);
+
+// OFFSET: LEGO1 0x100c7120
 MxDiskStreamController::MxDiskStreamController()
 {
-	// TODO
+	m_unk8c = 0;
 }
+
+// OFFSET: LEGO1 0x100c7330 TEMPLATE
+// list<MxDSAction *,allocator<MxDSAction *> >::_Buynode
+
+// OFFSET: LEGO1 0x100c7420 TEMPLATE
+// list<MxDSBuffer *,allocator<MxDSBuffer *> >::~list<MxDSBuffer *,allocator<MxDSBuffer *> >
+
+// OFFSET: LEGO1 0x100c7490 TEMPLATE
+// list<MxDSBuffer *,allocator<MxDSBuffer *> >::_Buynode
+
+// OFFSET: LEGO1 0x100c74e0 TEMPLATE
+// List<MxDSBuffer *>::~List<MxDSBuffer *>
 
 // OFFSET: LEGO1 0x100c7530 STUB
 MxDiskStreamController::~MxDiskStreamController()

--- a/LEGO1/mxdiskstreamcontroller.h
+++ b/LEGO1/mxdiskstreamcontroller.h
@@ -1,6 +1,9 @@
 #ifndef MXDISKSTREAMCONTROLLER_H
 #define MXDISKSTREAMCONTROLLER_H
 
+#include "compat.h" // STL
+#include "decomp.h"
+#include "mxdsbuffer.h"
 #include "mxstreamcontroller.h"
 #include "mxtypes.h"
 
@@ -34,6 +37,17 @@ public:
 	{
 		return !strcmp(name, MxDiskStreamController::ClassName()) || MxStreamController::IsA(name);
 	}
+
+private:
+	MxStreamListMxDSAction m_list0x64; // 0x64
+	undefined m_unk70;                 // 0x70
+	list<MxDSBuffer*> m_list0x74;      // 0x74
+	MxStreamListMxDSAction m_list0x80; // 0x80
+	undefined2 m_unk8c;                // 0x8c
+	MxStreamListMxDSAction m_list0x90; // 0x90
+	MxCriticalSection m_critical9c;    // 0x9c
+	MxStreamListMxDSAction m_list0xb8; // 0xb8
+	undefined m_unkc4;                 // 0xc4
 };
 
 #endif // MXDISKSTREAMCONTROLLER_H

--- a/LEGO1/mxdiskstreamprovider.h
+++ b/LEGO1/mxdiskstreamprovider.h
@@ -1,11 +1,13 @@
 #ifndef MXDISKSTREAMPROVIDER_H
 #define MXDISKSTREAMPROVIDER_H
 
+#include "compat.h"
 #include "decomp.h"
 #include "mxcriticalsection.h"
+#include "mxdsaction.h"
+#include "mxstreamlist.h"
 #include "mxstreamprovider.h"
 #include "mxthread.h"
-#include "mxunklist.h"
 
 class MxDiskStreamProvider;
 
@@ -57,7 +59,7 @@ private:
 	undefined m_remainingWork;           // 0x34
 	undefined m_unk35;                   // 0x35
 	MxCriticalSection m_criticalSection; // 0x38
-	MxUnkList m_list;
+	MxStreamListMxDSAction m_list;       // 0x54
 };
 
 #endif // MXDISKSTREAMPROVIDER_H

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -5,7 +5,8 @@
 #include "mxcore.h"
 #include "mxdschunk.h"
 #include "mxstreamchunk.h"
-#include "mxstreamcontroller.h"
+
+class MxStreamController;
 
 // VTABLE 0x100dc698
 // SIZE 0x4c

--- a/LEGO1/mxnextactiondatastart.h
+++ b/LEGO1/mxnextactiondatastart.h
@@ -28,6 +28,9 @@ public:
 		return !strcmp(name, MxNextActionDataStart::ClassName()) || MxCore::IsA(name);
 	}
 
+	inline MxU32 GetObjectId() const { return m_objectId; }
+	inline MxS16 GetUnknown24() const { return m_unk24val; }
+
 private:
 	MxU32 m_objectId;
 	MxS16 m_unk24val;

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -3,7 +3,9 @@
 #include "legoomni.h"
 #include "mxautolocker.h"
 #include "mxnextactiondatastart.h"
+#include "mxstreamchunk.h"
 
+DECOMP_SIZE_ASSERT(MxStreamController, 0x64)
 DECOMP_SIZE_ASSERT(MxNextActionDataStart, 0x14)
 
 // OFFSET: LEGO1 0x100b9400
@@ -24,11 +26,57 @@ MxResult MxStreamController::vtable0x28()
 	return SUCCESS;
 }
 
-// OFFSET: LEGO1 0x100c0b90 STUB
+// OFFSET: LEGO1 0x100c0b90
 MxStreamController::MxStreamController()
 {
-	// TODO
+	m_provider = NULL;
+	m_unk2c = 0; // TODO: probably also NULL
+	m_action0x60 = NULL;
 }
+
+// OFFSET: LEGO1 0x100c0d60 TEMPLATE
+// list<MxDSAction *,allocator<MxDSAction *> >::~list<MxDSAction *,allocator<MxDSAction *> >
+
+// OFFSET: LEGO1 0x100c0dd0 TEMPLATE
+// list<MxDSSubscriber *,allocator<MxDSSubscriber *> >::~list<MxDSSubscriber *,allocator<MxDSSubscriber *> >
+
+// OFFSET: LEGO1 0x100c0e40 TEMPLATE
+// list<MxDSSubscriber *,allocator<MxDSSubscriber *> >::_Buynode
+
+// clang-format off
+// OFFSET: LEGO1 0x100c0e70 TEMPLATE
+// list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >::~list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >
+// clang-format on
+
+// OFFSET: LEGO1 0x100c0ee0 TEMPLATE
+// list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >::_Buynode
+
+// OFFSET: LEGO1 0x100c0fc0 TEMPLATE
+// MxStreamListMxDSSubscriber::~MxStreamListMxDSSubscriber
+
+// OFFSET: LEGO1 0x100c1010 TEMPLATE
+// MxStreamListMxDSAction::~MxStreamListMxDSAction
+
+// OFFSET: LEGO1 0x100c1060 TEMPLATE
+// MxStreamListMxNextActionDataStart::~MxStreamListMxNextActionDataStart
+
+// OFFSET: LEGO1 0x100c10b0 TEMPLATE
+// MxStreamList<MxDSSubscriber *>::~MxStreamList<MxDSSubscriber *>
+
+// OFFSET: LEGO1 0x100c1100 TEMPLATE
+// MxStreamList<MxDSAction *>::~MxStreamList<MxDSAction *>
+
+// OFFSET: LEGO1 0x100c1150 TEMPLATE
+// MxStreamList<MxNextActionDataStart *>::~MxStreamList<MxNextActionDataStart *>
+
+// OFFSET: LEGO1 0x100c11a0 TEMPLATE
+// List<MxDSSubscriber *>::~List<MxDSSubscriber *>
+
+// OFFSET: LEGO1 0x100c11f0 TEMPLATE
+// List<MxDSAction *>::~List<MxDSAction *>
+
+// OFFSET: LEGO1 0x100c1240 TEMPLATE
+// List<MxNextActionDataStart *>::~List<MxNextActionDataStart *>
 
 // OFFSET: LEGO1 0x100c1290 STUB
 MxStreamController::~MxStreamController()
@@ -76,7 +124,7 @@ MxResult MxStreamController::vtable0x24(undefined4 p_unknown)
 	return FAILURE;
 }
 
-// OFFSET: LEGO1 0x100c1800 STUB
+// OFFSET: LEGO1 0x100c1800
 MxResult MxStreamController::FUN_100c1800(MxDSAction* p_action, MxU32 p_val)
 {
 	MxNextActionDataStart* dataActionStart =
@@ -84,8 +132,9 @@ MxResult MxStreamController::FUN_100c1800(MxDSAction* p_action, MxU32 p_val)
 	if (dataActionStart == NULL) {
 		return FAILURE;
 	}
-	// TODO: insert dataActionStart to a list
-	return FAILURE;
+
+	m_nextActionList.push_back(dataActionStart);
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100c1a00 STUB

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -1,12 +1,14 @@
 #ifndef MXSTREAMCONTROLLER_H
 #define MXSTREAMCONTROLLER_H
 
+#include "compat.h" // STL
 #include "decomp.h"
 #include "mxatomid.h"
 #include "mxcore.h"
 #include "mxcriticalsection.h"
 #include "mxdsaction.h"
 #include "mxdsobject.h"
+#include "mxstreamlist.h"
 #include "mxstreamprovider.h"
 
 // VTABLE 0x100dc968
@@ -46,11 +48,15 @@ public:
 	inline MxAtomId& GetAtom() { return atom; };
 
 protected:
-	MxCriticalSection m_criticalSection;
-	MxAtomId atom;
-	MxStreamProvider* m_provider; // MxStreamProvider*
-	undefined4 m_unk2c;
-	undefined m_unk30[0x34];
+	MxCriticalSection m_criticalSection;                // 0x8
+	MxAtomId atom;                                      // 0x24
+	MxStreamProvider* m_provider;                       // 0x28
+	undefined4 m_unk2c;                                 // 0x2c
+	MxStreamListMxDSSubscriber m_subscriberList;        // 0x30
+	MxStreamListMxDSAction m_unkList0x3c;               // 0x3c
+	MxStreamListMxNextActionDataStart m_nextActionList; // 0x48
+	MxStreamListMxDSAction m_unkList0x54;               // 0x54
+	MxDSAction* m_action0x60;                           // 0x60
 };
 
 #endif // MXSTREAMCONTROLLER_H

--- a/LEGO1/mxstreamlist.cpp
+++ b/LEGO1/mxstreamlist.cpp
@@ -1,0 +1,47 @@
+#include "mxstreamlist.h"
+
+// Wrappers around STL list that are used by the MxStream* classes.
+DECOMP_SIZE_ASSERT(MxStreamListMxDSAction, 0xc);
+DECOMP_SIZE_ASSERT(MxStreamListMxNextActionDataStart, 0xc);
+DECOMP_SIZE_ASSERT(MxStreamListMxDSSubscriber, 0xc);
+
+// OFFSET: LEGO1 0x100bfa80
+MxDSAction* MxStreamListMxDSAction::Find(MxDSAction* p_action, MxBool p_delete)
+{
+	// DECOMP: ALPHA 0x1008b99d ?
+
+	MxDSAction* found = NULL;
+
+	for (iterator it = begin(); it != end(); it++) {
+		if (p_action->GetObjectId() == -1 || p_action->GetObjectId() == (*it)->GetObjectId()) {
+			if (p_action->GetUnknown24() == -2 || p_action->GetUnknown24() == -3 ||
+				p_action->GetUnknown24() == (*it)->GetUnknown24()) {
+				found = *it;
+				if (p_action->GetUnknown24() != -3)
+					break;
+			}
+		}
+	}
+
+	if (p_delete && found != NULL) {
+		erase(it);
+	}
+
+	return found;
+}
+
+// OFFSET: LEGO1 0x100c2240
+MxNextActionDataStart* MxStreamListMxNextActionDataStart::Find(MxU32 p_id, MxS16 p_value)
+{
+	MxNextActionDataStart* match = NULL;
+
+	for (iterator it = begin(); it != end(); it++) {
+		if (p_id == (*it)->GetObjectId() && (p_value == -2 || p_value == (*it)->GetUnknown24())) {
+			match = *it;
+			erase(it);
+			break;
+		}
+	}
+
+	return match;
+}

--- a/LEGO1/mxstreamlist.h
+++ b/LEGO1/mxstreamlist.h
@@ -1,0 +1,27 @@
+#ifndef MXSTREAMLIST_H
+#define MXSTREAMLIST_H
+
+#include "compat.h" // STL
+#include "mxdsaction.h"
+#include "mxdssubscriber.h"
+#include "mxnextactiondatastart.h"
+
+template <class T>
+class MxStreamList : public list<T> {};
+
+// SIZE 0xc
+class MxStreamListMxDSAction : public MxStreamList<MxDSAction*> {
+public:
+	MxDSAction* Find(MxDSAction* p_action, MxBool p_delete);
+};
+
+// SIZE 0xc
+class MxStreamListMxNextActionDataStart : public MxStreamList<MxNextActionDataStart*> {
+public:
+	MxNextActionDataStart* Find(MxU32, MxS16);
+};
+
+// SIZE 0xc
+class MxStreamListMxDSSubscriber : public MxStreamList<MxDSSubscriber*> {};
+
+#endif // MXSTREAMLIST_H


### PR DESCRIPTION
I've been hacking away at `MxStreamController` and related classes, but I thought I would tie off some stuff related to the class members as it probably warrants its own review.

`MxStreamController`, `MxDiskStreamController` and `MxDiskStreamProvider` all use STL lists to hold data. Much like the `MxList` hierarchy, there are four classes in total: two from the STL layer, a wrapper class, and then a final most-derived class. For example:

- `list<MxDSAction *,allocator<MxDSAction *> >::~list<MxDSAction *,allocator<MxDSAction *> >`
- `List<MxDSAction *>::~List<MxDSAction *>`
- `MxStreamList<MxDSAction *>::~MxStreamList<MxDSAction *>`
- `MxStreamListMxDSAction::~MxStreamListMxDSAction`

There are no vtables here, so it (probably) doesn't matter whether the wrapper class (`MxStreamList`) is the same regardless of the type. I've done it that way for simplicity.

The way to tell what's going on is the chain of destructor methods for the member that get tacked onto the end of a constructor. Here is an excerpt from the end of the `MxStreamController` constructor that I've cleaned up a little:

```asm
100c0c84 8b 4d ec         MOV     ECX,dword ptr [EBP + -0x14]
100c0c87 83 c1 54         ADD     ECX,0x54
100c0c8a e9 d1 00 00 00   JMP     FUN_100c0d60

100c0c8f 8b 4d ec         MOV     ECX,dword ptr [EBP + -0x14]
100c0c92 83 c1 54         ADD     ECX,0x54
100c0c95 e9 56 05 00 00   JMP     FUN_100c11f0

100c0c9a 8b 4d ec         MOV     ECX,dword ptr [EBP + -0x14]
100c0c9d 83 c1 54         ADD     ECX,0x54
100c0ca0 e9 5b 04 00 00   JMP     FUN_100c1100

100c0ca5 8b 4d ec         MOV     ECX,dword ptr [EBP + -0x14]
100c0ca8 83 c1 54         ADD     ECX,0x54
100c0cab e9 60 03 00 00   JMP     FUN_100c1010
```

The four jumps here correspond to the four list functions on `MxDSAction*` seen above, in that order. I've added the `TEMPLATE` markers for all these so we can track them with reccmp. The actual datatypes used in the lists are not obvious, so I used the debugger to lookup the vtable for all these.

This also makes it easy to tell where the same class-type was used in multiple places. This list type was used twice in `MxStreamController` and four times in `MxDiskStreamController`. Ghidra (at least on my end) doesn't decompile these blocks automatically, so you have to already know what you're looking for instead of finding all cases where something is called via the xrefs. It might be worth writing a tool that will calculate the jump destination for all these (for each known constructor) and print out a nice report.

I also filled in the rest of the member types for these classes where I could. The constructor for `MxDiskStreamController` _was_ 100% with all my other unfinished code in there, but compiler weirdness knocked it down a peg with that stuff removed.

Speaking of `TEMPLATE` offsets: I had to use `clang-format off` for one very long symbol that exceeds 120 columns. It is:
`list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >::~list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >`

There's no way to make that any shorter. The class name for the datatype has a `ClassName()` method overridden from `MxCore`, so the name is correct. We could add `ReflowComments: false` to the clang-format config, but this of course applies globally. Another option is to reshuffle the parser in the `isledecomp` library so it can handle offset-by-name cases that span two lines.