### PR TITLE
Implement/match most of MxStillPresenter

### DIFF
--- a/LEGO1/mxcompositepresenter.cpp
+++ b/LEGO1/mxcompositepresenter.cpp
@@ -38,7 +38,7 @@ void MxCompositePresenter::VTable0x5c()
 }
 
 // OFFSET: LEGO1 0x100b6b40 STUB
-void MxCompositePresenter::VTable0x60(undefined4 p_unknown)
+void MxCompositePresenter::VTable0x60(MxPresenter* p_presenter)
 {
 	// TODO
 }

--- a/LEGO1/mxcompositepresenter.h
+++ b/LEGO1/mxcompositepresenter.h
@@ -26,7 +26,7 @@ public:
 
 	virtual void VTable0x58();
 	virtual void VTable0x5c();
-	virtual void VTable0x60(undefined4 p_unknown);
+	virtual void VTable0x60(MxPresenter* p_presenter);
 	virtual MxBool VTable0x64(undefined4 p_unknown);
 
 private:

--- a/LEGO1/mxdsmediaaction.h
+++ b/LEGO1/mxdsmediaaction.h
@@ -34,6 +34,7 @@ public:
 	void CopyMediaSrcPath(const char* p_mediaSrcPath);
 
 	inline MxS32 GetMediaFormat() const { return this->m_mediaFormat; }
+	inline MxS32 GetPaletteManagement() const { return this->m_paletteManagement; }
 	inline MxLong GetSustainTime() const { return this->m_sustainTime; }
 
 private:

--- a/LEGO1/mxflcpresenter.cpp
+++ b/LEGO1/mxflcpresenter.cpp
@@ -42,11 +42,9 @@ void MxFlcPresenter::CreateBitmap()
 }
 
 // OFFSET: LEGO1 0x100b3620
-void MxFlcPresenter::VTable0x70()
+void MxFlcPresenter::RealizePalette()
 {
-	MxPalette* pal = m_bitmap->CreatePalette();
-	MVideoManager()->RealizePalette(pal);
-
-	if (pal)
-		delete pal;
+	MxPalette* palette = m_bitmap->CreatePalette();
+	MVideoManager()->RealizePalette(palette);
+	delete palette;
 }

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -28,7 +28,7 @@ public:
 
 	virtual void LoadHeader(MxStreamChunk* p_chunk) override; // vtable+0x5c
 	virtual void CreateBitmap() override;                     // vtable+0x60
-	virtual void VTable0x70() override;                       // vtable+0x70
+	virtual void RealizePalette() override;                   // vtable+0x70
 
 protected:
 	FLIC_HEADER* m_flicHeader;

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -4,6 +4,7 @@
 #include "mxpoint32.h"
 #include "mxsize32.h"
 
+// SIZE 0x10
 class MxRect32 {
 public:
 	MxRect32() {}

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -85,7 +85,7 @@ MxU32 MxSmkPresenter::VTable0x88()
 }
 
 // OFFSET: LEGO1 0x100b42c0
-void MxSmkPresenter::VTable0x70()
+void MxSmkPresenter::RealizePalette()
 {
 	MxPalette* palette = m_bitmap->CreatePalette();
 	MVideoManager()->RealizePalette(palette);

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -30,7 +30,7 @@ public:
 	virtual void LoadHeader(MxStreamChunk* p_chunk) override; // vtable+0x5c
 	virtual void CreateBitmap() override;                     // vtable+0x60
 	virtual void LoadFrame(MxStreamChunk* p_chunk) override;  // vtable+0x68
-	virtual void VTable0x70() override;                       // vtable+0x70
+	virtual void RealizePalette() override;                   // vtable+0x70
 	virtual MxU32 VTable0x88();                               // vtable+0x88
 
 	struct MxSmack {

--- a/LEGO1/mxstillpresenter.h
+++ b/LEGO1/mxstillpresenter.h
@@ -32,14 +32,14 @@ public:
 	virtual void CreateBitmap() override;                     // vtable+0x60
 	virtual void NextFrame() override;                        // vtable+0x64
 	virtual void LoadFrame(MxStreamChunk* p_chunk) override;  // vtable+0x68
-	virtual void VTable0x70() override;                       // vtable+0x70
-	virtual void VTable0x88(undefined4, undefined4);          // vtable+0x88
+	virtual void RealizePalette() override;                   // vtable+0x70
+	virtual void VTable0x88(MxS32 p_x, MxS32 p_y);            // vtable+0x88
 	virtual MxStillPresenter* Clone();                        // vtable+0x8c
 
 private:
 	void Destroy(MxBool p_fromDestructor);
 
-	undefined4 m_unk64;         // 0x64
+	MxLong m_chunkTime;         // 0x64
 	MxBITMAPINFO* m_bitmapInfo; // 0x68
 };
 

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -29,8 +29,8 @@ public:
 	virtual MxResult Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x2c
 
 	__declspec(dllexport) void InvalidateRect(MxRect32&);
-	__declspec(dllexport) virtual MxResult RealizePalette(MxPalette*); // vtable+0x30
-	virtual void vtable0x34(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height);
+	__declspec(dllexport) virtual MxResult RealizePalette(MxPalette*);            // vtable+0x30
+	virtual void vtable0x34(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height); // vtable+0x34
 
 	MxResult Init();
 	void Destroy(MxBool p_fromDestructor);
@@ -42,12 +42,12 @@ public:
 	inline MxDisplaySurface* GetDisplaySurface() { return this->m_displaySurface; }
 
 protected:
-	MxVideoParam m_videoParam;
-	LPDIRECTDRAW m_pDirectDraw;
-	LPDIRECTDRAWSURFACE m_pDDSurface;
-	MxDisplaySurface* m_displaySurface;
-	MxRegion* m_region;
-	MxBool m_unk60;
+	MxVideoParam m_videoParam;          // 0x2c
+	LPDIRECTDRAW m_pDirectDraw;         // 0x50
+	LPDIRECTDRAWSURFACE m_pDDSurface;   // 0x54
+	MxDisplaySurface* m_displaySurface; // 0x58
+	MxRegion* m_region;                 // 0x5c
+	MxBool m_unk60;                     // 0x60
 };
 
 #endif // MXVIDEOMANAGER_H

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -1,7 +1,11 @@
 #include "mxvideoparam.h"
 
+#include "decomp.h"
+
 #include <stdlib.h>
 #include <string.h>
+
+DECOMP_SIZE_ASSERT(MxVideoParam, 0x24);
 
 // OFFSET: LEGO1 0x100bec70
 MxVideoParam::MxVideoParam()

--- a/LEGO1/mxvideoparam.h
+++ b/LEGO1/mxvideoparam.h
@@ -10,6 +10,7 @@
 
 #include <ddraw.h>
 
+// SIZE 0x24
 class MxVideoParam {
 public:
 	__declspec(dllexport) MxVideoParam();
@@ -31,12 +32,12 @@ public:
 	inline MxU32 GetBackBuffers() { return this->m_backBuffers; }
 
 private:
-	MxRect32 m_rect;
-	MxPalette* m_palette;
-	MxU32 m_backBuffers;
-	MxVideoParamFlags m_flags;
-	int m_unk1c;
-	char* m_deviceId;
+	MxRect32 m_rect;           // 0x00
+	MxPalette* m_palette;      // 0x10
+	MxU32 m_backBuffers;       // 0x14
+	MxVideoParamFlags m_flags; // 0x18
+	int m_unk1c;               // 0x1c
+	char* m_deviceId;          // 0x20
 };
 
 #endif // MXVIDEOPARAM_H

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -26,7 +26,7 @@ void MxVideoPresenter::LoadFrame(MxStreamChunk* p_chunk)
 }
 
 // OFFSET: LEGO1 0x1000c730
-void MxVideoPresenter::VTable0x70()
+void MxVideoPresenter::RealizePalette()
 {
 	// Empty
 }

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -48,7 +48,7 @@ public:
 	virtual void NextFrame();                            // vtable+0x64
 	virtual void LoadFrame(MxStreamChunk* p_chunk);      // vtable+0x68
 	virtual void VTable0x6c();                           // vtable+0x6c
-	virtual void VTable0x70();                           // vtable+0x70
+	virtual void RealizePalette();                       // vtable+0x70
 	virtual undefined VTable0x74();                      // vtable+0x74
 	virtual LPDIRECTDRAWSURFACE VTable0x78();            // vtable+0x78
 	virtual MxBool VTable0x7c();                         // vtable+0x7c


### PR DESCRIPTION
Most functions are quite straightforward. `VTable0x88` is the only one that doesn't match yet.

```
  MxStillPresenter::RealizePalette (0x100b9f30 / 0x10026c40) is 100.00% similar to the original
  MxStillPresenter::StartingTickle (0x100b9f60 / 0x10026c70) is 100.00% similar to the original
  MxStillPresenter::StreamingTickle (0x100b9f90 / 0x10026ca0) is 100.00% similar to the original
  MxStillPresenter::RepeatingTickle (0x100b9ff0 / 0x10026d00) is 100.00% similar to the original
  MxStillPresenter::VTable0x88 (0x100ba040 / 0x10026d50) is 39.76% similar to the original
  MxStillPresenter::Enable (0x100ba140 / 0x10026e50) is 100.00% similar to the original
```

I've also added size and member annotations in some related classes. `VTable0x70` has been renamed to `RealizePalette`.