### PR TITLE
Refactor MxList cursors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(lego1 SHARED
   LEGO1/legovehiclebuildstate.cpp
   LEGO1/legovideomanager.cpp
   LEGO1/legoworld.cpp
+  LEGO1/legoworldlist.cpp
   LEGO1/legoworldpresenter.cpp
   LEGO1/motorcycle.cpp
   LEGO1/mxactionnotificationparam.cpp

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -11,6 +11,7 @@
 #include "legoutil.h"
 #include "legovideomanager.h"
 #include "legoworld.h"
+#include "legoworldlist.h"
 #include "mxautolocker.h"
 #include "mxbackgroundaudiomanager.h"
 #include "mxdsfile.h"
@@ -358,7 +359,7 @@ void LegoOmni::Init()
 	m_inputMgr = NULL;
 	m_unk6c = 0;
 	m_gifManager = NULL;
-	m_unk78 = 0;
+	m_worldList = NULL;
 	m_currentWorld = NULL;
 	m_unk80 = FALSE;
 	m_currentVehicle = NULL;
@@ -427,9 +428,9 @@ MxResult LegoOmni::Create(MxOmniCreateParam& p)
 	m_animationManager = new LegoAnimationManager();
 	m_buildingManager = new LegoBuildingManager();
 	m_gameState = new LegoGameState();
-	// TODO: initialize list at m_unk78
+	m_worldList = new LegoWorldList();
 
-	if (m_unk6c && m_gifManager && m_unk78 && m_plantManager && m_animationManager && m_buildingManager) {
+	if (m_unk6c && m_gifManager && m_worldList && m_plantManager && m_animationManager && m_buildingManager) {
 		// TODO: initialize a bunch of MxVariables
 		RegisterScripts();
 		FUN_1001a700();

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -21,6 +21,7 @@ class LegoSoundManager;
 class LegoUnkSaveDataWriter;
 class LegoVideoManager;
 class LegoWorld;
+class LegoWorldList;
 class MxAtomId;
 class MxBackgroundAudioManager;
 class MxDSFile;
@@ -117,7 +118,7 @@ private:
 	undefined4 m_unk6c;
 	LegoInputManager* m_inputMgr; // 0x70
 	GifManager* m_gifManager;
-	undefined4 m_unk78;
+	LegoWorldList* m_worldList; // 0x78
 	LegoWorld* m_currentWorld;
 	MxBool m_unk80;
 	LegoNavController* m_navController; // 0x84

--- a/LEGO1/legoworld.cpp
+++ b/LEGO1/legoworld.cpp
@@ -67,6 +67,24 @@ MxResult LegoWorld::SetAsCurrentWorld(MxDSObject& p_dsObject)
 	return SUCCESS;
 }
 
+// SYNTHETIC: LEGO1 0x1001eed0
+// MxPresenterListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x1001ef40
+// MxPtrListCursor<MxPresenter>::~MxPtrListCursor<MxPresenter>
+
+// SYNTHETIC: LEGO1 0x1001ef90
+// MxListCursor<MxPresenter *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001f000
+// MxPtrListCursor<MxPresenter>::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x1001f070
+// MxListCursor<MxPresenter *>::~MxListCursor<MxPresenter *>
+
+// SYNTHETIC: LEGO1 0x1001f0c0
+// MxPresenterListCursor::~MxPresenterListCursor
+
 // FUNCTION: LEGO1 0x1001f5e0
 MxLong LegoWorld::Notify(MxParam& p_param)
 {

--- a/LEGO1/legoworld.cpp
+++ b/LEGO1/legoworld.cpp
@@ -82,7 +82,7 @@ MxResult LegoWorld::SetAsCurrentWorld(MxDSObject& p_dsObject)
 // TEMPLATE: LEGO1 0x1001f070
 // MxListCursor<MxPresenter *>::~MxListCursor<MxPresenter *>
 
-// SYNTHETIC: LEGO1 0x1001f0c0
+// FUNCTION: LEGO1 0x1001f0c0
 // MxPresenterListCursor::~MxPresenterListCursor
 
 // FUNCTION: LEGO1 0x1001f5e0

--- a/LEGO1/legoworldlist.cpp
+++ b/LEGO1/legoworldlist.cpp
@@ -1,0 +1,36 @@
+#include "legoworldlist.h"
+
+#include "legoworld.h"
+
+// FUNCTION: LEGO1 0x100598d0
+MxS8 LegoWorldList::Compare(LegoWorld* p_a, LegoWorld* p_b)
+{
+	return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
+}
+
+// TEMPLATE: LEGO1 0x100598f0
+// MxCollection<LegoWorld *>::Compare
+
+// TEMPLATE: LEGO1 0x10059900
+// MxCollection<LegoWorld *>::~MxCollection<LegoWorld *>
+
+// TEMPLATE: LEGO1 0x10059950
+// MxCollection<LegoWorld *>::Destroy
+
+// TEMPLATE: LEGO1 0x10059960
+// MxList<LegoWorld *>::~MxList<LegoWorld *>
+
+// FUNCTION: LEGO1 0x100599f0
+void LegoWorldList::Destroy(LegoWorld* p_world)
+{
+	delete p_world;
+}
+
+// SYNTHETIC: LEGO1 0x10059ac0
+// MxCollection<LegoWorld *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x10059b30
+// MxList<LegoWorld *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x10059be0
+// MxPtrList<LegoWorld>::`scalar deleting destructor'

--- a/LEGO1/legoworldlist.h
+++ b/LEGO1/legoworldlist.h
@@ -1,0 +1,27 @@
+#ifndef LEGOWORLDLIST_H
+#define LEGOWORLDLIST_H
+
+#include "mxlist.h"
+#include "mxtypes.h"
+
+class LegoWorld;
+
+// VTABLE: LEGO1 0x100d8700
+// class MxCollection<LegoWorld *>
+
+// VTABLE: LEGO1 0x100d8718
+// class MxList<LegoWorld *>
+
+// VTABLE: LEGO1 0x100d8730
+// class MxPtrList<LegoWorld>
+
+// VTABLE: LEGO1 0x100d8680
+// SIZE 0x18
+class LegoWorldList : public MxPtrList<LegoWorld> {
+public:
+	LegoWorldList() : MxPtrList<LegoWorld>(Destroy) {}
+	virtual MxS8 Compare(LegoWorld*, LegoWorld*) override; // vtable+0x14
+	static void Destroy(LegoWorld*);
+};
+
+#endif // LEGOWORLDLIST_H

--- a/LEGO1/mxdsactionlist.h
+++ b/LEGO1/mxdsactionlist.h
@@ -26,6 +26,10 @@ private:
 	undefined m_unk18;
 };
 
+// VTABLE: LEGO1 0x100d7e68
+// class MxListCursor<MxDSAction *>
+
+// VTABLE: LEGO1 0x100d7e50
 class MxDSActionListCursor : public MxListCursor<MxDSAction*> {
 public:
 	MxDSActionListCursor(MxDSActionList* p_list) : MxListCursor<MxDSAction*>(p_list){};

--- a/LEGO1/mxdsactionlist.h
+++ b/LEGO1/mxdsactionlist.h
@@ -26,6 +26,9 @@ private:
 	undefined m_unk18;
 };
 
-typedef MxListCursorChild<MxDSAction*> MxDSActionListCursor;
+class MxDSActionListCursor : public MxListCursor<MxDSAction*> {
+public:
+	MxDSActionListCursor(MxDSActionList* p_list) : MxListCursor<MxDSAction*>(p_list){};
+};
 
 #endif // MXDSACTIONLIST_H

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -12,7 +12,7 @@ DECOMP_SIZE_ASSERT(MxDSMultiAction, 0x9c)
 // SYNTHETIC: LEGO1 0x1004add0
 // MxListCursor<MxDSAction *>::`scalar deleting destructor'
 
-// SYNTHETIC: LEGO1 0x1004ae40
+// FUNCTION: LEGO1 0x1004ae40
 // MxDSActionListCursor::~MxDSActionListCursor
 
 // FUNCTION: LEGO1 0x100c9b90

--- a/LEGO1/mxdsmultiaction.cpp
+++ b/LEGO1/mxdsmultiaction.cpp
@@ -2,6 +2,19 @@
 
 DECOMP_SIZE_ASSERT(MxDSMultiAction, 0x9c)
 
+// TODO: Should be moved later
+// SYNTHETIC: LEGO1 0x1004ad10
+// MxDSActionListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x1004ad80
+// MxListCursor<MxDSAction *>::~MxListCursor<MxDSAction *>
+
+// SYNTHETIC: LEGO1 0x1004add0
+// MxListCursor<MxDSAction *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1004ae40
+// MxDSActionListCursor::~MxDSActionListCursor
+
 // FUNCTION: LEGO1 0x100c9b90
 MxDSMultiAction::MxDSMultiAction()
 {

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -42,7 +42,7 @@ void MxDSSelectAction::CopyFrom(MxDSSelectAction& p_dsSelectAction)
 // SYNTHETIC: LEGO1 0x100cbc90
 // MxListCursor<MxString>::`scalar deleting destructor'
 
-// SYNTHETIC: LEGO1 0x100cbd00
+// FUNCTION: LEGO1 0x100cbd00
 // MxStringListCursor::~MxStringListCursor
 
 // FUNCTION: LEGO1 0x100cbd50

--- a/LEGO1/mxdsselectaction.cpp
+++ b/LEGO1/mxdsselectaction.cpp
@@ -33,6 +33,18 @@ void MxDSSelectAction::CopyFrom(MxDSSelectAction& p_dsSelectAction)
 		this->m_unk0xac->Append(string);
 }
 
+// SYNTHETIC: LEGO1 0x100cbbd0
+// MxStringListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100cbc40
+// MxListCursor<MxString>::~MxListCursor<MxString>
+
+// SYNTHETIC: LEGO1 0x100cbc90
+// MxListCursor<MxString>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100cbd00
+// MxStringListCursor::~MxStringListCursor
+
 // FUNCTION: LEGO1 0x100cbd50
 MxDSSelectAction& MxDSSelectAction::operator=(MxDSSelectAction& p_dsSelectAction)
 {
@@ -130,3 +142,6 @@ void MxDSSelectAction::Deserialize(char** p_source, MxS16 p_unk24)
 
 	*p_source += extraFlag;
 }
+
+// TEMPLATE: LEGO1 0x100cc450
+// MxListEntry<MxString>::GetValue

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -100,18 +100,10 @@ private:
 	MxListEntry<T>* m_match;
 };
 
-// Unclear purpose
 template <class T>
-class MxListCursorChild : public MxListCursor<T> {
+class MxPtrListCursor : public MxListCursor<T*> {
 public:
-	MxListCursorChild(MxList<T>* p_list) : MxListCursor<T>(p_list) {}
-};
-
-// Unclear purpose
-template <class T>
-class MxListCursorChildChild : public MxListCursorChild<T> {
-public:
-	MxListCursorChildChild(MxList<T>* p_list) : MxListCursorChild<T>(p_list) {}
+	MxPtrListCursor(MxPtrList<T>* p_list) : MxListCursor<T*>(p_list){};
 };
 
 template <class T>

--- a/LEGO1/mxmediapresenter.cpp
+++ b/LEGO1/mxmediapresenter.cpp
@@ -31,7 +31,7 @@ void MxMediaPresenter::Destroy()
 // SYNTHETIC: LEGO1 0x100b47a0
 // MxListCursor<MxStreamChunk *>::`scalar deleting destructor'
 
-// SYNTHETIC: LEGO1 0x100b4810
+// FUNCTION: LEGO1 0x100b4810
 // MxStreamChunkListCursor::~MxStreamChunkListCursor
 
 // FUNCTION: LEGO1 0x100b54e0

--- a/LEGO1/mxmediapresenter.cpp
+++ b/LEGO1/mxmediapresenter.cpp
@@ -21,6 +21,19 @@ void MxMediaPresenter::Destroy()
 	Destroy(FALSE);
 }
 
+// TODO: These probably belong in another class
+// SYNTHETIC: LEGO1 0x100b46e0
+// MxStreamChunkListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100b4750
+// MxListCursor<MxStreamChunk *>::~MxListCursor<MxStreamChunk *>
+
+// SYNTHETIC: LEGO1 0x100b47a0
+// MxListCursor<MxStreamChunk *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100b4810
+// MxStreamChunkListCursor::~MxStreamChunkListCursor
+
 // FUNCTION: LEGO1 0x100b54e0
 void MxMediaPresenter::Init()
 {

--- a/LEGO1/mxpresenterlist.h
+++ b/LEGO1/mxpresenterlist.h
@@ -15,7 +15,10 @@ public:
 	virtual MxS8 Compare(MxPresenter*, MxPresenter*) override; // vtable+0x14
 };
 
-typedef MxListCursorChildChild<MxPresenter*> MxPresenterListCursor;
+class MxPresenterListCursor : public MxPtrListCursor<MxPresenter> {
+public:
+	MxPresenterListCursor(MxPresenterList* p_list) : MxPtrListCursor<MxPresenter>(p_list){};
+};
 
 // VTABLE: LEGO1 0x100d6350
 // class MxCollection<MxPresenter *>

--- a/LEGO1/mxpresenterlist.h
+++ b/LEGO1/mxpresenterlist.h
@@ -15,6 +15,13 @@ public:
 	virtual MxS8 Compare(MxPresenter*, MxPresenter*) override; // vtable+0x14
 };
 
+// VTABLE: LEGO1 0x100d6488
+// class MxListCursor<MxPresenter *>
+
+// VTABLE: LEGO1 0x100d6530
+// class MxPtrListCursor<MxPresenter>
+
+// VTABLE: LEGO1 0x100d6470
 class MxPresenterListCursor : public MxPtrListCursor<MxPresenter> {
 public:
 	MxPresenterListCursor(MxPresenterList* p_list) : MxPtrListCursor<MxPresenter>(p_list){};

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -86,6 +86,24 @@ void MxRegion::vtable18(MxRect32& p_rect)
 	m_rect.UpdateBounds(p_rect);
 }
 
+// SYNTHETIC: LEGO1 0x100c3be0
+// MxRegionListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100c3c50
+// MxPtrListCursor<MxRegionTopBottom>::~MxPtrListCursor<MxRegionTopBottom>
+
+// SYNTHETIC: LEGO1 0x100c3ca0
+// MxListCursor<MxRegionTopBottom *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100c3d10
+// MxPtrListCursor<MxRegionTopBottom>::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100c3d80
+// MxListCursor<MxRegionTopBottom *>::~MxListCursor<MxRegionTopBottom *>
+
+// SYNTHETIC: LEGO1 0x100c3dd0
+// MxRegionListCursor::~MxRegionListCursor
+
 // FUNCTION: LEGO1 0x100c3e20
 MxBool MxRegion::vtable1c(MxRect32& p_rect)
 {
@@ -104,6 +122,21 @@ MxBool MxRegion::vtable1c(MxRect32& p_rect)
 
 	return FALSE;
 }
+
+// SYNTHETIC: LEGO1 0x100c4790
+// MxRegionLeftRightListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100c4800
+// MxPtrListCursor<MxRegionLeftRight>::~MxPtrListCursor<MxRegionLeftRight>
+
+// SYNTHETIC: LEGO1 0x100c4850
+// MxListCursor<MxRegionLeftRight *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100c48c0
+// MxPtrListCursor<MxRegionLeftRight>::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100c4930
+// MxListCursor<MxRegionLeftRight *>::~MxListCursor<MxRegionLeftRight *>
 
 // FUNCTION: LEGO1 0x100c4c90
 MxRegionTopBottom::MxRegionTopBottom(MxS32 p_top, MxS32 p_bottom)
@@ -166,6 +199,15 @@ void MxRegionTopBottom::FUN_100c5280(MxS32 p_left, MxS32 p_right)
 		}
 	}
 }
+
+// TEMPLATE: LEGO1 0x100c54f0
+// MxListCursor<MxRegionLeftRight *>::MxListCursor<MxRegionLeftRight *>
+
+// TEMPLATE: LEGO1 0x100c5560
+// MxRegionLeftRightListCursor::~MxRegionLeftRightListCursor
+
+// TEMPLATE: LEGO1 0x100c55b0
+// MxListCursor<MxRegionLeftRight *>::operator=
 
 // FUNCTION: LEGO1 0x100c55d0
 MxRegionTopBottom* MxRegionTopBottom::Clone()

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -101,7 +101,7 @@ void MxRegion::vtable18(MxRect32& p_rect)
 // TEMPLATE: LEGO1 0x100c3d80
 // MxListCursor<MxRegionTopBottom *>::~MxListCursor<MxRegionTopBottom *>
 
-// SYNTHETIC: LEGO1 0x100c3dd0
+// FUNCTION: LEGO1 0x100c3dd0
 // MxRegionListCursor::~MxRegionListCursor
 
 // FUNCTION: LEGO1 0x100c3e20
@@ -203,7 +203,7 @@ void MxRegionTopBottom::FUN_100c5280(MxS32 p_left, MxS32 p_right)
 // TEMPLATE: LEGO1 0x100c54f0
 // MxListCursor<MxRegionLeftRight *>::MxListCursor<MxRegionLeftRight *>
 
-// TEMPLATE: LEGO1 0x100c5560
+// FUNCTION: LEGO1 0x100c5560
 // MxRegionLeftRightListCursor::~MxRegionLeftRightListCursor
 
 // TEMPLATE: LEGO1 0x100c55b0

--- a/LEGO1/mxregionlist.h
+++ b/LEGO1/mxregionlist.h
@@ -29,28 +29,15 @@ public:
 // VTABLE: LEGO1 0x100dcba0
 // class MxListCursor<MxRegionTopBottom *>
 
-// TODO: MxRegionListCursor should probably extend MxPtrListCursor. Doing this has
-// drastically reduced the match percentage for MxRegion::vtable18, so we will replicate
-// the previous cursor hierarchy with this dummy class for now.
-
-template <class T>
-class _ListCursorDummy : public MxListCursor<T> {
-public:
-	_ListCursorDummy(MxList<T>* p_list) : MxListCursor<T>(p_list){};
-};
+// TODO: The initialize list param type should be MxRegionList, but doing that
+// drastically reduced the match percentage for MxRegion::vtable18.
+// It also works with MxPtrList, so we'll do that until we figure this out.
 
 // VTABLE: LEGO1 0x100dcb88
-class MxRegionListCursor : public _ListCursorDummy<MxRegionTopBottom*> {
-public:
-	MxRegionListCursor(MxList<MxRegionTopBottom*>* p_list) : _ListCursorDummy<MxRegionTopBottom*>(p_list){};
-};
-
-/*
 class MxRegionListCursor : public MxPtrListCursor<MxRegionTopBottom> {
 public:
-  MxRegionListCursor(MxRegionList* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list){};
+	MxRegionListCursor(MxPtrList<MxRegionTopBottom>* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list){};
 };
-*/
 
 // VTABLE: LEGO1 0x100dcc40
 // class MxCollection<MxRegionLeftRight *>

--- a/LEGO1/mxregionlist.h
+++ b/LEGO1/mxregionlist.h
@@ -29,11 +29,28 @@ public:
 // VTABLE: LEGO1 0x100dcba0
 // class MxListCursor<MxRegionTopBottom *>
 
+// TODO: MxRegionListCursor should probably extend MxPtrListCursor. Doing this has
+// drastically reduced the match percentage for MxRegion::vtable18, so we will replicate
+// the previous cursor hierarchy with this dummy class for now.
+
+template <class T>
+class _ListCursorDummy : public MxListCursor<T> {
+public:
+	_ListCursorDummy(MxList<T>* p_list) : MxListCursor<T>(p_list){};
+};
+
 // VTABLE: LEGO1 0x100dcb88
+class MxRegionListCursor : public _ListCursorDummy<MxRegionTopBottom*> {
+public:
+	MxRegionListCursor(MxList<MxRegionTopBottom*>* p_list) : _ListCursorDummy<MxRegionTopBottom*>(p_list){};
+};
+
+/*
 class MxRegionListCursor : public MxPtrListCursor<MxRegionTopBottom> {
 public:
-	MxRegionListCursor(MxRegionList* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list){};
+  MxRegionListCursor(MxRegionList* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list){};
 };
+*/
 
 // VTABLE: LEGO1 0x100dcc40
 // class MxCollection<MxRegionLeftRight *>

--- a/LEGO1/mxregionlist.h
+++ b/LEGO1/mxregionlist.h
@@ -23,6 +23,12 @@ public:
 	static void Destroy(MxRegionTopBottom*);
 };
 
+// VTABLE: LEGO1 0x100dcb70
+// class MxPtrListCursor<MxRegionTopBottom>
+
+// VTABLE: LEGO1 0x100dcba0
+// class MxListCursor<MxRegionTopBottom *>
+
 // VTABLE: LEGO1 0x100dcb88
 class MxRegionListCursor : public MxPtrListCursor<MxRegionTopBottom> {
 public:
@@ -45,6 +51,12 @@ public:
 	MxRegionLeftRightList() : MxPtrList<MxRegionLeftRight>(Destroy) {}
 	static void Destroy(MxRegionLeftRight*);
 };
+
+// VTABLE: LEGO1 0x100dcbf8
+// class MxPtrListCursor<MxRegionLeftRight>
+
+// VTABLE: LEGO1 0x100dcc28
+// class MxListCursor<MxRegionLeftRight *>
 
 // VTABLE: LEGO1 0x100dcc10
 class MxRegionLeftRightListCursor : public MxPtrListCursor<MxRegionLeftRight> {

--- a/LEGO1/mxregionlist.h
+++ b/LEGO1/mxregionlist.h
@@ -24,12 +24,10 @@ public:
 };
 
 // VTABLE: LEGO1 0x100dcb88
-// class MxListCursorChildChild<MxRegionTopBottom *>
-typedef MxListCursorChildChild<MxRegionTopBottom*> MxRegionListCursor;
-
-// VTABLE: LEGO1 0x100dcc10
-// class MxListCursorChildChild<MxRegionLeftRight *>
-typedef MxListCursorChildChild<MxRegionLeftRight*> MxRegionLeftRightListCursor;
+class MxRegionListCursor : public MxPtrListCursor<MxRegionTopBottom> {
+public:
+	MxRegionListCursor(MxRegionList* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list){};
+};
 
 // VTABLE: LEGO1 0x100dcc40
 // class MxCollection<MxRegionLeftRight *>
@@ -46,6 +44,12 @@ class MxRegionLeftRightList : public MxPtrList<MxRegionLeftRight> {
 public:
 	MxRegionLeftRightList() : MxPtrList<MxRegionLeftRight>(Destroy) {}
 	static void Destroy(MxRegionLeftRight*);
+};
+
+// VTABLE: LEGO1 0x100dcc10
+class MxRegionLeftRightListCursor : public MxPtrListCursor<MxRegionLeftRight> {
+public:
+	MxRegionLeftRightListCursor(MxRegionLeftRightList* p_list) : MxPtrListCursor<MxRegionLeftRight>(p_list){};
 };
 
 #endif // MXREGIONLIST_H

--- a/LEGO1/mxstreamchunklist.h
+++ b/LEGO1/mxstreamchunklist.h
@@ -23,9 +23,13 @@ public:
 	static void Destroy(MxStreamChunk* p_chunk);
 };
 
+// VTABLE: LEGO1 0x100dc510
 class MxStreamChunkListCursor : public MxListCursor<MxStreamChunk*> {
 public:
 	MxStreamChunkListCursor(MxStreamChunkList* p_list) : MxListCursor<MxStreamChunk*>(p_list){};
 };
+
+// VTABLE: LEGO1 0x100dc528
+// class MxListCursor<MxStreamChunk *>
 
 #endif // MXSTREAMCHUNKLIST_H

--- a/LEGO1/mxstreamchunklist.h
+++ b/LEGO1/mxstreamchunklist.h
@@ -23,6 +23,9 @@ public:
 	static void Destroy(MxStreamChunk* p_chunk);
 };
 
-typedef MxListCursorChild<MxStreamChunk*> MxStreamChunkListCursor;
+class MxStreamChunkListCursor : public MxListCursor<MxStreamChunk*> {
+public:
+	MxStreamChunkListCursor(MxStreamChunkList* p_list) : MxListCursor<MxStreamChunk*>(p_list){};
+};
 
 #endif // MXSTREAMCHUNKLIST_H

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -51,13 +51,13 @@ MxStreamController::MxStreamController()
 // TEMPLATE: LEGO1 0x100c0ee0
 // list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >::_Buynode
 
-// TEMPLATE: LEGO1 0x100c0fc0
+// FUNCTION: LEGO1 0x100c0fc0
 // MxStreamListMxDSSubscriber::~MxStreamListMxDSSubscriber
 
-// TEMPLATE: LEGO1 0x100c1010
+// FUNCTION: LEGO1 0x100c1010
 // MxStreamListMxDSAction::~MxStreamListMxDSAction
 
-// TEMPLATE: LEGO1 0x100c1060
+// FUNCTION: LEGO1 0x100c1060
 // MxStreamListMxNextActionDataStart::~MxStreamListMxNextActionDataStart
 
 // TEMPLATE: LEGO1 0x100c10b0

--- a/LEGO1/mxstringlist.h
+++ b/LEGO1/mxstringlist.h
@@ -14,4 +14,7 @@ public:
 	MxStringListCursor(MxStringList* p_list) : MxListCursor<MxString>(p_list){};
 };
 
+// VTABLE: LEGO1 0x100dd070
+// class MxListCursor<MxString>
+
 #endif // MXSTRINGLIST_H

--- a/LEGO1/mxstringlist.h
+++ b/LEGO1/mxstringlist.h
@@ -9,6 +9,9 @@
 class MxStringList : public MxList<MxString> {};
 
 // VTABLE: LEGO1 0x100dd058
-typedef MxListCursorChild<MxString> MxStringListCursor;
+class MxStringListCursor : public MxListCursor<MxString> {
+public:
+	MxStringListCursor(MxStringList* p_list) : MxListCursor<MxString>(p_list){};
+};
 
 #endif // MXSTRINGLIST_H


### PR DESCRIPTION
Third and final `MxCollection` refactoring, following #290 and #283. I also added a new `MxList` of `LegoWorld` pointers to `LegoOmni`. Template type confirmed by debugger.

For cursors of a specific list type, we had been using a typedef on `MxListChild` or `MxListChildChild` for the specific situation. This PR replaces those with a dedicated class for the `MxList` derivative being used. `MxListChildChild` was used in conjunction with an `MxPtrList` so I replaced those with `MxPtrListCursor` and it lines up to the same number of vtables.

There is a slight added code overhead. Each cursor now needs its own initializer list to pacify the compiler. For example:
```cpp
// VTABLE: LEGO1 0x100d7e50
class MxDSActionListCursor : public MxListCursor<MxDSAction*> {
public:
    MxDSActionListCursor(MxDSActionList* p_list) : MxListCursor<MxDSAction*>(p_list){};
};
```

Fortunately, this lines up perfectly with the 96 source, so I think this is a reasonable solution to our problem.

Accuracy has fluctuated a little due to compiler weirdness, though it looks like a slight improvement overall. The biggest hit is in `MxRegion::vtable18`, but I think this is also compiler weirdness. The problem is that the previous method had all three cursor vtables assigned in a row, but we now call a constructor for `MxListCursor<MxRegionTopBottom *>` and this throws the stack out of alignment. I think this is okay, because the method right under this (`MxRegion::vtable1c`) uses the same cursor but does _not_ call a constructor. Meaning: this change didn't necessarily break anything.

Finally, I added a whole mess of decomp markers for any list cursors we were already using. I didn't always put the `// VTABLE` markers in virtual address order. I don't think we have any control over how the compiler orders these and I thought it helped readability to have the vtables for the superclass chain in a row where possible. Happy to change that after the review.