### PR TITLE
[Bugfix] checkorder python error

### DIFF
--- a/tools/checkorder/checkorder.py
+++ b/tools/checkorder/checkorder.py
@@ -49,7 +49,7 @@ def check_file(filename: str, verbose: bool = False) -> bool:
                         f"{fun.end_line - fun.line_number:4} lines",
                         f"{order_lookup[fun.offset]:3}",
                         "    ",
-                        sig_truncate(fun.signature),
+                        sig_truncate(fun.name),
                     ]
                 )
                 print(msg)


### PR DESCRIPTION
In the refactor of the parser and checkorder tool I somehow missed testing with an out-of-order file. I had changed the property name coming back from the parser and this no longer works. Fixed now.