### PR TITLE
Increased `ISLE` accuracy

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -24,6 +24,10 @@
 
 #include <dsound.h>
 
+// Might be static functions of IsleApp
+BOOL FindExistingInstance(void);
+BOOL StartDirectSound(void);
+
 // FUNCTION: ISLE 0x401000
 IsleApp::IsleApp()
 {
@@ -168,9 +172,6 @@ void IsleApp::SetupVideoFlags(
 		m_videoParam.flags().Set16Bit(1);
 	}
 }
-
-BOOL FindExistingInstance(void);
-BOOL StartDirectSound(void);
 
 // FUNCTION: ISLE 0x401610
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
@@ -421,15 +422,6 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			}
 		}
 		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
-	case WM_SETCURSOR:
-		if (g_isle) {
-			HCURSOR hCursor = g_isle->m_cursorCurrent;
-			if (hCursor == g_isle->m_cursorBusy || hCursor == g_isle->m_cursorNo || !hCursor) {
-				SetCursor(hCursor);
-				return 0;
-			}
-		}
-		break;
 	case WM_KEYDOWN:
 		// While this probably should be (HIWORD(lParam) & KF_REPEAT), this seems
 		// to be what the assembly is actually doing
@@ -457,6 +449,13 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	case 0x5400:
 		if (g_isle) {
 			g_isle->SetupCursor(wParam);
+			return 0;
+		}
+		break;
+	case WM_SETCURSOR:
+		if (g_isle && (g_isle->m_cursorCurrent == g_isle->m_cursorBusy ||
+					   g_isle->m_cursorCurrent == g_isle->m_cursorNo || !g_isle->m_cursorCurrent)) {
+			SetCursor(g_isle->m_cursorCurrent);
 			return 0;
 		}
 		break;
@@ -815,10 +814,8 @@ inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
 			}
 			this->m_gameStarted = 1;
 		}
-		return;
 	}
-
-	if (sleepIfNotNextFrame != 0)
+	else if (sleepIfNotNextFrame != 0)
 		Sleep(0);
 }
 

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -389,31 +389,34 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		}
 		return DefWindowProcA(hWnd, uMsg, wParam, lParam);
 	case WM_DISPLAYCHANGE:
-		if (g_isle && VideoManager() && g_isle->m_fullScreen && VideoManager()->GetDirect3D() &&
-			VideoManager()->GetDirect3D()->GetDeviceModeFinder()) {
-			int targetWidth = LOWORD(lParam);
-			int targetHeight = HIWORD(lParam);
-			int targetDepth = wParam;
+		if (g_isle && VideoManager() && g_isle->m_fullScreen && VideoManager()->GetDirect3D()) {
+			if (VideoManager()->GetDirect3D()->GetDeviceModeFinder()) {
+				int targetDepth = wParam;
+				int targetWidth = LOWORD(lParam);
+				int targetHeight = HIWORD(lParam);
 
-			if (g_waitingForTargetDepth) {
-				g_waitingForTargetDepth = 0;
-				g_targetDepth = targetDepth;
-			}
-			else {
-				BOOL valid = FALSE;
-				if (targetWidth == g_targetWidth && targetHeight == g_targetHeight && g_targetDepth == targetDepth) {
-					valid = TRUE;
+				if (g_waitingForTargetDepth) {
+					g_waitingForTargetDepth = 0;
+					g_targetDepth = targetDepth;
 				}
+				else {
+					BOOL valid = FALSE;
 
-				if (g_rmDisabled) {
-					if (valid) {
-						g_reqEnableRMDevice = 1;
+					if (g_targetWidth == targetWidth && g_targetHeight == targetHeight &&
+						g_targetDepth == targetDepth) {
+						valid = TRUE;
 					}
-				}
-				else if (!valid) {
-					g_rmDisabled = 1;
-					Lego()->StartTimer();
-					VideoManager()->DisableRMDevice();
+
+					if (g_rmDisabled) {
+						if (valid) {
+							g_reqEnableRMDevice = 1;
+						}
+					}
+					else if (!valid) {
+						g_rmDisabled = 1;
+						Lego()->StartTimer();
+						VideoManager()->DisableRMDevice();
+					}
 				}
 			}
 		}
@@ -433,8 +436,8 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		if (lParam & (KF_REPEAT << 16)) {
 			return DefWindowProcA(hWnd, uMsg, wParam, lParam);
 		}
-		keyCode = wParam;
 		type = c_notificationKeyPress;
+		keyCode = wParam;
 		break;
 	case WM_MOUSEMOVE:
 		g_mousemoved = 1;


### PR DESCRIPTION
`WndProc` has been the only function we have never seen a 100% match on, which led me to believe there must still be an inaccuracy left to be fixed (unrelated to compiler randomness).

Turned out that was correct, and with the changes in this PR and certain constellations (compiler randomness), `WndProc` is now able to match to 100%:

![image](https://github.com/isledecomp/isle/assets/1135351/ecde99e5-2641-4f3d-b461-4e2ea070a3de)

