### PR TITLE
Use relocation table with reccmp

### DIFF
--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -372,7 +372,7 @@ BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
 
 		m_bIgnoreWM_SIZE = TRUE;
 		dwStyle = GetWindowLong(m_hWndMain, GWL_STYLE);
-		dwStyle &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED);
+		dwStyle &= ~WS_POPUP;
 		dwStyle |= WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED;
 		SetWindowLong(m_hWndMain, GWL_STYLE, dwStyle);
 

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -87,7 +87,7 @@ def sanitize(file, placeholder_generator, mnemonic, op_str):
         for i, word in enumerate(words):
             try:
                 inttest = int(word, 16)
-                if inttest >= file.get_section_offset_by_index(1):
+                if file.is_relocated_addr(inttest):
                     words[i] = placeholder_generator.get(inttest)
             except ValueError:
                 pass


### PR DESCRIPTION
Extends the `Bin` component of the `isledecomp` library to read in the relocation table from the binary. This gives us the list of every virtual address that would be relocated upon loading the module. That is, broadly speaking, the location of every item of interest in the `.text`, `.rdata`, and `.data` sections.

This needs some filtering to become really useful. The list includes all of the `funcinfo` sections, along with the addresses in each for all the Unwind functions used in C++ exception handling. (More info here: http://www.openrce.org/articles/full_view/21) So there's some noise in the results for `.text` if you're just looking for the start of functions. `funcinfo` sections are easy to identify by the magic number `0x19930520` and I wonder whether a tool to examine those would be of any help to us.

The obvious use case for right now is with `reccmp`. We are already substituting immediate values that we think are addresses with the string `<OFFSETX>`, but we can be more certain that this is correct to do by checking the list of relocated addresses. (Strictly speaking, we should be using the relocation table directly to check whether the given instruction _contains_ a relocation, but this is clunkier to implement.)

That change already exposed one problem in `MxDirectDraw::DDSetMode` that I've fixed here. Accuracy went up slightly for a handful of functions, but down for `LegoUnkSaveDataWriter::WriteSaveData3`. I think that's because register swapping is no longer possible. The asm we have looks fine to me.