### PR TITLE
Decomp linter warning for offset reuse

### DIFF
--- a/LEGO1/isle.cpp
+++ b/LEGO1/isle.cpp
@@ -176,7 +176,7 @@ void Isle::VTable0x68(MxBool p_add)
 	// TODO
 }
 
-// STUB: LEGO1 0x10031820
+// STUB: LEGO1 0x100327a0
 MxLong Isle::HandleTransitionEnd()
 {
 	return 0;

--- a/LEGO1/legogamestate.cpp
+++ b/LEGO1/legogamestate.cpp
@@ -43,7 +43,6 @@ ColorStringStruct g_colorSaveData[43] = {
 
 // NOTE: This offset = the end of the variables table, the last entry
 // in that table is a special entry, the string "END_OF_VARIABLES"
-// GLOBAL: LEGO1 0x100f3e50
 extern const char* g_endOfVariables;
 
 // FUNCTION: LEGO1 0x10039550

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -112,8 +112,8 @@ const char* g_current = "current";
 // GLOBAL: LEGO1 0x101020e8
 void (*g_omniUserMessage)(const char*, int);
 
-// GLOBAL: LEGO1 0x100f4c54
-MxBool g_isWorldActive;
+// GLOBAL: LEGO1 0x100f4c58
+MxBool g_isWorldActive = TRUE;
 
 // FUNCTION: LEGO1 0x10015700
 LegoOmni* Lego()

--- a/LEGO1/legoworld.cpp
+++ b/LEGO1/legoworld.cpp
@@ -122,7 +122,7 @@ void LegoWorld::FUN_10073400()
 {
 }
 
-// STUB: LEGO1 0x10073400
+// STUB: LEGO1 0x10073430
 void LegoWorld::FUN_10073430()
 {
 }

--- a/LEGO1/motorcycle.h
+++ b/LEGO1/motorcycle.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10035840
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10035840
+		// GLOBAL: LEGO1 0x100f38e8
 		return "Motorcycle";
 	}
 

--- a/LEGO1/mxdsbuffer.h
+++ b/LEGO1/mxdsbuffer.h
@@ -27,7 +27,7 @@ public:
 	// FUNCTION: LEGO1 0x100c6500
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0568
+		// GLOBAL: LEGO1 0x101025b8
 		return "MxDSBuffer";
 	}
 

--- a/LEGO1/mxdsselectaction.h
+++ b/LEGO1/mxdsselectaction.h
@@ -49,7 +49,4 @@ private:
 // FUNCTION: LEGO1 0x100cbd00
 // MxStringListCursor::~MxStringListCursor
 
-// TEMPLATE: LEGO1 0x100cc450
-// MxListEntry<MxString>::GetValue
-
 #endif // MXDSSELECTACTION_H

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100b9430
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10102130
+		// GLOBAL: LEGO1 0x10102118
 		return "MxRAMStreamController";
 	}
 

--- a/LEGO1/score.h
+++ b/LEGO1/score.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x100010c0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0058
+		// GLOBAL: LEGO1 0x100f0050
 		return "Score";
 	}
 


### PR DESCRIPTION
The `decomplinter` tool will now alert to offsets being reused in a module when scanning the code base. You can call the `reset()` method with argument `True` to "fully" reset the linter's state.

I fixed the handful of files that had this new problem. Most were `// GLOBAL` markers pointing at the wrong string.