### PR TITLE
Implement/match rest of MxSmkPresenter

### DIFF
--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -65,6 +65,7 @@ public:
 		return m_bmiHeader->biHeight > 0 ? m_bmiHeader->biHeight : -m_bmiHeader->biHeight;
 	}
 	inline MxU8* GetBitmapData() const { return m_data; }
+	inline MxBITMAPINFO* GetBitmapInfo() const { return m_info; }
 
 private:
 	MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);

--- a/LEGO1/mxpoint32.h
+++ b/LEGO1/mxpoint32.h
@@ -12,6 +12,13 @@ public:
 		this->m_y = p_y;
 	}
 
+	inline MxS32 GetX() const { return m_x; }
+	inline MxS32 GetY() const { return m_y; }
+
+	inline void SetX(MxS32 p_x) { m_x = p_x; }
+	inline void SetY(MxS32 p_y) { m_y = p_y; }
+
+private:
 	MxS32 m_x;
 	MxS32 m_y;
 };

--- a/LEGO1/mxpoint32.h
+++ b/LEGO1/mxpoint32.h
@@ -12,6 +12,12 @@ public:
 		this->m_y = p_y;
 	}
 
+	MxPoint32(const MxPoint32& p_point)
+	{
+		this->m_x = p_point.m_x;
+		this->m_y = p_point.m_y;
+	}
+
 	inline MxS32 GetX() const { return m_x; }
 	inline MxS32 GetY() const { return m_y; }
 

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -69,8 +69,6 @@ public:
 
 	inline MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
 	inline MxPoint32 GetLocation() const { return this->m_location; }
-	inline MxS32 GetLocationX() const { return this->m_location.m_x; }
-	inline MxS32 GetLocationY() const { return this->m_location.m_y; }
 	inline MxS32 GetDisplayZ() const { return this->m_displayZ; }
 	inline MxDSAction* GetAction() const { return this->m_action; }
 

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -40,14 +40,6 @@ public:
 		return *this;
 	}
 
-	inline void CopyFrom(const MxRect32& p_rect)
-	{
-		this->m_left = p_rect.m_left;
-		this->m_top = p_rect.m_top;
-		this->m_right = p_rect.m_right;
-		this->m_bottom = p_rect.m_bottom;
-	}
-
 	inline void Intersect(const MxRect32& p_rect)
 	{
 		m_left = Max(p_rect.m_left, m_left);
@@ -107,6 +99,14 @@ public:
 	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
 private:
+	inline void CopyFrom(const MxRect32& p_rect)
+	{
+		this->m_left = p_rect.m_left;
+		this->m_top = p_rect.m_top;
+		this->m_right = p_rect.m_right;
+		this->m_bottom = p_rect.m_bottom;
+	}
+
 	inline static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; };
 	inline static MxS32 Max(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_b : p_a; };
 

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -32,13 +32,20 @@ public:
 		m_bottom = Min(p_a.m_bottom, p_b.m_bottom);
 	}
 
+	MxRect32(const MxRect32& p_rect) { CopyFrom(p_rect); }
+
 	MxRect32& MxRect32::operator=(const MxRect32& p_rect)
 	{
-		this->m_left = p_rect.m_left;
-		this->m_top = p_rect.m_top;
-		this->m_right = p_rect.m_right;
-		this->m_bottom = p_rect.m_bottom;
+		CopyFrom(p_rect);
 		return *this;
+	}
+
+	inline void Intersect(const MxRect32& p_rect)
+	{
+		m_left = Max(p_rect.m_left, m_left);
+		m_top = Max(p_rect.m_top, m_top);
+		m_right = Min(p_rect.m_right, m_right);
+		m_bottom = Min(p_rect.m_bottom, m_bottom);
 	}
 
 	inline void SetPoint(const MxPoint32& p_point)
@@ -61,12 +68,6 @@ public:
 		this->m_bottom = p_size.GetHeight();
 	}
 
-	inline MxBool IsValid() { return m_left < m_right && m_top < m_bottom; }
-	inline MxBool IntersectsWith(const MxRect32& p_rect)
-	{
-		return m_left < p_rect.m_right && p_rect.m_left < m_right && m_top < p_rect.m_bottom && p_rect.m_top < m_bottom;
-	}
-
 	inline void UpdateBounds(const MxRect32& p_rect)
 	{
 		m_left = Min(m_left, p_rect.m_left);
@@ -75,16 +76,22 @@ public:
 		m_bottom = Max(m_bottom, p_rect.m_bottom);
 	}
 
-	inline MxS32 GetWidth() { return (m_right - m_left) + 1; }
-	inline MxS32 GetHeight() { return (m_bottom - m_top) + 1; }
+	inline MxBool IsValid() const { return m_left < m_right && m_top < m_bottom; }
+	inline MxBool IntersectsWith(const MxRect32& p_rect) const
+	{
+		return m_left < p_rect.m_right && p_rect.m_left < m_right && m_top < p_rect.m_bottom && p_rect.m_top < m_bottom;
+	}
 
-	inline MxPoint32 GetPoint() { return MxPoint32(this->m_left, this->m_top); }
-	inline MxSize32 GetSize() { return MxSize32(this->m_right, this->m_bottom); }
+	inline MxS32 GetWidth() const { return (m_right - m_left) + 1; }
+	inline MxS32 GetHeight() const { return (m_bottom - m_top) + 1; }
 
-	inline MxS32 GetLeft() { return m_left; }
-	inline MxS32 GetTop() { return m_top; }
-	inline MxS32 GetRight() { return m_right; }
-	inline MxS32 GetBottom() { return m_bottom; }
+	inline MxPoint32 GetPoint() const { return MxPoint32(this->m_left, this->m_top); }
+	inline MxSize32 GetSize() const { return MxSize32(this->m_right, this->m_bottom); }
+
+	inline MxS32 GetLeft() const { return m_left; }
+	inline MxS32 GetTop() const { return m_top; }
+	inline MxS32 GetRight() const { return m_right; }
+	inline MxS32 GetBottom() const { return m_bottom; }
 
 	inline void SetLeft(MxS32 p_left) { m_left = p_left; }
 	inline void SetTop(MxS32 p_top) { m_top = p_top; }
@@ -92,6 +99,14 @@ public:
 	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
 private:
+	inline void CopyFrom(const MxRect32& p_rect)
+	{
+		this->m_left = p_rect.m_left;
+		this->m_top = p_rect.m_top;
+		this->m_right = p_rect.m_right;
+		this->m_bottom = p_rect.m_bottom;
+	}
+
 	inline static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; };
 	inline static MxS32 Max(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_b : p_a; };
 

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -18,10 +18,10 @@ public:
 
 	MxRect32(const MxPoint32& p_point, const MxSize32& p_size)
 	{
-		this->m_left = p_point.m_x;
-		this->m_top = p_point.m_y;
-		this->m_right = p_size.m_width;
-		this->m_bottom = p_size.m_height;
+		this->m_left = p_point.GetX();
+		this->m_top = p_point.GetY();
+		this->m_right = p_size.GetWidth();
+		this->m_bottom = p_size.GetHeight();
 	}
 
 	MxRect32(const MxRect32& p_a, const MxRect32& p_b)
@@ -32,16 +32,33 @@ public:
 		m_bottom = Min(p_a.m_bottom, p_b.m_bottom);
 	}
 
+	MxRect32& MxRect32::operator=(const MxRect32& p_rect)
+	{
+		this->m_left = p_rect.m_left;
+		this->m_top = p_rect.m_top;
+		this->m_right = p_rect.m_right;
+		this->m_bottom = p_rect.m_bottom;
+		return *this;
+	}
+
 	inline void SetPoint(const MxPoint32& p_point)
 	{
-		this->m_left = p_point.m_x;
-		this->m_top = p_point.m_y;
+		this->m_left = p_point.GetX();
+		this->m_top = p_point.GetY();
+	}
+
+	inline void AddPoint(const MxPoint32& p_point)
+	{
+		this->m_left += p_point.GetX();
+		this->m_top += p_point.GetY();
+		this->m_right += p_point.GetX();
+		this->m_bottom += p_point.GetY();
 	}
 
 	inline void SetSize(const MxSize32& p_size)
 	{
-		this->m_right = p_size.m_width;
-		this->m_bottom = p_size.m_height;
+		this->m_right = p_size.GetWidth();
+		this->m_bottom = p_size.GetHeight();
 	}
 
 	inline MxBool IsValid() { return m_left < m_right && m_top < m_bottom; }

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -34,7 +34,7 @@ public:
 
 	MxRect32(const MxRect32& p_rect) { CopyFrom(p_rect); }
 
-	MxRect32& MxRect32::operator=(const MxRect32& p_rect)
+	MxRect32& operator=(const MxRect32& p_rect)
 	{
 		CopyFrom(p_rect);
 		return *this;

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -40,6 +40,14 @@ public:
 		return *this;
 	}
 
+	inline void CopyFrom(const MxRect32& p_rect)
+	{
+		this->m_left = p_rect.m_left;
+		this->m_top = p_rect.m_top;
+		this->m_right = p_rect.m_right;
+		this->m_bottom = p_rect.m_bottom;
+	}
+
 	inline void Intersect(const MxRect32& p_rect)
 	{
 		m_left = Max(p_rect.m_left, m_left);
@@ -99,14 +107,6 @@ public:
 	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
 private:
-	inline void CopyFrom(const MxRect32& p_rect)
-	{
-		this->m_left = p_rect.m_left;
-		this->m_top = p_rect.m_top;
-		this->m_right = p_rect.m_right;
-		this->m_bottom = p_rect.m_bottom;
-	}
-
 	inline static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; };
 	inline static MxS32 Max(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_b : p_a; };
 

--- a/LEGO1/mxrectlist.h
+++ b/LEGO1/mxrectlist.h
@@ -1,5 +1,5 @@
-#ifndef MxRectList_H
-#define MxRectList_H
+#ifndef MXRECTLIST_H
+#define MXRECTLIST_H
 
 #include "mxlist.h"
 #include "mxrect32.h"
@@ -83,4 +83,4 @@ public:
 // TEMPLATE: LEGO1 0x100b4210
 // MxRectListCursor::~MxRectListCursor
 
-#endif // MxRectList_H
+#endif // MXRECTLIST_H

--- a/LEGO1/mxrectlist.h
+++ b/LEGO1/mxrectlist.h
@@ -1,0 +1,86 @@
+#ifndef MxRectList_H
+#define MxRectList_H
+
+#include "mxlist.h"
+#include "mxrect32.h"
+
+// VTABLE: LEGO1 0x100dc3f0
+// SIZE 0x18
+class MxRectList : public MxPtrList<MxRect32> {
+public:
+	MxRectList(MxBool p_ownership = FALSE) : MxPtrList<MxRect32>(p_ownership) {}
+};
+
+// VTABLE: LEGO1 0x100dc438
+// class MxListCursor<MxRect32 *>
+
+// VTABLE: LEGO1 0x100dc408
+// class MxPtrListCursor<MxRect32>
+
+// VTABLE: LEGO1 0x100dc420
+class MxRectListCursor : public MxPtrListCursor<MxRect32> {
+public:
+	MxRectListCursor(MxRectList* p_list) : MxPtrListCursor<MxRect32>(p_list){};
+};
+
+// VTABLE: LEGO1 0x100dc3d8
+// class MxPtrList<MxRect32>
+
+// VTABLE: LEGO1 0x100dc450
+// class MxList<MxRect32 *>
+
+// VTABLE: LEGO1 0x100dc468
+// class MxCollection<MxRect32 *>
+
+// TEMPLATE: LEGO1 0x100b3c00
+// MxCollection<MxRect32 *>::Compare
+
+// TEMPLATE: LEGO1 0x100b3c10
+// MxCollection<MxRect32 *>::MxCollection<MxRect32 *>
+
+// TEMPLATE: LEGO1 0x100b3c80
+// MxCollection<MxRect32 *>::~MxCollection<MxRect32 *>
+
+// TEMPLATE: LEGO1 0x100b3cd0
+// MxCollection<MxRect32 *>::Destroy
+
+// TEMPLATE: LEGO1 0x100b3ce0
+// MxList<MxRect32 *>::~MxList<MxRect32 *>
+
+// TEMPLATE: LEGO1 0x100b3d70
+// MxPtrList<MxRect32>::Destroy
+
+// SYNTHETIC: LEGO1 0x100b3d80
+// MxRectList::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100b3e40
+// MxCollection<MxRect32 *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100b3eb0
+// MxList<MxRect32 *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100b3f60
+// MxPtrList<MxRect32>::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100b3fd0
+// MxRectList::~MxRectList
+
+// SYNTHETIC: LEGO1 0x100b4020
+// MxRectListCursor::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100b4090
+// MxPtrListCursor<MxRect32 *>::~MxPtrListCursor<MxRect32 *>
+
+// SYNTHETIC: LEGO1 0x100b40e0
+// MxListCursor<MxRect32 *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x100b4150
+// MxPtrListCursor<MxRect32 *>::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x100b41c0
+// MxListCursor<MxRect32 *>::~MxListCursor<MxRect32 *>
+
+// TEMPLATE: LEGO1 0x100b4210
+// MxRectListCursor::~MxRectListCursor
+
+#endif // MxRectList_H

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -10,8 +10,7 @@ DECOMP_SIZE_ASSERT(MxRegionLeftRight, 0x08);
 MxRegion::MxRegion()
 {
 	m_list = new MxRegionList;
-	m_rect.SetPoint(MxPoint32(INT_MAX, INT_MAX));
-	m_rect.SetSize(MxSize32(-1, -1));
+	m_rect = MxRect32(INT_MAX, INT_MAX, -1, -1);
 }
 
 // FUNCTION: LEGO1 0x100c3660
@@ -31,8 +30,7 @@ MxRegion::~MxRegion()
 void MxRegion::Reset()
 {
 	m_list->DeleteAll();
-	m_rect.SetPoint(MxPoint32(INT_MAX, INT_MAX));
-	m_rect.SetSize(MxSize32(-1, -1));
+	m_rect = MxRect32(INT_MAX, INT_MAX, -1, -1);
 }
 
 // FUNCTION: LEGO1 0x100c3750

--- a/LEGO1/mxregion.cpp
+++ b/LEGO1/mxregion.cpp
@@ -36,7 +36,8 @@ void MxRegion::Reset()
 // FUNCTION: LEGO1 0x100c3750
 void MxRegion::VTable0x18(MxRect32& p_rect)
 {
-	MxRect32 rect(p_rect.GetPoint(), MxSize32(p_rect.GetRight(), p_rect.GetBottom()));
+	MxRect32 rect(p_rect);
+	MxRect32 newRect;
 	MxRegionListCursor cursor(m_list);
 	MxRegionTopBottom* topBottom;
 
@@ -48,7 +49,7 @@ void MxRegion::VTable0x18(MxRect32& p_rect)
 		}
 		else if (rect.GetTop() < topBottom->GetBottom()) {
 			if (rect.GetTop() < topBottom->GetTop()) {
-				MxRect32 newRect(rect);
+				newRect = rect;
 				newRect.SetBottom(topBottom->GetTop());
 				MxRegionTopBottom* newTopBottom = new MxRegionTopBottom(newRect);
 				cursor.Prepend(newTopBottom);

--- a/LEGO1/mxsize32.h
+++ b/LEGO1/mxsize32.h
@@ -12,6 +12,10 @@ public:
 		this->m_height = p_height;
 	}
 
+	inline MxS32 GetWidth() const { return m_width; }
+	inline MxS32 GetHeight() const { return m_height; }
+
+private:
 	MxS32 m_width;
 	MxS32 m_height;
 };

--- a/LEGO1/mxsmack.cpp
+++ b/LEGO1/mxsmack.cpp
@@ -139,3 +139,16 @@ void MxSmack::Destroy(MxSmack* p_mxSmack)
 	if (p_mxSmack->m_unk0x6b4)
 		delete[] p_mxSmack->m_unk0x6b4;
 }
+
+// STUB: LEGO1 0x100c5db0
+void MxSmack::FUN_100c5db0(
+	MxBITMAPINFO* p_bitmapInfo,
+	MxU8* p_bitmapData,
+	MxSmack* p_mxSmack,
+	MxU8* p_chunkData,
+	MxBool p_und,
+	MxRectList* p_list
+)
+{
+	// TODO
+}

--- a/LEGO1/mxsmack.h
+++ b/LEGO1/mxsmack.h
@@ -2,6 +2,8 @@
 #define MXSMACK_H
 
 #include "decomp.h"
+#include "mxbitmap.h"
+#include "mxrectlist.h"
 #include "mxtypes.h"
 
 #include <smack.h>
@@ -40,6 +42,14 @@ struct MxSmack {
 
 	static MxResult LoadHeaderAndTrees(MxU8* p_data, MxSmack* p_mxSmack);
 	static void Destroy(MxSmack* p_mxSmack);
+	static void FUN_100c5db0(
+		MxBITMAPINFO* p_bitmapInfo,
+		MxU8* p_bitmapData,
+		MxSmack* p_mxSmack,
+		MxU8* p_chunkData,
+		MxBool p_und,
+		MxRectList* p_list
+	);
 };
 
 #endif // MXSMACK_H

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -80,10 +80,8 @@ void MxSmkPresenter::LoadFrame(MxStreamChunk* p_chunk)
 	MxRect32* rect;
 
 	while (cursor.Next(rect)) {
-		// This should probably be using the assignment operator,
-		// but it's currently reducing the match significantly.
-		invalidateRect.CopyFrom(*rect);
-		invalidateRect.AddPoint(m_location);
+		invalidateRect = *rect;
+		invalidateRect.AddPoint(GetLocation());
 		MVideoManager()->InvalidateRect(invalidateRect);
 	}
 }

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -80,7 +80,9 @@ void MxSmkPresenter::LoadFrame(MxStreamChunk* p_chunk)
 	MxRect32* rect;
 
 	while (cursor.Next(rect)) {
-		invalidateRect = *rect;
+		// This should probably be using the assignment operator,
+		// but it's currently reducing the match significantly.
+		invalidateRect.CopyFrom(*rect);
 		invalidateRect.AddPoint(m_location);
 		MVideoManager()->InvalidateRect(invalidateRect);
 	}

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -1,6 +1,7 @@
 #include "mxsmkpresenter.h"
 
 #include "decomp.h"
+#include "mxdsmediaaction.h"
 #include "mxvideomanager.h"
 
 DECOMP_SIZE_ASSERT(MxSmkPresenter, 0x720);
@@ -57,10 +58,32 @@ void MxSmkPresenter::CreateBitmap()
 	m_bitmap->SetSize(m_mxSmack.m_smackTag.Width, m_mxSmack.m_smackTag.Height, NULL, FALSE);
 }
 
-// STUB: LEGO1 0x100b3a00
+// FUNCTION: LEGO1 0x100b3a00
 void MxSmkPresenter::LoadFrame(MxStreamChunk* p_chunk)
 {
-	// TODO
+	MxBITMAPINFO* bitmapInfo = m_bitmap->GetBitmapInfo();
+	MxU8* bitmapData = m_bitmap->GetBitmapData();
+	MxU8* chunkData = p_chunk->GetData();
+
+	MxBool und = m_mxSmack.m_frameTypes[m_unk0x71c] & 1;
+	m_unk0x71c++;
+	VTable0x88();
+
+	MxRectList list(TRUE);
+	MxSmack::FUN_100c5db0(bitmapInfo, bitmapData, &m_mxSmack, chunkData, und, &list);
+
+	if (((MxDSMediaAction*) m_action)->GetPaletteManagement() && und)
+		RealizePalette();
+
+	MxRect32 invalidateRect;
+	MxRectListCursor cursor(&list);
+	MxRect32* rect;
+
+	while (cursor.Next(rect)) {
+		invalidateRect = *rect;
+		invalidateRect.AddPoint(m_location);
+		MVideoManager()->InvalidateRect(invalidateRect);
+	}
 }
 
 // FUNCTION: LEGO1 0x100b4260

--- a/LEGO1/mxstillpresenter.cpp
+++ b/LEGO1/mxstillpresenter.cpp
@@ -73,8 +73,8 @@ void MxStillPresenter::LoadFrame(MxStreamChunk* p_chunk)
 
 	MxS32 height = GetHeight() - 1;
 	MxS32 width = GetWidth() - 1;
-	MxS32 x = m_location.m_x;
-	MxS32 y = m_location.m_y;
+	MxS32 x = m_location.GetX();
+	MxS32 y = m_location.GetY();
 
 	MxRect32 rect(x, y, width + x, height + y);
 	MVideoManager()->InvalidateRect(rect);
@@ -148,17 +148,17 @@ void MxStillPresenter::RepeatingTickle()
 // FUNCTION: LEGO1 0x100ba040
 void MxStillPresenter::VTable0x88(MxS32 p_x, MxS32 p_y)
 {
-	MxS32 x = m_location.m_x;
-	MxS32 y = m_location.m_y;
-	m_location.m_x = p_x;
-	m_location.m_y = p_y;
+	MxS32 x = m_location.GetX();
+	MxS32 y = m_location.GetY();
+	m_location.SetX(p_x);
+	m_location.SetY(p_y);
 
 	if (IsEnabled()) {
 		MxS32 height = GetHeight() - 1;
 		MxS32 width = GetWidth() - 1;
 
 		MxRect32 rectA(x, y, width + x, height + y);
-		MxRect32 rectB(m_location.m_x, m_location.m_y, width + m_location.m_x, height + m_location.m_y);
+		MxRect32 rectB(m_location.GetX(), m_location.GetY(), width + m_location.GetX(), height + m_location.GetY());
 
 		MVideoManager()->InvalidateRect(rectA);
 		MVideoManager()->VTable0x34(rectA.GetLeft(), rectA.GetTop(), rectA.GetWidth(), rectA.GetHeight());
@@ -176,8 +176,8 @@ void MxStillPresenter::Enable(MxBool p_enable)
 	if (MVideoManager() && (m_alpha || m_bitmap)) {
 		MxS32 height = GetHeight();
 		MxS32 width = GetWidth();
-		MxS32 x = m_location.m_x;
-		MxS32 y = m_location.m_y;
+		MxS32 x = m_location.GetX();
+		MxS32 y = m_location.GetY();
 
 		MxRect32 rect(x, y, width + x, height + y);
 		MVideoManager()->InvalidateRect(rect);

--- a/LEGO1/mxtransitionmanager.cpp
+++ b/LEGO1/mxtransitionmanager.cpp
@@ -541,8 +541,8 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 						  (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
 		MxU32 bytesPerPixel = p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-		m_copyRect.left = m_waitIndicator->GetLocationX();
-		m_copyRect.top = m_waitIndicator->GetLocationY();
+		m_copyRect.left = m_waitIndicator->GetLocation().GetX();
+		m_copyRect.top = m_waitIndicator->GetLocation().GetY();
 
 		MxS32 height = m_waitIndicator->GetHeight();
 		MxS32 width = m_waitIndicator->GetWidth();
@@ -577,8 +577,8 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 			m_waitIndicator->GetBitmap(),
 			0,
 			0,
-			m_waitIndicator->GetLocationX(),
-			m_waitIndicator->GetLocationY(),
+			m_waitIndicator->GetLocation().GetX(),
+			m_waitIndicator->GetLocation().GetY(),
 			m_waitIndicator->GetWidth(),
 			m_waitIndicator->GetHeight(),
 			und
@@ -591,8 +591,8 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 			m_waitIndicator->GetBitmap(),
 			0,
 			0,
-			m_waitIndicator->GetLocationX(),
-			m_waitIndicator->GetLocationY(),
+			m_waitIndicator->GetLocation().GetX(),
+			m_waitIndicator->GetLocation().GetY(),
 			m_waitIndicator->GetWidth(),
 			m_waitIndicator->GetHeight()
 		);

--- a/LEGO1/mxvideomanager.cpp
+++ b/LEGO1/mxvideomanager.cpp
@@ -75,7 +75,9 @@ void MxVideoManager::Destroy(MxBool p_fromDestructor)
 void MxVideoManager::UpdateRegion()
 {
 	if (m_region->VTable0x20() == FALSE) {
-		MxRect32 rect(m_region->GetRect(), m_videoParam.GetRect());
+		MxRect32 rect(m_region->GetRect());
+		rect.Intersect(m_videoParam.GetRect());
+
 		m_displaySurface
 			->Display(rect.GetLeft(), rect.GetTop(), rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight());
 	}

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -217,8 +217,8 @@ void MxVideoPresenter::Destroy(MxBool p_fromDestructor)
 		MxS32 height = GetHeight();
 		MxS32 width = GetWidth();
 
-		MxS32 x = GetLocationX();
-		MxS32 y = GetLocationY();
+		MxS32 x = m_location.GetX();
+		MxS32 y = m_location.GetY();
 		MxRect32 rect(x, y, x + width, y + height);
 
 		MVideoManager()->InvalidateRect(rect);
@@ -259,12 +259,12 @@ MxBool MxVideoPresenter::IsHit(MxS32 p_x, MxS32 p_y)
 		return FALSE;
 
 	if (!m_bitmap)
-		return m_alpha->IsHit(p_x - GetLocationX(), p_y - GetLocationY());
+		return m_alpha->IsHit(p_x - m_location.GetX(), p_y - m_location.GetY());
 
 	MxLong heightAbs = m_bitmap->GetBmiHeightAbs();
 
-	MxLong minX = GetLocationX();
-	MxLong minY = GetLocationY();
+	MxLong minX = m_location.GetX();
+	MxLong minY = m_location.GetY();
 
 	MxLong maxY = minY + heightAbs;
 	MxLong maxX = minX + m_bitmap->GetBmiWidth();
@@ -285,13 +285,13 @@ MxBool MxVideoPresenter::IsHit(MxS32 p_x, MxS32 p_y)
 	// the MxPresenter location x and y coordinates.
 	if (biCompression == BI_RGB) {
 		if (biCompression == BI_RGB_TOPDOWN || height < 0) {
-			seekRow = p_y - GetLocationY();
+			seekRow = p_y - m_location.GetY();
 		}
 		else {
 			height = height > 0 ? height : -height;
-			seekRow = height - p_y - 1 + GetLocationY();
+			seekRow = height - p_y - 1 + m_location.GetY();
 		}
-		pixel = m_bitmap->GetBmiStride() * seekRow + m_bitmap->GetBitmapData() - GetLocationX() + p_x;
+		pixel = m_bitmap->GetBmiStride() * seekRow + m_bitmap->GetBitmapData() - m_location.GetX() + p_x;
 	}
 	else if (biCompression == BI_RGB_TOPDOWN) {
 		pixel = m_bitmap->GetBitmapData();
@@ -466,8 +466,8 @@ void MxVideoPresenter::EndAction()
 		if (m_bitmap) {
 			MxLong height = m_bitmap->GetBmiHeightAbs();
 			MxLong width = m_bitmap->GetBmiWidth();
-			MxS32 x = m_location.m_x;
-			MxS32 y = m_location.m_y;
+			MxS32 x = m_location.GetX();
+			MxS32 y = m_location.GetY();
 
 			MxRect32 rect(x, y, x + width, y + height);
 


### PR DESCRIPTION
This PR implements `MxSmkPresenter::LoadFrame`, which requires a new list containing `MxRect32`. This is the first function I ran into that creates a `MxList`-based list on the stack; it took quite a while to get everything matching since there are a lot of inline functions again. It's at 100% now.

`LoadFrame` was the last function of that class without implementation. The heavy lifting of the Smack frame decoding happens in `MxSmack::FUN_100c5db0` though, which still needs some work.

I've also managed to match `MxRegion::VTable0x18` to almost 100% (some compiler randomness left). The key here was a missing copy constructor and assignment function in `MxRect32`.