### PR TITLE
Implement/match MxSmack::LoadFrame

### DIFF
--- a/LEGO1/mxsmack.h
+++ b/LEGO1/mxsmack.h
@@ -25,6 +25,9 @@ extern "C"
 		u32 p_typeSize
 	);
 
+	// (SMACK.LIB) FUNCTION: LEGO1 0x100cda83
+	void SmackDoFrameToBuffer(u8* p_source, u8* p_huffmanTables, u8* p_unk0x6b4);
+
 	// (SMACK.LIB) FUNCTION: LEGO1 0x100d052c
 	u32 SmackGetSizeDeltas(u32 p_width, u32 p_height);
 }
@@ -40,16 +43,17 @@ struct MxSmack {
 	MxU32 m_maxFrameSize;      // 0x6b0
 	MxU8* m_unk0x6b4;          // 0x6b4
 
-	static MxResult LoadHeaderAndTrees(MxU8* p_data, MxSmack* p_mxSmack);
+	static MxResult LoadHeader(MxU8* p_data, MxSmack* p_mxSmack);
 	static void Destroy(MxSmack* p_mxSmack);
-	static void FUN_100c5db0(
+	static MxResult LoadFrame(
 		MxBITMAPINFO* p_bitmapInfo,
 		MxU8* p_bitmapData,
 		MxSmack* p_mxSmack,
 		MxU8* p_chunkData,
-		MxBool p_und,
+		MxBool p_paletteChanged,
 		MxRectList* p_list
 	);
+	static MxBool FUN_100c6050(MxU8* p_unk0x6b4, MxS16* p_und1, MxU32* p_und2, MxRect32* p_rect);
 };
 
 #endif // MXSMACK_H

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -45,7 +45,7 @@ void MxSmkPresenter::Destroy(MxBool p_fromDestructor)
 // FUNCTION: LEGO1 0x100b3940
 void MxSmkPresenter::LoadHeader(MxStreamChunk* p_chunk)
 {
-	MxSmack::LoadHeaderAndTrees(p_chunk->GetData(), &m_mxSmack);
+	MxSmack::LoadHeader(p_chunk->GetData(), &m_mxSmack);
 }
 
 // FUNCTION: LEGO1 0x100b3960
@@ -65,14 +65,14 @@ void MxSmkPresenter::LoadFrame(MxStreamChunk* p_chunk)
 	MxU8* bitmapData = m_bitmap->GetBitmapData();
 	MxU8* chunkData = p_chunk->GetData();
 
-	MxBool und = m_mxSmack.m_frameTypes[m_unk0x71c] & 1;
+	MxBool paletteChanged = m_mxSmack.m_frameTypes[m_unk0x71c] & 1;
 	m_unk0x71c++;
 	VTable0x88();
 
 	MxRectList list(TRUE);
-	MxSmack::FUN_100c5db0(bitmapInfo, bitmapData, &m_mxSmack, chunkData, und, &list);
+	MxSmack::LoadFrame(bitmapInfo, bitmapData, &m_mxSmack, chunkData, paletteChanged, &list);
 
-	if (((MxDSMediaAction*) m_action)->GetPaletteManagement() && und)
+	if (((MxDSMediaAction*) m_action)->GetPaletteManagement() && paletteChanged)
 		RealizePalette();
 
 	MxRect32 invalidateRect;
@@ -98,7 +98,7 @@ void MxSmkPresenter::VTable0x88()
 		if (m_mxSmack.m_smackTag.Frames == m_unk0x71c) {
 			m_unk0x71c = 0;
 			// TODO: struct incorrect, Palette at wrong offset?
-			memset(m_mxSmack.m_smackTag.Palette, 0, sizeof(m_mxSmack.m_smackTag.Palette));
+			memset(&m_mxSmack.m_smackTag.Palette[4], 0, sizeof(m_mxSmack.m_smackTag.Palette));
 		}
 	}
 }


### PR DESCRIPTION
`MxSmack::LoadFrame` loads a frame. If there is a palette chunk - which means the palette has changed - it will be processed before the actual frame will be decoded by the Smacker SDK using the function `SmackDoFrameToBuffer`. Match is at 100%.

What remains unclear is the offset of the palette, which seems to be off by 4 byte for us. Maybe the version of the Smacker SDK we have is the problem here and the structure (past the header) has been different at the time; that would probably be the most likely scenario.