### PR TITLE
Refactor WinePathConverter into PathResolver

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,36 @@
+name: Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+  pytest-win:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install python libraries
+      shell: bash
+      run: |
+        pip install pytest -r tools/requirements.txt
+
+    - name: Run python unit tests (Windows)
+      shell: bash
+      run: |
+        pytest tools/isledecomp
+
+  pytest-ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install python libraries
+      shell: bash
+      run: |
+        pip install pytest -r tools/requirements.txt
+
+    - name: Run python unit tests (Ubuntu)
+      shell: bash
+      run: |
+        pytest tools/isledecomp

--- a/tools/isledecomp/tests/test_parser_statechange.py
+++ b/tools/isledecomp/tests/test_parser_statechange.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import pytest
 from isledecomp.parser.parser import (
     ReaderState as _rs,
@@ -70,7 +71,7 @@ state_change_marker_cases = [
     "state, marker_type, new_state, expected_error", state_change_marker_cases
 )
 def test_state_change_by_marker(
-    state: _rs, marker_type: str, new_state: _rs, expected_error: None | _pe
+    state: _rs, marker_type: str, new_state: _rs, expected_error: Optional[_pe]
 ):
     p = DecompParser()
     p.state = state

--- a/tools/isledecomp/tests/test_path_resolver_nt.py
+++ b/tools/isledecomp/tests/test_path_resolver_nt.py
@@ -1,0 +1,32 @@
+from os import name as os_name
+import pytest
+from isledecomp.dir import PathResolver
+
+
+if os_name != "nt":
+    pytest.skip(reason="Skip Windows-only tests", allow_module_level=True)
+
+
+@pytest.fixture(name="resolver")
+def fixture_resolver_win():
+    yield PathResolver("C:\\isle")
+
+
+def test_identity(resolver):
+    assert resolver.resolve_cvdump("C:\\isle\\test.h") == "C:\\isle\\test.h"
+
+
+def test_outside_basedir(resolver):
+    assert resolver.resolve_cvdump("C:\\lego\\test.h") == "C:\\lego\\test.h"
+
+
+def test_relative(resolver):
+    assert resolver.resolve_cvdump(".\\test.h") == "C:\\isle\\test.h"
+    assert resolver.resolve_cvdump("..\\test.h") == "C:\\test.h"
+
+
+def test_intermediate_relative(resolver):
+    """These paths may not register as `relative` paths, but we want to
+    produce a single absolute path for each."""
+    assert resolver.resolve_cvdump("C:\\isle\\test\\..\\test.h") == "C:\\isle\\test.h"
+    assert resolver.resolve_cvdump(".\\subdir\\..\\test.h") == "C:\\isle\\test.h"

--- a/tools/isledecomp/tests/test_path_resolver_posix.py
+++ b/tools/isledecomp/tests/test_path_resolver_posix.py
@@ -1,0 +1,69 @@
+from os import name as os_name
+from unittest.mock import patch
+import pytest
+from isledecomp.dir import PathResolver
+
+
+if os_name == "nt":
+    pytest.skip(reason="Skip Posix-only tests", allow_module_level=True)
+
+
+@pytest.fixture(name="resolver")
+def fixture_resolver_posix():
+    # Skip the call to winepath by using a patch, although this is not strictly necessary.
+    with patch("isledecomp.dir.winepath_unix_to_win", return_value="Z:\\usr\\isle"):
+        yield PathResolver("/usr/isle")
+
+
+@patch("isledecomp.dir.winepath_win_to_unix")
+def test_identity(winepath_mock, resolver):
+    """Test with an absolute Wine path where a path swap is possible."""
+    # In this and upcoming tests, patch is_file so we always assume there is
+    # a file at the given unix path. We want to test the conversion logic only.
+    with patch("pathlib.Path.is_file", return_value=True):
+        assert resolver.resolve_cvdump("Z:\\usr\\isle\\test.h") == "/usr/isle/test.h"
+    winepath_mock.assert_not_called()
+
+    # Without the patch, this should call the winepath_mock, but we have
+    # memoized the value from the previous run.
+    assert resolver.resolve_cvdump("Z:\\usr\\isle\\test.h") == "/usr/isle/test.h"
+    winepath_mock.assert_not_called()
+
+
+@patch("isledecomp.dir.winepath_win_to_unix")
+def test_file_does_not_exist(winepath_mock, resolver):
+    """These test files (probably) don't exist, so we always assume
+    the path swap failed and defer to winepath."""
+    resolver.resolve_cvdump("Z:\\usr\\isle\\test.h")
+    winepath_mock.assert_called_once_with("Z:\\usr\\isle\\test.h")
+
+
+@patch("isledecomp.dir.winepath_win_to_unix")
+def test_outside_basedir(winepath_mock, resolver):
+    """Test an absolute path where we cannot do a path swap."""
+    with patch("pathlib.Path.is_file", return_value=True):
+        resolver.resolve_cvdump("Z:\\lego\\test.h")
+    winepath_mock.assert_called_once_with("Z:\\lego\\test.h")
+
+
+@patch("isledecomp.dir.winepath_win_to_unix")
+def test_relative(winepath_mock, resolver):
+    """Test relative paths inside and outside of the base dir."""
+    with patch("pathlib.Path.is_file", return_value=True):
+        assert resolver.resolve_cvdump("./test.h") == "/usr/isle/test.h"
+
+        # This works because we will resolve "/usr/isle/test/../test.h"
+        assert resolver.resolve_cvdump("../test.h") == "/usr/test.h"
+    winepath_mock.assert_not_called()
+
+
+@patch("isledecomp.dir.winepath_win_to_unix")
+def test_intermediate_relative(winepath_mock, resolver):
+    """We can resolve intermediate backdirs if they are relative to the basedir."""
+    with patch("pathlib.Path.is_file", return_value=True):
+        assert (
+            resolver.resolve_cvdump("Z:\\usr\\isle\\test\\..\\test.h")
+            == "/usr/isle/test.h"
+        )
+        assert resolver.resolve_cvdump(".\\subdir\\..\\test.h") == "/usr/isle/test.h"
+    winepath_mock.assert_not_called()

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -16,7 +16,6 @@ from isledecomp import (
     print_diff,
     SymInfo,
     walk_source_dir,
-    WinePathConverter,
 )
 
 from capstone import Cs, CS_ARCH_X86, CS_MODE_32
@@ -295,13 +294,8 @@ def main():
 
     svg = args.svg
 
-    wine_path_converter = None
-    if os.name != "nt":
-        wine_path_converter = WinePathConverter(source)
     with Bin(original, logger) as origfile, Bin(recomp, logger) as recompfile:
-        syminfo = SymInfo(
-            syms, recompfile, logger, sym_wine_path_converter=wine_path_converter
-        )
+        syminfo = SymInfo(syms, recompfile, logger, source)
 
         print()
 


### PR DESCRIPTION
The `WinePathConverter` class was used as:
1. a wrapper around calls to `winepath`, for converting to and from Wine paths
2. for converting Windows-like paths in the `cvdump` output to match Unix paths returned by `os.walk`

This refactor to `PathResolver` doesn't add much in the way of features, but I think the added separation of concerns and documentation is useful. I'm working on adding more checks and comparisons to our palette with `cvdump` and the `SymInfo` module that drives it, and the fact that there was not a unified API across platforms for this path conversion was a sticking point.

If we are not on Windows, the goal in this and the previous module is actually to _avoid_ calling `winepath` whenever possible. This call is expensive, although this is mitigated a lot by having the `wineserver` daemon running in the background.

The other problem I aim to solve here is dealing with the wonky paths produced by MSVC. For example, my PDB has references to these two paths:

`C:\isle\LEGO1\viewmanager/../realtime/vector.h`
`C:\isle\LEGO1\realtime/vector.h`

They are the same file, but the way `SymInfo` groups the line numbers from `cvdump` together will cause us to miss lines for one of the paths. (And so we actually gain one new function for `reccmp` with this change.) I suspect this would become more of a problem later on as we move some of the code files out of the root LEGO1 directory and into subdirectories. (Probably matching the way the 96 source did it.)