### PR TITLE
Implement/match rest of MxDSSubscriber

### DIFF
--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -33,7 +33,7 @@ public:
 	inline MxU32 GetId() { return m_id; }
 
 private:
-	MxU32 m_id;
+	MxU32 m_id; // 0x04
 };
 
 #endif // MXCORE_H

--- a/LEGO1/mxdssubscriber.cpp
+++ b/LEGO1/mxdssubscriber.cpp
@@ -19,7 +19,7 @@ MxDSSubscriber::~MxDSSubscriber()
 	if (m_controller)
 		m_controller->FUN_100c1620(this);
 
-	FUN_100b8030();
+	DeleteChunks();
 
 	if (m_unk0x20)
 		delete m_unk0x20;
@@ -52,28 +52,74 @@ MxResult MxDSSubscriber::Create(MxStreamController* p_controller, MxU32 p_object
 	return SUCCESS;
 }
 
-// STUB: LEGO1 0x100b8030
-void MxDSSubscriber::FUN_100b8030()
+// FUNCTION: LEGO1 0x100b8030
+void MxDSSubscriber::DeleteChunks()
 {
-	// TODO
+	if (m_controller) {
+		MxStreamChunk* chunk = NULL;
+
+		while (m_unk0x20->First(chunk)) {
+			m_unk0x20->Detach();
+			delete chunk;
+		}
+
+		while (m_unk0x3c->First(chunk)) {
+			m_unk0x3c->Detach();
+			delete chunk;
+		}
+	}
 }
 
-// STUB: LEGO1 0x100b8250
+// FUNCTION: LEGO1 0x100b8150
+MxResult MxDSSubscriber::AddChunk(MxStreamChunk* p_chunk, MxBool p_append)
+{
+	if (m_unk0x20) {
+		if (p_append)
+			m_unk0x08.Append(p_chunk);
+		else
+			m_unk0x08.Prepend(p_chunk);
+	}
+
+	return SUCCESS;
+}
+
+// FUNCTION: LEGO1 0x100b8250
 MxStreamChunk* MxDSSubscriber::FUN_100b8250()
 {
-	// TODO
-	return NULL;
+	MxStreamChunk* chunk = NULL;
+
+	if (m_unk0x20)
+		m_unk0x20->First(chunk);
+
+	if (chunk) {
+		m_unk0x20->Detach();
+		m_unk0x24.Append(chunk);
+	}
+
+	return chunk;
 }
 
-// STUB: LEGO1 0x100b8360
+// FUNCTION: LEGO1 0x100b8360
 MxStreamChunk* MxDSSubscriber::FUN_100b8360()
 {
-	// TODO
-	return NULL;
+	MxStreamChunk* chunk = NULL;
+
+	if (m_unk0x20)
+		m_unk0x20->First(chunk);
+
+	return chunk;
 }
 
-// STUB: LEGO1 0x100b8390
-void MxDSSubscriber::FUN_100b8390(MxStreamChunk*)
+// FUNCTION: LEGO1 0x100b8390
+void MxDSSubscriber::FUN_100b8390(MxStreamChunk* p_chunk)
 {
-	// TODO
+	if (p_chunk) {
+		if (m_unk0x3c->Find(p_chunk)) {
+			m_unk0x3c->Detach();
+			if (p_chunk)
+				delete p_chunk;
+		}
+		else if ((p_chunk->GetFlags() & MxStreamChunk::Flag_Bit1) != 0 && p_chunk)
+			delete p_chunk;
+	}
 }

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -30,10 +30,11 @@ public:
 	}
 
 	MxResult Create(MxStreamController* p_controller, MxU32 p_objectId, MxS16 p_unk0x48);
-	void FUN_100b8030();
+	void DeleteChunks();
+	MxResult AddChunk(MxStreamChunk* p_chunk, MxBool p_append);
 	MxStreamChunk* FUN_100b8250();
 	MxStreamChunk* FUN_100b8360();
-	void FUN_100b8390(MxStreamChunk*);
+	void FUN_100b8390(MxStreamChunk* p_chunk);
 
 private:
 	MxStreamChunkList m_unk0x08;        // 0x08

--- a/LEGO1/mxlist.h
+++ b/LEGO1/mxlist.h
@@ -54,6 +54,7 @@ public:
 	virtual ~MxList() override;
 
 	void Append(T p_obj) { InsertEntry(p_obj, this->m_last, NULL); };
+	void Prepend(T p_obj) { InsertEntry(p_obj, NULL, this->m_first); };
 	void DeleteAll(MxBool p_destroy = TRUE);
 	MxU32 GetCount() { return this->m_count; }
 
@@ -195,8 +196,10 @@ inline MxBool MxListCursor<T>::Find(T p_obj)
 template <class T>
 inline void MxListCursor<T>::Detach()
 {
-	m_list->DeleteEntry(m_match);
-	m_match = NULL;
+	if (m_match) {
+		m_list->DeleteEntry(m_match);
+		m_match = NULL;
+	}
 }
 
 template <class T>
@@ -204,7 +207,8 @@ inline void MxListCursor<T>::Destroy()
 {
 	if (m_match) {
 		m_list->m_customDestructor(m_match->GetValue());
-		Detach();
+		m_list->DeleteEntry(m_match);
+		m_match = NULL;
 	}
 }
 

--- a/LEGO1/mxramstreamcontroller.cpp
+++ b/LEGO1/mxramstreamcontroller.cpp
@@ -86,11 +86,14 @@ MxResult MxRAMStreamController::DeserializeObject(MxDSStreamingAction& p_action)
 	MxAutoLocker locker(&m_criticalSection);
 	MxResult result;
 	MxDSStreamingAction* value = NULL;
+
 	do {
 		m_buffer.FUN_100c6f80(p_action.GetUnknown94());
+		// Probably not MxResult, see below
 		result = m_buffer.FUN_100c67b0(this, &p_action, &value);
 	} while (m_unk0x3c.Find(&p_action, FALSE) != NULL);
-	return result;
+
+	return result == SUCCESS ? SUCCESS : FAILURE;
 }
 
 // STUB: LEGO1 0x100d0d80

--- a/LEGO1/mxramstreamcontroller.cpp
+++ b/LEGO1/mxramstreamcontroller.cpp
@@ -40,8 +40,9 @@ MxResult MxRAMStreamController::Open(const char* p_filename)
 MxResult MxRAMStreamController::VTable0x20(MxDSAction* p_action)
 {
 	MxAutoLocker locker(&m_criticalSection);
-	MxS16 unk0x24 = 0;
+	MxS32 unk0x24 = 0;
 	MxResult result = FAILURE;
+
 	if (p_action->GetUnknown24() == -1) {
 		p_action->SetUnknown24(-3);
 		MxDSAction* action = m_unk0x54.Find(p_action, FALSE);


### PR DESCRIPTION
Implements the remaining functions of `MxDSSubscriber`, all 100% matches.

```
+  MxDSSubscriber::DeleteChunks (0x100b8030) is 100.00%* similar to the original
+  MxDSSubscriber::AddChunk (0x100b8150) is 100.00% similar to the original
+  MxDSSubscriber::FUN_100b8250 (0x100b8250) is 100.00%* similar to the original
+  MxDSSubscriber::FUN_100b8360 (0x100b8360) is 100.00% similar to the original
+  MxDSSubscriber::FUN_100b8390 (0x100b8390) is 100.00%* similar to the original
```