### PR TITLE
Implement MxStreamController::~MxStreamController

### DIFF
--- a/LEGO1/mxdiskstreamprovider.cpp
+++ b/LEGO1/mxdiskstreamprovider.cpp
@@ -72,7 +72,7 @@ done:
 }
 
 // STUB: LEGO1 0x100d15e0
-void MxDiskStreamProvider::VTable0x20(undefined4)
+void MxDiskStreamProvider::VTable0x20(MxDSAction* p_action)
 {
 	// TODO
 }

--- a/LEGO1/mxdiskstreamprovider.h
+++ b/LEGO1/mxdiskstreamprovider.h
@@ -50,7 +50,7 @@ public:
 	virtual MxResult SetResourceToGet(MxStreamController* p_resource) override; // vtable+0x14
 	virtual MxU32 GetFileSize() override;                                       // vtable+0x18
 	virtual MxS32 GetStreamBuffersNum() override;                               // vtable+0x1c
-	virtual void VTable0x20(undefined4) override;                               // vtable+0x20
+	virtual void VTable0x20(MxDSAction* p_action) override;                     // vtable+0x20
 	virtual MxU32 GetLengthInDWords() override;                                 // vtable+0x24
 	virtual MxU32* GetBufferForDWords() override;                               // vtable+0x28
 

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -31,14 +31,37 @@ MxDSStreamingAction* MxStreamController::VTable0x28()
 MxStreamController::MxStreamController()
 {
 	m_provider = NULL;
-	m_unk0x2c = 0; // TODO: probably also NULL
+	m_unk0x2c = NULL;
 	m_action0x60 = NULL;
 }
 
-// STUB: LEGO1 0x100c1290
+// FUNCTION: LEGO1 0x100c1290
 MxStreamController::~MxStreamController()
 {
-	// TODO
+	MxAutoLocker lock(&m_criticalSection);
+
+	MxDSSubscriber* subscriber;
+	while (m_subscriberList.PopFront(subscriber))
+		delete subscriber;
+
+	MxDSAction* action;
+	while (m_unk0x3c.PopFront(action))
+		delete action;
+
+	if (m_provider) {
+		MxStreamProvider* provider = m_provider;
+		m_provider = NULL;
+		provider->VTable0x20(&MxDSAction());
+		delete provider;
+	}
+
+	if (m_unk0x2c) {
+		delete m_unk0x2c;
+		m_unk0x2c = NULL;
+	}
+
+	while (m_unk0x54.PopFront(action))
+		delete action;
 }
 
 // FUNCTION: LEGO1 0x100c1520

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -59,7 +59,7 @@ protected:
 	MxCriticalSection m_criticalSection;                // 0x8
 	MxAtomId m_atom;                                    // 0x24
 	MxStreamProvider* m_provider;                       // 0x28
-	undefined4 m_unk0x2c;                               // 0x2c
+	undefined4* m_unk0x2c;                              // 0x2c
 	MxStreamListMxDSSubscriber m_subscriberList;        // 0x30
 	MxStreamListMxDSAction m_unk0x3c;                   // 0x3c
 	MxStreamListMxNextActionDataStart m_nextActionList; // 0x48

--- a/LEGO1/mxstreamlist.h
+++ b/LEGO1/mxstreamlist.h
@@ -7,24 +7,23 @@
 #include "mxstl/stlcompat.h"
 
 template <class T>
-class MxStreamList : public list<T> {};
+class MxStreamList : public list<T> {
+public:
+	MxBool PopFront(T& p_obj)
+	{
+		if (empty())
+			return FALSE;
+
+		p_obj = front();
+		pop_front();
+		return TRUE;
+	}
+};
 
 // SIZE 0xc
 class MxStreamListMxDSAction : public MxStreamList<MxDSAction*> {
 public:
 	MxDSAction* Find(MxDSAction* p_action, MxBool p_delete);
-
-	// Could move this to MxStreamList
-	MxBool PopFront(MxDSAction*& p_obj)
-	{
-		if (!empty()) {
-			p_obj = front();
-			pop_front();
-			return TRUE;
-		}
-
-		return FALSE;
-	}
 };
 
 // SIZE 0xc

--- a/LEGO1/mxstreamprovider.cpp
+++ b/LEGO1/mxstreamprovider.cpp
@@ -12,6 +12,6 @@ MxResult MxStreamProvider::SetResourceToGet(MxStreamController* p_resource)
 }
 
 // FUNCTION: LEGO1 0x100d07d0
-void MxStreamProvider::VTable0x20(undefined4)
+void MxStreamProvider::VTable0x20(MxDSAction* p_action)
 {
 }

--- a/LEGO1/mxstreamprovider.h
+++ b/LEGO1/mxstreamprovider.h
@@ -6,6 +6,7 @@
 #include "mxdsfile.h"
 
 class MxStreamController;
+class MxDSAction;
 
 // VTABLE: LEGO1 0x100dd100
 // SIZE 0x10
@@ -28,7 +29,7 @@ public:
 	virtual MxResult SetResourceToGet(MxStreamController* p_resource); // vtable+0x14
 	virtual MxU32 GetFileSize() = 0;                                   // vtable+0x18
 	virtual MxS32 GetStreamBuffersNum() = 0;                           // vtable+0x1c
-	virtual void VTable0x20(undefined4);                               // vtable+0x20
+	virtual void VTable0x20(MxDSAction* p_action);                     // vtable+0x20
 	virtual MxU32 GetLengthInDWords() = 0;                             // vtable+0x24
 	virtual MxU32* GetBufferForDWords() = 0;                           // vtable+0x28
 


### PR DESCRIPTION
Adds the destructor of `MxStreamController`, which mainly clears the lists and destroys its elements. Unfortunately the match isn't great (currently at ~60%), which seems to be mainly due to the inlining not coming out as desired. I've tried various things but this is the best I could come up with. Functionally it should be correct.