### PR TITLE
Implement MxStreamController::FUN_100c1a00

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -784,11 +784,11 @@ inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
 		LegoOmni::GetInstance()->CreateBackgroundAudio();
 		BackgroundAudioManager()->Enable(this->m_useMusic);
 
-		MxStreamController* stream = Streamer()->Open("\\lego\\scripts\\isle\\isle", 0);
+		MxStreamController* stream = Streamer()->Open("\\lego\\scripts\\isle\\isle", MxStreamer::e_DiskStream);
 		MxDSAction ds;
 
 		if (!stream) {
-			stream = Streamer()->Open("\\lego\\scripts\\nocd", 0);
+			stream = Streamer()->Open("\\lego\\scripts\\nocd", MxStreamer::e_DiskStream);
 			if (!stream) {
 				return;
 			}

--- a/LEGO1/mxdsstreamingaction.h
+++ b/LEGO1/mxdsstreamingaction.h
@@ -41,14 +41,14 @@ public:
 	inline void SetBufferOffset(MxU32 p_bufferOffset) { m_bufferOffset = p_bufferOffset; }
 
 private:
-	MxU32 m_unk0x94;
-	MxU32 m_bufferOffset;
-	MxS32 m_unk0x9c;
-	MxDSBuffer* m_unk0xa0;
-	MxDSBuffer* m_unk0xa4;
-	MxLong m_unk0xa8;
-	undefined2 m_unk0xac;
-	MxDSAction* m_internalAction;
+	MxU32 m_unk0x94;              // 0x94
+	MxU32 m_bufferOffset;         // 0x98
+	MxS32 m_unk0x9c;              // 0x9c
+	MxDSBuffer* m_unk0xa0;        // 0xa0
+	MxDSBuffer* m_unk0xa4;        // 0xa4
+	MxLong m_unk0xa8;             // 0xa8
+	undefined2 m_unk0xac;         // 0xac
+	MxDSAction* m_internalAction; // 0xb0
 };
 
 #endif // MXDSSTREAMINGACTION_H

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -36,6 +36,9 @@ public:
 	MxStreamChunk* FUN_100b8360();
 	void FUN_100b8390(MxStreamChunk* p_chunk);
 
+	inline MxU32 GetObjectId() { return m_objectId; }
+	inline MxS16 GetUnknown48() { return m_unk0x48; }
+
 private:
 	MxStreamChunkList m_unk0x08;        // 0x08
 	MxStreamChunkListCursor* m_unk0x20; // 0x20

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -46,7 +46,7 @@ public:
 	void FUN_100c15d0(MxDSSubscriber* p_subscriber);
 	void FUN_100c1620(MxDSSubscriber* p_subscriber);
 	MxResult FUN_100c1800(MxDSAction* p_action, MxU32 p_val);
-	MxResult FUN_100c1a00(MxDSAction* p_action, MxU32 p_bufferval);
+	MxResult FUN_100c1a00(MxDSAction* p_action, MxU32 p_offset);
 	MxPresenter* FUN_100c1e70(MxDSAction& p_action);
 	MxResult FUN_100c1f00(MxDSAction* p_action);
 	MxBool FUN_100c20d0(MxDSObject& p_obj);


### PR DESCRIPTION
This implements `FUN_100c1a00` in `MxStreamController`. Unfortunately the match isn't great with currently ~45%, which seems to be mainly due to incorrect inlining. I've tried various things like refactoring the loops into a template function but to no avail. Functionally it should be accurate.