### PR TITLE
Improve handling of variables for decomp parser

### DIFF
--- a/ISLE/define.h
+++ b/ISLE/define.h
@@ -8,9 +8,9 @@ class IsleApp;
 
 extern IsleApp* g_isle;
 extern int g_closed;
-// GLOBAL: ISLE 0x4101c4
+// STRING: ISLE 0x4101c4
 #define WNDCLASS_NAME "Lego Island MainNoM App"
-// GLOBAL: ISLE 0x4101dc
+// STRING: ISLE 0x4101dc
 #define WINDOW_TITLE "LEGO\xAE"
 extern unsigned char g_mousedown;
 extern unsigned char g_mousemoved;

--- a/LEGO1/act1state.h
+++ b/LEGO1/act1state.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x100338a0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0154
+		// STRING: LEGO1 0x100f0154
 		return "Act1State";
 	};
 

--- a/LEGO1/act2brick.h
+++ b/LEGO1/act2brick.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x1007a360
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0438
+		// STRING: LEGO1 0x100f0438
 		return "Act2Brick";
 	}
 

--- a/LEGO1/act2policestation.h
+++ b/LEGO1/act2policestation.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1000e200
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03fc
+		// STRING: LEGO1 0x100f03fc
 		return "Act2PoliceStation";
 	}
 

--- a/LEGO1/act3.h
+++ b/LEGO1/act3.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10072510
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f013c
+		// STRING: LEGO1 0x100f013c
 		return "Act3";
 	}
 

--- a/LEGO1/act3actor.h
+++ b/LEGO1/act3actor.h
@@ -8,7 +8,7 @@ public:
 	// FUNCTION: LEGO1 0x100431b0
 	inline virtual const char* ClassName() override
 	{
-		// GLOBAL: LEGO1 0x100f03ac
+		// STRING: LEGO1 0x100f03ac
 		return "Act3Actor";
 	}
 };

--- a/LEGO1/act3shark.h
+++ b/LEGO1/act3shark.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x100430c0
 	inline virtual const char* ClassName() const override
 	{
-		// GLOBAL: LEGO1 0x100f03a0
+		// STRING: LEGO1 0x100f03a0
 		return "Act3Shark";
 	}
 };

--- a/LEGO1/act3state.h
+++ b/LEGO1/act3state.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1000e300
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03f0
+		// STRING: LEGO1 0x100f03f0
 		return "Act3State";
 	}
 

--- a/LEGO1/ambulance.h
+++ b/LEGO1/ambulance.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x10035fa0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03c4
+		// STRING: LEGO1 0x100f03c4
 		return "Ambulance";
 	}
 

--- a/LEGO1/ambulancemissionstate.h
+++ b/LEGO1/ambulancemissionstate.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x10037600
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f00e8
+		// STRING: LEGO1 0x100f00e8
 		return "AmbulanceMissionState";
 	}
 

--- a/LEGO1/animstate.h
+++ b/LEGO1/animstate.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10065070
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0460
+		// STRING: LEGO1 0x100f0460
 		return "AnimState";
 	}
 

--- a/LEGO1/beachhouseentity.h
+++ b/LEGO1/beachhouseentity.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1000ee80
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0314
+		// STRING: LEGO1 0x100f0314
 		return "BeachHouseEntity";
 	}
 

--- a/LEGO1/bike.h
+++ b/LEGO1/bike.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x100766f0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03d0
+		// STRING: LEGO1 0x100f03d0
 		return "Bike";
 	}
 

--- a/LEGO1/buildingentity.h
+++ b/LEGO1/buildingentity.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10014f20
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f07e8
+		// STRING: LEGO1 0x100f07e8
 		return "BuildingEntity";
 	}
 

--- a/LEGO1/bumpbouy.h
+++ b/LEGO1/bumpbouy.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x100274e0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0394
+		// STRING: LEGO1 0x100f0394
 		return "BumpBouy";
 	}
 

--- a/LEGO1/carrace.h
+++ b/LEGO1/carrace.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10016b20
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0528
+		// STRING: LEGO1 0x100f0528
 		return "CarRace";
 	}
 

--- a/LEGO1/carracestate.h
+++ b/LEGO1/carracestate.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000dd30
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f009c
+		// STRING: LEGO1 0x100f009c
 		return "CarRaceState";
 	}
 

--- a/LEGO1/doors.h
+++ b/LEGO1/doors.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000e430
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03e8
+		// STRING: LEGO1 0x100f03e8
 		return "Doors";
 	}
 

--- a/LEGO1/dunebuggy.h
+++ b/LEGO1/dunebuggy.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10067c30
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0410
+		// STRING: LEGO1 0x100f0410
 		return "DuneBuggy";
 	}
 

--- a/LEGO1/elevatorbottom.h
+++ b/LEGO1/elevatorbottom.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10017f20
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f04ac
+		// STRING: LEGO1 0x100f04ac
 		return "ElevatorBottom";
 	}
 

--- a/LEGO1/gasstation.h
+++ b/LEGO1/gasstation.h
@@ -17,7 +17,7 @@ public:
 	// FUNCTION: LEGO1 0x10004780
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0168
+		// STRING: LEGO1 0x100f0168
 		return "GasStation";
 	}
 

--- a/LEGO1/gasstationentity.h
+++ b/LEGO1/gasstationentity.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000eb20
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0348
+		// STRING: LEGO1 0x100f0348
 		return "GasStationEntity";
 	}
 

--- a/LEGO1/gasstationstate.h
+++ b/LEGO1/gasstationstate.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x100061d0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0174
+		// STRING: LEGO1 0x100f0174
 		return "GasStationState";
 	}
 

--- a/LEGO1/helicopter.h
+++ b/LEGO1/helicopter.h
@@ -27,7 +27,7 @@ public:
 	// FUNCTION: LEGO1 0x10003070
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0130
+		// STRING: LEGO1 0x100f0130
 		return "Helicopter";
 	}
 

--- a/LEGO1/helicopterstate.h
+++ b/LEGO1/helicopterstate.h
@@ -11,7 +11,7 @@ public:
 	// FUNCTION: LEGO1 0x1000e0d0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0144
+		// STRING: LEGO1 0x100f0144
 		return "HelicopterState";
 	}
 

--- a/LEGO1/historybook.h
+++ b/LEGO1/historybook.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10082390
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f04bc
+		// STRING: LEGO1 0x100f04bc
 		return "HistoryBook";
 	}
 

--- a/LEGO1/hospital.h
+++ b/LEGO1/hospital.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x100746b0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0490
+		// STRING: LEGO1 0x100f0490
 		return "Hospital";
 	}
 

--- a/LEGO1/hospitalentity.h
+++ b/LEGO1/hospitalentity.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000ec40
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0338
+		// STRING: LEGO1 0x100f0338
 		return "HospitalEntity";
 	}
 

--- a/LEGO1/hospitalstate.h
+++ b/LEGO1/hospitalstate.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10076400
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0480
+		// STRING: LEGO1 0x100f0480
 		return "HospitalState";
 	}
 

--- a/LEGO1/infocenter.h
+++ b/LEGO1/infocenter.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x1006eb40
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f04ec
+		// STRING: LEGO1 0x100f04ec
 		return "Infocenter";
 	}
 

--- a/LEGO1/infocenterdoor.h
+++ b/LEGO1/infocenterdoor.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x100377b0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f049c
+		// STRING: LEGO1 0x100f049c
 		return "InfocenterDoor";
 	}
 

--- a/LEGO1/infocenterentity.h
+++ b/LEGO1/infocenterentity.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000ea00
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f035c
+		// STRING: LEGO1 0x100f035c
 		return "InfoCenterEntity";
 	}
 

--- a/LEGO1/infocenterstate.h
+++ b/LEGO1/infocenterstate.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10071840
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f04dc
+		// STRING: LEGO1 0x100f04dc
 		return "InfocenterState";
 	}
 

--- a/LEGO1/isle.h
+++ b/LEGO1/isle.h
@@ -30,7 +30,7 @@ public:
 	// FUNCTION: LEGO1 0x10030910
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0458
+		// STRING: LEGO1 0x100f0458
 		return "Isle";
 	}
 

--- a/LEGO1/isleactor.h
+++ b/LEGO1/isleactor.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x1000e660
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f07dc
+		// STRING: LEGO1 0x100f07dc
 		return "IsleActor";
 	}
 

--- a/LEGO1/islepathactor.h
+++ b/LEGO1/islepathactor.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x10002ea0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0104
+		// STRING: LEGO1 0x100f0104
 		return "IslePathActor";
 	}
 

--- a/LEGO1/jetski.h
+++ b/LEGO1/jetski.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1007e430
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03d8
+		// STRING: LEGO1 0x100f03d8
 		return "Jetski";
 	}
 

--- a/LEGO1/jetskirace.h
+++ b/LEGO1/jetskirace.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000daf0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0530
+		// STRING: LEGO1 0x100f0530
 		return "JetskiRace";
 	}
 

--- a/LEGO1/jetskiracestate.h
+++ b/LEGO1/jetskiracestate.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000dc40
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f00ac
+		// STRING: LEGO1 0x100f00ac
 		return "JetskiRaceState";
 	}
 

--- a/LEGO1/jukebox.h
+++ b/LEGO1/jukebox.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1005d6f0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f02cc
+		// STRING: LEGO1 0x100f02cc
 		return "JukeBox";
 	}
 

--- a/LEGO1/jukeboxentity.h
+++ b/LEGO1/jukeboxentity.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10085cc0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f02f0
+		// STRING: LEGO1 0x100f02f0
 		return "JukeBoxEntity";
 	}
 

--- a/LEGO1/jukeboxstate.h
+++ b/LEGO1/jukeboxstate.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000f310
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f02bc
+		// STRING: LEGO1 0x100f02bc
 		return "JukeBoxState";
 	}
 

--- a/LEGO1/lego3dwavepresenter.h
+++ b/LEGO1/lego3dwavepresenter.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000d890
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f058c
+		// STRING: LEGO1 0x100f058c
 		return "Lego3DWavePresenter";
 	}
 

--- a/LEGO1/legoact2state.h
+++ b/LEGO1/legoact2state.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000df80
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0428
+		// STRING: LEGO1 0x100f0428
 		return "LegoAct2State";
 	}
 

--- a/LEGO1/legoactioncontrolpresenter.h
+++ b/LEGO1/legoactioncontrolpresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x1000d0e0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f05bc
+		// STRING: LEGO1 0x100f05bc
 		return "LegoActionControlPresenter";
 	}
 

--- a/LEGO1/legoactor.h
+++ b/LEGO1/legoactor.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1002d210
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0124
+		// STRING: LEGO1 0x100f0124
 		return "LegoActor";
 	}
 

--- a/LEGO1/legoactorpresenter.h
+++ b/LEGO1/legoactorpresenter.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000cb10
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f06a4
+		// STRING: LEGO1 0x100f06a4
 		return "LegoActorPresenter";
 	}
 

--- a/LEGO1/legoanimationmanager.h
+++ b/LEGO1/legoanimationmanager.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x1005ec80
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f7508
+		// STRING: LEGO1 0x100f7508
 		return "LegoAnimationManager";
 	}
 

--- a/LEGO1/legoanimmmpresenter.h
+++ b/LEGO1/legoanimmmpresenter.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1004a950
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f046c
+		// STRING: LEGO1 0x100f046c
 		return "LegoAnimMMPresenter";
 	}
 

--- a/LEGO1/legoanimpresenter.h
+++ b/LEGO1/legoanimpresenter.h
@@ -11,7 +11,7 @@ public:
 	// FUNCTION: LEGO1 0x10068530
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f071c
+		// STRING: LEGO1 0x100f071c
 		return "LegoAnimPresenter";
 	}
 

--- a/LEGO1/legobuildingmanager.h
+++ b/LEGO1/legobuildingmanager.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1002f930
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f37d0
+		// STRING: LEGO1 0x100f37d0
 		return "LegoBuildingManager";
 	}
 

--- a/LEGO1/legocachesound.h
+++ b/LEGO1/legocachesound.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10006580
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f01c4
+		// STRING: LEGO1 0x100f01c4
 		return "LegoCacheSound";
 	}
 

--- a/LEGO1/legocameracontroller.h
+++ b/LEGO1/legocameracontroller.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10011ec0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0850
+		// STRING: LEGO1 0x100f0850
 		return "LegoCameraController";
 	}
 

--- a/LEGO1/legocarbuild.h
+++ b/LEGO1/legocarbuild.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x10022940
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0504
+		// STRING: LEGO1 0x100f0504
 		return "LegoCarBuild";
 	}
 

--- a/LEGO1/legocarbuildanimpresenter.h
+++ b/LEGO1/legocarbuildanimpresenter.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10078510
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f05ec
+		// STRING: LEGO1 0x100f05ec
 		return "LegoCarBuildAnimPresenter";
 	}
 

--- a/LEGO1/legocarraceactor.h
+++ b/LEGO1/legocarraceactor.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x10081650
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0568
+		// STRING: LEGO1 0x100f0568
 		return "LegoCarRaceActor";
 	}
 

--- a/LEGO1/legocontrolmanager.h
+++ b/LEGO1/legocontrolmanager.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10028cb0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f31b8
+		// STRING: LEGO1 0x100f31b8
 		return "LegoControlManager";
 	}
 

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -22,7 +22,7 @@ public:
 	// FUNCTION: LEGO1 0x1000c2f0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0064
+		// STRING: LEGO1 0x100f0064
 		return "LegoEntity";
 	}
 

--- a/LEGO1/legoentitypresenter.h
+++ b/LEGO1/legoentitypresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x100534b0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f06b8
+		// STRING: LEGO1 0x100f06b8
 		return "LegoEntityPresenter";
 	}
 

--- a/LEGO1/legoextraactor.h
+++ b/LEGO1/legoextraactor.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x1002b7a0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f3204
+		// STRING: LEGO1 0x100f3204
 		return "LegoExtraActor";
 	}
 

--- a/LEGO1/legoflctexturepresenter.h
+++ b/LEGO1/legoflctexturepresenter.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1005def0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0634
+		// STRING: LEGO1 0x100f0634
 		return "LegoFlcTexturePresenter";
 	}
 

--- a/LEGO1/legohideanimpresenter.h
+++ b/LEGO1/legohideanimpresenter.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1006d880
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f06cc
+		// STRING: LEGO1 0x100f06cc
 		return "LegoHideAnimPresenter";
 	}
 

--- a/LEGO1/legojetski.h
+++ b/LEGO1/legojetski.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x10013e80
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f053c
+		// STRING: LEGO1 0x100f053c
 		return "LegoJetski";
 	}
 

--- a/LEGO1/legojetskiraceactor.h
+++ b/LEGO1/legojetskiraceactor.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x10081d80
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0554
+		// STRING: LEGO1 0x100f0554
 		return "LegoJetskiRaceActor";
 	}
 

--- a/LEGO1/legoloadcachesoundpresenter.h
+++ b/LEGO1/legoloadcachesoundpresenter.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10018450
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f05a0
+		// STRING: LEGO1 0x100f05a0
 		return "LegoLoadCacheSoundPresenter";
 	}
 

--- a/LEGO1/legolocomotionanimpresenter.h
+++ b/LEGO1/legolocomotionanimpresenter.h
@@ -11,7 +11,7 @@ public:
 	// FUNCTION: LEGO1 0x1006ce50
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f06e4
+		// STRING: LEGO1 0x100f06e4
 		return "LegoLocomotionAnimPresenter";
 	}
 

--- a/LEGO1/legoloopinganimpresenter.h
+++ b/LEGO1/legoloopinganimpresenter.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000c9a0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0700
+		// STRING: LEGO1 0x100f0700
 		return "LegoLoopingAnimPresenter";
 	}
 

--- a/LEGO1/legomodelpresenter.h
+++ b/LEGO1/legomodelpresenter.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1000ccb0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f067c
+		// STRING: LEGO1 0x100f067c
 		return "LegoModelPresenter";
 	}
 

--- a/LEGO1/legonavcontroller.h
+++ b/LEGO1/legonavcontroller.h
@@ -42,7 +42,7 @@ public:
 	// FUNCTION: LEGO1 0x10054b80
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f66d8
+		// STRING: LEGO1 0x100f66d8
 		return "LegoNavController";
 	}
 

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -76,7 +76,7 @@ public:
 	// FUNCTION: LEGO1 0x10058aa0
 	inline virtual const char* ClassName() const override // vtable+0c
 	{
-		// GLOBAL: LEGO1 0x100f671c
+		// STRING: LEGO1 0x100f671c
 		return "LegoOmni";
 	}
 

--- a/LEGO1/legopalettepresenter.h
+++ b/LEGO1/legopalettepresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10079f30
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f061c
+		// STRING: LEGO1 0x100f061c
 		return "LegoPalettePresenter";
 	}
 

--- a/LEGO1/legopartpresenter.h
+++ b/LEGO1/legopartpresenter.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000cf70
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f05d8
+		// STRING: LEGO1 0x100f05d8
 		return "LegoPartPresenter";
 	}
 

--- a/LEGO1/legopathactor.h
+++ b/LEGO1/legopathactor.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x1000c430
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0114
+		// STRING: LEGO1 0x100f0114
 		return "LegoPathActor";
 	}
 

--- a/LEGO1/legopathcontroller.h
+++ b/LEGO1/legopathcontroller.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10045110
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f11b8
+		// STRING: LEGO1 0x100f11b8
 		return "LegoPathController";
 	}
 

--- a/LEGO1/legopathpresenter.h
+++ b/LEGO1/legopathpresenter.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x100449a0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0690
+		// STRING: LEGO1 0x100f0690
 		return "LegoPathPresenter";
 	}
 

--- a/LEGO1/legophonemepresenter.h
+++ b/LEGO1/legophonemepresenter.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x1004e310
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f064c
+		// STRING: LEGO1 0x100f064c
 		return "LegoPhonemePresenter";
 	}
 

--- a/LEGO1/legoplantmanager.h
+++ b/LEGO1/legoplantmanager.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10026290
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f318c
+		// STRING: LEGO1 0x100f318c
 		return "LegoPlantManager";
 	}
 

--- a/LEGO1/legorace.h
+++ b/LEGO1/legorace.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x10015ba0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f07c4
+		// STRING: LEGO1 0x100f07c4
 		return "LegoRace";
 	}
 

--- a/LEGO1/legoraceactor.h
+++ b/LEGO1/legoraceactor.h
@@ -9,7 +9,7 @@ public:
 	// FUNCTION: LEGO1 0x10014af0
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0bf4
+		// STRING: LEGO1 0x100f0bf4
 		return "LegoRaceActor";
 	}
 

--- a/LEGO1/legoracecar.h
+++ b/LEGO1/legoracecar.h
@@ -11,7 +11,7 @@ public:
 	// FUNCTION: LEGO1 0x10014290
 	inline const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0548
+		// STRING: LEGO1 0x100f0548
 		return "LegoRaceCar";
 	}
 

--- a/LEGO1/legostate.h
+++ b/LEGO1/legostate.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100060d0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f01b8
+		// STRING: LEGO1 0x100f01b8
 		return "LegoState";
 	}
 

--- a/LEGO1/legotexturepresenter.h
+++ b/LEGO1/legotexturepresenter.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1000ce50
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0664
+		// STRING: LEGO1 0x100f0664
 		return "LegoTexturePresenter";
 	}
 

--- a/LEGO1/legoworld.h
+++ b/LEGO1/legoworld.h
@@ -23,7 +23,7 @@ public:
 	// FUNCTION: LEGO1 0x1001d690
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0058
+		// STRING: LEGO1 0x100f0058
 		return "LegoWorld";
 	}
 

--- a/LEGO1/legoworldpresenter.h
+++ b/LEGO1/legoworldpresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10066630
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0608
+		// STRING: LEGO1 0x100f0608
 		return "LegoWorldPresenter";
 	}
 

--- a/LEGO1/motorcycle.h
+++ b/LEGO1/motorcycle.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x10035840
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f38e8
+		// STRING: LEGO1 0x100f38e8
 		return "Motorcycle";
 	}
 

--- a/LEGO1/mxaudiopresenter.h
+++ b/LEGO1/mxaudiopresenter.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1000d280
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f078c
+		// STRING: LEGO1 0x100f078c
 		return "MxAudioPresenter";
 	}
 

--- a/LEGO1/mxbackgroundaudiomanager.h
+++ b/LEGO1/mxbackgroundaudiomanager.h
@@ -21,7 +21,7 @@ public:
 	// FUNCTION: LEGO1 0x1007eb70
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f7ac4
+		// STRING: LEGO1 0x100f7ac4
 		return "MxBackgroundAudioManager";
 	}
 

--- a/LEGO1/mxcompositemediapresenter.h
+++ b/LEGO1/mxcompositemediapresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10073f10
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f02d4
+		// STRING: LEGO1 0x100f02d4
 		return "MxCompositeMediaPresenter";
 	}
 

--- a/LEGO1/mxcompositepresenter.h
+++ b/LEGO1/mxcompositepresenter.h
@@ -19,7 +19,7 @@ public:
 	// FUNCTION: LEGO1 0x100b6210
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0774
+		// STRING: LEGO1 0x100f0774
 		return "MxCompositePresenter";
 	}
 

--- a/LEGO1/mxcontrolpresenter.h
+++ b/LEGO1/mxcontrolpresenter.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10044000
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0514
+		// STRING: LEGO1 0x100f0514
 		return "MxControlPresenter";
 	}
 

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -20,7 +20,7 @@ public:
 	// FUNCTION: LEGO1 0x100144c0
 	inline virtual const char* ClassName() const // vtable+0c
 	{
-		// GLOBAL: LEGO1 0x100f007c
+		// STRING: LEGO1 0x100f007c
 		return "MxCore";
 	}
 

--- a/LEGO1/mxdiskstreamcontroller.h
+++ b/LEGO1/mxdiskstreamcontroller.h
@@ -29,7 +29,7 @@ public:
 	// FUNCTION: LEGO1 0x100c7360
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10102144
+		// STRING: LEGO1 0x10102144
 		return "MxDiskStreamController";
 	}
 

--- a/LEGO1/mxdiskstreamprovider.h
+++ b/LEGO1/mxdiskstreamprovider.h
@@ -32,7 +32,7 @@ public:
 	// FUNCTION: LEGO1 0x100d1160
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x1010287c
+		// STRING: LEGO1 0x1010287c
 		return "MxDiskStreamProvider";
 	}
 

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -33,7 +33,7 @@ public:
 	// FUNCTION: LEGO1 0x100ad980
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101013f4
+		// STRING: LEGO1 0x101013f4
 		return "MxDSAction";
 	}
 

--- a/LEGO1/mxdsanim.h
+++ b/LEGO1/mxdsanim.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x100c9060
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101025d8
+		// STRING: LEGO1 0x101025d8
 		return "MxDSAnim";
 	}
 

--- a/LEGO1/mxdsbuffer.h
+++ b/LEGO1/mxdsbuffer.h
@@ -27,7 +27,7 @@ public:
 	// FUNCTION: LEGO1 0x100c6500
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101025b8
+		// STRING: LEGO1 0x101025b8
 		return "MxDSBuffer";
 	}
 

--- a/LEGO1/mxdschunk.h
+++ b/LEGO1/mxdschunk.h
@@ -25,7 +25,7 @@ public:
 	// FUNCTION: LEGO1 0x100be0c0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10101e6c
+		// STRING: LEGO1 0x10101e6c
 		return "MxDSChunk";
 	}
 

--- a/LEGO1/mxdsevent.h
+++ b/LEGO1/mxdsevent.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100c9660
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101025f0
+		// STRING: LEGO1 0x101025f0
 		return "MxDSEvent";
 	}
 

--- a/LEGO1/mxdsfile.h
+++ b/LEGO1/mxdsfile.h
@@ -17,7 +17,7 @@ public:
 	// FUNCTION: LEGO1 0x100c0120
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10102594
+		// STRING: LEGO1 0x10102594
 		return "MxDSFile";
 	}
 

--- a/LEGO1/mxdsmediaaction.h
+++ b/LEGO1/mxdsmediaaction.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x100c8be0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f7624
+		// STRING: LEGO1 0x100f7624
 		return "MxDSMediaAction";
 	}
 

--- a/LEGO1/mxdsmultiaction.h
+++ b/LEGO1/mxdsmultiaction.h
@@ -17,7 +17,7 @@ public:
 	// FUNCTION: LEGO1 0x100c9f50
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10101dbc
+		// STRING: LEGO1 0x10101dbc
 		return "MxDSMultiAction";
 	}
 

--- a/LEGO1/mxdsobjectaction.h
+++ b/LEGO1/mxdsobjectaction.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x100c88e0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101025c4
+		// STRING: LEGO1 0x101025c4
 		return "MxDSObjectAction";
 	}
 

--- a/LEGO1/mxdsparallelaction.h
+++ b/LEGO1/mxdsparallelaction.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x100caf00
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10102608
+		// STRING: LEGO1 0x10102608
 		return "MxDSParallelAction";
 	}
 

--- a/LEGO1/mxdsselectaction.h
+++ b/LEGO1/mxdsselectaction.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x100cb6f0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x1010261c
+		// STRING: LEGO1 0x1010261c
 		return "MxDSSelectAction";
 	}
 

--- a/LEGO1/mxdsserialaction.h
+++ b/LEGO1/mxdsserialaction.h
@@ -17,7 +17,7 @@ public:
 	// FUNCTION: LEGO1 0x100caad0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f75dc
+		// STRING: LEGO1 0x100f75dc
 		return "MxDSSerialAction";
 	}
 

--- a/LEGO1/mxdssound.h
+++ b/LEGO1/mxdssound.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x100c9330
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101025e4
+		// STRING: LEGO1 0x101025e4
 		return "MxDSSound";
 	}
 

--- a/LEGO1/mxdssource.h
+++ b/LEGO1/mxdssource.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100c0010
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x10102588
+		// STRING: LEGO1 0x10102588
 		return "MxDSSource";
 	}
 

--- a/LEGO1/mxdsstill.h
+++ b/LEGO1/mxdsstill.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x100c9930
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101025fc
+		// STRING: LEGO1 0x101025fc
 		return "MxDSStill";
 	}
 

--- a/LEGO1/mxdssubscriber.h
+++ b/LEGO1/mxdssubscriber.h
@@ -19,7 +19,7 @@ public:
 	// FUNCTION: LEGO1 0x100b7d50
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x101020f8
+		// STRING: LEGO1 0x101020f8
 		return "MxDSSubscriber";
 	}
 

--- a/LEGO1/mxentity.h
+++ b/LEGO1/mxentity.h
@@ -17,7 +17,7 @@ public:
 	// FUNCTION: LEGO1 0x1000c180
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0070
+		// STRING: LEGO1 0x100f0070
 		return "MxEntity";
 	}
 

--- a/LEGO1/mxeventpresenter.h
+++ b/LEGO1/mxeventpresenter.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100c2c30
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101dcc
+		// STRING: LEGO1 0x10101dcc
 		return "MxEventPresenter";
 	}
 

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -22,7 +22,7 @@ public:
 	// FUNCTION: LEGO1 0x100b33f0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f43c8
+		// STRING: LEGO1 0x100f43c8
 		return "MxFlcPresenter";
 	}
 

--- a/LEGO1/mxloopingflcpresenter.h
+++ b/LEGO1/mxloopingflcpresenter.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100b4380
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101e20
+		// STRING: LEGO1 0x10101e20
 		return "MxLoopingFlcPresenter";
 	}
 

--- a/LEGO1/mxloopingmidipresenter.h
+++ b/LEGO1/mxloopingmidipresenter.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x100b1830
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101de0
+		// STRING: LEGO1 0x10101de0
 		return "MxLoopingMIDIPresenter";
 	}
 

--- a/LEGO1/mxloopingsmkpresenter.h
+++ b/LEGO1/mxloopingsmkpresenter.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100b4920
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101e08
+		// STRING: LEGO1 0x10101e08
 		return "MxLoopingSmkPresenter";
 	}
 

--- a/LEGO1/mxmediapresenter.h
+++ b/LEGO1/mxmediapresenter.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x1000c5c0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f074c
+		// STRING: LEGO1 0x100f074c
 		return "MxMediaPresenter";
 	}
 

--- a/LEGO1/mxmidipresenter.h
+++ b/LEGO1/mxmidipresenter.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100c2650
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101df8
+		// STRING: LEGO1 0x10101df8
 		return "MxMIDIPresenter";
 	}
 

--- a/LEGO1/mxmusicpresenter.h
+++ b/LEGO1/mxmusicpresenter.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x100c23a0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101e48
+		// STRING: LEGO1 0x10101e48
 		return "MxMusicPresenter";
 	}
 

--- a/LEGO1/mxnextactiondatastart.h
+++ b/LEGO1/mxnextactiondatastart.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x100c1900
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x101025a0
+		// STRING: LEGO1 0x101025a0
 		return "MxNextActionDataStart";
 	}
 

--- a/LEGO1/mxobjectfactory.h
+++ b/LEGO1/mxobjectfactory.h
@@ -26,7 +26,7 @@ public:
 	// FUNCTION: LEGO1 0x10008f70
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0730
+		// STRING: LEGO1 0x100f0730
 		return "MxObjectFactory";
 	}
 

--- a/LEGO1/mxpalette.cpp
+++ b/LEGO1/mxpalette.cpp
@@ -4,7 +4,6 @@
 #include "mxvideomanager.h"
 
 // GLOBAL: LEGO1 0x10102188
-// SIZE 0x400
 PALETTEENTRY g_defaultPaletteEntries[256] = {
 	{0u, 0u, 0u, 0u},       {128u, 0u, 0u, 0u},     {0u, 128u, 0u, 0u},     {128u, 128u, 0u, 0u},
 	{0u, 0u, 128u, 0u},     {128u, 0u, 128u, 0u},   {0u, 128u, 128u, 0u},   {128u, 128u, 128u, 0u},

--- a/LEGO1/mxpresenter.h
+++ b/LEGO1/mxpresenter.h
@@ -34,7 +34,7 @@ public:
 	// FUNCTION: LEGO1 0x1000bfe0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0740
+		// STRING: LEGO1 0x100f0740
 		return "MxPresenter";
 	}
 

--- a/LEGO1/mxramstreamcontroller.h
+++ b/LEGO1/mxramstreamcontroller.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x100b9430
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10102118
+		// STRING: LEGO1 0x10102118
 		return "MxRAMStreamController";
 	}
 

--- a/LEGO1/mxramstreamprovider.h
+++ b/LEGO1/mxramstreamprovider.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x100d0970
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10102864
+		// STRING: LEGO1 0x10102864
 		return "MxRAMStreamProvider";
 	}
 

--- a/LEGO1/mxsmkpresenter.h
+++ b/LEGO1/mxsmkpresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x100b3730
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101e38
+		// STRING: LEGO1 0x10101e38
 		return "MxSmkPresenter";
 	}
 

--- a/LEGO1/mxsoundpresenter.h
+++ b/LEGO1/mxsoundpresenter.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1000d4a0
 	inline virtual const char* ClassName() const // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f07a0
+		// STRING: LEGO1 0x100f07a0
 		return "MxSoundPresenter";
 	};
 

--- a/LEGO1/mxstillpresenter.h
+++ b/LEGO1/mxstillpresenter.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x100435c0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0184
+		// STRING: LEGO1 0x100f0184
 		return "MxStillPresenter";
 	}
 

--- a/LEGO1/mxstreamchunk.h
+++ b/LEGO1/mxstreamchunk.h
@@ -17,7 +17,7 @@ public:
 	// FUNCTION: LEGO1 0x100b1fe0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10101e5c
+		// STRING: LEGO1 0x10101e5c
 		return "MxStreamChunk";
 	}
 

--- a/LEGO1/mxstreamcontroller.h
+++ b/LEGO1/mxstreamcontroller.h
@@ -24,7 +24,7 @@ public:
 	// FUNCTION: LEGO1 0x100c0f10
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x10102130
+		// STRING: LEGO1 0x10102130
 		return "MxStreamController";
 	}
 

--- a/LEGO1/mxstreamer.h
+++ b/LEGO1/mxstreamer.h
@@ -78,7 +78,7 @@ public:
 	// FUNCTION: LEGO1 0x100b9000
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x1010210c
+		// STRING: LEGO1 0x1010210c
 		return "MxStreamer";
 	}
 

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -23,7 +23,7 @@ public:
 	// FUNCTION: LEGO1 0x1000c820
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0760
+		// STRING: LEGO1 0x100f0760
 		return "MxVideoPresenter";
 	}
 

--- a/LEGO1/mxwavepresenter.h
+++ b/LEGO1/mxwavepresenter.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x1000d6c0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f07b4
+		// STRING: LEGO1 0x100f07b4
 		return "MxWavePresenter";
 	}
 

--- a/LEGO1/pizza.h
+++ b/LEGO1/pizza.h
@@ -20,7 +20,7 @@ public:
 	// FUNCTION: LEGO1 0x10037f90
 	inline const char* ClassName() const // vtable+0c
 	{
-		// GLOBAL: LEGO1 0x100f038c
+		// STRING: LEGO1 0x100f038c
 		return "Pizza";
 	}
 

--- a/LEGO1/pizzamissionstate.h
+++ b/LEGO1/pizzamissionstate.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x10039290
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f00d4
+		// STRING: LEGO1 0x100f00d4
 		return "PizzaMissionState";
 	}
 

--- a/LEGO1/pizzeria.h
+++ b/LEGO1/pizzeria.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000e780
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0380
+		// STRING: LEGO1 0x100f0380
 		return "Pizzeria";
 	}
 

--- a/LEGO1/pizzeriastate.h
+++ b/LEGO1/pizzeriastate.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x10017c20
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0370
+		// STRING: LEGO1 0x100f0370
 		return "PizzeriaState";
 	}
 

--- a/LEGO1/police.h
+++ b/LEGO1/police.h
@@ -16,7 +16,7 @@ public:
 	// FUNCTION: LEGO1 0x1005e1e0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0450
+		// STRING: LEGO1 0x100f0450
 		return "Police";
 	}
 

--- a/LEGO1/policeentity.h
+++ b/LEGO1/policeentity.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000ed60
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
-		// GLOBAL: LEGO1 0x100f0328
+		// STRING: LEGO1 0x100f0328
 		return "PoliceEntity";
 	}
 

--- a/LEGO1/policestate.h
+++ b/LEGO1/policestate.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1005e860
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0444
+		// STRING: LEGO1 0x100f0444
 		return "PoliceState";
 	}
 

--- a/LEGO1/racecar.h
+++ b/LEGO1/racecar.h
@@ -14,7 +14,7 @@ public:
 	// FUNCTION: LEGO1 0x10028270
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03e0
+		// STRING: LEGO1 0x100f03e0
 		return "RaceCar";
 	}
 

--- a/LEGO1/racestate.h
+++ b/LEGO1/racestate.h
@@ -20,7 +20,7 @@ public:
 	// FUNCTION: LEGO1 0x10016010
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f07d0
+		// STRING: LEGO1 0x100f07d0
 		return "RaceState";
 	}
 

--- a/LEGO1/radio.h
+++ b/LEGO1/radio.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1002c8e0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f328c
+		// STRING: LEGO1 0x100f328c
 		return "Radio";
 	}
 

--- a/LEGO1/radiostate.h
+++ b/LEGO1/radiostate.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1002cf60
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f04f8
+		// STRING: LEGO1 0x100f04f8
 		return "RadioState";
 	}
 

--- a/LEGO1/realtime/matrix.cpp
+++ b/LEGO1/realtime/matrix.cpp
@@ -138,7 +138,7 @@ void Matrix4Impl::ToQuaternion(Vector4Impl* p_outQuat)
 		return;
 	}
 
-	// GLOBAL: LEGO1 0x100d4090
+	// ~GLOBAL: LEGO1 0x100d4090
 	static int rotateIndex[] = {1, 2, 0};
 
 	// Largest element along the trace

--- a/LEGO1/registrationbook.h
+++ b/LEGO1/registrationbook.h
@@ -15,7 +15,7 @@ public:
 	// FUNCTION: LEGO1 0x10076e10
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f04c8
+		// STRING: LEGO1 0x100f04c8
 		return "RegistrationBook";
 	}
 

--- a/LEGO1/score.h
+++ b/LEGO1/score.h
@@ -18,7 +18,7 @@ public:
 	// FUNCTION: LEGO1 0x100010c0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0050
+		// STRING: LEGO1 0x100f0050
 		return "Score";
 	}
 

--- a/LEGO1/scorestate.h
+++ b/LEGO1/scorestate.h
@@ -10,7 +10,7 @@ public:
 	// FUNCTION: LEGO1 0x1000de40
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f0084
+		// STRING: LEGO1 0x100f0084
 		return "ScoreState";
 	};
 

--- a/LEGO1/skateboard.h
+++ b/LEGO1/skateboard.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1000fdd0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f041c
+		// STRING: LEGO1 0x100f041c
 		return "SkateBoard";
 	}
 

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -61,7 +61,7 @@ Device* RendererImpl::CreateDevice(const DeviceDirect3DCreateData& data)
 }
 
 // GLOBAL: LEGO1 0x10101040
-static int gSetBufferCount = 1;
+static int g_SetBufferCount = 1;
 
 // FUNCTION: LEGO1 0x100a1900
 Device* RendererImpl::CreateDevice(const DeviceDirectDrawCreateData& data)

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -73,7 +73,7 @@ Device* RendererImpl::CreateDevice(const DeviceDirectDrawCreateData& data)
 		data.m_pBackBuffer,
 		&device->m_data
 	);
-	if (SUCCEEDED(result) && data.m_pBackBuffer && gSetBufferCount) {
+	if (SUCCEEDED(result) && data.m_pBackBuffer && g_SetBufferCount) {
 		device->m_data->SetBufferCount(2);
 	}
 	if (!SUCCEEDED(result)) {

--- a/LEGO1/towtrack.h
+++ b/LEGO1/towtrack.h
@@ -13,7 +13,7 @@ public:
 	// FUNCTION: LEGO1 0x1004c7c0
 	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f03b8
+		// STRING: LEGO1 0x100f03b8
 		return "TowTrack";
 	}
 

--- a/LEGO1/towtrackmissionstate.h
+++ b/LEGO1/towtrackmissionstate.h
@@ -12,7 +12,7 @@ public:
 	// FUNCTION: LEGO1 0x1004dfa0
 	inline virtual const char* ClassName() const // vtable+0x0c
 	{
-		// GLOBAL: LEGO1 0x100f00bc
+		// STRING: LEGO1 0x100f00bc
 		return "TowTrackMissionState";
 	}
 

--- a/tools/isledecomp/isledecomp/parser/error.py
+++ b/tools/isledecomp/isledecomp/parser/error.py
@@ -39,6 +39,14 @@ class ParserError(Enum):
     # WARN: We found a marker to be referenced by name outside of a header file.
     BYNAME_FUNCTION_IN_CPP = 109
 
+    # WARN: A GLOBAL marker appeared over a variable without the g_ prefix
+    GLOBAL_MISSING_PREFIX = 110
+
+    # WARN: GLOBAL marker points at something other than variable declaration.
+    # We can't match global variables based on position, but the goal here is
+    # to ignore things like string literal that are not variables.
+    GLOBAL_NOT_VARIABLE = 111
+
     # This code or higher is an error, not a warning
     DECOMP_ERROR_START = 200
 
@@ -50,12 +58,17 @@ class ParserError(Enum):
     # For example, a GLOBAL cannot follow FUNCTION/STUB
     INCOMPATIBLE_MARKER = 201
 
-    # ERROR: The line following a synthetic marker was not a comment
-    BAD_SYNTHETIC = 202
+    # ERROR: The line following an explicit by-name marker was not a comment
+    # We assume a syntax error here rather than try to use the next line
+    BAD_NAMEREF = 202
 
     # ERROR: This function offset comes before the previous offset from the same module
     # This hopefully gives some hint about which functions need to be rearranged.
     FUNCTION_OUT_OF_ORDER = 203
+
+    # ERROR: The line following an explicit by-name marker that does _not_ expect
+    # a comment -- i.e. VTABLE or GLOBAL -- could not extract the name
+    NO_SUITABLE_NAME = 204
 
 
 @dataclass

--- a/tools/isledecomp/isledecomp/parser/marker.py
+++ b/tools/isledecomp/isledecomp/parser/marker.py
@@ -1,0 +1,103 @@
+import re
+from typing import Optional
+from enum import Enum
+
+
+class MarkerType(Enum):
+    UNKNOWN = -100
+    FUNCTION = 1
+    STUB = 2
+    SYNTHETIC = 3
+    TEMPLATE = 4
+    GLOBAL = 5
+    VTABLE = 6
+    STRING = 7
+    LIBRARY = 8
+
+
+markerRegex = re.compile(
+    r"\s*//\s*(?P<type>\w+):\s*(?P<module>\w+)\s+(?P<offset>0x[a-f0-9]+)",
+    flags=re.I,
+)
+
+
+markerExactRegex = re.compile(
+    r"\s*// (?P<type>[A-Z]+): (?P<module>[A-Z0-9]+) (?P<offset>0x[a-f0-9]+)$"
+)
+
+
+class DecompMarker:
+    def __init__(self, marker_type: str, module: str, offset: int) -> None:
+        try:
+            self._type = MarkerType[marker_type.upper()]
+        except KeyError:
+            self._type = MarkerType.UNKNOWN
+
+        # Convert to upper here. A lot of other analysis depends on this name
+        # being consistent and predictable. If the name is _not_ capitalized
+        # we will emit a syntax error.
+        self._module: str = module.upper()
+        self._offset: int = offset
+
+    @property
+    def type(self) -> MarkerType:
+        return self._type
+
+    @property
+    def module(self) -> str:
+        return self._module
+
+    @property
+    def offset(self) -> int:
+        return self._offset
+
+    def is_regular_function(self) -> bool:
+        """Regular function, meaning: not an explicit byname lookup. FUNCTION
+        markers can be _implicit_ byname.
+        FUNCTION and STUB markers are (currently) the only heterogenous marker types that
+        can be lumped together, although the reasons for doing so are a little vague."""
+        return self._type in (MarkerType.FUNCTION, MarkerType.STUB)
+
+    def is_explicit_byname(self) -> bool:
+        return self._type in (
+            MarkerType.SYNTHETIC,
+            MarkerType.TEMPLATE,
+            MarkerType.LIBRARY,
+        )
+
+    def is_variable(self) -> bool:
+        return self._type == MarkerType.GLOBAL
+
+    def is_synthetic(self) -> bool:
+        return self._type == MarkerType.SYNTHETIC
+
+    def is_template(self) -> bool:
+        return self._type == MarkerType.TEMPLATE
+
+    def is_vtable(self) -> bool:
+        return self._type == MarkerType.VTABLE
+
+    def is_library(self) -> bool:
+        return self._type == MarkerType.LIBRARY
+
+    def is_string(self) -> bool:
+        return self._type == MarkerType.STRING
+
+    def allowed_in_func(self) -> bool:
+        return self._type in (MarkerType.GLOBAL, MarkerType.STRING)
+
+
+def match_marker(line: str) -> Optional[DecompMarker]:
+    match = markerRegex.match(line)
+    if match is None:
+        return None
+
+    return DecompMarker(
+        marker_type=match.group("type"),
+        module=match.group("module"),
+        offset=int(match.group("offset"), 16),
+    )
+
+
+def is_marker_exact(line: str) -> bool:
+    return markerExactRegex.match(line) is not None

--- a/tools/isledecomp/isledecomp/parser/node.py
+++ b/tools/isledecomp/isledecomp/parser/node.py
@@ -1,35 +1,58 @@
+from typing import Optional
 from dataclasses import dataclass
+from .marker import MarkerType
 
 
 @dataclass
-class ParserNode:
+class ParserSymbol:
+    """Exported decomp marker with all information (except the code filename) required to
+    cross-reference with cvdump data."""
+
+    type: MarkerType
     line_number: int
-
-
-@dataclass
-class ParserSymbol(ParserNode):
     module: str
     offset: int
+    name: str
+
+    # The parser doesn't (currently) know about the code filename, but if you
+    # wanted to set it here after the fact, here's the spot.
+    filename: Optional[str] = None
+
+    def should_skip(self) -> bool:
+        """The default is to compare any symbols we have"""
+        return False
+
+    def is_nameref(self) -> bool:
+        """All symbols default to name lookup"""
+        return True
 
 
 @dataclass
 class ParserFunction(ParserSymbol):
-    name: str
+    # We are able to detect the closing line of a function with some reliability.
+    # This isn't used for anything right now, but perhaps later it will be.
+    end_line: Optional[int] = None
+
+    # All marker types are referenced by name except FUNCTION/STUB. These can also be
+    # referenced by name, but only if this flag is true.
     lookup_by_name: bool = False
-    is_stub: bool = False
-    is_synthetic: bool = False
-    is_template: bool = False
-    end_line: int = -1
+
+    def should_skip(self) -> bool:
+        """Temporary helper function because reccmp expects this to be here"""
+        return self.type in (MarkerType.STUB, MarkerType.LIBRARY)
+
+    def is_nameref(self) -> bool:
+        return (
+            self.type in (MarkerType.SYNTHETIC, MarkerType.TEMPLATE, MarkerType.LIBRARY)
+            or self.lookup_by_name
+        )
 
 
 @dataclass
 class ParserVariable(ParserSymbol):
-    name: str
-    size: int = -1
     is_static: bool = False
 
 
 @dataclass
 class ParserVtable(ParserSymbol):
-    class_name: str
-    num_entries: int = -1
+    pass

--- a/tools/isledecomp/isledecomp/parser/node.py
+++ b/tools/isledecomp/isledecomp/parser/node.py
@@ -38,8 +38,7 @@ class ParserFunction(ParserSymbol):
     lookup_by_name: bool = False
 
     def should_skip(self) -> bool:
-        """Temporary helper function because reccmp expects this to be here"""
-        return self.type in (MarkerType.STUB, MarkerType.LIBRARY)
+        return self.type == MarkerType.STUB
 
     def is_nameref(self) -> bool:
         return (

--- a/tools/isledecomp/isledecomp/parser/util.py
+++ b/tools/isledecomp/isledecomp/parser/util.py
@@ -1,17 +1,6 @@
 # C++ Parser utility functions and data structures
-from __future__ import annotations  # python <3.10 compatibility
 import re
-from collections import namedtuple
-
-DecompMarker = namedtuple("DecompMarker", ["type", "module", "offset"])
-
-
-markerRegex = re.compile(
-    r"\s*//\s*(\w+):\s*(\w+)\s+(0x[a-f0-9]+)",
-    flags=re.I,
-)
-
-markerExactRegex = re.compile(r"\s*// ([A-Z]+): ([A-Z0-9]+) (0x[a-f0-9]+)$")
+from typing import Optional
 
 # The goal here is to just read whatever is on the next line, so some
 # flexibility in the formatting seems OK
@@ -23,7 +12,7 @@ templateCommentRegex = re.compile(r"\s*//\s+(.*)")
 trailingCommentRegex = re.compile(r"(\s*(?://|/\*).*)$")
 
 
-def get_synthetic_name(line: str) -> str | None:
+def get_synthetic_name(line: str) -> Optional[str]:
     """Synthetic names appear on a single line comment on the line after the marker.
     If that's not what we have, return None"""
     template_match = templateCommentRegex.match(line)
@@ -51,20 +40,6 @@ def is_blank_or_comment(line: str) -> bool:
     )
 
 
-def match_marker(line: str) -> DecompMarker | None:
-    match = markerRegex.match(line)
-    if match is None:
-        return None
-
-    return DecompMarker(
-        type=match.group(1), module=match.group(2), offset=int(match.group(3), 16)
-    )
-
-
-def is_marker_exact(line: str) -> bool:
-    return markerExactRegex.match(line) is not None
-
-
 template_class_decl_regex = re.compile(
     r"\s*(?:\/\/)?\s*(?:class|struct) (\w+)<([\w]+)\s*(\*+)?\s*>"
 )
@@ -73,7 +48,7 @@ template_class_decl_regex = re.compile(
 class_decl_regex = re.compile(r"\s*(?:\/\/)?\s*(?:class|struct) (\w+)")
 
 
-def get_class_name(line: str) -> str | None:
+def get_class_name(line: str) -> Optional[str]:
     """For VTABLE markers, extract the class name from the code line or comment
     where it appears."""
 
@@ -91,5 +66,23 @@ def get_class_name(line: str) -> str | None:
     match = class_decl_regex.match(line)
     if match is not None:
         return match.group(1)
+
+    return None
+
+
+global_regex = re.compile(r"(?P<name>g_\w+)")
+less_strict_global_regex = re.compile(r"(?P<name>\w+)(?:\)\(|\[.*|\s*=.*|;)")
+
+
+def get_variable_name(line: str) -> Optional[str]:
+    """Grab the name of the variable annotated with the GLOBAL marker.
+    Correct syntax would have the variable start with the prefix "g_"
+    but we will try to match regardless."""
+
+    if (match := global_regex.search(line)) is not None:
+        return match.group("name")
+
+    if (match := less_strict_global_regex.search(line)) is not None:
+        return match.group("name")
 
     return None

--- a/tools/isledecomp/tests/test_parser_statechange.py
+++ b/tools/isledecomp/tests/test_parser_statechange.py
@@ -11,9 +11,11 @@ state_change_marker_cases = [
     (_rs.SEARCH,          "FUNCTION",   _rs.WANT_SIG,        None),
     (_rs.SEARCH,          "GLOBAL",     _rs.IN_GLOBAL,       None),
     (_rs.SEARCH,          "STUB",       _rs.WANT_SIG,        None),
-    (_rs.SEARCH,          "SYNTHETIC",  _rs.IN_TEMPLATE,     None),
+    (_rs.SEARCH,          "SYNTHETIC",  _rs.IN_SYNTHETIC,    None),
     (_rs.SEARCH,          "TEMPLATE",   _rs.IN_TEMPLATE,     None),
     (_rs.SEARCH,          "VTABLE",     _rs.IN_VTABLE,       None),
+    (_rs.SEARCH,          "LIBRARY",    _rs.IN_LIBRARY,      None),
+    (_rs.SEARCH,          "STRING",     _rs.SEARCH,          None),
 
     (_rs.WANT_SIG,        "FUNCTION",   _rs.WANT_SIG,        None),
     (_rs.WANT_SIG,        "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
@@ -21,20 +23,26 @@ state_change_marker_cases = [
     (_rs.WANT_SIG,        "SYNTHETIC",  _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.WANT_SIG,        "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.WANT_SIG,        "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.WANT_SIG,        "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.WANT_SIG,        "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
 
     (_rs.IN_FUNC,         "FUNCTION",   _rs.WANT_SIG,        _pe.MISSED_END_OF_FUNCTION),
     (_rs.IN_FUNC,         "GLOBAL",     _rs.IN_FUNC_GLOBAL,  None),
     (_rs.IN_FUNC,         "STUB",       _rs.WANT_SIG,        _pe.MISSED_END_OF_FUNCTION),
-    (_rs.IN_FUNC,         "SYNTHETIC",  _rs.IN_TEMPLATE,     _pe.MISSED_END_OF_FUNCTION),
+    (_rs.IN_FUNC,         "SYNTHETIC",  _rs.IN_SYNTHETIC,    _pe.MISSED_END_OF_FUNCTION),
     (_rs.IN_FUNC,         "TEMPLATE",   _rs.IN_TEMPLATE,     _pe.MISSED_END_OF_FUNCTION),
     (_rs.IN_FUNC,         "VTABLE",     _rs.IN_VTABLE,       _pe.MISSED_END_OF_FUNCTION),
+    (_rs.IN_FUNC,         "LIBRARY",    _rs.IN_LIBRARY,      _pe.MISSED_END_OF_FUNCTION),
+    (_rs.IN_FUNC,         "STRING",     _rs.IN_FUNC,         None),
 
     (_rs.IN_TEMPLATE,     "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_TEMPLATE,     "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_TEMPLATE,     "STUB",       _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
-    (_rs.IN_TEMPLATE,     "SYNTHETIC",  _rs.IN_TEMPLATE,     None),
+    (_rs.IN_TEMPLATE,     "SYNTHETIC",  _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_TEMPLATE,     "TEMPLATE",   _rs.IN_TEMPLATE,     None),
     (_rs.IN_TEMPLATE,     "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_TEMPLATE,     "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_TEMPLATE,     "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
 
     (_rs.WANT_CURLY,      "FUNCTION",   _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
     (_rs.WANT_CURLY,      "GLOBAL",     _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
@@ -42,6 +50,8 @@ state_change_marker_cases = [
     (_rs.WANT_CURLY,      "SYNTHETIC",  _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
     (_rs.WANT_CURLY,      "TEMPLATE",   _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
     (_rs.WANT_CURLY,      "VTABLE",     _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
+    (_rs.WANT_CURLY,      "LIBRARY",    _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
+    (_rs.WANT_CURLY,      "STRING",     _rs.SEARCH,          _pe.UNEXPECTED_MARKER),
 
     (_rs.IN_GLOBAL,       "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_GLOBAL,       "GLOBAL",     _rs.IN_GLOBAL,       None),
@@ -49,6 +59,8 @@ state_change_marker_cases = [
     (_rs.IN_GLOBAL,       "SYNTHETIC",  _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_GLOBAL,       "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_GLOBAL,       "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_GLOBAL,       "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_GLOBAL,       "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
 
     (_rs.IN_FUNC_GLOBAL,  "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_FUNC_GLOBAL,  "GLOBAL",     _rs.IN_FUNC_GLOBAL,  None),
@@ -56,6 +68,8 @@ state_change_marker_cases = [
     (_rs.IN_FUNC_GLOBAL,  "SYNTHETIC",  _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_FUNC_GLOBAL,  "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_FUNC_GLOBAL,  "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_FUNC_GLOBAL,  "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_FUNC_GLOBAL,  "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
 
     (_rs.IN_VTABLE,       "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_VTABLE,       "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
@@ -63,6 +77,26 @@ state_change_marker_cases = [
     (_rs.IN_VTABLE,       "SYNTHETIC",  _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_VTABLE,       "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_VTABLE,       "VTABLE",     _rs.IN_VTABLE,       None),
+    (_rs.IN_VTABLE,       "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_VTABLE,       "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+
+    (_rs.IN_SYNTHETIC,    "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_SYNTHETIC,    "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_SYNTHETIC,    "STUB",       _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_SYNTHETIC,    "SYNTHETIC",  _rs.IN_SYNTHETIC,    None),
+    (_rs.IN_SYNTHETIC,    "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_SYNTHETIC,    "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_SYNTHETIC,    "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_SYNTHETIC,    "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+
+    (_rs.IN_LIBRARY,      "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_LIBRARY,      "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_LIBRARY,      "STUB",       _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_LIBRARY,      "SYNTHETIC",  _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_LIBRARY,      "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_LIBRARY,      "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_LIBRARY,      "LIBRARY",    _rs.IN_LIBRARY,      None),
+    (_rs.IN_LIBRARY,      "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
 ]
 # fmt: on
 
@@ -105,47 +139,3 @@ def test_state_search_line(line: str):
     p.read_line(line)
     assert p.state == _rs.SEARCH
     assert len(p.alerts) == 0
-
-
-global_lines = [
-    ("// A comment", _rs.IN_GLOBAL),
-    ("", _rs.IN_GLOBAL),
-    ("\t", _rs.IN_GLOBAL),
-    ("    ", _rs.IN_GLOBAL),
-    # TODO: no check for "likely" variable declaration so these all count
-    ("void function()", _rs.SEARCH),
-    ("int x = 123;", _rs.SEARCH),
-    ("just some text", _rs.SEARCH),
-]
-
-
-@pytest.mark.parametrize("line, new_state", global_lines)
-def test_state_global_line(line: str, new_state: _rs):
-    p = DecompParser()
-    p.read_line("// GLOBAL: TEST 0x1234")
-    assert p.state == _rs.IN_GLOBAL
-    p.read_line(line)
-    assert p.state == new_state
-
-
-# mostly same as above
-in_func_global_lines = [
-    ("// A comment", _rs.IN_FUNC_GLOBAL),
-    ("", _rs.IN_FUNC_GLOBAL),
-    ("\t", _rs.IN_FUNC_GLOBAL),
-    ("    ", _rs.IN_FUNC_GLOBAL),
-    # TODO: no check for "likely" variable declaration so these all count
-    ("void function()", _rs.IN_FUNC),
-    ("int x = 123;", _rs.IN_FUNC),
-    ("just some text", _rs.IN_FUNC),
-]
-
-
-@pytest.mark.parametrize("line, new_state", in_func_global_lines)
-def test_state_in_func_global_line(line: str, new_state: _rs):
-    p = DecompParser()
-    p.state = _rs.IN_FUNC
-    p.read_line("// GLOBAL: TEST 0x1234")
-    assert p.state == _rs.IN_FUNC_GLOBAL
-    p.read_line(line)
-    assert p.state == new_state

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -316,7 +316,7 @@ def main():
                 parser.read_lines(srcfile)
 
             for fun in parser.functions:
-                if fun.is_stub:
+                if fun.should_skip():
                     continue
 
                 if fun.module != basename:
@@ -330,7 +330,7 @@ def main():
                     else:
                         continue
 
-                if fun.lookup_by_name:
+                if fun.is_nameref():
                     recinfo = syminfo.get_recompiled_address_from_name(fun.name)
                     if not recinfo:
                         continue


### PR DESCRIPTION
Another refactor of the decomp parser to provide the following features:

- Extract the name of global variables. This is so we can cross-reference the variable name with the output from cvdump. If the data is initialized, we can compare it.

- If we find a variable inside a function, assume it is a static variable and set the `is_static` flag. In the `GLOBALS` section of cvdump, these variables are identified with `S_LDATA32`. Static variables of a _class_, however, are still `S_GDATA32` like regular global variables. We will not be able to match the names of those exactly without making the parser a lot more aware of class/function structure. We might be able to match them anyway by process of elimination. We'll cross that bridge when we come to it.

- Add a new marker type `// LIBRARY` to mark functions like `_malloc` and `_free` that come from the standard library. We (probably) don't need to compare these so this is effectively an alias for `// STUB`. We can't match these yet anyway, because it requires us to parse the `PUBLICS` section from cvdump, and that piece is unfinished. When it is time to annotate these, we could add a .h file to the codebase (so it will be picked up by the parser) but not include it in any .cpp files.

- Add a new marker type `// STRING` to indicate constant string values that appear on the next line. Right now, though, we are just ignoring these markers. My reason for changing these is to make them distinct from `// GLOBAL` markers that indicate a variable.

We don't actually need to use the `// STRING` markers, but I thought that we might as well keep them around since they are already here in the code. To match strings up, we can take advantage of two facts:
1. String constants are set into `.rdata` only once, and then referenced by pointer wherever they are used.
2. Strings are null-terminated.

So my strategy (in an upcoming PR) will be:
1. Use cvdump to find all string constants in the recomp. There is a specific mangled symbol prefix that will identify these.
2. In the original binary, look at relocated vaddrs from .rdata.
3. Try to match up string data from 1 with locations in 2.


The medium-long term goal here is to have a complete map of symbols between the original binary and the recomp. That will serve two main purposes:
1. When comparing code, we are substituting virtual addresses with strings like `<OFFSET1>` to help with text comparison via difflib. If we know that a certain address in the original maps to a certain address in the recomp, we can say for certain that the address used in the recomp is correct. For example: we can check whether a call to `_malloc` or any other function in the original is the same in the recomp.
2. We can compare symbols that are not code, like variables and vtables.