### PR TITLE
Fix new/delete symbol references

### DIFF
--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -1,11 +1,21 @@
 #ifdef 0
 
+// aka `operator new`
 // LIBRARY: ISLE 0x402f80
 // LIBRARY: LEGO1 0x10086240
-// _malloc
+// ??2@YAPAXI@Z
 
+// aka `operator delete`
 // LIBRARY: ISLE 0x402fa0
 // LIBRARY: LEGO1 0x10086260
+// ??3@YAXPAX@Z
+
+// LIBRARY: ISLE 0x406dd0
+// LIBRARY: LEGO1 0x1008a090
+// _malloc
+
+// LIBRARY: ISLE 0x406f00
+// LIBRARY: LEGO1 0x1008a1c0
 // _free
 
 // LIBRARY: ISLE 0x408220

--- a/tools/isledecomp/isledecomp/syminfo.py
+++ b/tools/isledecomp/isledecomp/syminfo.py
@@ -29,11 +29,7 @@ class SymInfo:
 
         contrib_dict = {(s.section, s.offset): s.size for s in cv.sizerefs}
         for pub in cv.publics:
-            if (
-                pub.type == "S_PUB32"
-                and pub.name.startswith("_")
-                and (pub.section, pub.offset) in contrib_dict
-            ):
+            if pub.type == "S_PUB32" and (pub.section, pub.offset) in contrib_dict:
                 size = contrib_dict[(pub.section, pub.offset)]
 
                 info = RecompiledInfo()


### PR DESCRIPTION
Quick addendum to #383 to get our match percentage back where it should be.

In the new `library_msvc.h` file where we can annotate functions from the standard library, I had `_malloc` and `_free` pointing at what should be the `operator new` and `operator delete` functions.

We are referencing those by the "decorated" ([as Microsoft calls them](https://learn.microsoft.com/en-us/cpp/build/reference/decorated-names)) or "mangled" symbol names `??2@YAPAXI@Z` and `??3@YAXPAX@Z`.