### PR TITLE
Implement MxVideoPresenter::PutFrame

### DIFF
--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -224,20 +224,28 @@ void MxDisplaySurface::SetPalette(MxPalette* p_palette)
 }
 
 // STUB: LEGO1 0x100bacc0
-MxBool MxDisplaySurface::VTable0x28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
+MxBool MxDisplaySurface::VTable0x28(
+	MxBitmap* p_bitmap,
+	MxS32 p_left,
+	MxS32 p_top,
+	MxS32 p_right,
+	MxS32 p_bottom,
+	MxS32 p_width,
+	MxS32 p_height
+)
 {
 	return 0;
 }
 
 // STUB: LEGO1 0x100bb1d0
 MxBool MxDisplaySurface::VTable0x30(
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4,
+	MxBitmap* p_bitmap,
+	MxS32 p_left,
+	MxS32 p_top,
+	MxS32 p_right,
+	MxS32 p_bottom,
+	MxS32 p_width,
+	MxS32 p_height,
 	MxBool
 )
 {

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -39,7 +39,15 @@ public:
 		undefined4,
 		undefined4
 	);
-	virtual MxBool VTable0x28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);
+	virtual MxBool VTable0x28(
+		MxBitmap* p_bitmap,
+		MxS32 p_left,
+		MxS32 p_top,
+		MxS32 p_right,
+		MxS32 p_bottom,
+		MxS32 p_width,
+		MxS32 p_height
+	);
 	virtual MxBool VTable0x2c(
 		LPDDSURFACEDESC,
 		MxBitmap*,
@@ -52,13 +60,13 @@ public:
 		MxBool
 	);
 	virtual MxBool VTable0x30(
-		undefined4,
-		undefined4,
-		undefined4,
-		undefined4,
-		undefined4,
-		undefined4,
-		undefined4,
+		MxBitmap* p_bitmap,
+		MxS32 p_left,
+		MxS32 p_top,
+		MxS32 p_right,
+		MxS32 p_bottom,
+		MxS32 p_width,
+		MxS32 p_height,
 		MxBool
 	);
 	virtual undefined4 VTable0x34(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4);

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -16,13 +16,7 @@ public:
 		this->m_bottom = p_bottom;
 	}
 
-	MxRect32(const MxPoint32& p_point, const MxSize32& p_size)
-	{
-		this->m_left = p_point.GetX();
-		this->m_top = p_point.GetY();
-		this->m_right = p_size.GetWidth();
-		this->m_bottom = p_size.GetHeight();
-	}
+	MxRect32(const MxPoint32& p_point, const MxSize32& p_size) { CopyFrom(p_point, p_size); }
 
 	MxRect32(const MxRect32& p_a, const MxRect32& p_b)
 	{
@@ -98,7 +92,6 @@ public:
 	inline void SetRight(MxS32 p_right) { m_right = p_right; }
 	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
-private:
 	inline void CopyFrom(const MxRect32& p_rect)
 	{
 		this->m_left = p_rect.m_left;
@@ -107,6 +100,15 @@ private:
 		this->m_bottom = p_rect.m_bottom;
 	}
 
+	inline void CopyFrom(const MxPoint32& p_point, const MxSize32& p_size)
+	{
+		this->m_left = p_point.GetX();
+		this->m_top = p_point.GetY();
+		this->m_right = p_size.GetWidth() + p_point.GetX();
+		this->m_bottom = p_size.GetHeight() + p_point.GetY();
+	}
+
+private:
 	inline static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; };
 	inline static MxS32 Max(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_b : p_a; };
 

--- a/LEGO1/mxsize32.h
+++ b/LEGO1/mxsize32.h
@@ -6,16 +6,18 @@
 class MxSize32 {
 public:
 	MxSize32() {}
-	MxSize32(MxS32 p_width, MxS32 p_height)
-	{
-		this->m_width = p_width;
-		this->m_height = p_height;
-	}
+	MxSize32(MxS32 p_width, MxS32 p_height) { Assign(p_width, p_height); }
 
 	inline MxS32 GetWidth() const { return m_width; }
 	inline MxS32 GetHeight() const { return m_height; }
 
 private:
+	inline void Assign(MxS32 p_width, MxS32 p_height)
+	{
+		this->m_width = p_width;
+		this->m_height = p_height;
+	}
+
 	MxS32 m_width;
 	MxS32 m_height;
 };

--- a/LEGO1/mxstillpresenter.cpp
+++ b/LEGO1/mxstillpresenter.cpp
@@ -71,12 +71,7 @@ void MxStillPresenter::LoadFrame(MxStreamChunk* p_chunk)
 {
 	memcpy(m_bitmap->GetBitmapData(), p_chunk->GetData(), p_chunk->GetLength());
 
-	MxS32 height = GetHeight() - 1;
-	MxS32 width = GetWidth() - 1;
-	MxS32 x = m_location.GetX();
-	MxS32 y = m_location.GetY();
-
-	MxRect32 rect(x, y, width + x, height + y);
+	MxRect32 rect(m_location, MxSize32(GetWidth() - 1, GetHeight() - 1));
 	MVideoManager()->InvalidateRect(rect);
 
 	if (m_flags & Flag_Bit2) {
@@ -154,6 +149,7 @@ void MxStillPresenter::VTable0x88(MxS32 p_x, MxS32 p_y)
 	m_location.SetY(p_y);
 
 	if (IsEnabled()) {
+		// Most likely needs to work with MxSize32 and MxPoint32
 		MxS32 height = GetHeight() - 1;
 		MxS32 width = GetWidth() - 1;
 
@@ -174,12 +170,7 @@ void MxStillPresenter::Enable(MxBool p_enable)
 	MxVideoPresenter::Enable(p_enable);
 
 	if (MVideoManager() && (m_alpha || m_bitmap)) {
-		MxS32 height = GetHeight();
-		MxS32 width = GetWidth();
-		MxS32 x = m_location.GetX();
-		MxS32 y = m_location.GetY();
-
-		MxRect32 rect(x, y, width + x, height + y);
+		MxRect32 rect(m_location, MxSize32(GetWidth(), GetHeight()));
 		MVideoManager()->InvalidateRect(rect);
 		MVideoManager()->VTable0x34(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight());
 	}

--- a/LEGO1/mxvideomanager.h
+++ b/LEGO1/mxvideomanager.h
@@ -40,6 +40,7 @@ public:
 	inline MxVideoParam& GetVideoParam() { return this->m_videoParam; }
 	inline LPDIRECTDRAW GetDirectDraw() { return this->m_pDirectDraw; }
 	inline MxDisplaySurface* GetDisplaySurface() { return this->m_displaySurface; }
+	inline MxRegion* GetRegion() { return this->m_region; }
 
 protected:
 	MxVideoParam m_videoParam;          // 0x2c

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -353,6 +353,7 @@ void MxVideoPresenter::PutFrame()
 	MxRect32 rectSrc, rectDest;
 	if (m_action->GetFlags() & MxDSAction::Flag_Bit5) {
 		if (m_unk0x58) {
+			// TODO: Match
 			rectSrc.CopyFrom(MxPoint32(0, 0), MxSize32(GetWidth(), GetHeight()));
 			rectDest.CopyFrom(m_location, MxSize32(GetWidth(), GetHeight()));
 
@@ -390,6 +391,7 @@ void MxVideoPresenter::PutFrame()
 		while (regionRect = cursor.VTable0x24(rect)) {
 			if (regionRect->GetWidth() >= 1 && regionRect->GetHeight() >= 1) {
 				if (m_unk0x58) {
+					// TODO: Match
 					rectSrc.CopyFrom(
 						MxPoint32(regionRect->GetLeft() - m_location.GetX(), regionRect->GetTop() - m_location.GetY()),
 						MxSize32(regionRect->GetWidth(), regionRect->GetHeight())

--- a/LEGO1/mxvideopresenter.h
+++ b/LEGO1/mxvideopresenter.h
@@ -4,6 +4,7 @@
 #include "decomp.h"
 #include "mxbitmap.h"
 #include "mxmediapresenter.h"
+#include "mxrect32.h"
 
 // VTABLE: LEGO1 0x100d4be8
 // SIZE 0x64
@@ -68,6 +69,7 @@ public:
 		MxS32 IsHit(MxU32 p_x, MxU32 p_y);
 	};
 
+	inline MxS32 PrepareRects(MxRect32& p_rectDest, MxRect32& p_rectSrc);
 	inline MxBitmap* GetBitmap() { return m_bitmap; }
 
 private:


### PR DESCRIPTION
This adds the implementation of `MxVideoPresenter::PutFrame`. Functionally it should be accurate, however the match is only at ~37% due to a large number of moving pieces, some of which aren't quite right yet (most notably, the initialization of the rectangles). The challenge lies in discovering the "correct" application of inline functions, similarly to other large function bodies in the code base.