### PR TITLE
Implement `FUN_100b6e10` and MxRect32 adjustments

### DIFF
--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -728,6 +728,7 @@ MxBool FUN_100b6e10(
 
 	if (!rect.IntersectsWith(videoParamRect))
 		return FALSE;
+
 	rect.Intersect(videoParamRect);
 	rect.SubtractPoint(bottomRight);
 
@@ -737,7 +738,6 @@ MxBool FUN_100b6e10(
 	*p_bottom += rect.GetTop();
 	*p_width = rect.GetWidth();
 	*p_height = rect.GetHeight();
-
 	return TRUE;
 }
 

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -695,6 +695,52 @@ MxResult Start(MxDSAction* p_dsAction)
 	return MxOmni::GetInstance()->Start(p_dsAction);
 }
 
+// Probably should be somewhere else
+// FUNCTION: LEGO1 0x100b6e10
+MxBool FUN_100b6e10(
+	MxS32 p_bitmapWidth,
+	MxS32 p_bitmapHeight,
+	MxS32 p_videoParamWidth,
+	MxS32 p_videoParamHeight,
+	MxS32* p_left,
+	MxS32* p_top,
+	MxS32* p_right,
+	MxS32* p_bottom,
+	MxS32* p_width,
+	MxS32* p_height
+)
+{
+	MxPoint32 topLeft(*p_left, *p_top);
+	MxRect32 bitmapRect(MxPoint32(0, 0), MxSize32(p_bitmapWidth, p_bitmapHeight));
+
+	MxPoint32 bottomRight(*p_right, *p_bottom);
+	MxRect32 videoParamRect(MxPoint32(0, 0), MxSize32(p_videoParamWidth, p_videoParamHeight));
+
+	MxRect32 rect(0, 0, *p_width, *p_height);
+	rect.AddPoint(topLeft);
+
+	if (!rect.IntersectsWith(bitmapRect))
+		return FALSE;
+
+	rect.Intersect(bitmapRect);
+	rect.SubtractPoint(topLeft);
+	rect.AddPoint(bottomRight);
+
+	if (!rect.IntersectsWith(videoParamRect))
+		return FALSE;
+	rect.Intersect(videoParamRect);
+	rect.SubtractPoint(bottomRight);
+
+	*p_left += rect.GetLeft();
+	*p_top += rect.GetTop();
+	*p_right += rect.GetLeft();
+	*p_bottom += rect.GetTop();
+	*p_width = rect.GetWidth();
+	*p_height = rect.GetHeight();
+
+	return TRUE;
+}
+
 // FUNCTION: LEGO1 0x100b6ff0
 void MakeSourceName(char* p_output, const char* p_input)
 {

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -166,6 +166,19 @@ void FUN_10015820(MxU32, MxU32);
 LegoEntity* FindEntityByAtomIdOrEntityId(const MxAtomId& p_atom, MxS32 p_entityid);
 MxDSAction& GetCurrentAction();
 
+MxBool FUN_100b6e10(
+	MxS32 p_bitmapWidth,
+	MxS32 p_bitmapHeight,
+	MxS32 p_videoParamWidth,
+	MxS32 p_videoParamHeight,
+	MxS32* p_left,
+	MxS32* p_top,
+	MxS32* p_right,
+	MxS32* p_bottom,
+	MxS32* p_width,
+	MxS32* p_height
+);
+
 void PlayMusic(MxU32 p_index);
 void SetIsWorldActive(MxBool p_isWorldActive);
 void RegisterScripts();

--- a/LEGO1/mxpoint32.h
+++ b/LEGO1/mxpoint32.h
@@ -6,12 +6,7 @@
 class MxPoint32 {
 public:
 	MxPoint32() {}
-	MxPoint32(MxS32 p_x, MxS32 p_y)
-	{
-		this->m_x = p_x;
-		this->m_y = p_y;
-	}
-
+	MxPoint32(MxS32 p_x, MxS32 p_y) { CopyFrom(p_x, p_y); }
 	MxPoint32(const MxPoint32& p_point)
 	{
 		this->m_x = p_point.m_x;
@@ -25,8 +20,14 @@ public:
 	inline void SetY(MxS32 p_y) { m_y = p_y; }
 
 private:
-	MxS32 m_x;
-	MxS32 m_y;
+	inline void CopyFrom(MxS32 p_x, MxS32 p_y)
+	{
+		this->m_x = p_x;
+		this->m_y = p_y;
+	}
+
+	MxS32 m_x; // 0x00
+	MxS32 m_y; // 0x04
 };
 
 #endif // MXPOINT32_H

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -9,10 +9,7 @@ class MxRect32 {
 public:
 	MxRect32() {}
 	MxRect32(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_bottom) { CopyFrom(p_left, p_top, p_right, p_bottom); }
-
-	// FUNCTION: LEGO1 0x100b6fc0
 	MxRect32(const MxPoint32& p_point, const MxSize32& p_size) { CopyFrom(p_point, p_size); }
-
 	MxRect32(const MxRect32& p_a, const MxRect32& p_b)
 	{
 		m_left = Max(p_a.m_left, p_b.m_left);
@@ -106,12 +103,15 @@ private:
 		this->m_bottom = p_rect.m_bottom;
 	}
 
-	inline void CopyFrom(const MxPoint32& p_point, const MxSize32& p_size)
+	// The address might also be the constructor that calls CopyFrom
+	// FUNCTION: LEGO1 0x100b6fc0
+	inline MxRect32* CopyFrom(const MxPoint32& p_point, const MxSize32& p_size)
 	{
 		this->m_left = p_point.GetX();
 		this->m_top = p_point.GetY();
 		this->m_right = p_size.GetWidth() + p_point.GetX() - 1;
 		this->m_bottom = p_size.GetHeight() + p_point.GetY() - 1;
+		return this;
 	}
 
 	inline static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; };

--- a/LEGO1/mxrect32.h
+++ b/LEGO1/mxrect32.h
@@ -56,6 +56,14 @@ public:
 		this->m_bottom += p_point.GetY();
 	}
 
+	inline void SubtractPoint(const MxPoint32& p_point)
+	{
+		this->m_left -= p_point.GetX();
+		this->m_top -= p_point.GetY();
+		this->m_right -= p_point.GetX();
+		this->m_bottom -= p_point.GetY();
+	}
+
 	inline void SetSize(const MxSize32& p_size)
 	{
 		this->m_right = p_size.GetWidth();

--- a/LEGO1/mxsize32.h
+++ b/LEGO1/mxsize32.h
@@ -6,13 +6,13 @@
 class MxSize32 {
 public:
 	MxSize32() {}
-	MxSize32(MxS32 p_width, MxS32 p_height) { Assign(p_width, p_height); }
+	MxSize32(MxS32 p_width, MxS32 p_height) { CopyFrom(p_width, p_height); }
 
 	inline MxS32 GetWidth() const { return m_width; }
 	inline MxS32 GetHeight() const { return m_height; }
 
 private:
-	inline void Assign(MxS32 p_width, MxS32 p_height)
+	inline void CopyFrom(MxS32 p_width, MxS32 p_height)
 	{
 		this->m_width = p_width;
 		this->m_height = p_height;

--- a/LEGO1/mxstillpresenter.cpp
+++ b/LEGO1/mxstillpresenter.cpp
@@ -183,7 +183,6 @@ void MxStillPresenter::Enable(MxBool p_enable)
 		MxS32 y = m_location.GetY();
 
 		MxRect32 rect(x, y, width + x, height + y);
-
 		MVideoManager()->InvalidateRect(rect);
 		MVideoManager()->VTable0x34(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight());
 	}

--- a/LEGO1/mxvideopresenter.cpp
+++ b/LEGO1/mxvideopresenter.cpp
@@ -222,7 +222,6 @@ void MxVideoPresenter::Destroy(MxBool p_fromDestructor)
 		MxS32 y = m_location.GetY();
 
 		MxRect32 rect(x, y, x + width, y + height);
-
 		MVideoManager()->InvalidateRect(rect);
 		MVideoManager()->VTable0x34(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight());
 	}


### PR DESCRIPTION
This implements `FUN_100b6e10`, a function that is being used by various methods in `MxDisplaySurface`. This function consists basically of a large sequence of inlined calls, which aren't quite right yet - which is the reason why the match seems currently very poor at ~4%. However, functionally it is equivalent.

What causes the poor match is the fact that only one rectangle initialization is not being inlined (the first one), even though it should be both which would cause both rects to be on the stack and prevent the optimization the compiler currently applies to the following inlined functions.

I've also made several adjustments to `MxRect32` and related classes.