### PR TITLE
Implement MxDisplaySurface::VTable0x28

### DIFF
--- a/LEGO1/legovideomanager.cpp
+++ b/LEGO1/legovideomanager.cpp
@@ -40,8 +40,9 @@ LegoVideoManager::~LegoVideoManager()
 // STUB: LEGO1 0x1007ac40
 MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread)
 {
-	// TODO
-	return MxVideoManager::Create(p_videoParam, p_frequencyMS, p_createThread);
+	MxResult result = MxVideoManager::Create(p_videoParam, p_frequencyMS, p_createThread);
+	m_videoParam.GetPalette()->CreateNativePalette();
+	return result;
 }
 
 // FUNCTION: LEGO1 0x1007b5e0

--- a/LEGO1/mxbitmap.h
+++ b/LEGO1/mxbitmap.h
@@ -81,6 +81,13 @@ public:
 		MxLong alignedWidth = AlignToFourByte(m_bmiHeader->biWidth);
 		return alignedWidth * absHeight;
 	}
+	inline MxLong GetAdjustedStride()
+	{
+		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN || m_bmiHeader->biHeight < 0)
+			return GetBmiStride();
+		else
+			return -GetBmiStride();
+	}
 
 private:
 	MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -387,7 +387,6 @@ void MxDisplaySurface::VTable0x28(
 
 					stride -= p_width;
 					MxS32 length = p_width * 4;
-					MxLong v56 = stride - p_width;
 					MxLong v62 = ddsd.lPitch - length;
 					MxU16* p16BitPal = m_16bitPal;
 					MxS32 height = p_height;
@@ -405,7 +404,7 @@ void MxDisplaySurface::VTable0x28(
 								surface += 2;
 							}
 
-							data += v56;
+							data += stride;
 							surface += v62;
 
 							// Odd expression for the length?

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -373,11 +373,11 @@ void MxDisplaySurface::VTable0x28(
 					while (p_height--) {
 						MxU8* surfaceBefore = surface;
 
-						for (MxS32 i = 0; p_width > i; *(surface - 1) = *(data - 1)) {
-							MxU8 element = *data++;
-							surface += 2;
-							++i;
-							*(surface - 2) = element;
+						for (MxS32 i = 0; p_width > i; i++) {
+							MxU8 element = *data;
+							*surface++ = element;
+							data++;
+							*surface++ = *(data - 1);
 						}
 
 						data += v22;

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -327,10 +327,9 @@ void MxDisplaySurface::VTable0x28(
 		}
 
 		if (hr == DD_OK) {
-			BITMAPINFOHEADER* biHeader = p_bitmap->GetBmiHeader();
 			MxU8* data;
 
-			switch (biHeader->biCompression) {
+			switch (p_bitmap->GetBmiHeader()->biCompression) {
 			case BI_RGB: {
 				MxS32 rowsBeforeTop;
 				if (p_bitmap->GetBmiHeight() < 0)
@@ -360,16 +359,10 @@ void MxDisplaySurface::VTable0x28(
 				switch (m_surfaceDesc.ddpfPixelFormat.dwRGBBitCount) {
 				case 8: {
 					MxU8* surface = (MxU8*) ddsd.lpSurface + p_right + (p_bottom * ddsd.lPitch);
-					MxLong stride;
-
-					if (biHeader->biCompression == BI_RGB_TOPDOWN || p_bitmap->GetBmiHeight() < 0)
-						stride = p_bitmap->GetBmiStride();
-					else
-						stride = -p_bitmap->GetBmiStride();
+					MxLong stride = p_bitmap->GetAdjustedStride();
 
 					MxLong v22 = stride - p_width;
-					MxLong v55 = ddsd.lPitch - (2 * p_width);
-
+					MxLong length = ddsd.lPitch - (2 * p_width);
 					while (p_height--) {
 						MxU8* surfaceBefore = surface;
 
@@ -381,7 +374,7 @@ void MxDisplaySurface::VTable0x28(
 						}
 
 						data += v22;
-						surface += v55;
+						surface += length;
 
 						memcpy(surface, surfaceBefore, 2 * p_width);
 						surface += ddsd.lPitch;
@@ -390,12 +383,7 @@ void MxDisplaySurface::VTable0x28(
 				}
 				case 16: {
 					MxU8* surface = (MxU8*) ddsd.lpSurface + (2 * p_right) + (p_bottom * ddsd.lPitch);
-					MxLong stride;
-
-					if (biHeader->biCompression == BI_RGB_TOPDOWN || p_bitmap->GetBmiHeight() < 0)
-						stride = p_bitmap->GetBmiStride();
-					else
-						stride = -p_bitmap->GetBmiStride();
+					MxLong stride = p_bitmap->GetAdjustedStride();
 
 					stride -= p_width;
 					MxS32 length = p_width * 4;
@@ -448,33 +436,22 @@ void MxDisplaySurface::VTable0x28(
 				switch (m_surfaceDesc.ddpfPixelFormat.dwRGBBitCount) {
 				case 8: {
 					MxU8* surface = (MxU8*) ddsd.lpSurface + p_right + (p_bottom * ddsd.lPitch);
-					MxLong stride;
+					MxLong stride = p_bitmap->GetAdjustedStride();
 
-					if (biHeader->biCompression == BI_RGB_TOPDOWN || p_bitmap->GetBmiHeight() < 0)
-						stride = p_bitmap->GetBmiStride();
-					else
-						stride = -p_bitmap->GetBmiStride();
-
-					MxLong v57 = ddsd.lPitch;
+					MxLong length = ddsd.lPitch;
 					while (p_height--) {
 						memcpy(surface, data, p_width);
 						data += stride;
-						surface += v57;
+						surface += length;
 					}
 					break;
 				}
 				case 16: {
 					MxU8* surface = (MxU8*) ddsd.lpSurface + (2 * p_right) + (p_bottom * ddsd.lPitch);
-					MxLong stride;
-
-					if (biHeader->biCompression == BI_RGB_TOPDOWN || p_bitmap->GetBmiHeight() < 0)
-						stride = p_bitmap->GetBmiStride();
-					else
-						stride = -p_bitmap->GetBmiStride();
+					MxLong stride = p_bitmap->GetAdjustedStride();
 
 					MxLong v50 = stride - p_width;
 					MxLong length = ddsd.lPitch - (2 * p_width);
-
 					for (MxS32 i = 0; p_height > i; i++) {
 						for (MxS32 j = 0; p_width > j; j++) {
 							*(MxU16*) surface = m_16bitPal[*data++];

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -396,17 +396,19 @@ void MxDisplaySurface::VTable0x28(
 					else
 						stride = -p_bitmap->GetBmiStride();
 
+					stride -= p_width;
 					MxS32 length = p_width * 4;
 					MxLong v56 = stride - p_width;
 					MxLong v62 = ddsd.lPitch - length;
 					MxU16* p16BitPal = m_16bitPal;
 					MxS32 height = p_height;
+					MxS32 width = p_width;
 
-					if (stride != p_width || v62) {
+					if (stride || v62) {
 						while (height--) {
 							MxU8* surfaceBefore = surface;
 
-							for (MxS32 i = p_width; i > 0; i--) {
+							for (MxS32 i = width; i > 0; i--) {
 								MxU16 element = p16BitPal[*data++];
 								*(MxU16*) surface = element;
 								surface += 2;
@@ -426,7 +428,7 @@ void MxDisplaySurface::VTable0x28(
 						while (height--) {
 							MxU8* surfaceBefore = surface;
 
-							for (MxS32 i = p_width; i > 0; i--) {
+							for (MxS32 i = width; i > 0; i--) {
 								MxU16 element = p16BitPal[*data++];
 								*(MxU16*) surface = element;
 								surface += 2;

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -400,9 +400,10 @@ void MxDisplaySurface::VTable0x28(
 					MxLong v56 = stride - p_width;
 					MxLong v62 = ddsd.lPitch - length;
 					MxU16* p16BitPal = m_16bitPal;
+					MxS32 height = p_height;
 
 					if (stride != p_width || v62) {
-						while (p_height--) {
+						while (height--) {
 							MxU8* surfaceBefore = surface;
 
 							for (MxS32 i = p_width; i > 0; i--) {
@@ -413,13 +414,14 @@ void MxDisplaySurface::VTable0x28(
 							}
 
 							data += v56;
+							surface += v62;
 
-							memcpy(&surface[v62], surfaceBefore, length);
-							surface = &surface[v62] + ddsd.lPitch;
+							memcpy(surface, surfaceBefore, length);
+							surface += ddsd.lPitch;
 						}
 					}
 					else {
-						while (p_height--) {
+						while (height--) {
 							MxU8* surfaceBefore = surface;
 
 							for (MxS32 i = p_width; i > 0; i--) {

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -468,8 +468,8 @@ void MxDisplaySurface::VTable0x28(
 					MxLong v50 = stride - p_width;
 					MxLong j = ddsd.lPitch - (2 * p_width);
 
-					for (MxU32 v51 = 0; p_height > v51; v51++) {
-						for (MxU32 k = 0; p_width > k; k++) {
+					for (MxS32 v51 = 0; p_height > v51; v51++) {
+						for (MxS32 k = 0; p_width > k; k++) {
 							MxU8 v53 = *data++;
 							surface += 2;
 							*(MxU16*) (surface - 2) = m_16bitPal[v53];

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -416,7 +416,8 @@ void MxDisplaySurface::VTable0x28(
 							data += v56;
 							surface += v62;
 
-							memcpy(surface, surfaceBefore, length);
+							// Odd expression for the length?
+							memcpy(surface, surfaceBefore, 4 * ((MxU32) (4 * p_width) / 4));
 							surface += ddsd.lPitch;
 						}
 					}

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -418,7 +418,7 @@ void MxDisplaySurface::VTable0x28(
 									surface += 4;
 									*((MxU16*) surface - 2) = element;
 									--v38;
-									*((MxU16*) surface - 2) = element;
+									*((MxU16*) surface - 1) = element;
 								} while (v38);
 							}
 
@@ -443,7 +443,7 @@ void MxDisplaySurface::VTable0x28(
 									surface += 4;
 									*((MxU16*) surface - 2) = element;
 									--v34;
-									*((MxU16*) surface - 2) = element;
+									*((MxU16*) surface - 1) = element;
 								} while (v34);
 							}
 
@@ -492,7 +492,6 @@ void MxDisplaySurface::VTable0x28(
 						for (MxU32 k = 0; p_width > k; k++) {
 							MxU8 v53 = *data++;
 							surface += 2;
-							//*(MxU16*) (surface - 2) = *(MxU16*) (*(MxU32*) (&m_16bitPal) + 2 * v53);
 							*(MxU16*) (surface - 2) = m_16bitPal[v53];
 						}
 						data += v50;

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -381,9 +381,10 @@ void MxDisplaySurface::VTable0x28(
 						}
 
 						data += v22;
+						surface += v55;
 
-						memcpy(&surface[v55], surfaceBefore, 2 * p_width);
-						surface = &surface[v55] + ddsd.lPitch;
+						memcpy(surface, surfaceBefore, 2 * p_width);
+						surface += ddsd.lPitch;
 					}
 					break;
 				}

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -449,9 +449,8 @@ void MxDisplaySurface::VTable0x28(
 
 					MxLong v57 = ddsd.lPitch;
 					while (p_height--) {
-						MxU8* prevData = data;
+						memcpy(surface, data, p_width);
 						data += stride;
-						memcpy(surface, prevData, p_width);
 						surface += v57;
 					}
 					break;
@@ -466,16 +465,16 @@ void MxDisplaySurface::VTable0x28(
 						stride = -p_bitmap->GetBmiStride();
 
 					MxLong v50 = stride - p_width;
-					MxLong j = ddsd.lPitch - (2 * p_width);
+					MxLong length = ddsd.lPitch - (2 * p_width);
 
-					for (MxS32 v51 = 0; p_height > v51; v51++) {
-						for (MxS32 k = 0; p_width > k; k++) {
-							MxU8 v53 = *data++;
+					for (MxS32 i = 0; p_height > i; i++) {
+						for (MxS32 j = 0; p_width > j; j++) {
+							*(MxU16*) (surface) = m_16bitPal[*data++];
 							surface += 2;
-							*(MxU16*) (surface - 2) = m_16bitPal[v53];
 						}
+
 						data += v50;
-						surface += j;
+						surface += length;
 					}
 				}
 				}

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -334,7 +334,7 @@ void MxDisplaySurface::VTable0x28(
 			case BI_RGB: {
 				MxS32 rowsBeforeTop;
 				if (p_bitmap->GetBmiHeight() < 0)
-					rowsBeforeTop = 0;
+					rowsBeforeTop = p_top;
 				else
 					rowsBeforeTop = p_bitmap->GetBmiHeightAbs() - p_top - 1;
 				data = p_bitmap->GetBitmapData() + p_left + (p_bitmap->GetBmiStride() * rowsBeforeTop);
@@ -359,7 +359,6 @@ void MxDisplaySurface::VTable0x28(
 
 				switch (m_surfaceDesc.ddpfPixelFormat.dwRGBBitCount) {
 				case 8: {
-					OutputDebugStr("Flag, Case 8bit");
 					MxU8* surface = (MxU8*) ddsd.lpSurface + p_right + (p_bottom * ddsd.lPitch);
 					MxLong stride;
 
@@ -382,10 +381,9 @@ void MxDisplaySurface::VTable0x28(
 						}
 
 						data += v22;
-						MxU8* dest = surface + v55;
 
-						memcpy(dest, surfaceBefore, 2 * p_width);
-						surface = dest + ddsd.lPitch;
+						memcpy(&surface[v55], surfaceBefore, 2 * p_width);
+						surface = &surface[v55] + ddsd.lPitch;
 					}
 					break;
 				}
@@ -398,56 +396,40 @@ void MxDisplaySurface::VTable0x28(
 					else
 						stride = -p_bitmap->GetBmiStride();
 
-					MxLong v31 = 4 * p_width;
+					MxS32 length = p_width * 4;
 					MxLong v56 = stride - p_width;
-					MxS32 v61 = p_width;
-					MxLong v62 = ddsd.lPitch - (4 * p_width);
+					MxLong v62 = ddsd.lPitch - length;
 					MxU16* p16BitPal = m_16bitPal;
 
 					if (stride != p_width || v62) {
-						OutputDebugStr("Flag, Case 16bit A");
 						while (p_height--) {
 							MxU8* surfaceBefore = surface;
 
-							if (v61 > 0) {
-								MxS32 v38 = v61;
-								do {
-									MxU32 element = *data++;
-									element = p16BitPal[element];
-
-									surface += 4;
-									*((MxU16*) surface - 2) = element;
-									--v38;
-									*((MxU16*) surface - 1) = element;
-								} while (v38);
+							for (MxS32 i = p_width; i > 0; i--) {
+								MxU16 element = p16BitPal[*data++];
+								surface += 4;
+								*((MxU16*) surface - 2) = element;
+								*((MxU16*) surface - 1) = element;
 							}
 
 							data += v56;
-							MxU8* dest = &surface[v62];
 
-							memcpy(dest, surfaceBefore, 4 * ((MxU32) (4 * p_width) >> 2));
-							surface = dest + ddsd.lPitch;
+							memcpy(&surface[v62], surfaceBefore, length);
+							surface = &surface[v62] + ddsd.lPitch;
 						}
 					}
 					else {
-						OutputDebugStr("Flag, Case 16bit B");
 						while (p_height--) {
 							MxU8* surfaceBefore = surface;
 
-							if (v61 > 0) {
-								MxS32 v34 = v61;
-								do {
-									MxU32 element = *data++;
-									element = p16BitPal[element];
-
-									surface += 4;
-									*((MxU16*) surface - 2) = element;
-									--v34;
-									*((MxU16*) surface - 1) = element;
-								} while (v34);
+							for (MxS32 i = p_width; i > 0; i--) {
+								MxU16 element = p16BitPal[*data++];
+								surface += 4;
+								*((MxU16*) surface - 2) = element;
+								*((MxU16*) surface - 1) = element;
 							}
 
-							memcpy(surface, surfaceBefore, v31);
+							memcpy(surface, surfaceBefore, length);
 							surface += ddsd.lPitch;
 						}
 					}
@@ -457,7 +439,6 @@ void MxDisplaySurface::VTable0x28(
 			else {
 				switch (m_surfaceDesc.ddpfPixelFormat.dwRGBBitCount) {
 				case 8: {
-					OutputDebugStr("No flag, Case 8bit");
 					MxU8* surface = (MxU8*) ddsd.lpSurface + p_right + (p_bottom * ddsd.lPitch);
 					MxLong stride;
 
@@ -476,7 +457,6 @@ void MxDisplaySurface::VTable0x28(
 					break;
 				}
 				case 16: {
-					OutputDebugStr("No flag, Case 16bit");
 					MxU8* surface = (MxU8*) ddsd.lpSurface + (2 * p_right) + (p_bottom * ddsd.lPitch);
 					MxLong stride;
 

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -385,12 +385,13 @@ void MxDisplaySurface::VTable0x28(
 					MxU8* surface = (MxU8*) ddsd.lpSurface + (2 * p_right) + (p_bottom * ddsd.lPitch);
 					MxLong stride = p_bitmap->GetAdjustedStride();
 
+					// TODO: Match
 					stride -= p_width;
 					MxS32 length = p_width * 4;
 					MxLong v62 = ddsd.lPitch - length;
-					MxU16* p16BitPal = m_16bitPal;
 					MxS32 height = p_height;
 					MxS32 width = p_width;
+					MxU16* p16BitPal = m_16bitPal;
 
 					if (stride || v62) {
 						while (height--) {

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -295,13 +295,13 @@ void MxDisplaySurface::SetPalette(MxPalette* p_palette)
 
 // FUNCTION: LEGO1 0x100bacc0
 void MxDisplaySurface::VTable0x28(
-	MxBitmap* p_bitmap, // a2
-	MxS32 p_left,       // a3
-	MxS32 p_top,        // a4
-	MxS32 p_right,      // a5
-	MxS32 p_bottom,     // a6
-	MxS32 p_width,      // a7
-	MxS32 p_height      // a8
+	MxBitmap* p_bitmap,
+	MxS32 p_left,
+	MxS32 p_top,
+	MxS32 p_right,
+	MxS32 p_bottom,
+	MxS32 p_width,
+	MxS32 p_height
 )
 {
 	if (FUN_100b6e10(

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -408,9 +408,10 @@ void MxDisplaySurface::VTable0x28(
 
 							for (MxS32 i = p_width; i > 0; i--) {
 								MxU16 element = p16BitPal[*data++];
-								surface += 4;
-								*((MxU16*) surface - 2) = element;
-								*((MxU16*) surface - 1) = element;
+								*(MxU16*) surface = element;
+								surface += 2;
+								*(MxU16*) surface = element;
+								surface += 2;
 							}
 
 							data += v56;
@@ -427,9 +428,10 @@ void MxDisplaySurface::VTable0x28(
 
 							for (MxS32 i = p_width; i > 0; i--) {
 								MxU16 element = p16BitPal[*data++];
-								surface += 4;
-								*((MxU16*) surface - 2) = element;
-								*((MxU16*) surface - 1) = element;
+								*(MxU16*) surface = element;
+								surface += 2;
+								*(MxU16*) surface = element;
+								surface += 2;
 							}
 
 							memcpy(surface, surfaceBefore, length);
@@ -472,7 +474,7 @@ void MxDisplaySurface::VTable0x28(
 
 					for (MxS32 i = 0; p_height > i; i++) {
 						for (MxS32 j = 0; p_width > j; j++) {
-							*(MxU16*) (surface) = m_16bitPal[*data++];
+							*(MxU16*) surface = m_16bitPal[*data++];
 							surface += 2;
 						}
 

--- a/LEGO1/mxdisplaysurface.h
+++ b/LEGO1/mxdisplaysurface.h
@@ -35,7 +35,7 @@ public:
 		undefined4,
 		undefined4
 	); // vtable+0x24
-	virtual MxBool VTable0x28(
+	virtual void VTable0x28(
 		MxBitmap* p_bitmap,
 		MxS32 p_left,
 		MxS32 p_top,


### PR DESCRIPTION
This adds the implementation for `VTable0x28`, which was the last piece necessary to render something from the initial Smacker video in `nocd.si`.

The match isn't great at ~30% and it will probably take a lot of further experimentation to get it right, since it's a very large function again and minor differences in variable placement/usage, inline functions etc. are highly important. Functionally I believe it should be accurate, although it's easy to miss something with a function of this size, so I'm inviting everyone to check it out and look for any issues. The 16-bit branches are the one currently most relevant.

Many variable names are also still placeholders or should be improved - suggestions welcome.

https://github.com/isledecomp/isle/assets/1135351/160b91bb-d31c-4aa9-87ab-1fbb29bdd428

