### PR TITLE
Implement/match MxDeviceEnumerate::ParseDeviceName and ProcessDeviceBytes

### DIFF
--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -454,7 +454,7 @@ MxS32 MxDeviceEnumerate::ProcessDeviceBytes(MxS32 p_num, DeviceHex& p_deviceHex)
 	DeviceHex deviceHex = p_deviceHex;
 
 	for (list<MxDeviceEnumerateElement>::iterator it = m_list.begin(); it != m_list.end(); it++) {
-		if (p_num >= 0 && p_num > i)
+		if (p_num >= 0 && p_num < i)
 			return -1;
 
 		MxDeviceEnumerateElement& elem = *it;

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -458,11 +458,11 @@ MxS32 MxDeviceEnumerate::ProcessDeviceBytes(MxS32 p_num, DeviceHex& p_deviceHex)
 			return -1;
 
 		MxDeviceEnumerateElement& elem = *it;
-		for (list<MxDisplayMode>::iterator it2 = elem.m_displayModes.begin(); it2 != elem.m_displayModes.end(); it2++) {
-			MxDisplayMode displayMode = *it2;
+		for (list<MxDevice>::iterator it2 = elem.m_devices.begin(); it2 != elem.m_devices.end(); it2++) {
+			DeviceHex hex;
+			memcpy(&hex, (*it2).m_guid, sizeof(GUID));
 
-			if (displayMode.m_width == deviceHex.hex1 && displayMode.m_height == deviceHex.hex2 &&
-				displayMode.m_bitsPerPixel == deviceHex.hex3 && i == p_num)
+			if (hex.hex1 == deviceHex.hex1 && hex.hex2 == deviceHex.hex2 && hex.hex3 == deviceHex.hex3 && i == p_num)
 				return j;
 
 			j++;

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -454,11 +454,11 @@ MxS32 MxDeviceEnumerate::ProcessDeviceBytes(MxS32 p_num, DeviceHex& p_deviceHex)
 	DeviceHex deviceHex = p_deviceHex;
 
 	for (list<MxDeviceEnumerateElement>::iterator it = m_list.begin(); it != m_list.end(); it++) {
-		if (p_num >= 0 && p_num < i)
+		if (p_num >= 0 && p_num > i)
 			return -1;
 
-		for (list<MxDisplayMode>::iterator it2 = (*it).m_displayModes.begin(); it2 != (*it).m_displayModes.end();
-			 it2++) {
+		MxDeviceEnumerateElement& elem = *it;
+		for (list<MxDisplayMode>::iterator it2 = elem.m_displayModes.begin(); it2 != elem.m_displayModes.end(); it2++) {
 			MxDisplayMode displayMode = *it2;
 
 			if (displayMode.m_width == deviceHex.hex1 && displayMode.m_height == deviceHex.hex2 &&

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -459,10 +459,11 @@ MxS32 MxDeviceEnumerate::ProcessDeviceBytes(MxS32 p_num, DeviceHex& p_deviceHex)
 
 		MxDeviceEnumerateElement& elem = *it;
 		for (list<MxDevice>::iterator it2 = elem.m_devices.begin(); it2 != elem.m_devices.end(); it2++) {
-			DeviceHex hex;
-			memcpy(&hex, (*it2).m_guid, sizeof(GUID));
+			DeviceHex guidHex;
+			memcpy(&guidHex, (*it2).m_guid, sizeof(GUID));
 
-			if (hex.hex1 == deviceHex.hex1 && hex.hex2 == deviceHex.hex2 && hex.hex3 == deviceHex.hex3 && i == p_num)
+			if (deviceHex.hex1 == guidHex.hex1 && deviceHex.hex2 == guidHex.hex2 && deviceHex.hex3 == guidHex.hex3 &&
+				deviceHex.hex4 == guidHex.hex4 && i == p_num)
 				return j;
 
 			j++;

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -150,13 +150,6 @@ struct MxDeviceEnumerateElement {
 // SIZE 0x14
 class MxDeviceEnumerate {
 public:
-	struct DeviceHex {
-		MxS32 hex1;
-		MxS32 hex2;
-		MxS32 hex3;
-		MxS32 hex4;
-	};
-
 	MxDeviceEnumerate();
 	// FUNCTION: LEGO1 0x1009c010
 	~MxDeviceEnumerate() {}
@@ -174,7 +167,7 @@ public:
 	);
 	const char* EnumerateErrorToString(HRESULT p_error);
 	MxS32 ParseDeviceName(const char* p_deviceId);
-	MxS32 ProcessDeviceBytes(MxS32 p_num, DeviceHex& p_deviceHex);
+	MxS32 ProcessDeviceBytes(MxS32 p_num, GUID& p_guid);
 	MxResult FUN_1009d030(MxS32 p_und1, undefined** p_und2, undefined** p_und3);
 	MxResult FUN_1009d0d0();
 	MxResult FUN_1009d210();

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -150,6 +150,13 @@ struct MxDeviceEnumerateElement {
 // SIZE 0x14
 class MxDeviceEnumerate {
 public:
+	struct DeviceHex {
+		MxS32 hex1;
+		MxS32 hex2;
+		MxS32 hex3;
+		MxS32 hex4;
+	};
+
 	MxDeviceEnumerate();
 	// FUNCTION: LEGO1 0x1009c010
 	~MxDeviceEnumerate() {}
@@ -167,6 +174,7 @@ public:
 	);
 	const char* EnumerateErrorToString(HRESULT p_error);
 	MxS32 ParseDeviceName(const char* p_deviceId);
+	MxS32 ProcessDeviceBytes(MxS32 p_num, DeviceHex& p_deviceHex);
 	MxResult FUN_1009d030(MxS32 p_und1, undefined** p_und2, undefined** p_und3);
 	MxResult FUN_1009d0d0();
 	MxResult FUN_1009d210();
@@ -186,7 +194,7 @@ public:
 
 private:
 	list<MxDeviceEnumerateElement> m_list; // 0x04
-	MxBool m_unk0x10;                      // 0x10
+	MxBool m_initialized;                  // 0x10
 };
 
 // VTABLE: LEGO1 0x100d9cc8

--- a/util/compat.h
+++ b/util/compat.h
@@ -21,8 +21,9 @@
 // We use `override` so newer compilers can tell us our vtables are valid,
 // however this keyword was added in C++11, so we define it as empty for
 // compatibility with older compilers.
-#if defined(_MSC_VER) && _MSC_VER <= 1200 // 1200 corresponds to VC6.0 but "override" was probably added even later
+#if __cplusplus < 201103L
 #define override
+#define static_assert(expr, msg)
 #endif
 
 #endif // COMPAT_H


### PR DESCRIPTION
`ParseDeviceName` matches 100%.

`ProcessDeviceBytes` is at 75%, however the code is pretty much equivalent except for a minor difference in stack allocation and the inner loop layout.

I've added a macro for C++11 `static_assert` since it comes in useful in cases such as seen in `ProcessDeviceBytes`.