### PR TITLE
Implement/match most remaining MxDirect3D device enumeration functions

### DIFF
--- a/LEGO1/legovideomanager.cpp
+++ b/LEGO1/legovideomanager.cpp
@@ -57,7 +57,7 @@ MxResult LegoVideoManager::CreateDirect3D()
 MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread)
 {
 	MxBool paletteCreated = FALSE;
-	MxDeviceEnumerateElement* deviceEnumerate = NULL;
+	MxDriver* driver = NULL;
 	MxDevice* device = NULL;
 	MxResult result = FAILURE;
 
@@ -91,7 +91,7 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	if (p_videoParam.GetDeviceName()) {
 		deviceNum = deviceEnumerator.ParseDeviceName(p_videoParam.GetDeviceName());
 		if (deviceNum >= 0) {
-			if ((deviceNum = deviceEnumerator.GetDevice(deviceNum, deviceEnumerate, device)) != SUCCESS)
+			if ((deviceNum = deviceEnumerator.GetDevice(deviceNum, driver, device)) != SUCCESS)
 				deviceNum = -1;
 		}
 	}
@@ -99,12 +99,12 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	if (deviceNum < 0) {
 		deviceEnumerator.FUN_1009d210();
 		deviceNum = deviceEnumerator.FUN_1009d0d0();
-		deviceEnumerator.GetDevice(deviceNum, deviceEnumerate, device);
+		deviceEnumerator.GetDevice(deviceNum, driver, device);
 	}
 
-	m_direct3d->FUN_1009b5f0(deviceEnumerator, deviceEnumerate, device);
+	m_direct3d->FUN_1009b5f0(deviceEnumerator, driver, device);
 
-	if (!deviceEnumerate->m_ddCaps.dwCaps2 && deviceEnumerate->m_ddCaps.dwSVBRops[7] != 2)
+	if (!driver->m_ddCaps.dwCaps2 && driver->m_ddCaps.dwSVBRops[7] != 2)
 		p_videoParam.Flags().SetF2bit0(TRUE);
 	else
 		p_videoParam.Flags().SetF2bit0(FALSE);

--- a/LEGO1/legovideomanager.cpp
+++ b/LEGO1/legovideomanager.cpp
@@ -57,18 +57,18 @@ MxResult LegoVideoManager::CreateDirect3D()
 MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread)
 {
 	MxBool paletteCreated = FALSE;
-	undefined* und1 = NULL;
-	undefined* und2 = NULL;
+	MxDeviceEnumerateElement* deviceEnumerate = NULL;
+	MxDevice* device = NULL;
 	MxResult result = FAILURE;
 
-	MxDeviceEnumerate100d9cc8 deviceEnumerate;
+	MxDeviceEnumerate100d9cc8 deviceEnumerator;
 	Vector3Data posVec(0.0, 1.25, -50.0);
 	Vector3Data dirVec(0.0, 0.0, 1.0);
 	Vector3Data upVec(0.0, 1.0, 0.0);
 	Matrix4Data outMatrix;
 	HWND hwnd = MxOmni::GetInstance()->GetWindowHandle();
 	MxS32 bits = p_videoParam.Flags().Get16Bit() ? 16 : 8;
-	MxS32 und3 = -1;
+	MxS32 deviceNum = -1;
 
 	if (!p_videoParam.GetPalette()) {
 		MxPalette* palette = new MxPalette;
@@ -85,26 +85,26 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	if (CreateDirect3D() != SUCCESS)
 		goto done;
 
-	if (deviceEnumerate.DoEnumerate() != SUCCESS)
+	if (deviceEnumerator.DoEnumerate() != SUCCESS)
 		goto done;
 
 	if (p_videoParam.GetDeviceName()) {
-		und3 = deviceEnumerate.ParseDeviceName(p_videoParam.GetDeviceName());
-		if (und3 >= 0) {
-			if ((und3 = deviceEnumerate.FUN_1009d030(und3, &und1, &und2)) != SUCCESS)
-				und3 = -1;
+		deviceNum = deviceEnumerator.ParseDeviceName(p_videoParam.GetDeviceName());
+		if (deviceNum >= 0) {
+			if ((deviceNum = deviceEnumerator.GetDevice(deviceNum, deviceEnumerate, device)) != SUCCESS)
+				deviceNum = -1;
 		}
 	}
 
-	if (und3 < 0) {
-		deviceEnumerate.FUN_1009d210();
-		und3 = deviceEnumerate.FUN_1009d0d0();
-		deviceEnumerate.FUN_1009d030(und3, &und1, &und2);
+	if (deviceNum < 0) {
+		deviceEnumerator.FUN_1009d210();
+		deviceNum = deviceEnumerator.FUN_1009d0d0();
+		deviceEnumerator.GetDevice(deviceNum, deviceEnumerate, device);
 	}
 
-	m_direct3d->FUN_1009b5f0(deviceEnumerate, und1, und2);
+	m_direct3d->FUN_1009b5f0(deviceEnumerator, deviceEnumerate, device);
 
-	if (!*((MxU32*) &und1[0x14]) && *((MxU32*) &und1[0xe0]) != 2)
+	if (!deviceEnumerate->m_ddCaps.dwCaps2 && deviceEnumerate->m_ddCaps.dwSVBRops[7] != 2)
 		p_videoParam.Flags().SetF2bit0(TRUE);
 	else
 		p_videoParam.Flags().SetF2bit0(FALSE);

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -473,8 +473,9 @@ MxS32 MxDeviceEnumerate::ProcessDeviceBytes(MxS32 p_deviceNum, GUID& p_guid)
 			return -1;
 
 		GUID4 compareGuid;
-		MxDeviceEnumerateElement& elem = *it;
-		for (list<MxDevice>::iterator it2 = elem.m_devices.begin(); it2 != elem.m_devices.end(); it2++) {
+		MxDeviceEnumerateElement& deviceEnumerate = *it;
+		for (list<MxDevice>::iterator it2 = deviceEnumerate.m_devices.begin(); it2 != deviceEnumerate.m_devices.end();
+			 it2++) {
 			memcpy(&compareGuid, (*it2).m_guid, sizeof(GUID4));
 
 			if (compareGuid.m_data1 == deviceGuid.m_data1 && compareGuid.m_data2 == deviceGuid.m_data2 &&
@@ -521,10 +522,51 @@ MxResult MxDeviceEnumerate::GetDevice(
 	return FAILURE;
 }
 
-// STUB: LEGO1 0x1009d0d0
-MxResult MxDeviceEnumerate::FUN_1009d0d0()
+// FUNCTION: LEGO1 0x1009d0d0
+MxS32 MxDeviceEnumerate::FUN_1009d0d0()
 {
-	return FAILURE;
+	if (!m_initialized)
+		return -1;
+
+	if (m_list.empty())
+		return -1;
+
+	MxS32 i = 0;
+	MxS32 j = 0;
+	MxS32 k = -1;
+	MxU32 und = FUN_1009d1a0();
+
+	for (list<MxDeviceEnumerateElement>::iterator it = m_list.begin();; it++) {
+		if (it == m_list.end())
+			return k;
+
+		for (list<MxDevice>::iterator it2 = (*it).m_devices.begin(); it2 != (*it).m_devices.end(); it2++) {
+			if ((*it2).m_HWDesc.dcmColorModel)
+				return j;
+
+			if ((und && (*it2).m_HELDesc.dcmColorModel == D3DCOLOR_RGB && i == 0) ||
+				(*it2).m_HELDesc.dcmColorModel == D3DCOLOR_MONO && i == 0 && k < 0)
+				k = j;
+
+			j++;
+		}
+
+		i++;
+	}
+
+	return -1;
+}
+
+// STUB: LEGO1 0x1009d1a0
+undefined4 MxDeviceEnumerate::FUN_1009d1a0()
+{
+	return 1;
+}
+
+// STUB: LEGO1 0x1009d1e0
+undefined4 MxDeviceEnumerate::FUN_1009d1e0()
+{
+	return 1;
 }
 
 // FUNCTION: LEGO1 0x1009d210
@@ -534,21 +576,22 @@ MxResult MxDeviceEnumerate::FUN_1009d210()
 		return FAILURE;
 
 	for (list<MxDeviceEnumerateElement>::iterator it = m_list.begin(); it != m_list.end();) {
-		MxDeviceEnumerateElement& elem = *it;
+		MxDeviceEnumerateElement& deviceEnumerate = *it;
 
-		if (!FUN_1009d370(elem))
+		if (!FUN_1009d370(deviceEnumerate))
 			m_list.erase(it++);
 		else {
-			for (list<MxDevice>::iterator it2 = elem.m_devices.begin(); it2 != elem.m_devices.end();) {
+			for (list<MxDevice>::iterator it2 = deviceEnumerate.m_devices.begin();
+				 it2 != deviceEnumerate.m_devices.end();) {
 				MxDevice& device = *it2;
 
 				if (!FUN_1009d3d0(device))
-					elem.m_devices.erase(it2++);
+					deviceEnumerate.m_devices.erase(it2++);
 				else
 					it2++;
 			}
 
-			if (elem.m_devices.empty())
+			if (deviceEnumerate.m_devices.empty())
 				m_list.erase(it++);
 			else
 				it++;
@@ -573,8 +616,19 @@ MxBool MxDeviceEnumerate::FUN_1009d370(MxDeviceEnumerateElement& p_deviceEnumera
 	return FALSE;
 }
 
-// STUB: LEGO1 0x1009d3d0
+// FUNCTION: LEGO1 0x1009d3d0
 MxBool MxDeviceEnumerate::FUN_1009d3d0(MxDevice& p_device)
 {
+	if (m_list.size() <= 0)
+		return FALSE;
+
+	if (p_device.m_HWDesc.dcmColorModel)
+		return p_device.m_HWDesc.dwDeviceZBufferBitDepth & DDBD_16 && p_device.m_HWDesc.dpcTriCaps.dwTextureCaps & 1;
+
+	for (list<MxDevice>::iterator it = m_list.front().m_devices.begin(); it != m_list.front().m_devices.end(); it++) {
+		if ((&*it) == &p_device)
+			return TRUE;
+	}
+
 	return FALSE;
 }

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -272,15 +272,15 @@ MxDeviceEnumerate::MxDeviceEnumerate()
 // FUNCTION: LEGO1 0x1009c070
 BOOL MxDeviceEnumerate::EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName)
 {
-	MxDriver device(p_guid, p_driverDesc, p_driverName);
-	m_list.push_back(device);
+	MxDriver driver(p_guid, p_driverDesc, p_driverName);
+	m_list.push_back(driver);
 
 	// Must be zeroed because held resources are copied by pointer only
 	// and should not be freed at the end of this function
-	device.m_guid = NULL;
-	device.m_driverDesc = NULL;
-	device.m_driverName = NULL;
-	memset(&device.m_ddCaps, 0, sizeof(device.m_ddCaps));
+	driver.m_guid = NULL;
+	driver.m_driverDesc = NULL;
+	driver.m_driverName = NULL;
+	memset(&driver.m_ddCaps, 0, sizeof(driver.m_ddCaps));
 
 	LPDIRECT3D2 lpDirect3d2 = NULL;
 	LPDIRECTDRAW lpDD = NULL;
@@ -469,9 +469,8 @@ MxS32 MxDeviceEnumerate::ProcessDeviceBytes(MxS32 p_deviceNum, GUID& p_guid)
 			return -1;
 
 		GUID4 compareGuid;
-		MxDriver& deviceEnumerate = *it;
-		for (list<MxDevice>::iterator it2 = deviceEnumerate.m_devices.begin(); it2 != deviceEnumerate.m_devices.end();
-			 it2++) {
+		MxDriver& driver = *it;
+		for (list<MxDevice>::iterator it2 = driver.m_devices.begin(); it2 != driver.m_devices.end(); it2++) {
 			memcpy(&compareGuid, (*it2).m_guid, sizeof(GUID4));
 
 			if (compareGuid.m_data1 == deviceGuid.m_data1 && compareGuid.m_data2 == deviceGuid.m_data2 &&
@@ -566,22 +565,21 @@ MxResult MxDeviceEnumerate::FUN_1009d210()
 		return FAILURE;
 
 	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end();) {
-		MxDriver& deviceEnumerate = *it;
+		MxDriver& driver = *it;
 
-		if (!FUN_1009d370(deviceEnumerate))
+		if (!FUN_1009d370(driver))
 			m_list.erase(it++);
 		else {
-			for (list<MxDevice>::iterator it2 = deviceEnumerate.m_devices.begin();
-				 it2 != deviceEnumerate.m_devices.end();) {
+			for (list<MxDevice>::iterator it2 = driver.m_devices.begin(); it2 != driver.m_devices.end();) {
 				MxDevice& device = *it2;
 
 				if (!FUN_1009d3d0(device))
-					deviceEnumerate.m_devices.erase(it2++);
+					driver.m_devices.erase(it2++);
 				else
 					it2++;
 			}
 
-			if (deviceEnumerate.m_devices.empty())
+			if (driver.m_devices.empty())
 				m_list.erase(it++);
 			else
 				it++;

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -19,6 +19,8 @@ public:
 };
 
 class MxDeviceEnumerate;
+struct MxDeviceEnumerateElement;
+struct MxDevice;
 
 // VTABLE: LEGO1 0x100db800
 // SIZE 0x894
@@ -43,7 +45,11 @@ public:
 
 	BOOL CreateIDirect3D();
 	BOOL D3DSetMode();
-	BOOL FUN_1009b5f0(MxDeviceEnumerate& p_deviceEnumerate, undefined* p_und1, undefined* p_und2);
+	BOOL FUN_1009b5f0(
+		MxDeviceEnumerate& p_deviceEnumerator,
+		MxDeviceEnumerateElement* p_deviceEnumerate,
+		MxDevice* p_device
+	);
 
 	inline MxDeviceModeFinder* GetDeviceModeFinder() { return this->m_pDeviceModeFinder; };
 	inline IDirect3D* GetDirect3D() { return this->m_pDirect3d; }
@@ -146,6 +152,12 @@ struct MxDeviceEnumerateElement {
 // SYNTHETIC: LEGO1 0x1009c290
 // MxDeviceEnumerateElement::MxDeviceEnumerateElement
 
+// SYNTHETIC: LEGO1 0x1009d450
+// MxDeviceEnumerateElement::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1009d470
+// MxDevice::`scalar deleting destructor'
+
 // VTABLE: LEGO1 0x100db814
 // SIZE 0x14
 class MxDeviceEnumerate {
@@ -167,10 +179,12 @@ public:
 	);
 	const char* EnumerateErrorToString(HRESULT p_error);
 	MxS32 ParseDeviceName(const char* p_deviceId);
-	MxS32 ProcessDeviceBytes(MxS32 p_num, GUID& p_guid);
-	MxResult FUN_1009d030(MxS32 p_und1, undefined** p_und2, undefined** p_und3);
+	MxS32 ProcessDeviceBytes(MxS32 p_deviceNum, GUID& p_guid);
+	MxResult GetDevice(MxS32 p_deviceNum, MxDeviceEnumerateElement*& p_deviceEnumerate, MxDevice*& p_device);
 	MxResult FUN_1009d0d0();
 	MxResult FUN_1009d210();
+	MxBool FUN_1009d370(MxDeviceEnumerateElement& p_deviceEnumerate);
+	MxBool FUN_1009d3d0(MxDevice& p_device);
 
 	static void BuildErrorString(const char*, ...);
 	static BOOL CALLBACK

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -19,7 +19,7 @@ public:
 };
 
 class MxDeviceEnumerate;
-struct MxDeviceEnumerateElement;
+struct MxDriver;
 struct MxDevice;
 
 // VTABLE: LEGO1 0x100db800
@@ -45,11 +45,7 @@ public:
 
 	BOOL CreateIDirect3D();
 	BOOL D3DSetMode();
-	BOOL FUN_1009b5f0(
-		MxDeviceEnumerate& p_deviceEnumerator,
-		MxDeviceEnumerateElement* p_deviceEnumerate,
-		MxDevice* p_device
-	);
+	BOOL FUN_1009b5f0(MxDeviceEnumerate& p_deviceEnumerator, MxDriver* p_driver, MxDevice* p_device);
 
 	inline MxDeviceModeFinder* GetDeviceModeFinder() { return this->m_pDeviceModeFinder; };
 	inline IDirect3D* GetDirect3D() { return this->m_pDirect3d; }
@@ -104,10 +100,10 @@ struct MxDisplayMode {
 };
 
 // SIZE 0x190
-struct MxDeviceEnumerateElement {
-	MxDeviceEnumerateElement() {}
-	~MxDeviceEnumerateElement();
-	MxDeviceEnumerateElement(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName);
+struct MxDriver {
+	MxDriver() {}
+	~MxDriver();
+	MxDriver(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName);
 
 	void Init(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName);
 
@@ -118,8 +114,8 @@ struct MxDeviceEnumerateElement {
 	list<MxDevice> m_devices;           // 0x178
 	list<MxDisplayMode> m_displayModes; // 0x184
 
-	MxBool operator==(MxDeviceEnumerateElement) const { return TRUE; }
-	MxBool operator<(MxDeviceEnumerateElement) const { return TRUE; }
+	MxBool operator==(MxDriver) const { return TRUE; }
+	MxBool operator<(MxDriver) const { return TRUE; }
 };
 
 // clang-format off
@@ -140,20 +136,20 @@ struct MxDeviceEnumerateElement {
 
 // clang-format off
 // TEMPLATE: LEGO1 0x1009bf50
-// list<MxDeviceEnumerateElement,allocator<MxDeviceEnumerateElement> >::~list<MxDeviceEnumerateElement,allocator<MxDeviceEnumerateElement> >
+// list<MxDriver,allocator<MxDriver> >::~list<MxDriver,allocator<MxDriver> >
 // clang-format on
 
 // TEMPLATE: LEGO1 0x1009bfc0
-// List<MxDeviceEnumerateElement>::~List<MxDeviceEnumerateElement>
+// List<MxDriver>::~List<MxDriver>
 
 // Compiler-generated copy ctor
 // Part of this function are two more synthetic sub-routines,
 // LEGO1 0x1009c400 and LEGO1 0x1009c460
 // SYNTHETIC: LEGO1 0x1009c290
-// MxDeviceEnumerateElement::MxDeviceEnumerateElement
+// MxDriver::MxDriver
 
 // SYNTHETIC: LEGO1 0x1009d450
-// MxDeviceEnumerateElement::`scalar deleting destructor'
+// MxDriver::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x1009d470
 // MxDevice::`scalar deleting destructor'
@@ -180,10 +176,10 @@ public:
 	const char* EnumerateErrorToString(HRESULT p_error);
 	MxS32 ParseDeviceName(const char* p_deviceId);
 	MxS32 ProcessDeviceBytes(MxS32 p_deviceNum, GUID& p_guid);
-	MxResult GetDevice(MxS32 p_deviceNum, MxDeviceEnumerateElement*& p_deviceEnumerate, MxDevice*& p_device);
+	MxResult GetDevice(MxS32 p_deviceNum, MxDriver*& p_driver, MxDevice*& p_device);
 	MxS32 FUN_1009d0d0();
 	MxResult FUN_1009d210();
-	MxBool FUN_1009d370(MxDeviceEnumerateElement& p_deviceEnumerate);
+	MxBool FUN_1009d370(MxDriver& p_driver);
 	MxBool FUN_1009d3d0(MxDevice& p_device);
 
 	static void BuildErrorString(const char*, ...);
@@ -202,8 +198,8 @@ public:
 	static undefined4 FUN_1009d1e0();
 
 private:
-	list<MxDeviceEnumerateElement> m_list; // 0x04
-	MxBool m_initialized;                  // 0x10
+	list<MxDriver> m_list; // 0x04
+	MxBool m_initialized;  // 0x10
 };
 
 // VTABLE: LEGO1 0x100d9cc8

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -181,7 +181,7 @@ public:
 	MxS32 ParseDeviceName(const char* p_deviceId);
 	MxS32 ProcessDeviceBytes(MxS32 p_deviceNum, GUID& p_guid);
 	MxResult GetDevice(MxS32 p_deviceNum, MxDeviceEnumerateElement*& p_deviceEnumerate, MxDevice*& p_device);
-	MxResult FUN_1009d0d0();
+	MxS32 FUN_1009d0d0();
 	MxResult FUN_1009d210();
 	MxBool FUN_1009d370(MxDeviceEnumerateElement& p_deviceEnumerate);
 	MxBool FUN_1009d3d0(MxDevice& p_device);
@@ -198,6 +198,8 @@ public:
 		LPD3DDEVICEDESC p_HELDesc,
 		LPVOID p_context
 	);
+	static undefined4 FUN_1009d1a0();
+	static undefined4 FUN_1009d1e0();
 
 private:
 	list<MxDeviceEnumerateElement> m_list; // 0x04


### PR DESCRIPTION
This implements most functions that are necessary to complete the sequence of routines that are required in `LegoVideoManager::Create`. Most of them match 100%, although a few of them have discrepancies with regards to how the loops are laid out, which I can't seem to get right - but functionally should be accurate.