### PR TITLE
implement MxDirect3D::GetZBufferDepth

### DIFF
--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -121,6 +121,32 @@ BOOL MxDirect3D::D3DSetMode()
 	OutputDebugString("MxDirect3D::D3DSetMode() back lock failed\n");
 	return TRUE;
 }
+// FUNCTION: LEGO1 0x1009b5a0
+MxU32 MxDirect3D::GetZBufferDepth(MxAssignedDevice* p_deviceInfo)
+{
+	int depth;
+	DWORD deviceDepth;
+
+	if ((p_deviceInfo->m_desc.dwFlags & D3DCOLOR_MONO)) {
+		deviceDepth = p_deviceInfo->m_desc.dwDeviceZBufferBitDepth;
+	}
+	else {
+		deviceDepth = 0;
+	}
+
+	if (deviceDepth & DDBD_32)
+		depth = 32;
+	else if (deviceDepth & DDBD_24)
+		depth = 24;
+	else if (deviceDepth & DDBD_16)
+		depth = 16;
+	else if (deviceDepth & DDBD_8)
+		depth = 8;
+	else
+		depth = -1;
+
+	return depth;
+}
 
 // FUNCTION: LEGO1 0x1009b5f0
 BOOL MxDirect3D::SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_driver, MxDevice* p_device)

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -121,31 +121,27 @@ BOOL MxDirect3D::D3DSetMode()
 	OutputDebugString("MxDirect3D::D3DSetMode() back lock failed\n");
 	return TRUE;
 }
+
 // FUNCTION: LEGO1 0x1009b5a0
-MxU32 MxDirect3D::GetZBufferDepth(MxAssignedDevice* p_deviceInfo)
+DWORD MxDirect3D::GetZBufferBitDepth(MxAssignedDevice* p_assignedDevice)
 {
-	int depth;
-	DWORD deviceDepth;
+	DWORD bitDepth;
 
-	if ((p_deviceInfo->m_desc.dwFlags & D3DCOLOR_MONO)) {
-		deviceDepth = p_deviceInfo->m_desc.dwDeviceZBufferBitDepth;
-	}
-	else {
-		deviceDepth = 0;
-	}
-
-	if (deviceDepth & DDBD_32)
-		depth = 32;
-	else if (deviceDepth & DDBD_24)
-		depth = 24;
-	else if (deviceDepth & DDBD_16)
-		depth = 16;
-	else if (deviceDepth & DDBD_8)
-		depth = 8;
+	if (p_assignedDevice->m_desc.dwFlags & D3DDD_DEVICEZBUFFERBITDEPTH)
+		bitDepth = p_assignedDevice->m_desc.dwDeviceZBufferBitDepth;
 	else
-		depth = -1;
+		bitDepth = 0;
 
-	return depth;
+	if (bitDepth & DDBD_32)
+		return 32;
+	if (bitDepth & DDBD_24)
+		return 24;
+	if (bitDepth & DDBD_16)
+		return 16;
+	if (bitDepth & DDBD_8)
+		return 8;
+
+	return -1;
 }
 
 // FUNCTION: LEGO1 0x1009b5f0

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -57,7 +57,7 @@ public:
 
 	BOOL CreateIDirect3D();
 	BOOL D3DSetMode();
-	MxU32 GetZBufferDepth(MxAssignedDevice* p_deviceInfo);
+	DWORD GetZBufferBitDepth(MxAssignedDevice* p_assignedDevice);
 	BOOL SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_driver, MxDevice* p_device);
 
 	inline MxAssignedDevice* GetAssignedDevice() { return this->m_assignedDevice; };

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -23,7 +23,7 @@ public:
 
 	friend class MxDirect3D;
 
-private:
+public:
 	GUID m_guid;                                 // 0x00
 	MxU32 m_flags;                               // 0x10
 	D3DDEVICEDESC m_desc;                        // 0x14
@@ -57,6 +57,7 @@ public:
 
 	BOOL CreateIDirect3D();
 	BOOL D3DSetMode();
+	MxU32 GetZBufferDepth(MxAssignedDevice* p_deviceInfo);
 	BOOL SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_driver, MxDevice* p_device);
 
 	inline MxAssignedDevice* GetAssignedDevice() { return this->m_assignedDevice; };


### PR DESCRIPTION
doesn't fully match due to some issue with the _D3DDeviceDesc / MxAssignedDevice structure. Based off of the leaked source code