### PR TITLE
Let game launch again

### DIFF
--- a/LEGO1/lego3dview.cpp
+++ b/LEGO1/lego3dview.cpp
@@ -18,7 +18,7 @@ Lego3DView::~Lego3DView()
 // STUB: LEGO1 0x100aaf90
 BOOL Lego3DView::Create(TglSurface::CreateStruct& p_createStruct, Tgl::Renderer* p_renderer)
 {
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x100ab100

--- a/LEGO1/viewmanager/viewlodlist.cpp
+++ b/LEGO1/viewmanager/viewlodlist.cpp
@@ -16,10 +16,30 @@ ViewLODListManager::~ViewLODListManager()
 }
 
 // STUB: LEGO1 0x100a72c0
-ViewLODList* ViewLODListManager::Create(const ROIName&, int lodCount)
+ViewLODList* ViewLODListManager::Create(const ROIName& rROIName, int lodCount)
 {
-	// TODO
-	return NULL;
+	// returned ViewLODList has a refCount of 1, i.e. caller must call Release()
+	// when it no longer holds on to the list
+
+	ViewLODList* pLODList;
+	int refCount;
+	char* pROIName;
+
+	assert(!Lookup(rROIName));
+
+	pLODList = new ViewLODList(lodCount);
+	refCount = pLODList->AddRef();
+	assert(refCount == 1);
+
+	pROIName = new char[strlen(rROIName) + 1];
+	strcpy(pROIName, rROIName);
+
+	m_map[pROIName] = pLODList;
+
+	// NOTE: Lookup() adds a refCount
+	assert((Lookup(rROIName) == pLODList) && (pLODList->Release() == 1));
+
+	return pLODList;
 }
 
 // STUB: LEGO1 0x100a7680

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -75,7 +75,7 @@ public:
 	// creates an LODList with room for lodCount LODs for a named ROI
 	// returned LODList has a refCount of 1, i.e. caller must call Release()
 	// when it no longer holds on to the list
-	ViewLODList* Create(const ROIName&, int lodCount);
+	ViewLODList* Create(const ROIName& rROIName, int lodCount);
 
 	// returns an LODList for a named ROI
 	// returned LODList's refCount is increased, i.e. caller must call Release()


### PR DESCRIPTION
This PR is just to allow the game to launch again after the implementation of `LegoVideoManager::Create`.

`ViewLODListManager::Create` has been copied verbatim from the 1996 code and does not match, however it's "good enough" for the startup routine to finish. Obviously there are still a lot of stubs in between and there is no new functionality, however the game launches again with the Smacker video (if `NOCD.SI` is loaded)