### PR TITLE
Implement/match LegoVideoManager::ConfigureD3DRM

### DIFF
--- a/LEGO1/lego3dmanager.cpp
+++ b/LEGO1/lego3dmanager.cpp
@@ -10,7 +10,7 @@ DECOMP_SIZE_ASSERT(Lego3DManager, 0x10);
 // FUNCTION: LEGO1 0x100ab2d0
 BOOL InitializeCreateStruct(TglSurface::CreateStruct& p_tglSurface, const Lego3DManager::CreateStruct& p_createStruct)
 {
-	p_tglSurface.m_unk0x00 = p_createStruct.m_unk0x00;
+	p_tglSurface.m_driverGUID = p_createStruct.m_driverGUID;
 	p_tglSurface.m_hwnd = p_createStruct.m_hwnd;
 	p_tglSurface.m_directDraw = p_createStruct.m_directDraw;
 	p_tglSurface.m_ddSurface1 = p_createStruct.m_ddSurface1;

--- a/LEGO1/lego3dmanager.h
+++ b/LEGO1/lego3dmanager.h
@@ -11,7 +11,7 @@ class Lego3DManager {
 public:
 	// SIZE 0x28
 	struct CreateStruct {
-		undefined4 m_unk0x00;             // 0x00
+		GUID* m_driverGUID;               // 0x00
 		HWND m_hwnd;                      // 0x04
 		IDirectDraw* m_directDraw;        // 0x08
 		IDirectDrawSurface* m_ddSurface1; // 0x0c

--- a/LEGO1/lego3dview.cpp
+++ b/LEGO1/lego3dview.cpp
@@ -18,6 +18,15 @@ Lego3DView::~Lego3DView()
 // STUB: LEGO1 0x100aaf90
 BOOL Lego3DView::Create(TglSurface::CreateStruct& p_createStruct, Tgl::Renderer* p_renderer)
 {
+	Tgl::DeviceDirectDrawCreateData createData = {
+		p_createStruct.m_driverGUID,
+		p_createStruct.m_hwnd,
+		p_createStruct.m_directDraw,
+		p_createStruct.m_ddSurface1,
+		p_createStruct.m_ddSurface2
+	};
+
+	m_device = p_renderer->CreateDevice(createData);
 	return TRUE;
 }
 

--- a/LEGO1/lego3dview.h
+++ b/LEGO1/lego3dview.h
@@ -28,7 +28,7 @@ public:
 private:
 	// TODO: all of these fields are in various base classes
 	undefined4 m_unk0x4;        // 0x04
-	Tgl::Renderer* m_render;    // 0x08
+	Tgl::Renderer* m_renderer;  // 0x08
 	Tgl::Device* m_device;      // 0x0c
 	Tgl::View* m_view;          // 0x10
 	undefined m_unk0x14[0x74];  // 0x14

--- a/LEGO1/lego3dview.h
+++ b/LEGO1/lego3dview.h
@@ -16,22 +16,24 @@ public:
 	Lego3DView();
 	virtual ~Lego3DView();
 
-	inline ViewManager* GetViewManager() { return this->m_viewManager; }
-	inline TglImpl::ViewImpl* GetViewPort() { return this->m_viewPort; }
 	BOOL Create(TglSurface::CreateStruct& p_createStruct, Tgl::Renderer* p_renderer);
 	LegoROI* PickROI(MxLong p_a, MxLong p_b);
 	void FUN_100ab100(LegoROI* p_roi);
 	void FUN_100ab1b0(LegoROI* p_roi);
 
+	inline ViewManager* GetViewManager() { return this->m_viewManager; }
+	inline Tgl::Device* GetDevice() { return this->m_device; }
+	inline Tgl::View* GetView() { return this->m_view; }
+
 private:
 	// TODO: all of these fields are in various base classes
-	undefined4 m_unk0x4;                 // 0x04
-	TglImpl::RendererImpl* m_renderImpl; // 0x08
-	TglImpl::DeviceImpl* m_deviceImpl;   // 0x0c
-	TglImpl::ViewImpl* m_viewPort;       // 0x10
-	undefined m_unk0x14[0x74];           // 0x14
-	ViewManager* m_viewManager;          // 0x88
-	undefined m_unk0x8c[0x1c];           // 0x8c
+	undefined4 m_unk0x4;        // 0x04
+	Tgl::Renderer* m_render;    // 0x08
+	Tgl::Device* m_device;      // 0x0c
+	Tgl::View* m_view;          // 0x10
+	undefined m_unk0x14[0x74];  // 0x14
+	ViewManager* m_viewManager; // 0x88
+	undefined m_unk0x8c[0x1c];  // 0x8c
 };
 
 // SYNTHETIC: LEGO1 0x100aaf10

--- a/LEGO1/lego3dview.h
+++ b/LEGO1/lego3dview.h
@@ -7,7 +7,6 @@
 #include "viewmanager/viewmanager.h"
 
 class LegoROI;
-class Tgl::Renderer;
 
 // VTABLE: LEGO1 0x100dbf78
 // SIZE 0xa8

--- a/LEGO1/legovideomanager.h
+++ b/LEGO1/legovideomanager.h
@@ -42,7 +42,7 @@ public:
 
 private:
 	MxResult CreateDirect3D();
-	MxResult FUN_1007c930();
+	MxResult ConfigureD3DRM();
 
 	Tgl::Renderer* m_renderer;
 	Lego3DManager* m_3dManager; // 0x68

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -21,6 +21,9 @@ public:
 	MxAssignedDevice();
 	~MxAssignedDevice();
 
+	inline MxU32 GetFlags() { return m_flags; }
+	inline D3DDEVICEDESC& GetDesc() { return m_desc; }
+
 	friend class MxDirect3D;
 
 private:

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -5,10 +5,10 @@
 #include <d3drm.h>
 
 // Forward declare D3D types
-struct IDirect3DRM;
-struct IDirect3DRMDevice;
+struct IDirect3DRM2;
+struct IDirect3DRMDevice2;
 struct IDirect3DRMViewport;
-struct IDirect3DRMFrame;
+struct IDirect3DRMFrame2;
 struct IDirect3DRMMesh;
 struct IDirect3DRMMeshBuilder;
 struct IDirect3DRMTexture;
@@ -82,7 +82,7 @@ public:
 	inline void Destroy();
 
 private:
-	IDirect3DRM* m_data;
+	IDirect3DRM2* m_data;
 };
 
 // VTABLE 0x100db988
@@ -114,12 +114,12 @@ public:
 	virtual void InitFromD3DDevice(Device*);
 	virtual void InitFromWindowsDevice(Device*);
 
-	inline IDirect3DRMDevice* ImplementationData() const { return m_data; }
+	inline IDirect3DRMDevice2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMDevice* m_data;
+	IDirect3DRMDevice2* m_data;
 };
 
 // VTABLE 0x100db9e8
@@ -166,7 +166,7 @@ public:
 
 	inline IDirect3DRMViewport* ImplementationData() const { return m_data; }
 
-	static Result ViewportCreateAppData(IDirect3DRM*, IDirect3DRMViewport*, IDirect3DRMFrame*);
+	static Result ViewportCreateAppData(IDirect3DRM2*, IDirect3DRMViewport*, IDirect3DRMFrame2*);
 
 	friend class RendererImpl;
 
@@ -191,12 +191,12 @@ public:
 	// vtable+0x08
 	virtual Result SetTransformation(const FloatMatrix4&);
 
-	inline IDirect3DRMFrame* ImplementationData() const { return m_data; }
+	inline IDirect3DRMFrame2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMFrame* m_data;
+	IDirect3DRMFrame2* m_data;
 };
 
 // VTABLE 0x100dbaf8
@@ -217,12 +217,12 @@ public:
 	virtual Result SetTransformation(const FloatMatrix4&);
 	virtual Result SetColor(float r, float g, float b);
 
-	inline IDirect3DRMFrame* ImplementationData() const { return m_data; }
+	inline IDirect3DRMFrame2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMFrame* m_data;
+	IDirect3DRMFrame2* m_data;
 };
 
 // VTABLE 0x100dbb88
@@ -301,7 +301,7 @@ public:
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMFrame* m_data;
+	IDirect3DRMFrame2* m_data;
 };
 
 // VTABLE 0x100dbb18

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -14,7 +14,7 @@ Renderer* Tgl::CreateRenderer()
 }
 
 // GLOBAL: LEGO1 0x1010103c
-IDirect3DRM* g_pD3DRM = NULL;
+IDirect3DRM2* g_pD3DRM = NULL;
 
 // Inlined only
 Result RendererImpl::Create()
@@ -31,7 +31,7 @@ Result RendererImpl::Create()
 	return (m_data != NULL) ? Success : Error;
 }
 
-inline void RendererDestroy(IDirect3DRM* pRenderer)
+inline void RendererDestroy(IDirect3DRM2* pRenderer)
 {
 	int refCount = pRenderer->Release();
 	if (refCount <= 0) {
@@ -84,9 +84,9 @@ Device* RendererImpl::CreateDevice(const DeviceDirectDrawCreateData& data)
 }
 
 inline Result RendererCreateView(
-	IDirect3DRM* pRenderer,
-	IDirect3DRMDevice* pDevice,
-	IDirect3DRMFrame* pCamera,
+	IDirect3DRM2* pRenderer,
+	IDirect3DRMDevice2* pDevice,
+	IDirect3DRMFrame2* pCamera,
 	IDirect3DRMViewport*& rpView,
 	unsigned long x,
 	unsigned long y,
@@ -133,7 +133,7 @@ View* RendererImpl::CreateView(
 	return view;
 }
 
-inline Result RendererCreateGroup(IDirect3DRM* pRenderer, IDirect3DRMFrame* pParent, IDirect3DRMFrame*& rpGroup)
+inline Result RendererCreateGroup(IDirect3DRM2* pRenderer, IDirect3DRMFrame2* pParent, IDirect3DRMFrame2*& rpGroup)
 {
 	Result result = ResultVal(pRenderer->CreateFrame(NULL, &rpGroup));
 	if (Succeeded(result) && pParent) {
@@ -195,7 +195,7 @@ Light* RendererImpl::CreateLight(LightType type, float r, float g, float b)
 		translatedType = D3DRMLIGHT_AMBIENT;
 	}
 
-	LPDIRECT3DRMFRAME frame;
+	LPDIRECT3DRMFRAME2 frame;
 	Result result = ResultVal(m_data->CreateFrame(NULL, &frame));
 	if (Succeeded(result)) {
 		LPDIRECT3DRMLIGHT d3dLight;
@@ -240,7 +240,7 @@ Unk* RendererImpl::CreateUnk()
 }
 
 inline Result RendererCreateTexture(
-	IDirect3DRM* renderer,
+	IDirect3DRM2* renderer,
 	IDirect3DRMTexture*& texture,
 	int width,
 	int height,
@@ -255,7 +255,8 @@ inline Result RendererCreateTexture(
 	Result result;
 
 	image = new TglD3DRMIMAGE(width, height, bytesPerPixel, pBuffer, useBuffer, paletteSize, pEntries);
-	result = ResultVal(renderer->CreateTexture(&image->m_image, &texture));
+	// TODO: LPDIRECT3DRMTEXTURE2?
+	result = ResultVal(renderer->CreateTexture(&image->m_image, (LPDIRECT3DRMTEXTURE2*) &texture));
 	if (Succeeded(result)) {
 		result = TextureImpl::SetImage(texture, image);
 		if (!Succeeded(result)) {

--- a/LEGO1/tgl/d3drm/view.cpp
+++ b/LEGO1/tgl/d3drm/view.cpp
@@ -3,12 +3,12 @@
 using namespace TglImpl;
 
 struct ViewportAppData {
-	ViewportAppData(IDirect3DRM* pRenderer);
+	ViewportAppData(IDirect3DRM2* pRenderer);
 	~ViewportAppData();
 
-	IDirect3DRMFrame* m_pLightFrame;
-	IDirect3DRMFrame* m_pCamera;
-	IDirect3DRMFrame* m_pLastRenderedFrame;
+	IDirect3DRMFrame2* m_pLightFrame;
+	IDirect3DRMFrame2* m_pCamera;
+	IDirect3DRMFrame2* m_pLastRenderedFrame;
 	float m_backgroundColorRed;
 	float m_backgroundColorGreen;
 	float m_backgroundColorBlue;
@@ -17,7 +17,7 @@ struct ViewportAppData {
 DECOMP_SIZE_ASSERT(ViewportAppData, 0x18);
 
 // FUNCTION: LEGO1 0x100a10b0
-ViewportAppData::ViewportAppData(IDirect3DRM* pRenderer)
+ViewportAppData::ViewportAppData(IDirect3DRM2* pRenderer)
 {
 	pRenderer->CreateFrame(NULL, &m_pLightFrame);
 	m_pCamera = NULL;
@@ -46,7 +46,7 @@ ViewportAppData::~ViewportAppData()
 void ViewportDestroyCallback(IDirect3DRMObject* pObject, void* pArg);
 
 // FUNCTION: LEGO1 0x100a1160
-Result ViewImpl::ViewportCreateAppData(IDirect3DRM* pDevice, IDirect3DRMViewport* pView, IDirect3DRMFrame* pCamera)
+Result ViewImpl::ViewportCreateAppData(IDirect3DRM2* pDevice, IDirect3DRMViewport* pView, IDirect3DRMFrame2* pCamera)
 {
 	ViewportAppData* data = new ViewportAppData(pDevice);
 	data->m_pCamera = pCamera;
@@ -145,7 +145,7 @@ Result ViewImpl::Remove(const Light* pLight)
 Result ViewImpl::SetCamera(const Camera* pCamera)
 {
 	const CameraImpl* camera = static_cast<const CameraImpl*>(pCamera);
-	IDirect3DRMFrame* frame = camera->ImplementationData();
+	IDirect3DRMFrame2* frame = camera->ImplementationData();
 
 	ViewportAppData* pViewportAppData;
 	Result result;
@@ -249,9 +249,9 @@ Result ViewImpl::Render(const Light* pCamera)
 {
 	ViewportAppData* appdata = ViewportGetData(m_data);
 
-	IDirect3DRMFrame* light = static_cast<const LightImpl*>(pCamera)->ImplementationData();
+	IDirect3DRMFrame2* light = static_cast<const LightImpl*>(pCamera)->ImplementationData();
 
-	IDirect3DRMFrame* lastRendered = appdata->m_pLastRenderedFrame;
+	IDirect3DRMFrame2* lastRendered = appdata->m_pLastRenderedFrame;
 	if (light != lastRendered) {
 		if (lastRendered) {
 			lastRendered->DeleteChild(appdata->m_pCamera);

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -57,8 +57,8 @@ struct PaletteEntry {
 };
 
 struct DeviceDirect3DCreateData {
-	IDirect3D* m_pDirect3D;
-	IDirect3DDevice* m_pDirect3DDevice;
+	IDirect3D2* m_pDirect3D;
+	IDirect3DDevice2* m_pDirect3DDevice;
 };
 
 struct DeviceDirectDrawCreateData {

--- a/LEGO1/tglsurface.h
+++ b/LEGO1/tglsurface.h
@@ -11,7 +11,7 @@ class TglSurface {
 public:
 	// SIZE 0x28
 	struct CreateStruct {
-		undefined4 m_unk0x00;             // 0x00
+		GUID* m_driverGUID;               // 0x00
 		HWND m_hwnd;                      // 0x04
 		IDirectDraw* m_directDraw;        // 0x08
 		IDirectDrawSurface* m_ddSurface1; // 0x0c


### PR DESCRIPTION
100% match. Note that this function unconventionally reaches into the implementation and uses the D3DRM interface directly, instead of using the TGL layer.

I've added the `Tgl::Device` creation in `Lego3DView` so that the game continues to start. It also became apparent that they are using the `Direct3DRM2` interface instead of `Direct3DRM` so I changed some of the TGL implementation accordingly.