### PR TITLE
Move MxDirectDraw and MxDirect3D to mxdirectx

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
           ISLE/*.cpp ISLE/*.h \
           LEGO1/*.cpp LEGO1/*.h \
           LEGO1/3dmanager/*.cpp LEGO1/3dmanager/*.h \
-          LEGO1/mxdirectx/*.h \
+          LEGO1/mxdirectx/*.cpp LEGO1/mxdirectx/*.h \
           LEGO1/mxstl/*.h \
           LEGO1/realtime/*.cpp LEGO1/realtime/*.h \
           LEGO1/tgl/*.h \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,8 @@ add_library(lego1 SHARED
   LEGO1/mxcontrolpresenter.cpp
   LEGO1/mxcore.cpp
   LEGO1/mxcriticalsection.cpp
-  LEGO1/mxdirect3d.cpp
-  LEGO1/mxdirectdraw.cpp
+  LEGO1/mxdirectx/mxdirect3d.cpp
+  LEGO1/mxdirectx/mxdirectdraw.cpp
   LEGO1/mxdiskstreamcontroller.cpp
   LEGO1/mxdiskstreamprovider.cpp
   LEGO1/mxdisplaysurface.cpp

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -12,7 +12,6 @@
 #include "legovideomanager.h"
 #include "legoworldpresenter.h"
 #include "mxbackgroundaudiomanager.h"
-#include "mxdirectdraw.h"
 #include "mxdsaction.h"
 #include "mxomnicreateflags.h"
 #include "mxomnicreateparam.h"

--- a/LEGO1/legovideomanager.h
+++ b/LEGO1/legovideomanager.h
@@ -3,7 +3,7 @@
 
 #include "3dmanager/lego3dmanager.h"
 #include "decomp.h"
-#include "mxdirect3d.h"
+#include "mxdirectx/mxdirect3d.h"
 #include "mxdirectx/mxstopwatch.h"
 #include "mxunknown100d9d00.h"
 #include "mxvideomanager.h"

--- a/LEGO1/mxdirectx/mxdirect3d.h
+++ b/LEGO1/mxdirectx/mxdirect3d.h
@@ -1,10 +1,9 @@
 #ifndef MXDIRECT3D_H
 #define MXDIRECT3D_H
 
+#include "../mxstl/stlcompat.h"
 #include "decomp.h"
 #include "mxdirectdraw.h"
-#include "mxstl/stlcompat.h"
-#include "mxtypes.h"
 
 #include <d3d.h>
 
@@ -21,14 +20,14 @@ public:
 	MxAssignedDevice();
 	~MxAssignedDevice();
 
-	inline MxU32 GetFlags() { return m_flags; }
+	inline unsigned int GetFlags() { return m_flags; }
 	inline D3DDEVICEDESC& GetDesc() { return m_desc; }
 
 	friend class MxDirect3D;
 
 private:
 	GUID m_guid;                                 // 0x00
-	MxU32 m_flags;                               // 0x10
+	unsigned int m_flags;                        // 0x10
 	D3DDEVICEDESC m_desc;                        // 0x14
 	MxDirectDraw::DeviceModesInfo* m_deviceInfo; // 0xe0
 };
@@ -101,8 +100,8 @@ struct MxDevice {
 	D3DDEVICEDESC m_HWDesc;  // 0x0c
 	D3DDEVICEDESC m_HELDesc; // 0xd8
 
-	MxBool operator==(MxDevice) const { return TRUE; }
-	MxBool operator<(MxDevice) const { return TRUE; }
+	int operator==(MxDevice) const { return 0; }
+	int operator<(MxDevice) const { return 0; }
 };
 
 // SIZE 0x0c
@@ -111,8 +110,8 @@ struct MxDisplayMode {
 	DWORD m_height;       // 0x04
 	DWORD m_bitsPerPixel; // 0x08
 
-	MxBool operator==(MxDisplayMode) const { return TRUE; }
-	MxBool operator<(MxDisplayMode) const { return TRUE; }
+	int operator==(MxDisplayMode) const { return 0; }
+	int operator<(MxDisplayMode) const { return 0; }
 };
 
 // SIZE 0x190
@@ -130,8 +129,8 @@ struct MxDriver {
 	list<MxDevice> m_devices;           // 0x178
 	list<MxDisplayMode> m_displayModes; // 0x184
 
-	MxBool operator==(MxDriver) const { return TRUE; }
-	MxBool operator<(MxDriver) const { return TRUE; }
+	int operator==(MxDriver) const { return 0; }
+	int operator<(MxDriver) const { return 0; }
 };
 
 // clang-format off
@@ -178,7 +177,7 @@ public:
 	// FUNCTION: LEGO1 0x1009c010
 	~MxDeviceEnumerate() {}
 
-	virtual MxResult DoEnumerate(); // vtable+0x00
+	virtual int DoEnumerate(); // vtable+0x00
 
 	BOOL EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName);
 	HRESULT EnumDisplayModesCallback(LPDDSURFACEDESC p_ddsd);
@@ -190,13 +189,13 @@ public:
 		LPD3DDEVICEDESC p_HELDesc
 	);
 	const char* EnumerateErrorToString(HRESULT p_error);
-	MxS32 ParseDeviceName(const char* p_deviceId);
-	MxS32 ProcessDeviceBytes(MxS32 p_deviceNum, GUID& p_guid);
-	MxResult GetDevice(MxS32 p_deviceNum, MxDriver*& p_driver, MxDevice*& p_device);
-	MxS32 FUN_1009d0d0();
-	MxResult FUN_1009d210();
-	MxBool FUN_1009d370(MxDriver& p_driver);
-	MxBool FUN_1009d3d0(MxDevice& p_device);
+	int ParseDeviceName(const char* p_deviceId);
+	int ProcessDeviceBytes(int p_deviceNum, GUID& p_guid);
+	int GetDevice(int p_deviceNum, MxDriver*& p_driver, MxDevice*& p_device);
+	int FUN_1009d0d0();
+	int FUN_1009d210();
+	unsigned char FUN_1009d370(MxDriver& p_driver);
+	unsigned char FUN_1009d3d0(MxDevice& p_device);
 
 	static void BuildErrorString(const char*, ...);
 	static BOOL CALLBACK
@@ -216,8 +215,8 @@ public:
 	friend class MxDirect3D;
 
 private:
-	list<MxDriver> m_list; // 0x04
-	MxBool m_initialized;  // 0x10
+	list<MxDriver> m_list;       // 0x04
+	unsigned char m_initialized; // 0x10
 };
 
 // VTABLE: LEGO1 0x100d9cc8

--- a/LEGO1/mxdirectx/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectx/mxdirectdraw.cpp
@@ -348,9 +348,9 @@ BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
 		}
 
 		if (!IsSupportedMode(width, height, bpp)) {
-			width = m_pCurrentDeviceModesList->m_modeArray[0].m_width;
-			height = m_pCurrentDeviceModesList->m_modeArray[0].m_height;
-			bpp = m_pCurrentDeviceModesList->m_modeArray[0].m_bitsPerPixel;
+			width = m_pCurrentDeviceModesList->m_modeArray[0].width;
+			height = m_pCurrentDeviceModesList->m_modeArray[0].height;
+			bpp = m_pCurrentDeviceModesList->m_modeArray[0].bitsPerPixel;
 		}
 
 		m_bIgnoreWMSIZE = TRUE;
@@ -396,9 +396,9 @@ BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
 		m_bIgnoreWMSIZE = FALSE;
 	}
 
-	m_currentMode.m_width = width;
-	m_currentMode.m_height = height;
-	m_currentMode.m_bitsPerPixel = bpp;
+	m_currentMode.width = width;
+	m_currentMode.height = height;
+	m_currentMode.bitsPerPixel = bpp;
 
 	if (!DDCreateSurfaces()) {
 		return FALSE;
@@ -506,8 +506,8 @@ BOOL MxDirectDraw::DDCreateSurfaces()
 			Error("CreateSurface for window front buffer failed", result);
 			return FALSE;
 		}
-		ddsd.dwHeight = m_currentMode.m_height;
-		ddsd.dwWidth = m_currentMode.m_width;
+		ddsd.dwHeight = m_currentMode.height;
+		ddsd.dwWidth = m_currentMode.width;
 		ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
 		ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE;
 		if (m_bOnlySystemMemory)
@@ -640,7 +640,7 @@ BOOL MxDirectDraw::CreateTextSurfaces()
 	}
 
 	m_hFont = CreateFontA(
-		m_currentMode.m_width <= 600 ? 12 : 24,
+		m_currentMode.width <= 600 ? 12 : 24,
 		0,
 		0,
 		0,
@@ -774,8 +774,8 @@ BOOL MxDirectDraw::CreateZBuffer(DWORD memorytype, DWORD depth)
 
 	memset(&ddsd, 0, sizeof(ddsd));
 	ddsd.dwSize = sizeof(ddsd);
-	ddsd.dwHeight = m_currentMode.m_height;
-	ddsd.dwWidth = m_currentMode.m_width;
+	ddsd.dwHeight = m_currentMode.height;
+	ddsd.dwWidth = m_currentMode.width;
 	ddsd.dwZBufferBitDepth = depth;
 	ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS | DDSD_ZBUFFERBITDEPTH;
 	ddsd.ddsCaps.dwCaps = DDSCAPS_ZBUFFER | memorytype;
@@ -889,7 +889,7 @@ int MxDirectDraw::FlipToGDISurface()
 }
 
 // FUNCTION: LEGO1 0x1009e830
-void MxDirectDraw::Error(const char* p_message, MxS32 p_error)
+void MxDirectDraw::Error(const char* p_message, int p_error)
 {
 	// GLOBAL: LEGO1 0x10100c70
 	static BOOL g_isInsideError = FALSE;

--- a/LEGO1/mxdirectx/mxdirectdraw.h
+++ b/LEGO1/mxdirectx/mxdirectdraw.h
@@ -1,8 +1,6 @@
 #ifndef MXDIRECTDRAW_H
 #define MXDIRECTDRAW_H
 
-#include "mxtypes.h"
-
 #include <ddraw.h>
 #include <windows.h>
 
@@ -14,17 +12,14 @@ public:
 
 	// SIZE 0x0c
 	struct Mode {
-		MxS32 operator==(const Mode& p_mode) const
+		int operator==(const Mode& p_mode) const
 		{
-			return (
-				(m_width == p_mode.m_width) && (m_height == p_mode.m_height) &&
-				(m_bitsPerPixel == p_mode.m_bitsPerPixel)
-			);
+			return ((width == p_mode.width) && (height == p_mode.height) && (bitsPerPixel == p_mode.bitsPerPixel));
 		}
 
-		MxS32 m_width;        // 0x00
-		MxS32 m_height;       // 0x04
-		MxS32 m_bitsPerPixel; // 0x08
+		int width;        // 0x00
+		int height;       // 0x04
+		int bitsPerPixel; // 0x08
 	};
 
 	// SIZE 0x17c
@@ -34,7 +29,7 @@ public:
 
 		GUID* m_guid;      // 0x00
 		Mode* m_modeArray; // 0x04
-		MxS32 m_count;     // 0x08
+		int m_count;       // 0x08
 		DDCAPS m_ddcaps;   // 0x0c
 		void* m_unk0x178;  // 0x178
 	};
@@ -68,7 +63,7 @@ public:
 	BOOL DDCreateSurfaces();
 	BOOL DDInit(BOOL fullscreen);
 	BOOL DDSetMode(int width, int height, int bpp);
-	void Error(const char* p_message, MxS32 p_error);
+	void Error(const char* p_message, int p_error);
 
 	BOOL GetDDSurfaceDesc(LPDDSURFACEDESC lpDDSurfDesc, LPDIRECTDRAWSURFACE lpDDSurf);
 	BOOL IsSupportedMode(int width, int height, int bpp);


### PR DESCRIPTION
This PR relocates the two classes `MxDirectDraw` and `MxDirect3D` to the `mxdirectx` submodule, as seen in the original sources. Those classes do not make use of Omni types, so I've changed them back to the intrinsic ones.