### PR TITLE
Support building isle with modern MSVC + msys2

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   decomplint-isle:
+    name: 'ISLE annotations'
     runs-on: ubuntu-latest
 
     steps:
@@ -18,6 +19,7 @@ jobs:
         python3 tools/decomplint/decomplint.py ISLE --module ISLE --warnfail
 
   decomplint-lego1:
+    name: 'LEGO1 annotations'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,45 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  build-current-toolchain:
+    name: 'Current ${{ matrix.compiler.name }}'
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        compiler:
+        - { name: 'msvc', setup-ninja: true, setup-cmake: true }
+        - { name: 'msys2 mingw32', setup-msys2: true }
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup cmake
+        if: matrix.compiler.setup-cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          # Use minimum supported version
+          cmake-version: '3.13.x'
+
+      - name: Setup ninja
+        if: matrix.compiler.setup-ninja
+        uses: ashutoshvarma/setup-ninja@master
+
+      - name: Set up MSYS2
+        if: matrix.compiler.setup-msys2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw32
+          install: >-
+            mingw-w64-i686-cc
+            mingw-w64-i686-cmake
+            mingw-w64-i686-ninja
+
+      - name: Build
+        shell: cmd
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja
+          cmake --build build
+
   build:
     runs-on: windows-latest
 
@@ -28,10 +67,8 @@ jobs:
       shell: cmd
       run: |
         call .\msvc420\bin\VCVARS32.BAT x86
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G "NMake Makefiles"
-        cmake --build .
+        cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -G "NMake Makefiles"
+        cmake --build build
 
     - name: Upload Artifact
       uses: actions/upload-artifact@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
       run:
         shell: ${{ matrix.toolchain.shell }}
     strategy:
+      fail-fast: false
       matrix:
         toolchain:
         - { name: 'MSVC',           shell: 'sh',        setup-cmake: true, setup-ninja: true, setup-msvc: true }
@@ -29,9 +30,6 @@ jobs:
       - name: Setup cmake
         if: matrix.toolchain.setup-cmake
         uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          # Use minimum supported version
-          cmake-version: '3.13.x'
 
       - name: Setup ninja
         if: matrix.toolchain.setup-ninja
@@ -41,7 +39,7 @@ jobs:
         if: matrix.toolchain.setup-msvc
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: x86
+          arch: amd64_x86  # Use the 64-bit x64-native cross tools to build 32-bit x86 code
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja -Werror=dev
           cmake --build build
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
           cmake --build build
 
   build:
+    name: 'MSVC 4.20'
     runs-on: windows-latest
 
     steps:
@@ -87,6 +88,7 @@ jobs:
           build/LEGO1.PDB
 
   compare:
+    name: 'Compare with master'
     needs: build
     runs-on: windows-latest
     steps:
@@ -152,6 +154,7 @@ jobs:
           LEGO1PROGRESS.*
 
   upload:
+    name: 'Upload artifacts'
     needs: [build, compare]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-        - { name: 'msvc',           shell: 'sh',        setup-cmake: true, setup-ninja: true, setup-msvc: true }
+        - { name: 'MSVC',           shell: 'sh',        setup-cmake: true, setup-ninja: true, setup-msvc: true }
         - { name: 'msys2 mingw32',  shell: 'msys2 {0}', setup-msys2: true }
 
     steps:
@@ -44,7 +44,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        shell: cmd
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja
           cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Setup vcvars
         if: matrix.toolchain.setup-msvc
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         compiler:
-        - { name: 'msvc', setup-ninja: true, setup-cmake: true }
+        - { name: 'msvc', setup-cmake: true, setup-ninja: true, setup-msvc: true }
         - { name: 'msys2 mingw32', setup-msys2: true }
 
     steps:
@@ -25,6 +25,10 @@ jobs:
       - name: Setup ninja
         if: matrix.compiler.setup-ninja
         uses: ashutoshvarma/setup-ninja@master
+
+      - name: Setup vcvars
+        if: matrix.compiler.setup-msvc
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Set up MSYS2
         if: matrix.compiler.setup-msys2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,34 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build-current-toolchain:
-    name: 'Current ${{ matrix.compiler.name }}'
+    name: 'Current ${{ matrix.toolchain.name }}'
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: ${{ matrix.toolchain.shell }}
     strategy:
       matrix:
-        compiler:
-        - { name: 'msvc', setup-cmake: true, setup-ninja: true, setup-msvc: true }
-        - { name: 'msys2 mingw32', setup-msys2: true }
+        toolchain:
+        - { name: 'msvc',           shell: 'sh',        setup-cmake: true, setup-ninja: true, setup-msvc: true }
+        - { name: 'msys2 mingw32',  shell: 'msys2 {0}', setup-msys2: true }
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup cmake
-        if: matrix.compiler.setup-cmake
-        uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          # Use minimum supported version
-          cmake-version: '3.13.x'
-
-      - name: Setup ninja
-        if: matrix.compiler.setup-ninja
-        uses: ashutoshvarma/setup-ninja@master
-
-      - name: Setup vcvars
-        if: matrix.compiler.setup-msvc
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: Set up MSYS2
-        if: matrix.compiler.setup-msys2
+        if: matrix.toolchain.setup-msys2
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw32
@@ -39,6 +25,23 @@ jobs:
             mingw-w64-i686-cc
             mingw-w64-i686-cmake
             mingw-w64-i686-ninja
+
+      - name: Setup cmake
+        if: matrix.toolchain.setup-cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          # Use minimum supported version
+          cmake-version: '3.13.x'
+
+      - name: Setup ninja
+        if: matrix.toolchain.setup-ninja
+        uses: ashutoshvarma/setup-ninja@master
+
+      - name: Setup vcvars
+        if: matrix.toolchain.setup-msvc
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - uses: actions/checkout@v3
 
       - name: Build
         shell: cmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,18 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(isle CXX)
 
+set(MSVC_FOR_DECOMP FALSE)
+if (MSVC)
+    # Visual C++ 4.2 -> cl version 10.2.0
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0")
+        set(MSVC_FOR_DECOMP TRUE)
+    endif()
+endif()
+
+message(STATUS "MSVC for decompilation: ${MSVC_FOR_DECOMP}")
+
 option(ISLE_BUILD_APP "Build ISLE.EXE application" ON)
-option(ISLE_USE_SMARTHEAP "Build with SmartHeap" ${MSVC})
+option(ISLE_USE_SMARTHEAP "Build with SmartHeap" ${MSVC_FOR_DECOMP})
 option(ISLE_USE_DX5 "Build with internal DirectX 5 SDK" ON)
 
 add_library(lego1 SHARED
@@ -299,7 +309,14 @@ if (ISLE_BUILD_APP)
   set_property(TARGET isle PROPERTY SUFFIX ".EXE")
 endif()
 
-if (MSVC)
+if (MSVC_FOR_DECOMP OR MINGW)
+    target_compile_definitions(lego1 PRIVATE "ENABLE_DECOMP_ASSERTS")
+    if (ISLE_BUILD_APP)
+        target_compile_definitions(isle PRIVATE "ENABLE_DECOMP_ASSERTS")
+    endif()
+endif()
+
+if (MSVC_FOR_DECOMP)
   # These flags have been taken from the defaults for a Visual C++ 4.20 project (the compiler the
   # game was originally built with) and tweaked slightly to produce more debugging info for reccmp.
   # They ensure a recompilation that can be byte/instruction accurate to the original binaries.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(isle CXX)
 
+math(EXPR bits "8 * ${CMAKE_SIZEOF_VOID_P}")
+message(STATUS "Building ${bits}-bit Lego Island")
+if (NOT bits EQUAL 32)
+    message(WARNING "Only 32-bit executables are supported")
+endif()
+
 set(MSVC_FOR_DECOMP FALSE)
 if (MSVC)
     # Visual C++ 4.2 -> cl version 10.2.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,7 @@ if (MSVC)
   endif()
 endif()
 
-if (MSVC_FOR_DECOMP OR MINGW)
+if (MSVC_FOR_DECOMP)
     target_compile_definitions(lego1 PRIVATE "ENABLE_DECOMP_ASSERTS")
     if (ISLE_BUILD_APP)
         target_compile_definitions(isle PRIVATE "ENABLE_DECOMP_ASSERTS")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,12 @@ if (ISLE_BUILD_APP)
 endif()
 
 if (MSVC)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15")
+    target_compile_definitions(lego1 PRIVATE _CRT_SECURE_NO_WARNINGS)
+    if (ISLE_BUILD_APP)
+      target_compile_definitions(isle PRIVATE "_CRT_SECURE_NO_WARNINGS")
+    endif()
+  endif()
   # Visual Studio 2017 version 15.7 needs "/Zc:__cplusplus" for __cplusplus
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.14.26428")
     target_compile_options(lego1 PRIVATE "-Zc:__cplusplus")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,16 @@ if (ISLE_BUILD_APP)
   set_property(TARGET isle PROPERTY SUFFIX ".EXE")
 endif()
 
+if (MSVC)
+  # Visual Studio 2017 version 15.7 needs "/Zc:__cplusplus" for __cplusplus
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.14.26428")
+    target_compile_options(lego1 PRIVATE "-Zc:__cplusplus")
+    if (ISLE_BUILD_APP)
+      target_compile_options(isle PRIVATE "-Zc:__cplusplus")
+    endif()
+  endif()
+endif()
+
 if (MSVC_FOR_DECOMP OR MINGW)
     target_compile_definitions(lego1 PRIVATE "ENABLE_DECOMP_ASSERTS")
     if (ISLE_BUILD_APP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(isle CXX)
 
 math(EXPR bits "8 * ${CMAKE_SIZEOF_VOID_P}")
-message(STATUS "Building ${bits}-bit Lego Island")
+message(STATUS "Building ${bits}-bit LEGO Island")
 if (NOT bits EQUAL 32)
     message(WARNING "Only 32-bit executables are supported")
 endif()

--- a/LEGO1/lego/legoomni/include/legocameracontroller.h
+++ b/LEGO1/lego/legoomni/include/legocameracontroller.h
@@ -36,7 +36,7 @@ public:
 	virtual void OnMouseMove(MxU8 p_modifier, MxPoint32 p_point); // vtable+0x40
 	virtual MxResult Create();                                    // vtable+0x44
 
-	void SetWorldTransform(Vector3Impl& p_at, Vector3Impl& p_dir, Vector3Impl& p_up);
+	void SetWorldTransform(const Vector3Impl& p_at, const Vector3Impl& p_dir, const Vector3Impl& p_up);
 	void FUN_100123e0(Matrix4Data& p_transform, MxU32);
 	Vector3Data& FUN_10012740();
 	Vector3Data& FUN_100127f0();

--- a/LEGO1/lego/legoomni/include/legocameracontroller.h
+++ b/LEGO1/lego/legoomni/include/legocameracontroller.h
@@ -29,12 +29,12 @@ public:
 		return !strcmp(p_name, ClassName()) || MxCore::IsA(p_name);
 	}
 
-	virtual void OnLButtonDown(MxPoint32 p_point) override;                // vtable+0x30
-	virtual void OnLButtonUp(MxPoint32 p_point) override;                  // vtable+0x34
-	virtual void OnRButtonDown(MxPoint32 p_point) override;                // vtable+0x38
-	virtual void OnRButtonUp(MxPoint32 p_point) override;                  // vtable+0x3c
-	virtual void OnMouseMove(MxU8 p_modifier, MxPoint32 p_point) override; // vtable+0x40
-	virtual MxResult Create();                                             // vtable+0x44
+	virtual void OnLButtonDown(MxPoint32 p_point);                // vtable+0x30
+	virtual void OnLButtonUp(MxPoint32 p_point);                  // vtable+0x34
+	virtual void OnRButtonDown(MxPoint32 p_point);                // vtable+0x38
+	virtual void OnRButtonUp(MxPoint32 p_point);                  // vtable+0x3c
+	virtual void OnMouseMove(MxU8 p_modifier, MxPoint32 p_point); // vtable+0x40
+	virtual MxResult Create();                                    // vtable+0x44
 
 	void SetWorldTransform(Vector3Impl& p_at, Vector3Impl& p_dir, Vector3Impl& p_up);
 	void FUN_100123e0(Matrix4Data& p_transform, MxU32);

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -32,12 +32,16 @@ public:
 		return !strcmp(p_name, LegoEntity::ClassName()) || MxEntity::IsA(p_name);
 	}
 
-	virtual MxResult Create(MxDSObject& p_dsObject);                                           // vtable+0x18
-	virtual void Destroy(MxBool p_fromDestructor);                                             // vtable+0x1c
-	virtual void ParseAction(char*);                                                           // vtable+0x20
-	virtual void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2);                       // vtable+0x24
-	virtual void SetWorldTransform(Vector3Impl& p_loc, Vector3Impl& p_dir, Vector3Impl& p_up); // vtable+0x28
-	virtual void ResetWorldTransform(MxBool p_inVehicle);                                      // vtable+0x2c
+	virtual MxResult Create(MxDSObject& p_dsObject);                     // vtable+0x18
+	virtual void Destroy(MxBool p_fromDestructor);                       // vtable+0x1c
+	virtual void ParseAction(char*);                                     // vtable+0x20
+	virtual void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2); // vtable+0x24
+	virtual void SetWorldTransform(
+		const Vector3Impl& p_loc,
+		const Vector3Impl& p_dir,
+		const Vector3Impl& p_up
+	);                                                    // vtable+0x28
+	virtual void ResetWorldTransform(MxBool p_inVehicle); // vtable+0x2c
 	// FUNCTION: LEGO1 0x10001090
 	virtual void SetWorldSpeed(MxFloat p_worldSpeed) { m_worldSpeed = p_worldSpeed; } // vtable+0x30
 	virtual void VTable0x34();                                                        // vtable+0x34

--- a/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
@@ -22,18 +22,12 @@ public:
 	LegoMouseController();
 	virtual ~LegoMouseController() override;
 
-	virtual void LeftDown(int, int);                              // vtable+0x14
-	virtual void LeftDrag(int, int);                              // vtable+0x18
-	virtual void LeftUp(int, int);                                // vtable+0x1c
-	virtual void RightDown(int, int);                             // vtable+0x20
-	virtual void RightDrag(int, int);                             // vtable+0x24
-	virtual void RightUp(int, int);                               // vtable+0x28
-	virtual void vmethod_0x2c();                                  // vtable+0x2c
-	virtual void OnLButtonDown(MxPoint32 p_point);                // vtable+0x30
-	virtual void OnLButtonUp(MxPoint32 p_point);                  // vtable+0x34
-	virtual void OnRButtonDown(MxPoint32 p_point);                // vtable+0x38
-	virtual void OnRButtonUp(MxPoint32 p_point);                  // vtable+0x3c
-	virtual void OnMouseMove(MxU8 p_modifier, MxPoint32 p_point); // vtable+0x40
+	virtual void LeftDown(int, int);  // vtable+0x14
+	virtual void LeftDrag(int, int);  // vtable+0x18
+	virtual void LeftUp(int, int);    // vtable+0x1c
+	virtual void RightDown(int, int); // vtable+0x20
+	virtual void RightDrag(int, int); // vtable+0x24
+	virtual void RightUp(int, int);   // vtable+0x28
 
 private:
 	BOOL m_isButtonDown; // 0x08

--- a/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
@@ -3,6 +3,7 @@
 
 #include "decomp.h"
 #include "mxcore.h"
+#include "mxpoint32.h"
 
 #include <windows.h>
 
@@ -21,12 +22,18 @@ public:
 	LegoMouseController();
 	virtual ~LegoMouseController() override;
 
-	virtual void LeftDown(int, int);  // vtable+0x14
-	virtual void LeftDrag(int, int);  // vtable+0x18
-	virtual void LeftUp(int, int);    // vtable+0x1c
-	virtual void RightDown(int, int); // vtable+0x20
-	virtual void RightDrag(int, int); // vtable+0x24
-	virtual void RightUp(int, int);   // vtable+0x28
+	virtual void LeftDown(int, int);                              // vtable+0x14
+	virtual void LeftDrag(int, int);                              // vtable+0x18
+	virtual void LeftUp(int, int);                                // vtable+0x1c
+	virtual void RightDown(int, int);                             // vtable+0x20
+	virtual void RightDrag(int, int);                             // vtable+0x24
+	virtual void RightUp(int, int);                               // vtable+0x28
+	virtual void vmethod_0x2c();                                  // vtable+0x2c
+	virtual void OnLButtonDown(MxPoint32 p_point);                // vtable+0x30
+	virtual void OnLButtonUp(MxPoint32 p_point);                  // vtable+0x34
+	virtual void OnRButtonDown(MxPoint32 p_point);                // vtable+0x38
+	virtual void OnRButtonUp(MxPoint32 p_point);                  // vtable+0x3c
+	virtual void OnMouseMove(MxU8 p_modifier, MxPoint32 p_point); // vtable+0x40
 
 private:
 	BOOL m_isButtonDown; // 0x08

--- a/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
@@ -39,7 +39,14 @@ void LegoActionControlPresenter::RepeatingTickle()
 			ParseExtra();
 		}
 
+#ifdef COMPAT_MODE
+		{
+			MxAtomId atom(m_unk0x54.GetData(), LookupMode_LowerCase2);
+			InvokeAction(m_unk0x50, atom, m_unk0x64, NULL);
+		}
+#else
 		InvokeAction(m_unk0x50, MxAtomId(m_unk0x54.GetData(), LookupMode_LowerCase2), m_unk0x64, NULL);
+#endif
 		m_previousTickleStates |= 1 << (unsigned char) m_currentTickleState;
 		m_currentTickleState = TickleState_Done;
 	}

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -10,14 +10,7 @@ DECOMP_SIZE_ASSERT(LegoCameraController, 0xc8);
 // FUNCTION: LEGO1 0x10011d50
 LegoCameraController::LegoCameraController()
 {
-#ifdef COMPAT_MODE
-	Vector3Data at(0, 0, 0);
-	Vector3Data dir(0, 0, 1);
-	Vector3Data up(0, 1, 0);
-	SetWorldTransform(at, dir, up);
-#else
 	SetWorldTransform(Vector3Data(0, 0, 0), Vector3Data(0, 0, 1), Vector3Data(0, 1, 0));
-#endif
 }
 
 // FUNCTION: LEGO1 0x10011f70
@@ -78,7 +71,7 @@ void LegoCameraController::OnMouseMove(MxU8 p_modifier, MxPoint32 p_point)
 }
 
 // FUNCTION: LEGO1 0x10012260
-void LegoCameraController::SetWorldTransform(Vector3Impl& p_at, Vector3Impl& p_dir, Vector3Impl& p_up)
+void LegoCameraController::SetWorldTransform(const Vector3Impl& p_at, const Vector3Impl& p_dir, const Vector3Impl& p_up)
 {
 	CalcLocalTransform(p_at, p_dir, p_up, m_matrix1);
 	m_matrix2 = m_matrix1;

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -10,7 +10,14 @@ DECOMP_SIZE_ASSERT(LegoCameraController, 0xc8);
 // FUNCTION: LEGO1 0x10011d50
 LegoCameraController::LegoCameraController()
 {
+#ifdef COMPAT_MODE
+	Vector3Data at(0, 0, 0);
+	Vector3Data dir(0, 0, 1);
+	Vector3Data up(0, 1, 0);
+	SetWorldTransform(at, dir, up);
+#else
 	SetWorldTransform(Vector3Data(0, 0, 0), Vector3Data(0, 0, 1), Vector3Data(0, 1, 0));
+#endif
 }
 
 // FUNCTION: LEGO1 0x10011f70

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -36,7 +36,7 @@ void LegoEntity::ResetWorldTransform(MxBool p_inVehicle)
 }
 
 // STUB: LEGO1 0x10010790
-void LegoEntity::SetWorldTransform(Vector3Impl& p_loc, Vector3Impl& p_dir, Vector3Impl& p_up)
+void LegoEntity::SetWorldTransform(const Vector3Impl& p_loc, const Vector3Impl& p_dir, const Vector3Impl& p_up)
 {
 	// TODO
 }

--- a/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
@@ -65,38 +65,6 @@ void LegoMouseController::RightDrag(int p_x, int p_y)
 	m_buttonY = p_y;
 }
 
-
-void LegoMouseController::vmethod_0x2c()
-{
-	// FIXME: not sure this method actually exists: LegoCameraController overrides something
-}
-
-void LegoMouseController::OnLButtonDown(MxPoint32 p_point)
-{
-	// FIXME: not sure this method actually exists: LegoCameraController overrides something
-}
-
-void LegoMouseController::OnLButtonUp(MxPoint32 p_point)
-{
-	// FIXME: not sure this method actually exists: LegoCameraController overrides something
-}
-
-void LegoMouseController::OnRButtonDown(MxPoint32 p_point)
-{
-	// FIXME: not sure this method actually exists: LegoCameraController overrides something
-}
-
-void LegoMouseController::OnRButtonUp(MxPoint32 p_point)
-{
-	// FIXME: not sure this method actually exists: LegoCameraController overrides something
-}
-
-void LegoMouseController::OnMouseMove(MxU8 p_modifier, MxPoint32 p_point)
-{
-	// FIXME: not sure this method actually exists: LegoCameraController overrides something
-}
-
-
 //////////////////////////////////////////////////////////////////////
 
 // FUNCTION: LEGO1 0x100656e0

--- a/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
@@ -65,6 +65,38 @@ void LegoMouseController::RightDrag(int p_x, int p_y)
 	m_buttonY = p_y;
 }
 
+
+void LegoMouseController::vmethod_0x2c()
+{
+	// FIXME: not sure this method actually exists: LegoCameraController overrides something
+}
+
+void LegoMouseController::OnLButtonDown(MxPoint32 p_point)
+{
+	// FIXME: not sure this method actually exists: LegoCameraController overrides something
+}
+
+void LegoMouseController::OnLButtonUp(MxPoint32 p_point)
+{
+	// FIXME: not sure this method actually exists: LegoCameraController overrides something
+}
+
+void LegoMouseController::OnRButtonDown(MxPoint32 p_point)
+{
+	// FIXME: not sure this method actually exists: LegoCameraController overrides something
+}
+
+void LegoMouseController::OnRButtonUp(MxPoint32 p_point)
+{
+	// FIXME: not sure this method actually exists: LegoCameraController overrides something
+}
+
+void LegoMouseController::OnMouseMove(MxU8 p_modifier, MxPoint32 p_point)
+{
+	// FIXME: not sure this method actually exists: LegoCameraController overrides something
+}
+
+
 //////////////////////////////////////////////////////////////////////
 
 // FUNCTION: LEGO1 0x100656e0

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -10,6 +10,7 @@
 
 DECOMP_SIZE_ASSERT(LegoVideoManager, 0x590);
 DECOMP_SIZE_ASSERT(MxStopWatch, 0x18);
+DECOMP_SIZE_ASSERT(MxFrequencyMeter, 0x20);
 
 // FUNCTION: LEGO1 0x1007aa20
 LegoVideoManager::LegoVideoManager()

--- a/LEGO1/lego/sources/3dmanager/lego3dmanager.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dmanager.h
@@ -4,10 +4,12 @@
 #include "assert.h"
 #include "lego3dview.h"
 
-namespace Tgl {
+namespace Tgl
+{
 class Renderer;
 class Group;
-}
+} // namespace Tgl
+
 class ViewROI;
 
 // ??? for now

--- a/LEGO1/lego/sources/3dmanager/lego3dmanager.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dmanager.h
@@ -4,8 +4,10 @@
 #include "assert.h"
 #include "lego3dview.h"
 
-class Tgl::Renderer;
-class Tgl::Group;
+namespace Tgl {
+class Renderer;
+class Group;
+}
 class ViewROI;
 
 // ??? for now

--- a/LEGO1/lego/sources/3dmanager/lego3dview.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.h
@@ -35,7 +35,7 @@ public:
 
 private:
 	ViewManager* m_pViewManager; // 0x88
-	double m_previousRenderTime; // 0x8c
+	double m_previousRenderTime; // 0x8c  FIXME: incorrect tags: sizeof(double) = 8 -> 0x8c + 08 = 0x94 > offsetof(Lego3dView, m_pPointOfView)
 
 	ViewROI* m_pPointOfView; // 0x90
 

--- a/LEGO1/lego/sources/3dmanager/lego3dview.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.h
@@ -35,11 +35,9 @@ public:
 
 private:
 	ViewManager* m_pViewManager; // 0x88
-	double m_previousRenderTime; // 0x8c  FIXME: incorrect tags: sizeof(double) = 8 -> 0x8c + 08 = 0x94 > offsetof(Lego3dView, m_pPointOfView)
-
-	ViewROI* m_pPointOfView; // 0x90
-
-	undefined m_unk0x94[0x0c]; // 0x94
+	double m_previousRenderTime; // 0x8c
+	ViewROI* m_pPointOfView;     // 0x94
+	undefined m_unk0x98[0x0c];   // 0x98
 };
 
 // SYNTHETIC: LEGO1 0x100aaf10

--- a/LEGO1/lego/sources/3dmanager/legoview1.h
+++ b/LEGO1/lego/sources/3dmanager/legoview1.h
@@ -4,7 +4,9 @@
 #include "compat.h"
 #include "tglsurface.h"
 
-class Tgl::Camera;
+namespace tgl {
+class Camera;
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // LegoView

--- a/LEGO1/lego/sources/3dmanager/legoview1.h
+++ b/LEGO1/lego/sources/3dmanager/legoview1.h
@@ -1,6 +1,7 @@
 #ifndef _LegoView1_h
 #define _LegoView1_h
 
+#include "decomp.h"
 #include "compat.h"
 #include "tglsurface.h"
 
@@ -66,6 +67,7 @@ private:
 	Tgl::Light* m_pSunLight;         // 0x78
 	Tgl::Light* m_pDirectionalLight; // 0x7c
 	Tgl::Light* m_pAmbientLight;     // 0x80
+	undefined m_unk0x84[4];          // 0x84
 };
 
 // SYNTHETIC: LEGO1 0x100ab7a0

--- a/LEGO1/lego/sources/3dmanager/legoview1.h
+++ b/LEGO1/lego/sources/3dmanager/legoview1.h
@@ -1,11 +1,12 @@
 #ifndef _LegoView1_h
 #define _LegoView1_h
 
-#include "decomp.h"
 #include "compat.h"
+#include "decomp.h"
 #include "tglsurface.h"
 
-namespace tgl {
+namespace Tgl
+{
 class Camera;
 }
 
@@ -67,7 +68,6 @@ private:
 	Tgl::Light* m_pSunLight;         // 0x78
 	Tgl::Light* m_pDirectionalLight; // 0x7c
 	Tgl::Light* m_pAmbientLight;     // 0x80
-	undefined m_unk0x84[4];          // 0x84
 };
 
 // SYNTHETIC: LEGO1 0x100ab7a0

--- a/LEGO1/lego/sources/3dmanager/tglsurface.cpp
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.cpp
@@ -195,7 +195,12 @@ double TglSurface::Render()
 
 #ifdef _DEBUG
 		{
+#if 0
+			// FIXME: Tgl::Device::GetDrawnTriangleCount does not exist
 			unsigned long triangleCount = m_pDevice->GetDrawnTriangleCount();
+#else
+			unsigned long triangleCount = 0;
+#endif
 
 			m_triangleRateMeter.IncreaseOperationCount(triangleCount - m_triangleCount - 1);
 			m_triangleCount = triangleCount;

--- a/LEGO1/lego/sources/3dmanager/tglsurface.h
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.h
@@ -4,10 +4,12 @@
 #include "mxdirectx/mxstopwatch.h"
 #include "tgl/tgl.h"
 
-class Tgl::Renderer;
-class Tgl::Device;
-class Tgl::View;
-class Tgl::Group;
+namespace Tgl {
+class Renderer;
+class Device;
+class View;
+class Group;
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // TglSurface

--- a/LEGO1/lego/sources/3dmanager/tglsurface.h
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.h
@@ -4,12 +4,13 @@
 #include "mxdirectx/mxstopwatch.h"
 #include "tgl/tgl.h"
 
-namespace Tgl {
+namespace Tgl
+{
 class Renderer;
 class Device;
 class View;
 class Group;
-}
+} // namespace Tgl
 
 /////////////////////////////////////////////////////////////////////////////
 // TglSurface

--- a/LEGO1/omni/include/mxutil.h
+++ b/LEGO1/omni/include/mxutil.h
@@ -3,6 +3,8 @@
 
 #include "mxtypes.h"
 
+#include <string.h>
+
 class MxDSFile;
 class MxDSObject;
 

--- a/LEGO1/res/resource.h
+++ b/LEGO1/res/resource.h
@@ -8,5 +8,3 @@
 #define LEGO1_LEAF5 108
 #define LEGO1_LEAF3 109
 #define LEGO1_BUSY 111
-
-#define APP_ICON 105

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -119,4 +119,11 @@ inline int ViewLODList::Release()
 	return m_refCount;
 }
 
+#ifdef _DEBUG
+inline void ViewLODList::Dump(void (*pTracer)(const char*, ...)) const
+{
+	// FIXME: dump something
+}
+#endif
+
 #endif // VIEWLODLIST_H

--- a/util/compat.h
+++ b/util/compat.h
@@ -3,13 +3,13 @@
 
 // Various macros to enable compiling with other/newer compilers.
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER >= 1100)
 #define COMPAT_MODE
 #endif
 
 // Use `COMPAT_CONST` where something ought to be 'const', and a newer compiler would complain if it
 // wasn't, but we know it isn't 'const' in the original code.
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER >= 1100)
 #define COMPAT_CONST const
 #else
 #define COMPAT_CONST

--- a/util/decomp.h
+++ b/util/decomp.h
@@ -1,7 +1,7 @@
 #ifndef DECOMP_H
 #define DECOMP_H
 
-#if defined(_MSC_VER)
+#if defined(ENABLE_DECOMP_ASSERTS)
 #define DECOMP_STATIC_ASSERT(V)                                                                                        \
 	namespace                                                                                                          \
 	{                                                                                                                  \


### PR DESCRIPTION
- Enable decomilation assertions when Visual C++ version <= 5.0
  Visual C++ 4.2.0 == cl version 10.20 ([wikipedia](https://en.wikipedia.org/w/index.php?title=Microsoft_Visual_C%2B%2B&section=4#Internal_version_numbering))
- Disable assertions for modern C++ + mingw: the size assertions did not fail in minw@Linux, but failed when building with Visual Studio 2019 or msys2 mingw.
- Pass `-Zc:__cplusplus` to make the `__cplusplus` macro contain the actual `__cplusplus` version (needed for `static_assert`)
- `LegoCameraController` overrides methods that are not declared/implemented in its parents
- Don't forward declare namespaced classes as `class Tgl::Device` but as `namespace Tgl { class Device; }`.
  msys2 mingw complained with the following warning: `declaration 'class Tgl::Device' does not declare anything`
- `ViewLODList::Dump` does not have an implementation
- `Tgl::Device::GetDrawnTriangleCount` does not exist: my fix is WRONG
- Remove `APP_ICON` from lego/res/resource.h`

Using these patches, I can run `ISLE.EXE` + `LEGO1.DLL` built with mingw + Visual Studio, and let them fail identically.

For me, the stacktrace is:
```
LegoVideoManager::Create(MxVideoParam &, unsigned int, unsigned char) legovideomanager.cpp:109
LegoOmni::Create(MxOmniCreateParam &) legoomni.cpp:510
IsleApp::SetupLegoOmni() isleapp.cpp:138
IsleApp::SetupWindow(HINSTANCE__ *, char *) isleapp.cpp:588
WinMain(HINSTANCE__ *, HINSTANCE__ *, char *, int) isleapp.cpp:218
invoke_main() 0x0000000000e171cd
__scrt_common_main_seh() 0x0000000000e17027
__scrt_common_main() 0x0000000000e16ebd
WinMainCRTStartup(void *) 0x0000000000e17248
```
`driver` in [`LegoVideoManager::Create`](https://github.com/isledecomp/isle/blob/5a2be934be68db6eea90b2711a3cad07284788a8/LEGO1/lego/legoomni/src/video/legovideomanager.cpp#L109) is `NULL`