### PR TITLE
Implement lists used in LegoWorld

### DIFF
--- a/LEGO1/lego/legoomni/include/legoentitylist.h
+++ b/LEGO1/lego/legoomni/include/legoentitylist.h
@@ -1,0 +1,89 @@
+#ifndef LEGOENTITYLIST_H
+#define LEGOENTITYLIST_H
+
+#include "mxlist.h"
+#include "mxtypes.h"
+
+class LegoEntity;
+
+// VTABLE: LEGO1 0x100d6410
+// class MxCollection<LegoEntity *>
+
+// VTABLE: LEGO1 0x100d6428
+// class MxList<LegoEntity *>
+
+// VTABLE: LEGO1 0x100d6440
+// class MxPtrList<LegoEntity>
+
+// VTABLE: LEGO1 0x100d6458
+// SIZE 0x18
+class LegoEntityList : public MxPtrList<LegoEntity> {
+public:
+	LegoEntityList(MxBool p_ownership = FALSE) : MxPtrList<LegoEntity>(p_ownership) {}
+
+	// FUNCTION: LEGO1 0x1001e2d0
+	virtual MxS8 Compare(LegoEntity* p_a, LegoEntity* p_b) override
+	{
+		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
+	}; // vtable+0x14
+};
+
+// VTABLE: LEGO1 0x100d64e8
+// class MxListCursor<LegoEntity *>
+
+// VTABLE: LEGO1 0x100d64b8
+// class MxPtrListCursor<LegoEntity>
+
+// VTABLE: LEGO1 0x100d64d0
+// SIZE 0x10
+class LegoEntityListCursor : public MxPtrListCursor<LegoEntity> {
+public:
+	LegoEntityListCursor(LegoEntityList* p_list) : MxPtrListCursor<LegoEntity>(p_list){};
+};
+
+// TEMPLATE: LEGO1 0x1001e2f0
+// MxCollection<LegoEntity *>::Compare
+
+// XTEMPLATE: LEGO1 0x1001e300
+// MxCollection<LegoEntity *>::~MxCollection<LegoEntity *>
+
+// TEMPLATE: LEGO1 0x1001e350
+// MxCollection<LegoEntity *>::Destroy
+
+// TEMPLATE: LEGO1 0x1001e360
+// MxList<LegoEntity *>::~MxList<LegoEntity *>
+
+// TEMPLATE: LEGO1 0x1001e3f0
+// MxPtrList<LegoEntity>::Destroy
+
+// SYNTHETIC: LEGO1 0x1001e400
+// LegoEntityList::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001e4c0
+// MxCollection<LegoEntity *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001e530
+// MxList<LegoEntity *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001e5e0
+// MxPtrList<LegoEntity>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001f110
+// LegoEntityListCursor::`scalar deleting destructor'
+
+// FUNCTION: LEGO1 0x1001f180
+// MxPtrListCursor<LegoEntity>::~MxPtrListCursor<LegoEntity>
+
+// SYNTHETIC: LEGO1 0x1001f1d0
+// MxListCursor<LegoEntity *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001f240
+// MxPtrListCursor<LegoEntity>::`scalar deleting destructor'
+
+// FUNCTION: LEGO1 0x1001f2b0
+// MxListCursor<LegoEntity *>::~MxListCursor<LegoEntity *>
+
+// FUNCTION: LEGO1 0x1001edc6
+// LegoEntityListCursor::~LegoEntityListCursor
+
+#endif // LEGOENTITYLIST_H

--- a/LEGO1/lego/legoomni/include/legoentitylist.h
+++ b/LEGO1/lego/legoomni/include/legoentitylist.h
@@ -44,7 +44,7 @@ public:
 // TEMPLATE: LEGO1 0x1001e2f0
 // MxCollection<LegoEntity *>::Compare
 
-// XTEMPLATE: LEGO1 0x1001e300
+// TEMPLATE: LEGO1 0x1001e300
 // MxCollection<LegoEntity *>::~MxCollection<LegoEntity *>
 
 // TEMPLATE: LEGO1 0x1001e350
@@ -58,6 +58,9 @@ public:
 
 // SYNTHETIC: LEGO1 0x1001e400
 // LegoEntityList::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x1001e470
+// MxPtrList<LegoEntity>::~MxPtrList<LegoEntity>
 
 // SYNTHETIC: LEGO1 0x1001e4c0
 // MxCollection<LegoEntity *>::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -3,6 +3,7 @@
 
 #include "legocameracontroller.h"
 #include "legoentity.h"
+#include "legoentitylist.h"
 #include "legopathcontrollerlist.h"
 #include "mxpresenter.h"
 #include "mxpresenterlist.h"
@@ -59,7 +60,8 @@ protected:
 	LegoPathControllerList m_list0x68;        // 0x68
 	MxPresenterList m_list0x80;               // 0x80
 	LegoCameraController* m_cameraController; // 0x98
-	undefined m_unk0x9c[0x1c];                // 0x9c
+	LegoEntityList* m_entityList;             // 0x9c
+	undefined m_unk0xa0[0x18];                // 0xa0
 	MxPresenterList m_list0xb8;               // 0xb8
 	undefined m_unk0xd0[0x1c];                // 0xd0
 	undefined4 m_unk0xec;                     // 0xec

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -5,6 +5,7 @@
 #include "legoentity.h"
 #include "legoentitylist.h"
 #include "legopathcontrollerlist.h"
+#include "mxcorelist.h"
 #include "mxpresenter.h"
 #include "mxpresenterlist.h"
 
@@ -39,8 +40,10 @@ public:
 	virtual LegoCameraController* VTable0x54();               // vtable+0x54
 	virtual void VTable0x58(MxCore* p_object);                // vtable+0x58
 	virtual MxBool VTable0x5c();                              // vtable+0x5c
+
 	// FUNCTION: LEGO1 0x100010a0
-	virtual void VTable0x60() {}           // vtable+0x60
+	virtual void VTable0x60() {} // vtable+0x60
+
 	virtual MxBool VTable0x64();           // vtable+0x64
 	virtual void VTable0x68(MxBool p_add); // vtable+0x68
 
@@ -61,7 +64,8 @@ protected:
 	MxPresenterList m_list0x80;               // 0x80
 	LegoCameraController* m_cameraController; // 0x98
 	LegoEntityList* m_entityList;             // 0x9c
-	undefined m_unk0xa0[0x18];                // 0xa0
+	MxCoreList* m_coreList;                   // 0xa0
+	undefined m_unk0xa4[0x14];                // 0xa4
 	MxPresenterList m_list0xb8;               // 0xb8
 	undefined m_unk0xd0[0x1c];                // 0xd0
 	undefined4 m_unk0xec;                     // 0xec

--- a/LEGO1/lego/legoomni/include/legoworldlist.h
+++ b/LEGO1/lego/legoomni/include/legoworldlist.h
@@ -41,6 +41,18 @@ public:
 	LegoWorldListCursor(LegoWorldList* p_list) : MxPtrListCursor<LegoWorld>(p_list){};
 };
 
+// SYNTHETIC: LEGO1 0x1003e870
+// LegoWorldListCursor::`scalar deleting destructor'
+
+// FUNCTION: LEGO1 0x1003e8e0
+// MxPtrListCursor<LegoWorld>::~MxPtrListCursor<LegoWorld>
+
+// FUNCTION: LEGO1 0x1003ea10
+// MxListCursor<LegoWorld *>::~MxListCursor<LegoWorld *>
+
+// FUNCTION: LEGO1 0x1003ea60
+// LegoWorldListCursor::~LegoWorldListCursor
+
 // TEMPLATE: LEGO1 0x100598f0
 // MxCollection<LegoWorld *>::Compare
 
@@ -64,17 +76,5 @@ public:
 
 // SYNTHETIC: LEGO1 0x10059be0
 // MxPtrList<LegoWorld>::`scalar deleting destructor'
-
-// SYNTHETIC: LEGO1 0x1003e870
-// LegoWorldListCursor::`scalar deleting destructor'
-
-// FUNCTION: LEGO1 0x1003e8e0
-// MxPtrListCursor<LegoWorld>::~MxPtrListCursor<LegoWorld>
-
-// FUNCTION: LEGO1 0x1003ea10
-// MxListCursor<LegoWorld *>::~MxListCursor<LegoWorld *>
-
-// FUNCTION: LEGO1 0x1003ea60
-// LegoWorldListCursor::~LegoWorldListCursor
 
 #endif // LEGOWORLDLIST_H

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -40,29 +40,37 @@ LegoWorld::~LegoWorld()
 	// TODO
 }
 
-// STUB: LEGO1 0x1001e0b0
+// FUNCTION: LEGO1 0x1001e0b0
 MxResult LegoWorld::Create(MxDSAction& p_dsAction)
 {
 	MxEntity::Create(p_dsAction);
 
 	m_entityList = new LegoEntityList(TRUE);
 
-	if (VTable0x54()) {
-		if (p_dsAction.GetFlags() & MxDSAction::Flag_Enabled) {
-			if (GetCurrentWorld()) {
-				GetCurrentWorld()->VTable0x68(0);
-			}
+	if (!m_entityList)
+		return FAILURE;
 
-			SetCurrentWorld(this);
-			ControlManager()->FUN_10028df0(&m_list0xb8);
+	m_coreList = new MxCoreList(TRUE);
+
+	if (!m_coreList)
+		return FAILURE;
+
+	if (!VTable0x54())
+		return FAILURE;
+
+	if (p_dsAction.GetFlags() & MxDSAction::Flag_Enabled) {
+		if (GetCurrentWorld()) {
+			GetCurrentWorld()->VTable0x68(0);
 		}
 
-		SetIsWorldActive(TRUE);
-		m_unk0xec = -1;
-
-		return SUCCESS;
+		SetCurrentWorld(this);
+		ControlManager()->FUN_10028df0(&m_list0xb8);
 	}
-	return FAILURE;
+
+	SetIsWorldActive(TRUE);
+	m_unk0xec = -1;
+
+	return SUCCESS;
 }
 
 // FUNCTION: LEGO1 0x1001f5e0

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -45,7 +45,7 @@ MxResult LegoWorld::Create(MxDSAction& p_dsAction)
 {
 	MxEntity::Create(p_dsAction);
 
-	// TODO: Intitialize lists
+	m_entityList = new LegoEntityList(TRUE);
 
 	if (VTable0x54()) {
 		if (p_dsAction.GetFlags() & MxDSAction::Flag_Enabled) {

--- a/LEGO1/omni/include/mxcorelist.h
+++ b/LEGO1/omni/include/mxcorelist.h
@@ -1,0 +1,95 @@
+#ifndef MXCORELIST_H
+#define MXCORELIST_H
+
+#include "mxlist.h"
+#include "mxtypes.h"
+
+class MxCore;
+
+// VTABLE: LEGO1 0x100d63b0
+// class MxCollection<MxCore *>
+
+// VTABLE: LEGO1 0x100d63c8
+// class MxList<MxCore *>
+
+// VTABLE: LEGO1 0x100d63e0
+// class MxPtrList<MxCore>
+
+// VTABLE: LEGO1 0x100d63f8
+// SIZE 0x18
+class MxCoreList : public MxPtrList<MxCore> {
+public:
+	MxCoreList(MxBool p_ownership = FALSE) : MxPtrList<MxCore>(p_ownership) {}
+
+	// FUNCTION: LEGO1 0x1001e650
+	virtual MxS8 Compare(MxCore* p_a, MxCore* p_b) override
+	{
+		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
+	}; // vtable+0x14
+};
+
+// VTABLE: LEGO1 0x100d64a0
+// class MxListCursor<MxCore *>
+
+// VTABLE: LEGO1 0x100d6500
+// class MxPtrListCursor<MxCore>
+
+// VTABLE: LEGO1 0x100d6518
+// SIZE 0x10
+class MxCoreListCursor : public MxPtrListCursor<MxCore> {
+public:
+	MxCoreListCursor(MxCoreList* p_list) : MxPtrListCursor<MxCore>(p_list){};
+};
+
+// TEMPLATE: LEGO1 0x1001e670
+// MxCollection<MxCore *>::Compare
+
+// TEMPLATE: LEGO1 0x1001e680
+// MxCollection<MxCore *>::~MxCollection<MxCore *>
+
+// TEMPLATE: LEGO1 0x1001e6d0
+// MxCollection<MxCore *>::Destroy
+
+// TEMPLATE: LEGO1 0x1001e6e0
+// MxList<MxCore *>::~MxList<MxCore *>
+
+// TEMPLATE: LEGO1 0x1001e770
+// MxPtrList<MxCore>::Destroy
+
+// SYNTHETIC: LEGO1 0x1001e780
+// MxCoreList::`scalar deleting destructor'
+
+// TEMPLATE: LEGO1 0x1001e7f0
+// MxPtrList<MxCore>::~MxPtrList<MxCore>
+
+// SYNTHETIC: LEGO1 0x1001e840
+// MxCollection<MxCore *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001e8b0
+// MxList<MxCore *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001e960
+// MxPtrList<MxCore>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001f350
+// MxCoreListCursor::`scalar deleting destructor'
+
+// FUNCTION: LEGO1 0x1001f3c0
+// MxPtrListCursor<MxCore>::~MxPtrListCursor<MxCore>
+
+// SYNTHETIC: LEGO1 0x1001f410
+// MxListCursor<MxCore *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001f480
+// MxPtrListCursor<MxCore>::`scalar deleting destructor'
+
+// FUNCTION: LEGO1 0x1001f4f0
+// MxListCursor<MxCore *>::~MxListCursor<MxCore *>
+
+// FUNCTION: LEGO1 0x1001f540
+// MxCoreListCursor::~MxCoreListCursor
+
+// TEMPLATE: LEGO1 0x10020840
+// MxListCursor<MxCore *>::MxListCursor<MxCore *>
+
+#endif // MXCORELIST_H


### PR DESCRIPTION
100% match for `LegoWorld::Create` which instantiates both lists. They are fairly standard and based on `MxPtrList`. I've added the cursors as well, though they aren't used anywhere yet but should be correct as well.