### PR TITLE
Decomp parser: indirect globals and string markers

### DIFF
--- a/ISLE/library_msvc.h
+++ b/ISLE/library_msvc.h
@@ -1,0 +1,63 @@
+#ifdef 0
+// For ISLE symbols only
+
+// aka `operator new`
+// LIBRARY: ISLE 0x402f80
+// ??2@YAPAXI@Z
+
+// aka `operator delete`
+// LIBRARY: ISLE 0x402fa0
+// ??3@YAXPAX@Z
+
+// LIBRARY: ISLE 0x406dd0
+// _malloc
+
+// LIBRARY: ISLE 0x406f00
+// _free
+
+// LIBRARY: ISLE 0x407ec0
+// ___CxxFrameHandler
+
+// LIBRARY: ISLE 0x4081e0
+// _srand
+
+// LIBRARY: ISLE 0x4081f0
+// _rand
+
+// LIBRARY: ISLE 0x408220
+// _atol
+
+// LIBRARY: ISLE 0x4082d0
+// _atoi
+
+// LIBRARY: ISLE 0x4084c0
+// ?_query_new_handler@@YAP6AHI@ZXZ
+
+// LIBRARY: ISLE 0x4084d0
+// ?_query_new_mode@@YAHXZ
+
+// LIBRARY: ISLE 0x4085c0
+// _sprintf
+
+// LIBRARY: ISLE 0x408630
+// _abort
+
+// LIBRARY: ISLE 0x409110
+// __mtinit
+
+// LIBRARY: ISLE 0x409190
+// __getptd
+
+// GLOBAL: ISLE 0x4108e8
+// __osver
+
+// GLOBAL: ISLE 0x4108f0
+// __winmajor
+
+// GLOBAL: ISLE 0x4108f4
+// __winminor
+
+// GLOBAL: ISLE 0x410d50
+// __newmode
+
+#endif

--- a/ISLE/library_smartheap.h
+++ b/ISLE/library_smartheap.h
@@ -1,0 +1,312 @@
+#ifdef 0
+
+// LIBRARY: ISLE 0x402f10
+// ?shi_New@@YAPAXKIPAU_SHI_Pool@@@Z
+
+// LIBRARY: ISLE 0x402fb0
+// _MemInitDefaultPool@0
+
+// LIBRARY: ISLE 0x403020
+// _shi_call_new_handler_msc
+
+// LIBRARY: ISLE 0x403050
+// _MemPoolShrink@4
+
+// LIBRARY: ISLE 0x403180
+// _MemPoolPreAllocate@12
+
+// LIBRARY: ISLE 0x403300
+// @_shi_initPageHeaders@4
+
+// LIBRARY: ISLE 0x403570
+// @shi_allocPageHeader@4
+
+// LIBRARY: ISLE 0x4035a0
+// @shi_freePageHeader@8
+
+// LIBRARY: ISLE 0x403750
+// @_shi_deletePage@8
+
+// LIBRARY: ISLE 0x403830
+// @_shi_allocExternal@12
+
+// LIBRARY: ISLE 0x403a50
+// @_shi_initPageVariable@8
+
+// LIBRARY: ISLE 0x403b00
+// _MemAllocPtr@12
+
+// LIBRARY: ISLE 0x403d60
+// @_shi_allocVar@12
+
+// LIBRARY: ISLE 0x403ef0
+// @_shi_allocBlock@12
+
+// LIBRARY: ISLE 0x4040c0
+// _MemFreePtr@4
+
+// LIBRARY: ISLE 0x404170
+// @_shi_freeVar@4
+
+// LIBRARY: ISLE 0x404260
+// _MemReAllocPtr@12
+
+// LIBRARY: ISLE 0x4043b0
+// @_shi_resizeAny@16
+
+// LIBRARY: ISLE 0x404650
+// @_shi_resizeVar@8
+
+// LIBRARY: ISLE 0x404820
+// _MemSizePtr@4
+
+// LIBRARY: ISLE 0x4048d0
+// @shi_findAllocAddress@4
+
+// LIBRARY: ISLE 0x404910
+// @_shi_sysAlloc@8
+
+// LIBRARY: ISLE 0x4049a0
+// @_shi_sysFree@4
+
+// LIBRARY: ISLE 0x404a00
+// @_shi_sysRealloc@12
+
+// LIBRARY: ISLE 0x404ab0
+// @_shi_sysResize@12
+
+// LIBRARY: ISLE 0x404b90
+// @_shi_sysSize@4
+
+// LIBRARY: ISLE 0x404bd0
+// @_shi_sysAllocNear@4
+
+// LIBRARY: ISLE 0x404bf0
+// @_shi_sysFreeNear@4
+
+// LIBRARY: ISLE 0x404c10
+// @_shi_sysValidatePtr@12
+
+// LIBRARY: ISLE 0x404d10
+// @_shi_sysValidateFunction@4
+
+// LIBRARY: ISLE 0x405300
+// @_shi_sysAllocPool@12
+
+// LIBRARY: ISLE 0x405520
+// @_shi_sysResizePool@16
+
+// LIBRARY: ISLE 0x405690
+// @_shi_sysFreePage@4
+
+// LIBRARY: ISLE 0x4057b0
+// @_shi_sysSizePage@4
+
+// LIBRARY: ISLE 0x4057e0
+// @_shi_sysSizePool@8
+
+// LIBRARY: ISLE 0x405800
+// @_shi_registerShared@16
+
+// LIBRARY: ISLE 0x405a00
+// @_shi_unregisterShared@8
+
+// LIBRARY: ISLE 0x405b20
+// @_shi_getNextPool@4
+
+// LIBRARY: ISLE 0x405b30
+// @shi_delNextPool@4
+
+// LIBRARY: ISLE 0x405d30
+// @shi_createAndEnterMutexShr@12
+
+// LIBRARY: ISLE 0x405e20
+// @shi_termPoolMutexShr@4
+
+// LIBRARY: ISLE 0x405e40
+// @shi_enterPoolMutexShr@4
+
+// LIBRARY: ISLE 0x405e60
+// @shi_leavePoolMutexShr@4
+
+// LIBRARY: ISLE 0x405e80
+// __shi_enterCriticalSection@0
+
+// LIBRARY: ISLE 0x405ea0
+// __shi_leaveCriticalSection@0
+
+// LIBRARY: ISLE 0x405ec0
+// __shi_createAndEnterMutex
+
+// LIBRARY: ISLE 0x405ef0
+// _shi_enterPoolMutexSafely
+
+// LIBRARY: ISLE 0x405fd0
+// _shi_enterPoolInitMutexReader
+
+// LIBRARY: ISLE 0x406060
+// _shi_leavePoolInitMutexReader
+
+// LIBRARY: ISLE 0x406090
+// _shi_enterPoolInitMutexWriter
+
+// LIBRARY: ISLE 0x406160
+// _shi_leavePoolInitMutexWriter
+
+// LIBRARY: ISLE 0x406180
+// _shi_isNT
+
+// LIBRARY: ISLE 0x4061b0
+// _MemPoolInit@4
+
+// LIBRARY: ISLE 0x406520
+// _MemPoolSetPageSize@8
+
+// LIBRARY: ISLE 0x406630
+// _MemPoolSetBlockSizeFS@8
+
+// LIBRARY: ISLE 0x406710
+// @_shi_poolFree@8
+
+// LIBRARY: ISLE 0x4068c0
+// @_shi_invokeErrorHandler1@8
+
+// LIBRARY: ISLE 0x406be0
+// _MemErrorUnwind@0
+
+// LIBRARY: ISLE 0x406c30
+// _MemDefaultErrorHandler@4
+
+// LIBRARY: ISLE 0x406cb0
+// @_shi_taskRemovePool@4
+
+// LIBRARY: ISLE 0x406d50
+// @_shi_getCurrentThreadContext@8
+
+// LIBRARY: ISLE 0x406db0
+// @_shi_deleteThreadContext@8
+
+// LIBRARY: ISLE 0x406e40
+// _calloc
+
+// LIBRARY: ISLE 0x406ea0
+// _realloc
+
+// LIBRARY: ISLE 0x406f10
+// __expand
+
+// LIBRARY: ISLE 0x406f50
+// __heapadd
+
+// LIBRARY: ISLE 0x406f60
+// __heapwalk
+
+// LIBRARY: ISLE 0x406ff0
+// __heapused
+
+// LIBRARY: ISLE 0x407020
+// __heapmin
+
+// LIBRARY: ISLE 0x407040
+// __msize
+
+// LIBRARY: ISLE 0x407050
+// __heapchk
+
+// LIBRARY: ISLE 0x407080
+// __heapset
+
+// LIBRARY: ISLE 0x407090
+// @_shi_sysReportError@16
+
+// LIBRARY: ISLE 0x407110
+// _MemPoolSize@4
+
+// LIBRARY: ISLE 0x4071a0
+// _MemPoolWalk@8
+
+// LIBRARY: ISLE 0x407240
+// @_shi_walkPool@16
+
+// LIBRARY: ISLE 0x407540
+// @shi_isBlockInUseSmall@8
+
+// LIBRARY: ISLE 0x407800
+// @_shi_isBlockInUseFS@12
+
+// LIBRARY: ISLE 0x407880
+// _MemPoolCheck@4
+
+// LIBRARY: ISLE 0x407b20
+// _MemCheckPtr@8
+
+// LIBRARY: ISLE 0x4084e0
+// __except_handler3
+
+// GLOBAL: ISLE 0x40f0a0
+// _szLibName
+
+// GLOBAL: ISLE 0x4102f4
+// ?_new_handler@@3P6AXXZA
+
+// GLOBAL: ISLE 0x4102fc
+// _MemDefaultPool
+
+// GLOBAL: ISLE 0x41031c
+// __shi_compactPoolFn
+
+// GLOBAL: ISLE 0x410320
+// __shi_compactPageFn
+
+// GLOBAL: ISLE 0x410324
+// _MemDefaultPoolFlags
+
+// GLOBAL: ISLE 0x41032c
+// __shi_mutexGlobalInit
+
+// GLOBAL: ISLE 0x410330
+// __shi_mutexMovInit
+
+// GLOBAL: ISLE 0x410334
+// __shi_mutexMovLockCount
+
+// GLOBAL: ISLE 0x410338
+// _shi_initPoolReaders
+
+// GLOBAL: ISLE 0x41033c
+// _shi_eventInitPool
+
+// GLOBAL: ISLE 0x410340
+// _shi_mutexMovShr
+
+// GLOBAL: ISLE 0x410368
+// _shi_deferFreePools
+
+// GLOBAL: ISLE 0x410378
+// __shi_poolTerminating
+
+// GLOBAL: ISLE 0x41037c
+// _MemDefaultPoolBlockSizeFS
+
+// GLOBAL: ISLE 0x410380
+// _MemDefaultPoolPageSize
+
+// GLOBAL: ISLE 0x410384
+// _SmartHeap_malloc
+
+// GLOBAL: ISLE 0x4105b0
+// __shi_TaskRecord
+
+// GLOBAL: ISLE 0x4125f8
+// ?_pnhHeap@@3P6AHI@ZA
+
+// GLOBAL: ISLE 0x412830
+// __shi_mutexMov
+
+// GLOBAL: ISLE 0x412850
+// _shi_mutexPoolSynch
+
+// GLOBAL: ISLE 0x412870
+// __shi_mutexGlobal
+
+#endif

--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -11,19 +11,25 @@ MxS32 g_mxcoreCount[101] = {0,     -6643, -5643, -5058, -4643, -4321, -4058, -38
 							-136,  -120,  -104,  -89,   -74,   -58,   -43,   -29,   -14,   0};
 
 // GLOBAL: LEGO1 0x10102048
+// STRING: LEGO1 0x10102040
 const char* g_strACTION = "ACTION";
 
 // GLOBAL: LEGO1 0x1010209c
+// STRING: LEGO1 0x10101f58
 const char* g_strOBJECT = "OBJECT";
 
 // GLOBAL: LEGO1 0x101020b0
+// STRING: LEGO1 0x10101f20
 const char* g_strSOUND = "SOUND";
 
 // GLOBAL: LEGO1 0x101020cc
+// STRING: LEGO1 0x100f3808
 const char* g_strVISIBILITY = "VISIBILITY";
 
 // GLOBAL: LEGO1 0x101020d0
+// STRING: LEGO1 0x10101edc
 const char* g_strWORLD = "WORLD";
 
 // GLOBAL: LEGO1 0x101020e4
+// STRING: LEGO1 0x10101eac
 const char* g_parseExtraTokens = ":;";

--- a/LEGO1/lego/legoomni/src/common/legobackgroundcolor.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobackgroundcolor.cpp
@@ -8,12 +8,15 @@
 DECOMP_SIZE_ASSERT(LegoBackgroundColor, 0x30)
 
 // GLOBAL: LEGO1 0x100f3fb0
-const char* g_delimiter = "\t";
+// STRING: LEGO1 0x100f3a18
+const char* g_delimiter = " \t";
 
 // GLOBAL: LEGO1 0x100f3fb4
+// STRING: LEGO1 0x100f3bf0
 const char* g_set = "set";
 
 // GLOBAL: LEGO1 0x100f3fb8
+// STRING: LEGO1 0x100f0cdc
 const char* g_reset = "reset";
 
 // FUNCTION: LEGO1 0x1003bfb0

--- a/LEGO1/lego/legoomni/src/common/legofullscreenmovie.cpp
+++ b/LEGO1/lego/legoomni/src/common/legofullscreenmovie.cpp
@@ -8,9 +8,11 @@
 DECOMP_SIZE_ASSERT(LegoFullScreenMovie, 0x24)
 
 // GLOBAL: LEGO1 0x100f3fbc
+// STRING: LEGO1 0x100f3be8
 const char* g_strEnable = "enable";
 
 // GLOBAL: LEGO1 0x100f3fc0
+// STRING: LEGO1 0x100f3bf4
 const char* g_strDisable = "disable";
 
 // FUNCTION: LEGO1 0x1003c500

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -20,12 +20,15 @@
 DECOMP_SIZE_ASSERT(LegoGameState, 0x430)
 
 // GLOBAL: LEGO1 0x100f3e40
+// STRING: LEGO1 0x100f3e3c
 const char* g_fileExtensionGS = ".GS";
 
 // GLOBAL: LEGO1 0x100f3e44
+// STRING: LEGO1 0x100f3e30
 const char* g_playersGSI = "Players.gsi";
 
 // GLOBAL: LEGO1 0x100f3e48
+// STRING: LEGO1 0x100f3e24
 const char* g_historyGSI = "History.gsi";
 
 // GLOBAL: LEGO1 0x100f3e58

--- a/LEGO1/lego/legoomni/src/common/legostream.cpp
+++ b/LEGO1/lego/legoomni/src/common/legostream.cpp
@@ -10,6 +10,7 @@
 // the text "END_OF_VARIABLES" in it.
 // TODO: make g_endOfVariables reference the actual end of the variable array.
 // GLOBAL: LEGO1 0x100f3e50
+// STRING: LEGO1 0x100f3e00
 const char* g_endOfVariables = "END_OF_VARIABLES";
 
 // Very likely but not certain sizes.

--- a/LEGO1/lego/legoomni/src/main/legoomni.cpp
+++ b/LEGO1/lego/legoomni/src/main/legoomni.cpp
@@ -110,6 +110,7 @@ MxAtomId* g_creditsScript = NULL;
 MxAtomId* g_nocdSourceName = NULL;
 
 // GLOBAL: LEGO1 0x100f6718
+// STRING: LEGO1 0x100f6710
 const char* g_current = "current";
 
 // GLOBAL: LEGO1 0x100f4c58

--- a/LEGO1/lego/legoomni/src/video/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legometerpresenter.cpp
@@ -7,24 +7,31 @@
 DECOMP_SIZE_ASSERT(LegoMeterPresenter, 0x94)
 
 // GLOBAL: LEGO1 0x1010207c
+// STRING: LEGO1 0x10101fb4
 const char* g_filterIndex = "FILTER_INDEX";
 
 // GLOBAL: LEGO1 0x10102094
+// STRING: LEGO1 0x10101f70
 const char* g_type = "TYPE";
 
 // GLOBAL: LEGO1 0x10102088
+// STRING: LEGO1 0x10101f94
 const char* g_leftToRight = "LEFT_TO_RIGHT";
 
 // GLOBAL: LEGO1 0x101020ac
+// STRING: LEGO1 0x10101f28
 const char* g_rightToLeft = "RIGHT_TO_LEFT";
 
 // GLOBAL: LEGO1 0x1010205c
+// STRING: LEGO1 0x10102000
 const char* g_bottomToTop = "BOTTOM_TO_TOP";
 
 // GLOBAL: LEGO1 0x101020c0
+// STRING: LEGO1 0x10101f00
 const char* g_topToBottom = "TOP_TO_BOTTOM";
 
 // GLOBAL: LEGO1 0x101020c8
+// STRING: LEGO1 0x10101ee4
 const char* g_variable = "VARIABLE";
 
 // FUNCTION: LEGO1 0x10043430

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -1,39 +1,32 @@
 #ifdef 0
+// For LEGO1 symbols only
 
 // aka `operator new`
-// LIBRARY: ISLE 0x402f80
 // LIBRARY: LEGO1 0x10086240
 // ??2@YAPAXI@Z
 
 // aka `operator delete`
-// LIBRARY: ISLE 0x402fa0
 // LIBRARY: LEGO1 0x10086260
 // ??3@YAXPAX@Z
 
-// LIBRARY: ISLE 0x406dd0
 // LIBRARY: LEGO1 0x1008a090
 // _malloc
 
-// LIBRARY: ISLE 0x406f00
 // LIBRARY: LEGO1 0x1008a1c0
 // _free
 
-// LIBRARY: ISLE 0x407ec0
 // LIBRARY: LEGO1 0x1008b020
 // ___CxxFrameHandler
 
-// LIBRARY: ISLE 0x408220
 // LIBRARY: LEGO1 0x1008b400
 // _atol
 
-// LIBRARY: ISLE 0x4082d0
 // LIBRARY: LEGO1 0x1008b4b0
 // _atoi
 
 // LIBRARY: LEGO1 0x1008b4c0
 // _strtok
 
-// LIBRARY: ISLE 0x4085c0
 // LIBRARY: LEGO1 0x1008b5a0
 // _sprintf
 
@@ -42,6 +35,9 @@
 
 // LIBRARY: LEGO1 0x1008b630
 // _srand
+
+// LIBRARY: LEGO1 0x1008b640
+// _rand
 
 // LIBRARY: LEGO1 0x1008b680
 // _strncmp
@@ -90,19 +86,6 @@
 
 // LIBRARY: LEGO1 0x10097b10
 // _strchr
-
-// LIBRARY: ISLE 0x4081e0
-// _srand
-
-// LIBRARY: ISLE 0x4081f0
-// LIBRARY: LEGO1 0x1008b640
-// _rand
-
-// LIBRARY: ISLE 0x409110
-// __mtinit
-
-// LIBRARY: ISLE 0x409190
-// __getptd
 
 // LIBRARY: LEGO1 0x100d1ed0
 // _strnicmp

--- a/LEGO1/omni/src/common/mxvariabletable.cpp
+++ b/LEGO1/omni/src/common/mxvariabletable.cpp
@@ -50,6 +50,8 @@ void MxVariableTable::SetVariable(MxVariable* p_var)
 // FUNCTION: LEGO1 0x100b78f0
 const char* MxVariableTable::GetVariable(const char* p_key)
 {
+	// STRING: ISLE 0x41008c
+	// STRING: LEGO1 0x100f01d4
 	const char* value = "";
 	MxHashTableCursor<MxVariable*> cursor(this);
 	MxVariable* var = new MxVariable(p_key);

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -11,6 +11,7 @@
 DECOMP_SIZE_ASSERT(MxStillPresenter, 0x6c);
 
 // GLOBAL: LEGO1 0x101020e0
+// STRING: LEGO1 0x10101eb0
 const char* g_strBmpIsmap = "BMP_ISMAP";
 
 // FUNCTION: LEGO1 0x100b9c70

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -43,7 +43,8 @@ class MatchInfo:
             return None
 
         ctype = self.compare_type.name if self.compare_type is not None else "UNK"
-        return f"{self.name} ({ctype})"
+        name = repr(self.name) if ctype == "STRING" else self.name
+        return f"{name} ({ctype})"
 
 
 def matchinfo_factory(_, row):
@@ -197,3 +198,5 @@ class CompareDb:
         if not did_match:
             escaped = repr(value)
             logger.error("Failed to find string: %s", escaped)
+
+        return did_match

--- a/tools/isledecomp/isledecomp/cvdump/analysis.py
+++ b/tools/isledecomp/isledecomp/cvdump/analysis.py
@@ -94,7 +94,11 @@ class CvdumpNode:
     def name(self) -> Optional[str]:
         """Prefer "friendly" name if we have it.
         This is what we have been using to match functions."""
-        return self.friendly_name or self.decorated_name
+        return (
+            self.friendly_name
+            if self.friendly_name is not None
+            else self.decorated_name
+        )
 
     def size(self) -> Optional[int]:
         if self.confirmed_size is not None:

--- a/tools/isledecomp/isledecomp/cvdump/demangler.py
+++ b/tools/isledecomp/isledecomp/cvdump/demangler.py
@@ -4,6 +4,7 @@ https://en.wikiversity.org/wiki/Visual_C%2B%2B_name_mangling
 """
 import re
 from collections import namedtuple
+from typing import Optional
 
 
 class InvalidEncodedNumberError(Exception):
@@ -30,13 +31,12 @@ string_const_regex = re.compile(
 StringConstInfo = namedtuple("StringConstInfo", "len is_utf16")
 
 
-def demangle_string_const(symbol: str) -> StringConstInfo:
+def demangle_string_const(symbol: str) -> Optional[StringConstInfo]:
     """Don't bother to decode the string text from the symbol.
     We can just read it from the binary once we have the length."""
     match = string_const_regex.match(symbol)
     if match is None:
-        # See below
-        return StringConstInfo(0, False)
+        return None
 
     try:
         strlen = (
@@ -45,10 +45,7 @@ def demangle_string_const(symbol: str) -> StringConstInfo:
             else int(match.group("len"))
         )
     except (ValueError, InvalidEncodedNumberError):
-        # This would be an annoying error to fail on if we get a bad symbol.
-        # For now, just assume a zero length string because this will probably
-        # raise some eyebrows during the comparison.
-        strlen = 0
+        return None
 
     is_utf16 = match.group("is_utf16") == "1"
     return StringConstInfo(len=strlen, is_utf16=is_utf16)

--- a/tools/isledecomp/isledecomp/parser/codebase.py
+++ b/tools/isledecomp/isledecomp/parser/codebase.py
@@ -6,6 +6,7 @@ from .node import (
     ParserFunction,
     ParserVtable,
     ParserVariable,
+    ParserString,
 )
 
 
@@ -42,3 +43,6 @@ class DecompCodebase:
 
     def iter_variables(self) -> Iterator[ParserVariable]:
         return filter(lambda s: isinstance(s, ParserVariable), self._symbols)
+
+    def iter_strings(self) -> Iterator[ParserString]:
+        return filter(lambda s: isinstance(s, ParserString), self._symbols)

--- a/tools/isledecomp/isledecomp/parser/error.py
+++ b/tools/isledecomp/isledecomp/parser/error.py
@@ -70,6 +70,10 @@ class ParserError(Enum):
     # a comment -- i.e. VTABLE or GLOBAL -- could not extract the name
     NO_SUITABLE_NAME = 204
 
+    # ERROR: Two STRING markers have the same module and offset, but the strings
+    # they annotate are different.
+    WRONG_STRING = 205
+
 
 @dataclass
 class ParserAlert:

--- a/tools/isledecomp/isledecomp/parser/marker.py
+++ b/tools/isledecomp/isledecomp/parser/marker.py
@@ -3,6 +3,19 @@ from typing import Optional
 from enum import Enum
 
 
+class MarkerCategory(Enum):
+    """For the purposes of grouping multiple different DecompMarkers together,
+    assign a rough "category" for the MarkerType values below.
+    It's really only the function types that have to get folded down, but
+    we'll do that in a structured way to permit future expansion."""
+
+    FUNCTION = 1
+    VARIABLE = 2
+    STRING = 3
+    VTABLE = 4
+    ADDRESS = 100  # i.e. no comparison required or possible
+
+
 class MarkerType(Enum):
     UNKNOWN = -100
     FUNCTION = 1
@@ -50,6 +63,23 @@ class DecompMarker:
     @property
     def offset(self) -> int:
         return self._offset
+
+    @property
+    def category(self) -> MarkerCategory:
+        if self.is_vtable():
+            return MarkerCategory.VTABLE
+
+        if self.is_variable():
+            return MarkerCategory.VARIABLE
+
+        if self.is_string():
+            return MarkerCategory.STRING
+
+        # TODO: worth another look if we add more types, but this covers it
+        if self.is_regular_function() or self.is_explicit_byname():
+            return MarkerCategory.FUNCTION
+
+        return MarkerCategory.ADDRESS
 
     def is_regular_function(self) -> bool:
         """Regular function, meaning: not an explicit byname lookup. FUNCTION

--- a/tools/isledecomp/isledecomp/parser/node.py
+++ b/tools/isledecomp/isledecomp/parser/node.py
@@ -55,3 +55,8 @@ class ParserVariable(ParserSymbol):
 @dataclass
 class ParserVtable(ParserSymbol):
     pass
+
+
+@dataclass
+class ParserString(ParserSymbol):
+    pass

--- a/tools/isledecomp/tests/test_demangler.py
+++ b/tools/isledecomp/tests/test_demangler.py
@@ -14,6 +14,7 @@ string_demangle_cases = [
         14,
         True,
     ),
+    ("??_C@_00A@?$AA@", 0, False),
 ]
 
 

--- a/tools/isledecomp/tests/test_parser_statechange.py
+++ b/tools/isledecomp/tests/test_parser_statechange.py
@@ -15,7 +15,7 @@ state_change_marker_cases = [
     (_rs.SEARCH,          "TEMPLATE",   _rs.IN_TEMPLATE,     None),
     (_rs.SEARCH,          "VTABLE",     _rs.IN_VTABLE,       None),
     (_rs.SEARCH,          "LIBRARY",    _rs.IN_LIBRARY,      None),
-    (_rs.SEARCH,          "STRING",     _rs.SEARCH,          None),
+    (_rs.SEARCH,          "STRING",     _rs.IN_GLOBAL,       None),
 
     (_rs.WANT_SIG,        "FUNCTION",   _rs.WANT_SIG,        None),
     (_rs.WANT_SIG,        "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
@@ -33,7 +33,7 @@ state_change_marker_cases = [
     (_rs.IN_FUNC,         "TEMPLATE",   _rs.IN_TEMPLATE,     _pe.MISSED_END_OF_FUNCTION),
     (_rs.IN_FUNC,         "VTABLE",     _rs.IN_VTABLE,       _pe.MISSED_END_OF_FUNCTION),
     (_rs.IN_FUNC,         "LIBRARY",    _rs.IN_LIBRARY,      _pe.MISSED_END_OF_FUNCTION),
-    (_rs.IN_FUNC,         "STRING",     _rs.IN_FUNC,         None),
+    (_rs.IN_FUNC,         "STRING",     _rs.IN_FUNC_GLOBAL,  None),
 
     (_rs.IN_TEMPLATE,     "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_TEMPLATE,     "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
@@ -60,7 +60,7 @@ state_change_marker_cases = [
     (_rs.IN_GLOBAL,       "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_GLOBAL,       "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_GLOBAL,       "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
-    (_rs.IN_GLOBAL,       "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_GLOBAL,       "STRING",     _rs.IN_GLOBAL,       None),
 
     (_rs.IN_FUNC_GLOBAL,  "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_FUNC_GLOBAL,  "GLOBAL",     _rs.IN_FUNC_GLOBAL,  None),
@@ -69,7 +69,7 @@ state_change_marker_cases = [
     (_rs.IN_FUNC_GLOBAL,  "TEMPLATE",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_FUNC_GLOBAL,  "VTABLE",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_FUNC_GLOBAL,  "LIBRARY",    _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
-    (_rs.IN_FUNC_GLOBAL,  "STRING",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
+    (_rs.IN_FUNC_GLOBAL,  "STRING",     _rs.IN_FUNC_GLOBAL,  None),
 
     (_rs.IN_VTABLE,       "FUNCTION",   _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),
     (_rs.IN_VTABLE,       "GLOBAL",     _rs.SEARCH,          _pe.INCOMPATIBLE_MARKER),

--- a/tools/isledecomp/tests/test_parser_util.py
+++ b/tools/isledecomp/tests/test_parser_util.py
@@ -10,6 +10,7 @@ from isledecomp.parser.util import (
     is_blank_or_comment,
     get_class_name,
     get_variable_name,
+    get_string_contents,
 )
 
 
@@ -158,3 +159,18 @@ variable_name_cases = [
 @pytest.mark.parametrize("line,name", variable_name_cases)
 def test_get_variable_name(line: str, name: str):
     assert get_variable_name(line) == name
+
+
+string_match_cases = [
+    ('return "hello world";', "hello world"),
+    ('"hello\\\\"', "hello\\"),
+    ('"hello \\"world\\""', 'hello "world"'),
+    ('"hello\\nworld"', "hello\nworld"),
+    # Only match first string if there are multiple options
+    ('Method("hello", "world");', "hello"),
+]
+
+
+@pytest.mark.parametrize("line, string", string_match_cases)
+def test_get_string_contents(line: str, string: str):
+    assert get_string_contents(line) == string


### PR DESCRIPTION
The `// GLOBAL` annotation marks where we have a variable with global scope that is declared on the next line of code. This PR adds the option to identify these variables indirectly, either because they are in generated code or library code. The syntax is the same as other annotations that allow you to pinpoint something by name reference:

```cpp
// GLOBAL: ISLE 0x4108e8
// __osver
```

Variables identified this way do not require the `g_` prefix that we use for variables in our code, for obvious reasons.

String literals are annotated with `// STRING`. It is possible to track these down without an annotation, which is what we have been doing, but it is nice to have the documentation right in the code. These are now enabled for use by `reccmp` comparison. We will still search the original binary for any strings not annotated, so 100% coverage is not a high priority item. If the string you annotated is _wrong_, we will alert you to that, too.

In many cases there is a global variable initialized to a string. You can now get the two-fer-one annotation special as in the following:

```cpp
// GLOBAL: LEGO1 0x101020b0
// STRING: LEGO1 0x10101f20
const char* g_strSOUND = "SOUND";
```

This only works for the first C string that appears on the line, so it is probably not a good idea to annotate a line like this where it would be ambiguous:

```cpp
m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
```

Lastly, strings are deduplicated in the binary to save space. If you annotate the same string in multiple places, the linter will allow it, provided that they are actually the same string.

As a bonus: annotations for the SmartHeap library for ISLE, and some examples of `// STRING` markers.
