### PR TITLE
name nearly every infomain action

### DIFF
--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -71,16 +71,16 @@ public:
 		c_bricksterEscapedDialogue7 = 531,
 
 		c_infomanHiccup = 532,
-		c_infomanWalkOffScreenLeft = 533,
+		c_infomanWalkOffScreenLeftUnused = 533,
 		c_infomanSneeze = 534,
-		c_infomanWalkOffScreenRight = 535,
+		c_infomanWalkOffScreenRightUnused = 535,
 		c_infomanLaughs = 536,
 		c_infomanLooksBehindAtScreenUnused = 537,
 		c_infomanReturnsFromScreenUnused = 538,
 
 		c_goodEndingDialogue = 539,
 		c_badEndingDialogue = 540,
-		
+
 		c_pepperCharacterSelect = 541,
 		c_mamaCharacterSelect = 542,
 		c_papaCharacterSelect = 543,

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -30,18 +30,77 @@ public:
 
 	enum InfomainScript {
 		c_noInfomain = -1,
+
 		c_welcomeDialogue = 500,
-		c_randomDialogue1 = 502,
-		c_letsGetStarted = 504,
-		c_returnBack = 514,
-		c_exitConfirmation = 522,
+		c_goodJobDialogue = 501,
+
+		c_clickOnInfomanDialogue = 502,
+		c_tickleInfomanDialogue = 503,
+
+		c_letsGetStartedDialogue = 504,
+
+		c_clickOnObjectsGuidanceDialogue = 505,
+		c_arrowNavigationGuidanceDialogue = 506,
+		c_elevatorGuidanceDialogue = 507,
+		c_radioGuidanceDialogue = 508,
+		c_exitGuidanceDialogue1 = 509,
+		c_exitGuidanceDialogue2 = 510,
+		c_goOutsideGuidanceDialogue = 511,
+		c_experimentGuidanceDialogue = 512,
+		c_returnBackGuidanceDialogue1 = 513,
+		c_returnBackGuidanceDialogue2 = 514,
+		c_bricksterWarningDialogue = 515,
+		c_newGameGuidanceDialogue = 516,
+		c_returnBackGuidanceDialogue3 = 517,
+
+		c_reenterInfoCenterDialogue1 = 518,
+		c_reenterInfoCenterDialogue2 = 519,
+		c_reenterInfoCenterDialogue3 = 520,
+		c_reenterInfoCenterDialogue4 = 521,
+
+		c_exitConfirmationDialogue = 522,
+		c_saveGameOptionsDialogueUnused = 523,
+		c_exitGameDialogue = 524,
+
+		c_bricksterEscapedDialogue1 = 525,
+		c_bricksterEscapedDialogue2 = 526,
+		c_bricksterEscapedDialogue3 = 527,
+		c_bricksterEscapedDialogue4 = 528,
+		c_bricksterEscapedDialogue5 = 529,
+		c_bricksterEscapedDialogue6 = 530,
+		c_bricksterEscapedDialogue7 = 531,
+
+		c_infomanHiccup = 532,
+		c_infomanWalkOffScreenLeft = 533,
+		c_infomanSneeze = 534,
+		c_infomanWalkOffScreenRight = 535,
+		c_infomanLaughs = 536,
+		c_infomanLooksBehindAtScreenUnused = 537,
+		c_infomanReturnsFromScreenUnused = 538,
+
 		c_goodEndingDialogue = 539,
 		c_badEndingDialogue = 540,
+		
 		c_pepperCharacterSelect = 541,
 		c_mamaCharacterSelect = 542,
 		c_papaCharacterSelect = 543,
-		c_officierCharacterSelect = 544,
-		c_loraCharacterSelect = 545,
+		c_nickCharacterSelect = 544,
+		c_lauraCharacterSelect = 545,
+
+		c_creditsDialogue = 551,
+
+		c_noCDDialogueUnused1 = 552,
+		c_noCDDialogueUnused2 = 553,
+
+		c_leaveInfoCenterDialogue1 = 562,
+		c_leaveInfoCenterDialogue2 = 563,
+		c_leaveInfoCenterDialogue3 = 564,
+		c_leaveInfoCenterDialogue4 = 565,
+
+		c_registerToContinueDialogue = 573,
+
+		c_bricksterDialogue = 574,
+		c_bricksterLaughs = 575,
 	};
 
 	enum SndAmimScript {

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -159,10 +159,10 @@ MxLong Infocenter::HandleEndAction(MxParam& p_param)
 				PlayDialogue(c_papaCharacterSelect);
 				break;
 			case 4:
-				PlayDialogue(c_officierCharacterSelect);
+				PlayDialogue(c_nickCharacterSelect);
 				break;
 			case 5:
-				PlayDialogue(c_loraCharacterSelect);
+				PlayDialogue(c_lauraCharacterSelect);
 				break;
 			default:
 				break;
@@ -177,7 +177,7 @@ MxLong Infocenter::HandleEndAction(MxParam& p_param)
 	if (result || (action->GetAtomId() != m_atom && action->GetAtomId() != *g_introScript))
 		return result;
 
-	if (action->GetObjectId() == c_returnBack) {
+	if (action->GetObjectId() == c_returnBackGuidanceDialogue2) {
 		ControlManager()->FUN_100293c0(0x10, action->GetAtomId(), 0);
 		m_unk0x1d6 = 0;
 	}
@@ -302,7 +302,7 @@ void Infocenter::VTable0x50()
 				m_unk0x1d2 = 1;
 			}
 
-			PlayDialogue(c_letsGetStarted);
+			PlayDialogue(c_letsGetStartedDialogue);
 			PlayMusic(11);
 			FUN_10015820(0, 7);
 			return;
@@ -312,7 +312,7 @@ void Infocenter::VTable0x50()
 			break;
 		case 8:
 			PlayMusic(11);
-			PlayDialogue(c_exitConfirmation);
+			PlayDialogue(c_exitConfirmationDialogue);
 			FUN_10015820(0, 7);
 			return;
 		case 0xf:
@@ -320,7 +320,7 @@ void Infocenter::VTable0x50()
 				m_unk0x1d2 = 1;
 			}
 
-			PlayDialogue(c_randomDialogue1);
+			PlayDialogue(c_clickOnInfomanDialogue);
 			PlayMusic(11);
 			FUN_10015820(0, 7);
 			return;


### PR DESCRIPTION
This PR names nearly every single action in INFOMAIN.SI in the associated enum. I organized and named them the best way I saw fit.

Actions intended to point the player in the right direction are labeled as "Guidance". I was initially using the name "Pointer" for these, but I didn't want there to be any confusion between these and actual C++ pointers. Any actions that are completely unused in normal gameplay are labeled as "Unused".

Additionally, I've made some small tweaks to the naming of already documented actions. I've appended "Dialogue" to all of the actions names that represent dialogue. Laura Brick was erroneously named "lora", and Nick Brick was named "officier"; both of which I've corrected here.