### PR TITLE
initialize more members in LegoGameState

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -60,7 +60,15 @@ LegoGameState::LegoGameState()
 	// TODO
 	SetROIHandlerFunction();
 
-	m_stateCount = 0;
+	this->m_stateCount = 0;
+	this->m_unk0xc = 0;
+	this->m_savePath = NULL;
+	this->m_unk0x424 = 0;
+	this->m_prevArea = 0;
+	this->m_unk0x42c = 0;
+	this->m_isDirty = FALSE;
+	this->m_currentAct = -1;
+
 	m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
 	VariableTable()->SetVariable(m_backgroundColor);
 


### PR DESCRIPTION
Noticed some of these LegoGameState members were missing and not being initialized in the constructor like the original function. Adding these fixes the recompiled LEGO1.DLL instantly crashing in Wine (before, it was trying to access m_savePath before its initialization; no idea why this behavior is acceptable in Windows).