### PR TITLE
reccmp: vtable comparison

### DIFF
--- a/LEGO1/lego/legoomni/include/act1state.h
+++ b/LEGO1/lego/legoomni/include/act1state.h
@@ -29,6 +29,9 @@ public:
 
 	void FUN_10034d00();
 
+	// SYNTHETIC: LEGO1 0x10033960
+	// Act1State::`scalar deleting destructor'
+
 protected:
 	undefined m_unk0x8[0x10]; // 0x8
 	MxU32 m_unk0x18;          // 0x18

--- a/LEGO1/lego/legoomni/include/act2brick.h
+++ b/LEGO1/lego/legoomni/include/act2brick.h
@@ -25,6 +25,9 @@ public:
 	{
 		return !strcmp(p_name, Act2Brick::ClassName()) || LegoEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1007a450
+	// Act2Brick::`scalar deleting destructor'
 };
 
 #endif // ACT2BRICK_H

--- a/LEGO1/lego/legoomni/include/act2policestation.h
+++ b/LEGO1/lego/legoomni/include/act2policestation.h
@@ -21,6 +21,9 @@ public:
 	{
 		return !strcmp(p_name, Act2PoliceStation::ClassName()) || LegoEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f610
+	// Act2PoliceStation::`scalar deleting destructor'
 };
 
 #endif // ACT2POLICESTATION_H

--- a/LEGO1/lego/legoomni/include/act3.h
+++ b/LEGO1/lego/legoomni/include/act3.h
@@ -27,6 +27,9 @@ public:
 	inline void SetUnkown420c(MxEntity* p_entity) { m_unk0x420c = p_entity; }
 	inline void SetUnkown4270(MxU32 p_unk0x4270) { m_unk0x4270 = p_unk0x4270; }
 
+	// SYNTHETIC: LEGO1 0x10072630
+	// Act3::`scalar deleting destructor'
+
 protected:
 	undefined m_unk0xf8[0x4114]; // 0xf8
 	MxEntity* m_unk0x420c;       // 0x420c

--- a/LEGO1/lego/legoomni/include/act3shark.h
+++ b/LEGO1/lego/legoomni/include/act3shark.h
@@ -12,6 +12,9 @@ public:
 		// STRING: LEGO1 0x100f03a0
 		return "Act3Shark";
 	}
+
+	// SYNTHETIC: LEGO1 0x10043020
+	// Act3Shark::`scalar deleting destructor'
 };
 
 #endif // ACT3SHARK_H

--- a/LEGO1/lego/legoomni/include/act3state.h
+++ b/LEGO1/lego/legoomni/include/act3state.h
@@ -24,6 +24,9 @@ public:
 
 	virtual MxBool VTable0x14() override;
 
+	// SYNTHETIC: LEGO1 0x1000e3c0
+	// Act3State::`scalar deleting destructor'
+
 private:
 	// FIXME: May be part of LegoState? Uncertain...
 	MxU32 m_unk0x08;

--- a/LEGO1/lego/legoomni/include/ambulance.h
+++ b/LEGO1/lego/legoomni/include/ambulance.h
@@ -22,6 +22,9 @@ public:
 		return !strcmp(p_name, Ambulance::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10036130
+	// Ambulance::`scalar deleting destructor'
+
 private:
 	// TODO: Ambulance fields
 	undefined m_unk0x160[4];

--- a/LEGO1/lego/legoomni/include/ambulancemissionstate.h
+++ b/LEGO1/lego/legoomni/include/ambulancemissionstate.h
@@ -40,6 +40,9 @@ public:
 		}
 	}
 
+	// SYNTHETIC: LEGO1 0x100376c0
+	// AmbulanceMissionState::`scalar deleting destructor'
+
 protected:
 	undefined4 m_unk0x8; // 0x08
 	undefined4 m_unk0xc; // 0x0c

--- a/LEGO1/lego/legoomni/include/animstate.h
+++ b/LEGO1/lego/legoomni/include/animstate.h
@@ -26,6 +26,9 @@ public:
 	virtual MxBool SetFlag() override;                                      // vtable+0x18
 	virtual MxResult VTable0x1c(LegoFileStream* p_legoFileStream) override; // vtable+0x1C
 
+	// SYNTHETIC: LEGO1 0x10065130
+	// AnimState::`scalar deleting destructor'
+
 private:
 	undefined4 m_unk0x8;
 	undefined4 m_unk0xc;

--- a/LEGO1/lego/legoomni/include/beachhouseentity.h
+++ b/LEGO1/lego/legoomni/include/beachhouseentity.h
@@ -21,6 +21,9 @@ public:
 	{
 		return !strcmp(p_name, BeachHouseEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f970
+	// BeachHouseEntity::`scalar deleting destructor'
 };
 
 #endif // BEACHHOUSEENTITY_H

--- a/LEGO1/lego/legoomni/include/bike.h
+++ b/LEGO1/lego/legoomni/include/bike.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, Bike::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10076880
+	// Bike::`scalar deleting destructor'
+
 private:
 	// TODO: Bike fields
 	undefined m_unk0x160[4];

--- a/LEGO1/lego/legoomni/include/buildingentity.h
+++ b/LEGO1/lego/legoomni/include/buildingentity.h
@@ -22,6 +22,9 @@ public:
 	{
 		return !strcmp(p_name, BuildingEntity::ClassName()) || LegoEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10015010
+	// BuildingEntity::`scalar deleting destructor'
 };
 
 #endif // BUILDINGENTITY_H

--- a/LEGO1/lego/legoomni/include/bumpbouy.h
+++ b/LEGO1/lego/legoomni/include/bumpbouy.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, BumpBouy::ClassName()) || LegoAnimActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10027490
+	// BumpBouy::`scalar deleting destructor'
 };
 
 #endif // BUMPBOUY_H

--- a/LEGO1/lego/legoomni/include/carrace.h
+++ b/LEGO1/lego/legoomni/include/carrace.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, CarRace::ClassName()) || LegoRace::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10016c70
+	// CarRace::`scalar deleting destructor'
+
 private:
 	undefined m_unk0x144[12]; // 0x144
 	undefined4 m_unk0x150;    // 0x150

--- a/LEGO1/lego/legoomni/include/carracestate.h
+++ b/LEGO1/lego/legoomni/include/carracestate.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, CarRaceState::ClassName()) || RaceState::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f740
+	// CarRaceState::`scalar deleting destructor'
 };
 
 #endif // CARRACESTATE_H

--- a/LEGO1/lego/legoomni/include/doors.h
+++ b/LEGO1/lego/legoomni/include/doors.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, Doors::ClassName()) || LegoPathActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000e580
+	// Doors::`scalar deleting destructor'
 };
 
 #endif // DOORS_H

--- a/LEGO1/lego/legoomni/include/dunebuggy.h
+++ b/LEGO1/lego/legoomni/include/dunebuggy.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, DuneBuggy::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10067dc0
+	// DuneBuggy::`scalar deleting destructor'
+
 private:
 	// TODO: Double check DuneBuggy field types
 	undefined4 m_unk0x160;

--- a/LEGO1/lego/legoomni/include/elevatorbottom.h
+++ b/LEGO1/lego/legoomni/include/elevatorbottom.h
@@ -26,6 +26,9 @@ public:
 		return !strcmp(p_name, ElevatorBottom::ClassName()) || LegoWorld::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10018040
+	// ElevatorBottom::`scalar deleting destructor'
+
 private:
 	undefined4 m_unk0xf8; // 0xf8
 };

--- a/LEGO1/lego/legoomni/include/gasstation.h
+++ b/LEGO1/lego/legoomni/include/gasstation.h
@@ -29,6 +29,9 @@ public:
 		return !strcmp(p_name, GasStation::ClassName()) || LegoWorld::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x100048a0
+	// GasStation::`scalar deleting destructor'
+
 private:
 	undefined2 m_unk0xf8;  // 0xf8
 	undefined2 m_unk0xfa;  // 0xfa

--- a/LEGO1/lego/legoomni/include/gasstationentity.h
+++ b/LEGO1/lego/legoomni/include/gasstationentity.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, GasStationEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f890
+	// GasStationEntity::`scalar deleting destructor'
 };
 
 #endif // GASSTATIONENTITY_H

--- a/LEGO1/lego/legoomni/include/gasstationstate.h
+++ b/LEGO1/lego/legoomni/include/gasstationstate.h
@@ -22,6 +22,9 @@ public:
 		return !strcmp(p_name, GasStationState::ClassName()) || LegoState::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10006290
+	// GasStationState::`scalar deleting destructor'
+
 private:
 	undefined4 m_unk0x08[3];
 	undefined4 m_unk0x14;

--- a/LEGO1/lego/legoomni/include/gifmanager.h
+++ b/LEGO1/lego/legoomni/include/gifmanager.h
@@ -1,6 +1,7 @@
 #ifndef GIFMANAGER_H
 #define GIFMANAGER_H
 
+#include "compat.h"
 #include "decomp.h"
 #include "mxtypes.h"
 
@@ -45,8 +46,11 @@ public:
 // VTABLE: LEGO1 0x100d86d4
 class GifManagerBase {
 public:
-	// STUB: LEGO1 0x1005a310
-	virtual ~GifManagerBase() {} // vtable+00
+	// STUB: LEGO1 0x1005b660
+	virtual ~GifManagerBase() {}
+
+	// SYNTHETIC: LEGO1 0x1005a310
+	// GifManagerBase::`scalar deleting destructor'
 
 	inline GifData* Get(const char* p_name) { return m_unk0x8.Get(p_name); }
 
@@ -59,8 +63,10 @@ protected:
 // VTABLE: LEGO1 0x100d86fc
 class GifManager : public GifManagerBase {
 public:
-	// STUB: LEGO1 0x1005a580
-	virtual ~GifManager() {} // vtable+00
+	virtual ~GifManager() override;
+
+	// SYNTHETIC: LEGO1 0x1005a580
+	// GifManager::`scalar deleting destructor'
 
 protected:
 	undefined m_unk0x14[0x1c];

--- a/LEGO1/lego/legoomni/include/helicopterstate.h
+++ b/LEGO1/lego/legoomni/include/helicopterstate.h
@@ -24,6 +24,9 @@ public:
 	inline void SetUnknown8(MxU32 p_unk0x8) { m_unk0x8 = p_unk0x8; }
 	inline MxU32 GetUnkown8() { return m_unk0x8; }
 
+	// SYNTHETIC: LEGO1 0x1000e190
+	// HelicopterState::`scalar deleting destructor'
+
 protected:
 	MxU32 m_unk0x8; // 0x8
 };

--- a/LEGO1/lego/legoomni/include/historybook.h
+++ b/LEGO1/lego/legoomni/include/historybook.h
@@ -24,6 +24,9 @@ public:
 	{
 		return !strcmp(p_name, HistoryBook::ClassName()) || LegoWorld::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x100824b0
+	// HistoryBook::`scalar deleting destructor'
 };
 
 #endif // HISTORYBOOK_H

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -26,6 +26,9 @@ public:
 		return !strcmp(p_name, Hospital::ClassName()) || LegoWorld::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x100747d0
+	// Hospital::`scalar deleting destructor'
+
 private:
 	undefined2 m_unk0xf8;    // 0xf8
 	undefined4 m_unk0xfc;    // 0xfc

--- a/LEGO1/lego/legoomni/include/hospitalentity.h
+++ b/LEGO1/lego/legoomni/include/hospitalentity.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, HospitalEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f820
+	// HospitalEntity::`scalar deleting destructor'
 };
 
 #endif // HOSPITALENTITY_H

--- a/LEGO1/lego/legoomni/include/hospitalstate.h
+++ b/LEGO1/lego/legoomni/include/hospitalstate.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, HospitalState::ClassName()) || LegoState::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x100764c0
+	// HospitalState::`scalar deleting destructor'
+
 private:
 	undefined m_unk0x8[4]; // 0x8
 	undefined2 m_unk0xc;   // 0xc

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -132,6 +132,9 @@ public:
 	virtual MxBool VTable0x64() override;                     // vtable+0x64
 	virtual void VTable0x68(MxBool p_add) override;           // vtable+0x68
 
+	// SYNTHETIC: LEGO1 0x1006ec60
+	// Infocenter::`scalar deleting destructor'
+
 private:
 	void InitializeBitmaps();
 

--- a/LEGO1/lego/legoomni/include/infocenterdoor.h
+++ b/LEGO1/lego/legoomni/include/infocenterdoor.h
@@ -24,6 +24,9 @@ public:
 	{
 		return !strcmp(p_name, InfocenterDoor::ClassName()) || LegoWorld::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x100378d0
+	// InfocenterDoor::`scalar deleting destructor'
 };
 
 #endif // INFOCENTERDOOR_H

--- a/LEGO1/lego/legoomni/include/infocenterentity.h
+++ b/LEGO1/lego/legoomni/include/infocenterentity.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, InfoCenterEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f7b0
+	// InfoCenterEntity::`scalar deleting destructor'
 };
 
 #endif // INFOCENTERENTITY_H

--- a/LEGO1/lego/legoomni/include/infocenterstate.h
+++ b/LEGO1/lego/legoomni/include/infocenterstate.h
@@ -29,6 +29,9 @@ public:
 
 	inline void SetUnknown0x74(MxU32 p_unk0x74) { m_unk0x74 = p_unk0x74; }
 
+	// SYNTHETIC: LEGO1 0x10071900
+	// InfocenterState::`scalar deleting destructor'
+
 private:
 	// Members should be renamed with their offsets before use
 	/*

--- a/LEGO1/lego/legoomni/include/isle.h
+++ b/LEGO1/lego/legoomni/include/isle.h
@@ -59,6 +59,9 @@ public:
 	MxLong HandleTransitionEnd();
 	void FUN_10032620();
 
+	// SYNTHETIC: LEGO1 0x10030a30
+	// Isle::`scalar deleting destructor'
+
 protected:
 	Act1State* m_act1state;   // 0xf8
 	Pizza* m_pizza;           // 0xfc

--- a/LEGO1/lego/legoomni/include/jetski.h
+++ b/LEGO1/lego/legoomni/include/jetski.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, Jetski::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x1007e5c0
+	// Jetski::`scalar deleting destructor'
+
 private:
 	// TODO: Jetski fields
 	undefined m_unk0x160[4];

--- a/LEGO1/lego/legoomni/include/jetskiracestate.h
+++ b/LEGO1/lego/legoomni/include/jetskiracestate.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, JetskiRaceState::ClassName()) || RaceState::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f680
+	// JetskiRaceState::`scalar deleting destructor'
 };
 
 #endif // JETSKIRACESTATE_H

--- a/LEGO1/lego/legoomni/include/jukebox.h
+++ b/LEGO1/lego/legoomni/include/jukebox.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, JukeBox::ClassName()) || LegoWorld::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x1005d810
+	// JukeBox::`scalar deleting destructor'
+
 private:
 	undefined m_unk0xf8[4]; // 0xf8
 	undefined4 m_unk0xfc;   // 0xfc

--- a/LEGO1/lego/legoomni/include/jukeboxentity.h
+++ b/LEGO1/lego/legoomni/include/jukeboxentity.h
@@ -22,6 +22,9 @@ public:
 	{
 		return !strcmp(p_name, JukeBoxEntity::ClassName()) || LegoEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10085db0
+	// JukeBoxEntity::`scalar deleting destructor'
 };
 
 #endif // JUKEBOXENTITY_H

--- a/LEGO1/lego/legoomni/include/jukeboxstate.h
+++ b/LEGO1/lego/legoomni/include/jukeboxstate.h
@@ -21,6 +21,9 @@ public:
 	}
 
 	virtual MxBool VTable0x14() override; // vtable+0x14
+
+	// SYNTHETIC: LEGO1 0x1000f3d0
+	// JukeBoxState::`scalar deleting destructor'
 };
 
 #endif // JUKEBOXSTATE_H

--- a/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
+++ b/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, Lego3DWavePresenter::ClassName()) || MxWavePresenter::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f4b0
+	// Lego3DWavePresenter::`scalar deleting destructor'
 };
 
 #endif // LEGO3DWAVEPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legoact2.h
+++ b/LEGO1/lego/legoomni/include/legoact2.h
@@ -6,6 +6,9 @@
 
 // VTABLE: LEGO1 0x100d82e0
 // SIZE 0x1154
-class LegoAct2 : public LegoWorld {};
+class LegoAct2 : public LegoWorld {
+	// SYNTHETIC: LEGO1 0x1004fe20
+	// LegoAct2::`scalar deleting destructor'
+};
 
 #endif // LEGOACT2_H

--- a/LEGO1/lego/legoomni/include/legoact2state.h
+++ b/LEGO1/lego/legoomni/include/legoact2state.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, LegoAct2State::ClassName()) || LegoState::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000e040
+	// LegoAct2State::`scalar deleting destructor'
 };
 
 #endif // LEGOACT2STATE_H

--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -34,6 +34,9 @@ public:
 
 	__declspec(dllexport) static void configureLegoAnimationManager(MxS32 p_legoAnimationManagerConfig);
 
+	// SYNTHETIC: LEGO1 0x1005ed10
+	// LegoAnimationManager::`scalar deleting destructor'
+
 private:
 	void Init();
 };

--- a/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
@@ -21,6 +21,9 @@ public:
 	{
 		return !strcmp(p_name, LegoAnimMMPresenter::ClassName()) || MxCompositePresenter::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1004aa40
+	// LegoAnimMMPresenter::`scalar deleting destructor'
 };
 
 #endif // LEGOANIMMMPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legobuildingmanager.h
+++ b/LEGO1/lego/legoomni/include/legobuildingmanager.h
@@ -21,6 +21,9 @@ public:
 
 	void FUN_1002fa00();
 
+	// SYNTHETIC: LEGO1 0x1002f940
+	// LegoBuildingManager::`scalar deleting destructor'
+
 private:
 	void Init();
 };

--- a/LEGO1/lego/legoomni/include/legocachesound.h
+++ b/LEGO1/lego/legoomni/include/legocachesound.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, LegoCacheSound::ClassName()) || MxCore::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10006610
+	// LegoCacheSound::`scalar deleting destructor'
+
 private:
 	void Init();
 };

--- a/LEGO1/lego/legoomni/include/legocarbuild.h
+++ b/LEGO1/lego/legoomni/include/legocarbuild.h
@@ -25,6 +25,9 @@ public:
 	{
 		return !strcmp(p_name, LegoCarBuild::ClassName()) || LegoWorld::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10022a60
+	// LegoCarBuild::`scalar deleting destructor'
 };
 
 #endif // LEGOCARBUILD_H

--- a/LEGO1/lego/legoomni/include/legocarbuildanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildanimpresenter.h
@@ -22,6 +22,9 @@ public:
 	{
 		return !strcmp(p_name, LegoCarBuildAnimPresenter::ClassName()) || LegoAnimPresenter::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10078660
+	// LegoCarBuildAnimPresenter::`scalar deleting destructor'
 };
 
 #endif // LEGOCARBUILDANIMPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -18,6 +18,9 @@ public:
 	{
 		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10081610
+	// LegoCarRaceActor::`scalar deleting destructor'
 };
 
 #endif // LEGOCARRACEACTOR_H

--- a/LEGO1/lego/legoomni/include/legocontrolmanager.h
+++ b/LEGO1/lego/legoomni/include/legocontrolmanager.h
@@ -29,6 +29,9 @@ public:
 	void Register(MxCore* p_listener);
 	void Unregister(MxCore* p_listener);
 	void FUN_100293c0(undefined4, const MxAtomId&, undefined2);
+
+	// SYNTHETIC: LEGO1 0x10028d40
+	// LegoControlManager::`scalar deleting destructor'
 };
 
 #endif // LEGOCONTROLMANAGER_H

--- a/LEGO1/lego/legoomni/include/legoentitypresenter.h
+++ b/LEGO1/lego/legoomni/include/legoentitypresenter.h
@@ -35,6 +35,9 @@ public:
 
 	void SetEntityLocation(Mx3DPointFloat& p_location, Mx3DPointFloat& p_direction, Mx3DPointFloat& p_up);
 
+	// SYNTHETIC: LEGO1 0x100535a0
+	// LegoEntityPresenter::`scalar deleting destructor'
+
 private:
 	void Destroy(MxBool p_fromDestructor);
 

--- a/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
@@ -17,6 +17,9 @@ public:
 		return "LegoFlcTexturePresenter";
 	}
 
+	// SYNTHETIC: LEGO1 0x1005df00
+	// LegoFlcTexturePresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -71,6 +71,9 @@ public:
 	void ProcessEvents();
 	MxBool ProcessOneEvent(LegoEventNotificationParam& p_param);
 
+	// SYNTHETIC: LEGO1 0x1005b8d0
+	// LegoInputManager::`scalar deleting destructor'
+
 private:
 	MxCriticalSection m_criticalSection;
 	MxList<undefined4>* m_unk0x5c; // list or hash table

--- a/LEGO1/lego/legoomni/include/legojetski.h
+++ b/LEGO1/lego/legoomni/include/legojetski.h
@@ -18,6 +18,9 @@ public:
 	{
 		return !strcmp(p_name, LegoJetski::ClassName()) || LegoJetskiRaceActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10013e20
+	// LegoJetski::`scalar deleting destructor'
 };
 
 #endif // LEGOJETSKI_H

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -18,6 +18,9 @@ public:
 	{
 		return !strcmp(p_name, LegoJetskiRaceActor::ClassName()) || LegoCarRaceActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10081d40
+	// LegoJetskiRaceActor::`scalar deleting destructor'
 };
 
 #endif // LEGOJETSKIRACEACTOR_H

--- a/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
@@ -21,6 +21,9 @@ public:
 		return !strcmp(p_name, ClassName()) || LegoLoopingAnimPresenter::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x1006cfe0
+	// LegoLocomotionAnimPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 };

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -26,6 +26,9 @@ public:
 	virtual void ParseExtra() override;  // vtable+0x30
 	virtual void Destroy() override;     // vtable+0x38
 
+	// SYNTHETIC: LEGO1 0x1000cdd0
+	// LegoModelPresenter::`scalar deleting destructor'
+
 protected:
 	void Destroy(MxBool p_fromDestructor);
 

--- a/LEGO1/lego/legoomni/include/legonavcontroller.h
+++ b/LEGO1/lego/legoomni/include/legonavcontroller.h
@@ -61,6 +61,9 @@ public:
 
 	inline void SetTrackDefaultParams(MxBool p_trackDefault) { m_trackDefault = p_trackDefault; }
 
+	// SYNTHETIC: LEGO1 0x10054c10
+	// LegoNavController::`scalar deleting destructor'
+
 private:
 	int m_hMax;
 	int m_vMax;

--- a/LEGO1/lego/legoomni/include/legoobjectfactory.h
+++ b/LEGO1/lego/legoomni/include/legoobjectfactory.h
@@ -108,6 +108,9 @@ public:
 	virtual MxCore* Create(const char* p_name) override; // vtable 0x14
 	virtual void Destroy(MxCore* p_object) override;     // vtable 0x18
 
+	// SYNTHETIC: LEGO1 0x10009000
+	// LegoObjectFactory::`scalar deleting destructor'
+
 private:
 #define X(V) MxAtomId m_id##V;
 	FOR_LEGOOBJECTFACTORY_OBJECTS(X)

--- a/LEGO1/lego/legoomni/include/legoomni.h
+++ b/LEGO1/lego/legoomni/include/legoomni.h
@@ -129,6 +129,9 @@ public:
 
 	inline void CloseMainWindow() { PostMessageA(m_windowHandle, WM_CLOSE, 0, 0); }
 
+	// SYNTHETIC: LEGO1 0x10058b30
+	// LegoOmni::`scalar deleting destructor'
+
 private:
 	undefined4* m_unk0x68;                       // 0x68
 	ViewLODListManager* m_viewLODListManager;    // 0x6c

--- a/LEGO1/lego/legoomni/include/legopalettepresenter.h
+++ b/LEGO1/lego/legoomni/include/legopalettepresenter.h
@@ -30,6 +30,9 @@ public:
 
 	MxResult ParsePalette(MxStreamChunk* p_chunk);
 
+	// SYNTHETIC: LEGO1 0x1007a050
+	// LegoPalettePresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/lego/legoomni/include/legopartpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopartpresenter.h
@@ -21,6 +21,9 @@ public:
 	}
 
 	__declspec(dllexport) static void configureLegoPartPresenter(MxS32, MxS32);
+
+	// SYNTHETIC: LEGO1 0x1000d060
+	// LegoPartPresenter::`scalar deleting destructor'
 };
 
 #endif // LEGOPARTPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -66,6 +66,9 @@ public:
 
 	inline void SetUnknownDC(MxU32 p_unk0xdc) { m_unk0xdc = p_unk0xdc; }
 
+	// SYNTHETIC: LEGO1 0x1002d800
+	// LegoPathActor::`scalar deleting destructor'
+
 protected:
 	undefined m_unk0x78[0x64]; // 0x78
 	MxU32 m_unk0xdc;           // 0xdc

--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -8,7 +8,7 @@
 class LegoPathController : public MxCore {
 public:
 	LegoPathController();
-	virtual ~LegoPathController() override;
+	virtual ~LegoPathController() override { Destroy(); };
 
 	virtual MxResult Tickle() override; // vtable+08
 
@@ -24,6 +24,12 @@ public:
 	{
 		return !strcmp(p_name, LegoPathController::ClassName()) || MxCore::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10045740
+	// LegoPathController::`scalar deleting destructor'
+
+	virtual void VTable0x14(); // vtable+0x14
+	virtual void Destroy();    // vtable+0x18
 };
 
 #endif // LEGOPATHCONTROLLER_H

--- a/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
+++ b/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
@@ -19,6 +19,9 @@ public:
 	{
 		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 	} // vtable+0x14
+
+	// SYNTHETIC: LEGO1 0x1001d3d0
+	// LegoPathControllerList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100d6380

--- a/LEGO1/lego/legoomni/include/legopathpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopathpresenter.h
@@ -30,6 +30,9 @@ public:
 	virtual MxResult AddToManager() override; // vtable+0x34
 	virtual void Destroy() override;          // vtable+0x38
 
+	// SYNTHETIC: LEGO1 0x10044a90
+	// LegoPathPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 

--- a/LEGO1/lego/legoomni/include/legophonemepresenter.h
+++ b/LEGO1/lego/legoomni/include/legophonemepresenter.h
@@ -20,6 +20,9 @@ public:
 		return "LegoPhonemePresenter";
 	}
 
+	// SYNTHETIC: LEGO1 0x1004e320
+	// LegoPhonemePresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 	int m_unk0x68;

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -22,6 +22,9 @@ public:
 
 	void FUN_10026360(undefined4 p_world);
 
+	// SYNTHETIC: LEGO1 0x100262a0
+	// LegoPlantManager::`scalar deleting destructor'
+
 private:
 	void Init();
 };

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -38,6 +38,9 @@ public:
 	virtual undefined4 VTable0x78(undefined4);                // vtable+0x78
 	virtual void VTable0x7c(undefined4, undefined4);          // vtable+0x7c
 
+	// SYNTHETIC: LEGO1 0x10015cc0
+	// LegoRace::`scalar deleting destructor'
+
 private:
 	undefined4 m_unk0xf8;  // 0xf8
 	undefined4 m_unk0xfc;  // 0xfc

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -18,6 +18,9 @@ public:
 	{
 		return !strcmp(p_name, LegoRaceActor::ClassName()) || LegoAnimActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10014ab0
+	// LegoRaceActor::`scalar deleting destructor'
 };
 
 #endif // LEGORACEACTOR_H

--- a/LEGO1/lego/legoomni/include/legoracecar.h
+++ b/LEGO1/lego/legoomni/include/legoracecar.h
@@ -20,6 +20,9 @@ public:
 	{
 		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoCarRaceActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10014230
+	// LegoRaceCar::`scalar deleting destructor'
 };
 
 #endif // LEGOCARRACE_H

--- a/LEGO1/lego/legoomni/include/legosoundmanager.h
+++ b/LEGO1/lego/legoomni/include/legosoundmanager.h
@@ -14,6 +14,9 @@ public:
 	virtual void Destroy() override;                                              // vtable+18
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread) override; // vtable+0x30
 
+	// SYNTHETIC: LEGO1 0x10029920
+	// LegoSoundManager::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/lego/legoomni/include/legostate.h
+++ b/LEGO1/lego/legoomni/include/legostate.h
@@ -27,6 +27,9 @@ public:
 	virtual MxBool VTable0x14();                                   // vtable+0x14
 	virtual MxBool SetFlag();                                      // vtable+0x18
 	virtual MxResult VTable0x1c(LegoFileStream* p_legoFileStream); // vtable+0x1C
+
+	// SYNTHETIC: LEGO1 0x10006160
+	// LegoState::`scalar deleting destructor'
 };
 
 #endif // LEGOSTATE_H

--- a/LEGO1/lego/legoomni/include/legotexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legotexturepresenter.h
@@ -25,6 +25,9 @@ public:
 	virtual void DoneTickle() override;       // vtable+0x2c
 	virtual MxResult AddToManager() override; // vtable+0x34
 	virtual MxResult PutData() override;      // vtable+0x4c
+
+	// SYNTHETIC: LEGO1 0x1000cf40
+	// LegoTexturePresenter::`scalar deleting destructor'
 };
 
 #endif // LEGOTEXTUREPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legovehiclebuildstate.h
+++ b/LEGO1/lego/legoomni/include/legovehiclebuildstate.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, this->m_className.GetData()) || LegoState::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x100260a0
+	// LegoVehicleBuildState::`scalar deleting destructor'
+
 public:
 	struct UnkStruct {
 		undefined4 m_unk0x00;

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -60,6 +60,9 @@ public:
 	MxS32 GetCurrPathInfo(LegoPathBoundary** p_path, MxS32& p_value);
 	MxPresenter* FindPresenter(const char* p_presenter, const char* p_name);
 
+	// SYNTHETIC: LEGO1 0x1001dee0
+	// LegoWorld::`scalar deleting destructor'
+
 protected:
 	LegoPathControllerList m_list0x68;        // 0x68
 	MxPresenterList m_list0x80;               // 0x80

--- a/LEGO1/lego/legoomni/include/legoworldlist.h
+++ b/LEGO1/lego/legoomni/include/legoworldlist.h
@@ -26,6 +26,9 @@ public:
 	{
 		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 	}; // vtable+0x14
+
+	// SYNTHETIC: LEGO1 0x10059a00
+	// LegoWorldList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100d75b8
@@ -46,6 +49,12 @@ public:
 
 // FUNCTION: LEGO1 0x1003e8e0
 // MxPtrListCursor<LegoWorld>::~MxPtrListCursor<LegoWorld>
+
+// SYNTHETIC: LEGO1 0x1003e930
+// MxListCursor<LegoWorld *>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1003e9a0
+// MxPtrListCursor<LegoWorld>::`scalar deleting destructor'
 
 // FUNCTION: LEGO1 0x1003ea10
 // MxListCursor<LegoWorld *>::~MxListCursor<LegoWorld *>

--- a/LEGO1/lego/legoomni/include/legoworldpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoworldpresenter.h
@@ -31,6 +31,9 @@ public:
 	virtual MxResult StartAction(MxStreamController* p_controller, MxDSAction* p_action) override; // vtable+0x3c
 	virtual void VTable0x60(MxPresenter* p_presenter) override;                                    // vtable+0x60
 
+	// SYNTHETIC: LEGO1 0x10066750
+	// LegoWorldPresenter::`scalar deleting destructor'
+
 private:
 	undefined4 m_unk0x50;
 };

--- a/LEGO1/lego/legoomni/include/motocycle.h
+++ b/LEGO1/lego/legoomni/include/motocycle.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, Motocycle::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x100359d0
+	// Motocycle::`scalar deleting destructor'
+
 private:
 	undefined m_unk0x160[4];
 	MxFloat m_unk0x164;

--- a/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
+++ b/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
@@ -46,6 +46,9 @@ public:
 	void LowerVolume();
 	void RaiseVolume();
 
+	// SYNTHETIC: LEGO1 0x1007ec00
+	// MxBackgroundAudioManager::`scalar deleting destructor'
+
 private:
 	void Init();
 	MxResult OpenMusic(MxAtomId& p_script);

--- a/LEGO1/lego/legoomni/include/mxtransitionmanager.h
+++ b/LEGO1/lego/legoomni/include/mxtransitionmanager.h
@@ -45,6 +45,9 @@ public:
 
 	inline TransitionType GetTransitionType() { return m_transitionType; }
 
+	// SYNTHETIC: LEGO1 0x1004b9e0
+	// MxTransitionManager::`scalar deleting destructor'
+
 private:
 	void EndTransition(MxBool p_notifyWorld);
 	void TransitionNone();

--- a/LEGO1/lego/legoomni/include/pizza.h
+++ b/LEGO1/lego/legoomni/include/pizza.h
@@ -30,6 +30,9 @@ public:
 		return !strcmp(p_name, Pizza::ClassName()) || IsleActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x100380e0
+	// Pizza::`scalar deleting destructor'
+
 private:
 	undefined4 m_unk0x78;
 	undefined4 m_unk0x7c;

--- a/LEGO1/lego/legoomni/include/pizzamissionstate.h
+++ b/LEGO1/lego/legoomni/include/pizzamissionstate.h
@@ -30,6 +30,9 @@ public:
 
 	inline MxU16 GetColor(MxU8 p_id) { return GetState(p_id)->m_color; }
 
+	// SYNTHETIC: LEGO1 0x10039350
+	// PizzaMissionState::`scalar deleting destructor'
+
 private:
 	PizzaMissionStateEntry* GetState(MxU8 p_id);
 

--- a/LEGO1/lego/legoomni/include/pizzeria.h
+++ b/LEGO1/lego/legoomni/include/pizzeria.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, Pizzeria::ClassName()) || IsleActor::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000e8d0
+	// Pizzeria::`scalar deleting destructor'
 };
 
 #endif // PIZZERIA_H

--- a/LEGO1/lego/legoomni/include/pizzeriastate.h
+++ b/LEGO1/lego/legoomni/include/pizzeriastate.h
@@ -21,6 +21,9 @@ public:
 	{
 		return !strcmp(p_name, PizzeriaState::ClassName()) || LegoState::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10017ce0
+	// PizzeriaState::`scalar deleting destructor'
 };
 
 #endif // PIZZERIASTATE_H

--- a/LEGO1/lego/legoomni/include/police.h
+++ b/LEGO1/lego/legoomni/include/police.h
@@ -25,6 +25,9 @@ public:
 	{
 		return !strcmp(p_name, Police::ClassName()) || LegoWorld::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1005e300
+	// Police::`scalar deleting destructor'
 };
 
 #endif // POLICE_H

--- a/LEGO1/lego/legoomni/include/policeentity.h
+++ b/LEGO1/lego/legoomni/include/policeentity.h
@@ -19,6 +19,9 @@ public:
 	{
 		return !strcmp(p_name, PoliceEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1000f900
+	// PoliceEntity::`scalar deleting destructor'
 };
 
 #endif // POLICEENTITY_H

--- a/LEGO1/lego/legoomni/include/policestate.h
+++ b/LEGO1/lego/legoomni/include/policestate.h
@@ -21,6 +21,9 @@ public:
 	{
 		return !strcmp(p_name, PoliceState::ClassName()) || LegoState::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1005e920
+	// PoliceState::`scalar deleting destructor'
 };
 
 #endif // POLICESTATE_H

--- a/LEGO1/lego/legoomni/include/racecar.h
+++ b/LEGO1/lego/legoomni/include/racecar.h
@@ -24,6 +24,9 @@ public:
 		return !strcmp(p_name, RaceCar::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x10028400
+	// RaceCar::`scalar deleting destructor'
+
 private:
 	// TODO: RaceCar fields
 	undefined m_unk0x160[4];

--- a/LEGO1/lego/legoomni/include/racestandsentity.h
+++ b/LEGO1/lego/legoomni/include/racestandsentity.h
@@ -5,6 +5,9 @@
 
 // VTABLE: LEGO1 0x100d48a8
 // SIZE 0x68
-class RaceStandsEntity : public BuildingEntity {};
+class RaceStandsEntity : public BuildingEntity {
+	// SYNTHETIC: LEGO1 0x1000f9e0
+	// RaceStandsEntity::`scalar deleting destructor'
+};
 
 #endif // RACESTANDSENTITY_H

--- a/LEGO1/lego/legoomni/include/racestate.h
+++ b/LEGO1/lego/legoomni/include/racestate.h
@@ -32,6 +32,9 @@ public:
 
 	inline MxU16 GetColor(MxU8 p_id) { return GetState(p_id)->m_color; }
 
+	// SYNTHETIC: LEGO1 0x100160d0
+	// RaceState::`scalar deleting destructor'
+
 private:
 	RaceStateEntry* GetState(MxU8 p_id);
 

--- a/LEGO1/lego/legoomni/include/radio.h
+++ b/LEGO1/lego/legoomni/include/radio.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, Radio::ClassName()) || MxCore::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x1002c970
+	// Radio::`scalar deleting destructor'
+
 private:
 	RadioState* m_state; // 0x08
 	MxBool m_unk0xc;     // 0x0c

--- a/LEGO1/lego/legoomni/include/radiostate.h
+++ b/LEGO1/lego/legoomni/include/radiostate.h
@@ -21,6 +21,9 @@ public:
 	{
 		return !strcmp(p_name, RadioState::ClassName()) || LegoState::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x1002d020
+	// RadioState::`scalar deleting destructor'
 };
 
 #endif // RADIOSTATE_H

--- a/LEGO1/lego/legoomni/include/registrationbook.h
+++ b/LEGO1/lego/legoomni/include/registrationbook.h
@@ -24,6 +24,9 @@ public:
 	{
 		return !strcmp(p_name, RegistrationBook::ClassName()) || LegoWorld::IsA(p_name);
 	}
+
+	// SYNTHETIC: LEGO1 0x10076f30
+	// RegistrationBook::`scalar deleting destructor'
 };
 
 #endif // REGISTRATIONBOOK_H

--- a/LEGO1/lego/legoomni/include/scorestate.h
+++ b/LEGO1/lego/legoomni/include/scorestate.h
@@ -26,6 +26,9 @@ public:
 	inline MxBool GetTutorialFlag() { return m_playCubeTutorial; }
 	inline void SetTutorialFlag(MxBool p_playCubeTutorial) { m_playCubeTutorial = p_playCubeTutorial; }
 
+	// SYNTHETIC: LEGO1 0x1000df00
+	// ScoreState::`scalar deleting destructor'
+
 private:
 	MxBool m_playCubeTutorial;
 };

--- a/LEGO1/lego/legoomni/include/skateboard.h
+++ b/LEGO1/lego/legoomni/include/skateboard.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, SkateBoard::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x1000ff60
+	// SkateBoard::`scalar deleting destructor'
+
 private:
 	// TODO: SkateBoard types
 	undefined m_unk0x160;

--- a/LEGO1/lego/legoomni/include/towtrack.h
+++ b/LEGO1/lego/legoomni/include/towtrack.h
@@ -23,6 +23,9 @@ public:
 		return !strcmp(p_name, TowTrack::ClassName()) || IslePathActor::IsA(p_name);
 	}
 
+	// SYNTHETIC: LEGO1 0x1004c950
+	// TowTrack::`scalar deleting destructor'
+
 private:
 	// TODO: TowTrack field types
 	undefined m_unk0x154[4];

--- a/LEGO1/lego/legoomni/include/towtrackmissionstate.h
+++ b/LEGO1/lego/legoomni/include/towtrackmissionstate.h
@@ -41,6 +41,9 @@ public:
 		}
 	}
 
+	// SYNTHETIC: LEGO1 0x1004e060
+	// TowTrackMissionState::`scalar deleting destructor'
+
 protected:
 	undefined4 m_unk0x08; // 0x08
 	undefined4 m_unk0x0c; // 0x0c

--- a/LEGO1/lego/legoomni/src/common/gifmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/gifmanager.cpp
@@ -24,3 +24,9 @@ GifMapEntry* GifMap::FindNode(const char*& p_string)
 	}
 	return ret;
 }
+
+// STUB: LEGO1 0x10099870
+GifManager::~GifManager()
+{
+	// TODO
+}

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -6,8 +6,14 @@ LegoPathController::LegoPathController()
 	// TODO
 }
 
-// STUB: LEGO1 0x10045740
-LegoPathController::~LegoPathController()
+// STUB: LEGO1 0x10045880
+void LegoPathController::VTable0x14()
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10045b20
+void LegoPathController::Destroy()
 {
 	// TODO
 }

--- a/LEGO1/lego/sources/3dmanager/lego3dmanager.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dmanager.h
@@ -57,6 +57,9 @@ public:
 	// ??? for now
 	ViewLODListManager* GetViewLODListManager();
 
+	// SYNTHETIC: LEGO1 0x100ab340
+	// Lego3DManager::`scalar deleting destructor'
+
 private:
 	Tgl::Renderer* m_pRenderer; // 0x04
 

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -40,6 +40,9 @@ public:
 	inline LegoEntity* GetUnknown0x104() { return m_unk0x104; }
 	inline void SetUnknown0x104(LegoEntity* p_unk0x104) { m_unk0x104 = p_unk0x104; }
 
+	// SYNTHETIC: LEGO1 0x100a9ad0
+	// LegoROI::`scalar deleting destructor'
+
 private:
 	undefined m_pad[0x24];  // 0xe0
 	LegoEntity* m_unk0x104; // 0x104

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -45,6 +45,9 @@
 // LIBRARY: LEGO1 0x1008b730
 // _fprintf
 
+// LIBRARY: LEGO1 0x1008b670
+// __purecall
+
 // LIBRARY: LEGO1 0x1008b780
 // _fwrite
 

--- a/LEGO1/mxdirectx/mxdirect3d.h
+++ b/LEGO1/mxdirectx/mxdirect3d.h
@@ -66,6 +66,9 @@ public:
 	inline IDirect3D2* GetDirect3D() { return this->m_pDirect3d; }
 	inline IDirect3DDevice2* GetDirect3DDevice() { return this->m_pDirect3dDevice; }
 
+	// SYNTHETIC: LEGO1 0x1009b120
+	// MxDirect3D::`scalar deleting destructor'
+
 private:
 	MxAssignedDevice* m_assignedDevice;  // 0x880
 	IDirect3D2* m_pDirect3d;             // 0x884

--- a/LEGO1/mxdirectx/mxdirectdraw.h
+++ b/LEGO1/mxdirectx/mxdirectdraw.h
@@ -83,6 +83,9 @@ public:
 	inline IDirectDrawSurface* GetBackBuffer() { return m_pBackBuffer; }
 	inline IDirectDrawClipper* GetClipper() { return m_pClipper; }
 
+	// SYNTHETIC: LEGO1 0x1009d510
+	// MxDirectDraw::`scalar deleting destructor'
+
 protected:
 	BOOL m_bOnlySoftRender;                     // 0x04
 	BOOL m_bFlipSurfaces;                       // 0x08

--- a/LEGO1/omni/include/mxaudiomanager.h
+++ b/LEGO1/omni/include/mxaudiomanager.h
@@ -19,6 +19,9 @@ public:
 
 	virtual void SetVolume(MxS32 p_volume); // vtable+2c
 
+	// SYNTHETIC: LEGO1 0x100b8d70
+	// MxAudioManager::`scalar deleting destructor'
+
 private:
 	void Destroy(MxBool p_fromDestructor);
 

--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -92,6 +92,9 @@ public:
 			return -GetBmiStride();
 	}
 
+	// SYNTHETIC: LEGO1 0x100bc9f0
+	// MxBitmap::`scalar deleting destructor'
+
 private:
 	MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);
 

--- a/LEGO1/omni/include/mxcore.h
+++ b/LEGO1/omni/include/mxcore.h
@@ -34,6 +34,9 @@ public:
 
 	inline MxU32 GetId() { return m_id; }
 
+	// SYNTHETIC: LEGO1 0x100ae1c0
+	// MxCore::`scalar deleting destructor'
+
 private:
 	MxU32 m_id; // 0x04
 };

--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -83,6 +83,9 @@ public:
 			SetFlags(GetFlags() | MxDSAction::c_bit3);
 	}
 
+	// SYNTHETIC: LEGO1 0x100ada60
+	// MxDSAction::`scalar deleting destructor'
+
 protected:
 	MxU32 m_sizeOnDisk;         // 0x2c
 	MxU32 m_flags;              // 0x30

--- a/LEGO1/omni/include/mxdsactionlist.h
+++ b/LEGO1/omni/include/mxdsactionlist.h
@@ -27,6 +27,9 @@ public:
 	// FUNCTION: LEGO1 0x100c9cb0
 	static void Destroy(MxDSAction* p_action) { delete p_action; }
 
+	// SYNTHETIC: LEGO1 0x100c9dc0
+	// MxDSActionList::`scalar deleting destructor'
+
 private:
 	undefined m_unk0x18;
 };

--- a/LEGO1/omni/include/mxdsanim.h
+++ b/LEGO1/omni/include/mxdsanim.h
@@ -27,6 +27,9 @@ public:
 	}
 
 	virtual MxDSAction* Clone() override; // vtable+2c;
+
+	// SYNTHETIC: LEGO1 0x100c9180
+	// MxDSAnim::`scalar deleting destructor'
 };
 
 #endif // MXDSANIM_H

--- a/LEGO1/omni/include/mxdsbuffer.h
+++ b/LEGO1/omni/include/mxdsbuffer.h
@@ -75,6 +75,9 @@ public:
 	inline void SetMode(Type p_mode) { m_mode = p_mode; }
 	inline void SetUnk30(MxDSStreamingAction* p_unk0x30) { m_unk0x30 = p_unk0x30; }
 
+	// SYNTHETIC: LEGO1 0x100c6510
+	// MxDSBuffer::`scalar deleting destructor'
+
 private:
 	MxU8* m_pBuffer;                // 0x08
 	MxU8* m_pIntoBuffer;            // 0x0c

--- a/LEGO1/omni/include/mxdschunk.h
+++ b/LEGO1/omni/include/mxdschunk.h
@@ -57,6 +57,9 @@ public:
 			delete[] m_data;
 	}
 
+	// SYNTHETIC: LEGO1 0x100be150
+	// MxDSChunk::`scalar deleting destructor'
+
 protected:
 	MxU16 m_flags;    // 0x8
 	MxU32 m_objectId; // 0xc

--- a/LEGO1/omni/include/mxdsevent.h
+++ b/LEGO1/omni/include/mxdsevent.h
@@ -26,6 +26,9 @@ public:
 	}
 
 	virtual MxDSAction* Clone() override; // vtable+2c;
+
+	// SYNTHETIC: LEGO1 0x100c9780
+	// MxDSEvent::`scalar deleting destructor'
 };
 
 #endif // MXDSEVENT_H

--- a/LEGO1/omni/include/mxdsfile.h
+++ b/LEGO1/omni/include/mxdsfile.h
@@ -38,6 +38,9 @@ public:
 
 	inline MxS32 CalcFileSize() { return GetFileSize(m_io.m_info.hmmio, NULL); }
 
+	// SYNTHETIC: LEGO1 0x100c01e0
+	// MxDSFile::`scalar deleting destructor'
+
 private:
 	MxLong ReadChunks();
 	struct ChunkHeader {

--- a/LEGO1/omni/include/mxdsmultiaction.h
+++ b/LEGO1/omni/include/mxdsmultiaction.h
@@ -38,6 +38,9 @@ public:
 
 	inline MxDSActionList* GetActionList() const { return m_actions; };
 
+	// SYNTHETIC: LEGO1 0x100ca040
+	// MxDSMultiAction::`scalar deleting destructor'
+
 protected:
 	MxU32 m_sizeOnDisk;        // 0x94
 	MxDSActionList* m_actions; // 0x98

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -63,6 +63,9 @@ public:
 
 	inline void ClearAtom() { m_atomId.Clear(); }
 
+	// SYNTHETIC: LEGO1 0x100bf7c0
+	// MxDSObject::`scalar deleting destructor'
+
 private:
 	MxU32 m_sizeOnDisk;     // 0x8
 	MxU16 m_type;           // 0xc

--- a/LEGO1/omni/include/mxdsobjectaction.h
+++ b/LEGO1/omni/include/mxdsobjectaction.h
@@ -27,6 +27,9 @@ public:
 
 	virtual MxDSAction* Clone() override;                      // vtable+2c;
 	virtual void CopyFrom(MxDSObjectAction& p_dsObjectAction); // vtable+44;
+
+	// SYNTHETIC: LEGO1 0x100c8a00
+	// MxDSObjectAction::`scalar deleting destructor'
 };
 
 #endif // MXDSOBJECTACTION_H

--- a/LEGO1/omni/include/mxdsselectaction.h
+++ b/LEGO1/omni/include/mxdsselectaction.h
@@ -32,6 +32,9 @@ public:
 	virtual void Deserialize(MxU8** p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	virtual MxDSAction* Clone() override;                                // vtable+2c;
 
+	// SYNTHETIC: LEGO1 0x100cb840
+	// MxDSSelectAction::`scalar deleting destructor'
+
 private:
 	MxString m_unk0x9c;
 	MxStringList* m_unk0xac;

--- a/LEGO1/omni/include/mxdsserialaction.h
+++ b/LEGO1/omni/include/mxdsserialaction.h
@@ -31,6 +31,9 @@ public:
 	virtual void SetDuration(MxLong p_duration) override; // vtable+28;
 	virtual MxDSAction* Clone() override;                 // vtable+2c;
 
+	// SYNTHETIC: LEGO1 0x100cabf0
+	// MxDSSerialAction::`scalar deleting destructor'
+
 private:
 	MxDSActionListCursor* m_cursor;
 	undefined4 m_unk0xa0;

--- a/LEGO1/omni/include/mxdssound.h
+++ b/LEGO1/omni/include/mxdssound.h
@@ -32,6 +32,9 @@ public:
 
 	inline MxS32 GetVolume() const { return m_volume; }
 
+	// SYNTHETIC: LEGO1 0x100c9450
+	// MxDSSound::`scalar deleting destructor'
+
 private:
 	MxU32 m_sizeOnDisk;
 	MxS32 m_volume; // 0xbc

--- a/LEGO1/omni/include/mxdsstill.h
+++ b/LEGO1/omni/include/mxdsstill.h
@@ -27,6 +27,9 @@ public:
 	}
 
 	virtual MxDSAction* Clone() override; // vtable+2c;
+
+	// SYNTHETIC: LEGO1 0x100c9a50
+	// MxDSStill::`scalar deleting destructor'
 };
 
 #endif // MXDSSTILL_H

--- a/LEGO1/omni/include/mxdsstreamingaction.h
+++ b/LEGO1/omni/include/mxdsstreamingaction.h
@@ -44,6 +44,9 @@ public:
 	inline void SetUnknowna4(MxDSBuffer* p_unk0xa4) { m_unk0xa4 = p_unk0xa4; }
 	inline void SetBufferOffset(MxU32 p_bufferOffset) { m_bufferOffset = p_bufferOffset; }
 
+	// SYNTHETIC: LEGO1 0x100cd0b0
+	// MxDSStreamingAction::`scalar deleting destructor'
+
 private:
 	MxU32 m_unk0x94;              // 0x94
 	MxU32 m_bufferOffset;         // 0x98

--- a/LEGO1/omni/include/mxentity.h
+++ b/LEGO1/omni/include/mxentity.h
@@ -48,6 +48,9 @@ public:
 	inline MxS32 GetEntityId() { return m_mxEntityId; }
 	inline MxAtomId& GetAtom() { return m_atom; }
 
+	// SYNTHETIC: LEGO1 0x1000c210
+	// MxEntity::`scalar deleting destructor'
+
 protected:
 	MxS32 m_mxEntityId; // 0x8
 	MxAtomId m_atom;    // 0xc

--- a/LEGO1/omni/include/mxeventmanager.h
+++ b/LEGO1/omni/include/mxeventmanager.h
@@ -14,6 +14,9 @@ public:
 	virtual void Destroy() override;                                     // vtable+18
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+28
 
+	// SYNTHETIC: LEGO1 0x100c03d0
+	// MxEventManager::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/omni/include/mxeventpresenter.h
+++ b/LEGO1/omni/include/mxeventpresenter.h
@@ -31,6 +31,9 @@ public:
 	virtual MxResult PutData() override;           // vtable+0x4c
 	virtual void CopyData(MxStreamChunk* p_chunk); // vtable+0x5c
 
+	// SYNTHETIC: LEGO1 0x100c2d20
+	// MxEventPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 

--- a/LEGO1/omni/include/mxflcpresenter.h
+++ b/LEGO1/omni/include/mxflcpresenter.h
@@ -30,6 +30,9 @@ public:
 	virtual void CreateBitmap() override;                     // vtable+0x60
 	virtual void RealizePalette() override;                   // vtable+0x70
 
+	// SYNTHETIC: LEGO1 0x100b3400
+	// MxFlcPresenter::`scalar deleting destructor'
+
 protected:
 	FLIC_HEADER* m_flicHeader;
 };

--- a/LEGO1/omni/include/mxloopingflcpresenter.h
+++ b/LEGO1/omni/include/mxloopingflcpresenter.h
@@ -20,6 +20,9 @@ public:
 
 	virtual void NextFrame() override; // vtable+0x64
 
+	// SYNTHETIC: LEGO1 0x100b4390
+	// MxLoopingFlcPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/omni/include/mxmediamanager.h
+++ b/LEGO1/omni/include/mxmediamanager.h
@@ -23,6 +23,9 @@ public:
 
 	MxResult Init();
 
+	// SYNTHETIC: LEGO1 0x100b8540
+	// MxMediaManager::`scalar deleting destructor'
+
 protected:
 	MxPresenterList* m_presenters;       // 0x8
 	MxThread* m_thread;                  // 0xc

--- a/LEGO1/omni/include/mxmediapresenter.h
+++ b/LEGO1/omni/include/mxmediapresenter.h
@@ -42,6 +42,9 @@ public:
 	virtual void Enable(MxBool p_enable) override;                           // vtable+0x54
 	virtual void LoopChunk(MxStreamChunk* p_chunk);                          // vtable+0x58
 
+	// SYNTHETIC: LEGO1 0x1000c680
+	// MxMediaPresenter::`scalar deleting destructor'
+
 protected:
 	MxDSSubscriber* m_subscriber;                  // 0x40
 	MxStreamChunkList* m_loopingChunks;            // 0x44

--- a/LEGO1/omni/include/mxmidipresenter.h
+++ b/LEGO1/omni/include/mxmidipresenter.h
@@ -33,6 +33,9 @@ public:
 	virtual MxResult PutData() override;             // vtable+0x4c
 	virtual void SetVolume(MxS32 p_volume) override; // vtable+0x60
 
+	// SYNTHETIC: LEGO1 0x100c27a0
+	// MxMIDIPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/omni/include/mxmusicmanager.h
+++ b/LEGO1/omni/include/mxmusicmanager.h
@@ -38,6 +38,9 @@ private:
 	MxS32 m_multiplier;       // 0x50
 	DWORD m_midiVolume;       // 0x54
 
+	// SYNTHETIC: LEGO1 0x100c0610
+	// MxMusicManager::`scalar deleting destructor'
+
 protected:
 	void Init();
 	void InitData();

--- a/LEGO1/omni/include/mxmusicpresenter.h
+++ b/LEGO1/omni/include/mxmusicpresenter.h
@@ -26,6 +26,9 @@ public:
 	virtual MxResult AddToManager() override; // vtable+0x34
 	virtual void Destroy() override;          // vtable+0x38
 
+	// SYNTHETIC: LEGO1 0x100c24c0
+	// MxMusicPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/omni/include/mxnextactiondatastart.h
+++ b/LEGO1/omni/include/mxnextactiondatastart.h
@@ -33,6 +33,9 @@ public:
 	inline MxU32 GetData() const { return m_data; }
 	inline void SetData(MxU32 p_data) { m_data = p_data; }
 
+	// SYNTHETIC: LEGO1 0x100c1990
+	// MxNextActionDataStart::`scalar deleting destructor'
+
 private:
 	MxU32 m_objectId; // 0x08
 	MxS16 m_unk0x24;  // 0x0c

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -48,6 +48,9 @@ public:
 	inline MxNotificationPtrList* GetQueue() { return m_queue; }
 	inline void SetActive(MxBool p_active) { m_active = p_active; }
 
+	// SYNTHETIC: LEGO1 0x100ac390
+	// MxNotificationManager::`scalar deleting destructor'
+
 private:
 	void FlushPending(MxCore* p_listener);
 };

--- a/LEGO1/omni/include/mxobjectfactory.h
+++ b/LEGO1/omni/include/mxobjectfactory.h
@@ -39,6 +39,9 @@ public:
 	virtual MxCore* Create(const char* p_name); // vtable 0x14
 	virtual void Destroy(MxCore* p_object);     // vtable 0x18
 
+	// SYNTHETIC: LEGO1 0x100b1160
+	// MxObjectFactory::`scalar deleting destructor'
+
 private:
 #define X(V) MxAtomId m_id##V;
 	FOR_MXOBJECTFACTORY_OBJECTS(X)

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -73,6 +73,9 @@ public:
 	MxAtomIdCounterSet* GetAtomIdCounterSet() const { return this->m_atomIdCounterSet; }
 	MxLong HandleActionEnd(MxParam& p_param);
 
+	// SYNTHETIC: LEGO1 0x100aefd0
+	// MxOmni::`scalar deleting destructor'
+
 protected:
 	static MxOmni* g_instance;
 

--- a/LEGO1/omni/include/mxomnicreateparam.h
+++ b/LEGO1/omni/include/mxomnicreateparam.h
@@ -24,6 +24,9 @@ public:
 	MxVideoParam& GetVideoParam() { return m_videoParam; }
 	const MxVideoParam& GetVideoParam() const { return m_videoParam; }
 
+	// SYNTHETIC: LEGO1 0x100b0a70
+	// MxOmniCreateParam::`scalar deleting destructor'
+
 private:
 	MxString m_mediaPath;
 	HWND m_windowHandle;

--- a/LEGO1/omni/include/mxpalette.h
+++ b/LEGO1/omni/include/mxpalette.h
@@ -28,6 +28,9 @@ public:
 
 	inline void SetOverrideSkyColor(MxBool p_value) { this->m_overrideSkyColor = p_value; }
 
+	// SYNTHETIC: LEGO1 0x100beeb0
+	// MxPalette::`scalar deleting destructor'
+
 private:
 	LPDIRECTDRAWPALETTE m_palette;
 	PALETTEENTRY m_entries[256]; // 0xc

--- a/LEGO1/omni/include/mxpresenter.h
+++ b/LEGO1/omni/include/mxpresenter.h
@@ -129,6 +129,9 @@ public:
 		m_compositePresenter = p_compositePresenter;
 	}
 
+	// SYNTHETIC: LEGO1 0x1000c070
+	// MxPresenter::`scalar deleting destructor'
+
 protected:
 	__declspec(dllexport) void Init();
 

--- a/LEGO1/omni/include/mxpresenterlist.h
+++ b/LEGO1/omni/include/mxpresenterlist.h
@@ -18,6 +18,9 @@ public:
 	{
 		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
 	}; // vtable+0x14
+
+	// SYNTHETIC: LEGO1 0x1001ceb0
+	// MxPresenterList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100d6488

--- a/LEGO1/omni/include/mxregion.h
+++ b/LEGO1/omni/include/mxregion.h
@@ -23,6 +23,9 @@ public:
 
 	friend class MxRegionCursor;
 
+	// SYNTHETIC: LEGO1 0x100c3670
+	// MxRegion::`scalar deleting destructor'
+
 private:
 	MxRegionTopBottomList* m_list; // 0x08
 	MxRect32 m_rect;               // 0x0c

--- a/LEGO1/omni/include/mxregionlist.h
+++ b/LEGO1/omni/include/mxregionlist.h
@@ -40,6 +40,9 @@ private:
 class MxRegionLeftRightList : public MxPtrList<MxRegionLeftRight> {
 public:
 	MxRegionLeftRightList() : MxPtrList<MxRegionLeftRight>(TRUE) {}
+
+	// SYNTHETIC: LEGO1 0x100c4e90
+	// MxRegionLeftRightList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dcbf8
@@ -95,6 +98,9 @@ private:
 class MxRegionTopBottomList : public MxPtrList<MxRegionTopBottom> {
 public:
 	MxRegionTopBottomList() : MxPtrList<MxRegionTopBottom>(TRUE) {}
+
+	// SYNTHETIC: LEGO1 0x100c3410
+	// MxRegionTopBottomList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dcb70

--- a/LEGO1/omni/include/mxsmkpresenter.h
+++ b/LEGO1/omni/include/mxsmkpresenter.h
@@ -33,6 +33,9 @@ public:
 	virtual void RealizePalette() override;                   // vtable+0x70
 	virtual void VTable0x88();                                // vtable+0x88
 
+	// SYNTHETIC: LEGO1 0x100b3850
+	// MxSmkPresenter::`scalar deleting destructor'
+
 private:
 	void Init();
 	void Destroy(MxBool p_fromDestructor);

--- a/LEGO1/omni/include/mxsoundpresenter.h
+++ b/LEGO1/omni/include/mxsoundpresenter.h
@@ -29,6 +29,9 @@ public:
 	// FUNCTION: LEGO1 0x1000d490
 	virtual void Destroy() override { Destroy(FALSE); }; // vtable+0x38
 
+	// SYNTHETIC: LEGO1 0x1000d5c0
+	// MxSoundPresenter::`scalar deleting destructor'
+
 protected:
 	void Destroy(MxBool p_fromDestructor);
 };

--- a/LEGO1/omni/include/mxstreamchunklist.h
+++ b/LEGO1/omni/include/mxstreamchunklist.h
@@ -26,6 +26,9 @@ public:
 
 	// FUNCTION: LEGO1 0x100b5920
 	static void Destroy(MxStreamChunk* p_chunk) { delete p_chunk; }
+
+	// SYNTHETIC: LEGO1 0x100b5a30
+	// MxStreamChunkList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dc510

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -22,6 +22,9 @@ public:
 	inline MxS8 Compare(const MxString& p_str) const { return strcmp(m_data, p_str.m_data); }
 	inline const char* GetData() const { return m_data; }
 
+	// SYNTHETIC: LEGO1 0x100ae280
+	// MxString::`scalar deleting destructor'
+
 private:
 	char* m_data;   // 0x08
 	MxU16 m_length; // 0x0c

--- a/LEGO1/omni/include/mxstringlist.h
+++ b/LEGO1/omni/include/mxstringlist.h
@@ -13,6 +13,9 @@ class MxStringList : public MxList<MxString> {};
 class MxStringListCursor : public MxListCursor<MxString> {
 public:
 	MxStringListCursor(MxStringList* p_list) : MxListCursor<MxString>(p_list){};
+
+	// SYNTHETIC: LEGO1 0x100cb860
+	// MxStringList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dd010

--- a/LEGO1/omni/include/mxthread.h
+++ b/LEGO1/omni/include/mxthread.h
@@ -21,6 +21,9 @@ public:
 
 	inline MxBool IsRunning() { return m_running; }
 
+	// SYNTHETIC: LEGO1 0x100bf580
+	// MxThread::`scalar deleting destructor'
+
 protected:
 	MxThread();
 
@@ -47,6 +50,9 @@ public:
 	virtual ~MxTickleThread() {}
 
 	MxResult Run() override;
+
+	// SYNTHETIC: LEGO1 0x100b8c20
+	// MxTickleThread::`scalar deleting destructor'
 
 private:
 	MxS32 m_frequencyMS; // 0x1c

--- a/LEGO1/omni/include/mxticklemanager.h
+++ b/LEGO1/omni/include/mxticklemanager.h
@@ -44,6 +44,9 @@ public:
 	virtual void SetClientTickleInterval(MxCore* p_client, MxTime p_interval); // vtable+0x1c
 	virtual MxTime GetClientTickleInterval(MxCore* p_client);                  // vtable+0x20
 
+	// SYNTHETIC: LEGO1 0x1005a510
+	// MxTickleManager::`scalar deleting destructor'
+
 private:
 	MxTickleClientPtrList m_clients; // 0x8
 };

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -22,6 +22,9 @@ public:
 			return g_lastTimeCalculated - this->m_startTime;
 	}
 
+	// SYNTHETIC: LEGO1 0x100ae0d0
+	// MxTimer::`scalar deleting destructor'
+
 private:
 	MxLong m_startTime;
 	MxBool m_isRunning;

--- a/LEGO1/omni/include/mxvariabletable.h
+++ b/LEGO1/omni/include/mxvariabletable.h
@@ -18,6 +18,9 @@ public:
 
 	virtual MxS8 Compare(MxVariable*, MxVariable*) override; // vtable+0x14
 	virtual MxU32 Hash(MxVariable*) override;                // vtable+0x18
+
+	// SYNTHETIC: LEGO1 0x100afdd0
+	// MxVariableTable::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dc1b0
@@ -55,6 +58,9 @@ public:
 
 // TEMPLATE: LEGO1 0x100b7680
 // MxHashTableCursor<MxVariable *>::~MxHashTableCursor<MxVariable *>
+
+// SYNTHETIC: LEGO1 0x100b76d0
+// MxHashTableCursor<MxVariable *>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b7ab0
 // MxHashTable<MxVariable *>::Resize

--- a/LEGO1/omni/include/mxvideomanager.h
+++ b/LEGO1/omni/include/mxvideomanager.h
@@ -44,6 +44,9 @@ public:
 	inline MxDisplaySurface* GetDisplaySurface() { return this->m_displaySurface; }
 	inline MxRegion* GetRegion() { return this->m_region; }
 
+	// SYNTHETIC: LEGO1 0x100be280
+	// MxVideoManager::`scalar deleting destructor'
+
 protected:
 	MxVideoParam m_videoParam;          // 0x2c
 	LPDIRECTDRAW m_pDirectDraw;         // 0x50

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -92,10 +92,16 @@ public:
 		virtual ~AlphaMask();
 
 		MxS32 IsHit(MxU32 p_x, MxU32 p_y);
+
+		// SYNTHETIC: LEGO1 0x100b2650
+		// MxVideoPresenter::AlphaMask::`scalar deleting destructor'
 	};
 
 	inline MxS32 PrepareRects(MxRect32& p_rectDest, MxRect32& p_rectSrc);
 	inline MxBitmap* GetBitmap() { return m_bitmap; }
+
+	// SYNTHETIC: LEGO1 0x1000c910
+	// MxVideoPresenter::`scalar deleting destructor'
 
 private:
 	void Init();

--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -57,6 +57,9 @@ public:
 		MxU32 m_flags;
 	};
 
+	// SYNTHETIC: LEGO1 0x1000d810
+	// MxWavePresenter::`scalar deleting destructor'
+
 protected:
 	void Destroy(MxBool p_fromDestructor);
 

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -58,7 +58,7 @@ public:
 		m_data[3][3] = 1.0f;
 	} // vtable+0x24
 
-	// FUNCTION: LEGO1 0x10002850
+	// FUNCTION: LEGO1 0x10002420
 	virtual void operator=(const Matrix4& p_matrix) { Equals(p_matrix); } // vtable+0x28
 
 	// FUNCTION: LEGO1 0x10002430

--- a/LEGO1/realtime/roi.h
+++ b/LEGO1/realtime/roi.h
@@ -103,6 +103,9 @@ public:
 	int GetLODCount() const { return m_lods ? m_lods->Size() : 0; }
 	const CompoundObject* GetComp() const { return m_comp; }
 
+	// SYNTHETIC: LEGO1 0x100a5d60
+	// ROI::`scalar deleting destructor'
+
 protected:
 	CompoundObject* m_comp; // 0x4
 	LODListBase* m_lods;    // 0x8

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -104,6 +104,9 @@ public:
 	virtual ~Object() {}
 
 	virtual void* ImplementationDataPtr() = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2250
+	// Tgl::Object::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100db948
@@ -142,6 +145,9 @@ public:
 
 	// vtable+0x30
 	virtual Result SetTextureDefaultColorCount(unsigned long) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a17c0
+	// Tgl::Renderer::`scalar deleting destructor'
 };
 
 Renderer* CreateRenderer();
@@ -163,6 +169,9 @@ public:
 	virtual Result Update() = 0;
 	virtual void InitFromD3DDevice(Device*) = 0;
 	virtual void InitFromWindowsDevice(Device*) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a28e0
+	// Tgl::Device::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dba28
@@ -217,12 +226,18 @@ public:
 		const Group**& rppPickedGroups,
 		int& rPickedGroupCount
 	) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2950
+	// Tgl::View::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbae8
 class Camera : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2a30
+	// Tgl::Camera::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbb08
@@ -230,6 +245,9 @@ class Light : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
 	virtual Result SetColor(float r, float g, float b) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2aa0
+	// Tgl::Light::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbbb0
@@ -247,6 +265,9 @@ public:
 
 	// Just get another Group pointing to the same underlying data
 	virtual Mesh* ShallowClone(Unk*) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a3e60
+	// Tgl::Mesh::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbaa0
@@ -266,6 +287,9 @@ public:
 	// This is TransformLocalToWorld in the leak, however it seems
 	// to have been replaced by something else in the shipped code.
 	virtual Result Unknown() = 0;
+
+	// SYNTHETIC: LEGO1 0x100a29c0
+	// Tgl::Group::`scalar deleting destructor'
 };
 
 // Don't know what this is. Seems like another Tgl object which
@@ -285,6 +309,9 @@ public:
 	) = 0;
 	virtual Result GetBoundingBox(float min[3], float max[3]) = 0;
 	virtual Unk* Clone() = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2b10
+	// Tgl::Unk::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbb68
@@ -305,6 +332,9 @@ public:
 		PaletteEntry** ppPalette
 	) = 0;
 	virtual Result SetPalette(int entryCount, PaletteEntry* pEntries) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2b80
+	// Tgl::Texture::`scalar deleting destructor'
 };
 
 } // namespace Tgl

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -89,6 +89,9 @@ public:
 	void Dump(void (*pTracer)(const char*, ...)) const;
 #endif
 
+	// SYNTHETIC: LEGO1 0x100a70c0
+	// ViewLODListManager::`scalar deleting destructor'
+
 private:
 	ViewLODListMap m_map;
 };

--- a/LEGO1/viewmanager/viewmanager.h
+++ b/LEGO1/viewmanager/viewmanager.h
@@ -16,6 +16,9 @@ public:
 	void SetResolution(int width, int height);
 	void SetFrustrum(float fov, float front, float back);
 
+	// SYNTHETIC: LEGO1 0x100a6000
+	// ViewManager::`scalar deleting destructor'
+
 private:
 	undefined m_pad[0x1b8];
 };

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -82,17 +82,29 @@ class CompareDb:
 
         return [string for (string,) in cur.fetchall()]
 
-    def get_one_function(self, addr: int) -> Optional[MatchInfo]:
+    def get_matches(self) -> Optional[MatchInfo]:
         cur = self._db.execute(
             """SELECT compare_type, orig_addr, recomp_addr, name, size
             FROM `symbols`
-            WHERE compare_type = ?
-            AND orig_addr = ?
+            WHERE orig_addr IS NOT NULL
             AND recomp_addr IS NOT NULL
             AND should_skip IS FALSE
             ORDER BY orig_addr
             """,
-            (SymbolType.FUNCTION.value, addr),
+        )
+        cur.row_factory = matchinfo_factory
+
+        return cur.fetchall()
+
+    def get_one_match(self, addr: int) -> Optional[MatchInfo]:
+        cur = self._db.execute(
+            """SELECT compare_type, orig_addr, recomp_addr, name, size
+            FROM `symbols`
+            WHERE orig_addr = ?
+            AND recomp_addr IS NOT NULL
+            AND should_skip IS FALSE
+            """,
+            (addr,),
         )
         cur.row_factory = matchinfo_factory
         return cur.fetchone()
@@ -119,7 +131,7 @@ class CompareDb:
         cur.row_factory = matchinfo_factory
         return cur.fetchone()
 
-    def get_matches(self, compare_type: SymbolType) -> List[MatchInfo]:
+    def get_matches_by_type(self, compare_type: SymbolType) -> List[MatchInfo]:
         cur = self._db.execute(
             """SELECT compare_type, orig_addr, recomp_addr, name, size
             FROM `symbols`

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -12,6 +12,7 @@ from isledecomp import (
     print_diff,
 )
 from isledecomp.compare import Compare as IsleCompare
+from isledecomp.types import SymbolType
 from pystache import Renderer
 import colorama
 
@@ -225,9 +226,9 @@ def main():
         ### Compare one or none.
 
         if args.verbose is not None:
-            match = isle_compare.compare_function(args.verbose)
+            match = isle_compare.compare_address(args.verbose)
             if match is None:
-                print(f"Failed to find the function with address 0x{args.verbose:x}")
+                print(f"Failed to find a match at address 0x{args.verbose:x}")
                 return
 
             print_match_verbose(
@@ -242,14 +243,15 @@ def main():
         total_effective_accuracy = 0
         htmlinsert = []
 
-        for match in isle_compare.compare_functions():
+        for match in isle_compare.compare_all():
             print_match_oneline(
                 match, show_both_addrs=args.print_rec_addr, is_plain=args.no_color
             )
 
-            function_count += 1
-            total_accuracy += match.ratio
-            total_effective_accuracy += match.effective_ratio
+            if match.match_type == SymbolType.FUNCTION:
+                function_count += 1
+                total_accuracy += match.ratio
+                total_effective_accuracy += match.effective_ratio
 
             # If html, record the diffs to an HTML file
             if args.html is not None:


### PR DESCRIPTION
Virtual table contents are now compared by reccmp. The technique is as follows:
1. Read the vtable from `cvdump` output. The mangled symbols all begin with `??_7` and it is straightforward to derive the class name and optional template type.
2. Read the `// VTABLE` annotations from the code files, which also gives us the class name.
3. Match these in our database, where we also have the size of the recomp symbol. The size should be a multiple of 4 because it is just a list of pointers.
4. Read the data from original and recomp binaries. For each pointer in the original, consult the database to see whether the matched recomp address equals the actual recomp address read from the recomp binary.
5. If we have a match, we are done. If we could not match for any reason (i.e. there is no entry in the database for the original address, or the pointers don't point at the same thing), mark this as a diff.

To save time and avoid changing the `reccmp` terminal or html output, we just return a standard diff report for vtables as we are doing with functions. The output will tell where things aren't right. For example (InfocenterState):

```diff
-  vtable0x00  :  0x10071900 from orig not annotated.
+  vtable0x00  :  (no orig    / 0x10018120)  :  InfocenterState::`scalar deleting destructor'
   vtable0x04  :  (0x100ae1f0 / 0x10031510)  :  MxCore::Notify
   vtable0x08  :  (0x10001f70 / 0x10001090)  :  MxCore::Tickle
   vtable0x0c  :  (0x10071840 / 0x10018060)  :  InfocenterState::ClassName
   vtable0x10  :  (0x10071850 / 0x10018070)  :  InfocenterState::IsA
-  vtable0x14  :  0x10071830 from orig not annotated.
+  vtable0x14  :  (0x10005f90 / 0x100100a0)  :  LegoState::VTable0x14
   vtable0x18  :  (0x10005fa0 / 0x100100b0)  :  LegoState::SetFlag
   vtable0x1c  :  (0x10005fb0 / 0x100100c0)  :  LegoState::VTable0x1c
```

The first entry should be `InfocenterState::scalar deleting destructor`. The problem is that it was not annotated in the file, so there is no match in our database for the original address (`0x10071900`) and we also do not have a complete match for the (current) recomp address (`0x10018120`).

The entry `vtable0x14` has a different problem. The recomp shows `LegoState::VTable0x14` which is from the superclass. We do not have an annotation for the original address `0x10071830` because we have not implemented the override function `InfocenterState::VTable0x14`.

I've added all the missing `scalar deleting destructor` functions. There are (at least) three problem cases where the first vtable entry points at the regular destructor instead: LegoPathController, GifManagerBase, GifManager. These need more investigation.

The final match percentage reported by `reccmp` is still for functions only, but each vtable has its own percentage reported.