### PR TITLE
implement/match InfoCenter::~InfoCenter()

### DIFF
--- a/LEGO1/lego/legoomni/include/infocenterstate.h
+++ b/LEGO1/lego/legoomni/include/infocenterstate.h
@@ -3,6 +3,7 @@
 
 #include "decomp.h"
 #include "legostate.h"
+#include "mxstillpresenter.h";
 
 // VTABLE: LEGO1 0x100d93a8
 // SIZE 0x94
@@ -24,7 +25,7 @@ public:
 		return !strcmp(p_name, InfocenterState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	inline MxU32 GetInfocenterBufferElement(MxS32 p_index) { return m_buffer[p_index]; }
+	inline MxStillPresenter* GetInfocenterBufferElement(MxS32 p_index) { return m_buffer[p_index]; }
 	inline MxU32 GetUnknown0x74() { return m_unk0x74; }
 
 	inline void SetUnknown0x74(MxU32 p_unk0x74) { m_unk0x74 = p_unk0x74; }
@@ -63,7 +64,7 @@ private:
 
 	undefined m_pad[0x6c];
 	MxU32 m_unk0x74;   // 0x74
-	MxU32 m_buffer[7]; // 0x78
+	MxStillPresenter* m_buffer[7]; // 0x78
 };
 
 #endif // INFOCENTERSTATE_H

--- a/LEGO1/lego/legoomni/include/infocenterstate.h
+++ b/LEGO1/lego/legoomni/include/infocenterstate.h
@@ -28,6 +28,7 @@ public:
 	// FUNCTION: LEGO1 0x10071830
 	virtual MxBool VTable0x14() override { return FALSE; } // vtable+0x14
 
+	inline MxS16 GetInfocenterBufferSize() { return sizeof(m_buffer) / sizeof(m_buffer[0]); }
 	inline MxStillPresenter* GetInfocenterBufferElement(MxS32 p_index) { return m_buffer[p_index]; }
 	inline MxU32 GetUnknown0x74() { return m_unk0x74; }
 

--- a/LEGO1/lego/legoomni/include/infocenterstate.h
+++ b/LEGO1/lego/legoomni/include/infocenterstate.h
@@ -66,7 +66,7 @@ private:
 	*/
 
 	undefined m_pad[0x6c];
-	MxU32 m_unk0x74;   // 0x74
+	MxU32 m_unk0x74;               // 0x74
 	MxStillPresenter* m_buffer[7]; // 0x78
 };
 

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -112,7 +112,7 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	MxResult result;
 	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
 
-	if (!infocenterState || infocenterState->GetInfocenterBufferElement(0) == 0)
+	if (!infocenterState || infocenterState->GetInfocenterBufferElement(0) == NULL)
 		result = SUCCESS;
 	else {
 		result = FAILURE;

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -11,8 +11,8 @@
 #include "mxbackgroundaudiomanager.h"
 #include "mxnotificationmanager.h"
 #include "mxstillpresenter.h"
-#include "mxtransitionmanager.h"
 #include "mxticklemanager.h"
+#include "mxtransitionmanager.h"
 
 DECOMP_SIZE_ASSERT(Infocenter, 0x1d8)
 DECOMP_SIZE_ASSERT(InfocenterUnkDataEntry, 0x18)

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -58,7 +58,7 @@ Infocenter::~Infocenter()
 			m_infocenterState->GetInfocenterBufferElement(i)->Enable(FALSE);
 		}
 		i++;
-	} while (i < 7);
+	} while (i < m_infocenterState->GetInfocenterBufferSize());
 
 	ControlManager()->Unregister(this);
 

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -12,6 +12,7 @@
 #include "mxnotificationmanager.h"
 #include "mxstillpresenter.h"
 #include "mxtransitionmanager.h"
+#include "mxticklemanager.h"
 
 DECOMP_SIZE_ASSERT(Infocenter, 0x1d8)
 DECOMP_SIZE_ASSERT(InfocenterUnkDataEntry, 0x18)
@@ -46,10 +47,29 @@ Infocenter::Infocenter()
 	m_unk0x1d6 = 0;
 }
 
-// STUB: LEGO1 0x1006ec90
+// FUNCTION: LEGO1 0x1006ec90
 Infocenter::~Infocenter()
 {
-	// TODO
+	BackgroundAudioManager()->Stop();
+
+	MxS16 i = 0;
+	do {
+		if (m_infocenterState->GetInfocenterBufferElement(i) != NULL) {
+			m_infocenterState->GetInfocenterBufferElement(i)->Enable(FALSE);
+		}
+		i++;
+	} while (i < 7);
+
+	ControlManager()->Unregister(this);
+
+	InputManager()->UnRegister(this);
+	if (InputManager()->GetWorld() == this) {
+		InputManager()->ClearWorld();
+	}
+
+	NotificationManager()->Unregister(this);
+
+	TickleManager()->UnregisterClient(this);
 }
 
 // STUB: LEGO1 0x1006ed90


### PR DESCRIPTION
This PR implements InfoCenter's destructor. This function is 100% matching.

It remains to be seen what the true purpose of `m_buffer` is, but I confirmed through dynamic analysis that this loop in the destructor was resolving to `MxStillPresenter::Enable()` through it; I've made this member an array of MxStillPresenters to accommodate.