### PR TITLE
add jukeboxscript enum

### DIFF
--- a/LEGO1/lego/legoomni/include/jukebox.h
+++ b/LEGO1/lego/legoomni/include/jukebox.h
@@ -25,7 +25,6 @@ public:
 
 	// SYNTHETIC: LEGO1 0x1005d810
 	// JukeBox::`scalar deleting destructor'
-public:
 	enum JukeBoxScript {
 		e_mamaPapaBrickolini,
 		e_jailUnused,

--- a/LEGO1/lego/legoomni/include/jukebox.h
+++ b/LEGO1/lego/legoomni/include/jukebox.h
@@ -25,6 +25,90 @@ public:
 
 	// SYNTHETIC: LEGO1 0x1005d810
 	// JukeBox::`scalar deleting destructor'
+public:
+	enum JukeBoxScript {
+		e_mamaPapaBrickolini,
+		e_jailUnused,
+		e_act2Cave,
+		e_bricksterChase,
+		e_brickHunt,
+		e_residentialArea,
+		e_beachBlvd,
+		e_cave,
+		e_centralRoads,
+		e_jail,
+		e_hospital,
+		e_informationCenter,
+		e_policeStation,
+		e_park,
+		e_centralNorthRoad,
+		e_garageArea,
+		e_raceTrack,
+		e_beach,
+		e_quietChirping,
+		e_jetskiRace,
+		e_act3Pursuit,
+
+		e_legoRadioReminder1,
+		e_legoRadioJingle1,
+		e_legoRadioJingle2,
+		e_legoRadioJingle3,
+		e_legoRadioJingle4,
+		e_legoRadioReminder2,
+
+		e_legoRadioRacingAd,
+
+		e_legoRadioNews1,
+		e_legoRadioNews2,
+
+		e_legoRadioPizzaAd1,
+
+		e_legoRadioBricksterPSA,
+
+		e_legoRadioSports1,
+
+		e_legoRadioIntermission1,
+		e_legoRadioIntermission2,
+
+		e_legoRadioPizzaAd2,
+
+		e_legoRadioWeatherReport,
+
+		e_legoRadioSports2,
+
+		e_legoRadioPizzaAd3,
+
+		e_legoRadioIntermission3,
+
+		e_legoRadioSuperStoreAd,
+
+		e_legoRadioLuckyYou,
+		e_legoRadioJazzInterlude,
+		e_legoRadioPianoInterlude1,
+		e_legoRadioPoliceStation,
+		e_legoRadioPianoInterlude2,
+		e_legoRadioCredits,
+
+		e_helicopterBuild,
+		e_padding1,
+		e_duneBuggyBuild,
+		e_padding2,
+		e_jetskiBuild,
+		e_padding3,
+		e_raceCarBuild,
+		e_padding4,
+
+		e_jukeBoxMamaPapaBrickolini,
+		e_jukeBoxBrickByBrick,
+		e_jukeBoxTheBrickster,
+		e_jukeBoxBuildMeABridgeToday,
+		e_jukeBoxBaroqueInBrick,
+		e_jukeBoxMantaRay,
+
+		e_observationDeck,
+		e_elevator,
+		e_pizzaMission,
+	};
 
 private:
 	undefined m_unk0xf8[4]; // 0xf8

--- a/LEGO1/lego/legoomni/src/build/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/build/helicopter.cpp
@@ -3,6 +3,7 @@
 #include "act1state.h"
 #include "act3.h"
 #include "isle.h"
+#include "jukebox.h"
 #include "legoanimationmanager.h"
 #include "legocontrolmanager.h"
 #include "legogamestate.h"
@@ -102,7 +103,7 @@ MxU32 Helicopter::VTable0xcc()
 		FUN_10015820(TRUE, 0);
 		TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, TRUE);
 		SetUnknownDC(4);
-		PlayMusic(9);
+		PlayMusic(JukeBox::e_jail);
 		break;
 	case 1:
 		m_script = *g_act2mainScript;

--- a/LEGO1/lego/legoomni/src/infocenter/elevatorbottom.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/elevatorbottom.cpp
@@ -1,5 +1,6 @@
 #include "elevatorbottom.h"
 
+#include "jukebox.h"
 #include "legocontrolmanager.h"
 #include "legogamestate.h"
 #include "legoinputmanager.h"
@@ -67,7 +68,7 @@ MxLong ElevatorBottom::Notify(MxParam& p_param)
 void ElevatorBottom::VTable0x50()
 {
 	LegoWorld::VTable0x50();
-	PlayMusic(11);
+	PlayMusic(JukeBox::e_informationCenter);
 	FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 }
 

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -1,6 +1,7 @@
 #include "infocenter.h"
 
 #include "infocenterstate.h"
+#include "jukebox.h"
 #include "legocontrolmanager.h"
 #include "legogamestate.h"
 #include "legoinputmanager.h"
@@ -165,7 +166,7 @@ MxLong Infocenter::HandleEndAction(MxParam& p_param)
 		}
 
 		if (!m_unk0x1d4) {
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 			GameState()->FUN_10039780(m_unk0xfc);
 
 			switch (m_unk0xfc) {
@@ -279,7 +280,7 @@ MxLong Infocenter::HandleEndAction(MxParam& p_param)
 			m_currentInfomainScript != 41 && m_currentInfomainScript != 42 && m_currentInfomainScript != 43 &&
 			m_currentInfomainScript != 44) {
 			m_infoManDialogueTimer = 1;
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 		}
 
 		m_infocenterState->SetUnknown0x74(2);
@@ -323,15 +324,15 @@ void Infocenter::VTable0x50()
 			}
 
 			PlayAction(c_letsGetStartedDialogue);
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 			FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 			return;
 		default:
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 			// TODO
 			break;
 		case 8:
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 			PlayAction(c_exitConfirmationDialogue);
 			FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 			return;
@@ -341,7 +342,7 @@ void Infocenter::VTable0x50()
 			}
 
 			PlayAction(c_clickOnInfomanDialogue);
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 			FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 			return;
 		}

--- a/LEGO1/lego/legoomni/src/infocenter/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenterdoor.cpp
@@ -1,5 +1,6 @@
 #include "infocenterdoor.h"
 
+#include "jukebox.h"
 #include "legocontrolmanager.h"
 #include "legogamestate.h"
 #include "legoinputmanager.h"
@@ -55,7 +56,7 @@ MxLong InfocenterDoor::Notify(MxParam& p_param)
 void InfocenterDoor::VTable0x50()
 {
 	LegoWorld::VTable0x50();
-	PlayMusic(11);
+	PlayMusic(JukeBox::e_informationCenter);
 	FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 }
 

--- a/LEGO1/lego/legoomni/src/infocenter/score.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/score.cpp
@@ -2,6 +2,7 @@
 
 #include "ambulancemissionstate.h"
 #include "gifmanager.h"
+#include "jukebox.h"
 #include "legocontrolmanager.h"
 #include "legogamestate.h"
 #include "legoinputmanager.h"
@@ -119,7 +120,7 @@ MxLong Score::FUN_10001510(MxEndActionNotificationParam& p_param)
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
 			break;
 		case 0x1f5:
-			PlayMusic(11);
+			PlayMusic(JukeBox::e_informationCenter);
 			m_state->SetTutorialFlag(FALSE);
 		}
 	}
@@ -145,7 +146,7 @@ void Score::VTable0x50()
 		Start(&action);
 	}
 	else
-		PlayMusic(11);
+		PlayMusic(JukeBox::e_informationCenter);
 
 	FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 }


### PR DESCRIPTION
This PR adds an enum representing all JUKEBOX.SI actions/songs into jukebox.h. I've structured them as follows:

* L.E.G.O. Radio exclusive sounds are prefixed with legoRadio (including duplicates of already existing tracks in the index meant to be played on the radio; probably duplicated to avoid seeking backwards in JUKEBOX.SI during radio playback)
* Songs played from the Jukebox are prefixed with jukeBox.

Additionally, I've updated all calls to PlayMusic to make use of this enum.