### PR TITLE
Implement MxDisplaySurface::VTable0x44

### DIFF
--- a/LEGO1/omni/include/mxdisplaysurface.h
+++ b/LEGO1/omni/include/mxdisplaysurface.h
@@ -80,10 +80,15 @@ public:
 		MxS32 p_top2,
 		MxS32 p_width,
 		MxS32 p_height
-	);                                                                                      // vtable+0x38
-	virtual void GetDC(HDC* p_hdc);                                                         // vtable+0x3c
-	virtual void ReleaseDC(HDC p_hdc);                                                      // vtable+0x40
-	virtual LPDIRECTDRAWSURFACE VTable0x44(MxBitmap*, undefined4*, undefined4, undefined4); // vtable+0x44
+	);                                 // vtable+0x38
+	virtual void GetDC(HDC* p_hdc);    // vtable+0x3c
+	virtual void ReleaseDC(HDC p_hdc); // vtable+0x40
+	virtual LPDIRECTDRAWSURFACE VTable0x44(
+		MxBitmap* p_bitmap,
+		undefined4* p_ret,
+		undefined4 p_doNotWriteToSurface,
+		undefined4 p_transparent
+	); // vtable+0x44
 
 	void ClearScreen();
 	static LPDIRECTDRAWSURFACE FUN_100bc070();

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -694,7 +694,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 				for (int y = heightAbs; y > 0; y--) {
 					for (int x = widthNormal; x > 0; x--) {
 						if (*bitmapSrcPtr) {
-							*surfaceData = m_16bitPal[*bitmapSrcPtr++];
+							*surfaceData = m_16bitPal[*bitmapSrcPtr];
 						}
 						else {
 							*surfaceData = 31775;

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -641,8 +641,8 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 				newPitch -= 2 * p_bitmap->GetBmiWidth();
 
 				if (p_transparent) {
-					for (int y = heightAbs; y > 0; y--) {
-						for (int x = widthNormal; x > 0; x--) {
+					for (MxS32 y = heightAbs; y > 0; y--) {
+						for (MxS32 x = widthNormal; x > 0; x--) {
 							if (*bitmapSrcPtr) {
 								*surfaceData = m_16bitPal[*bitmapSrcPtr];
 							}
@@ -660,7 +660,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 					DDCOLORKEY key;
 					key.dwColorSpaceHighValue = 31775;
 					key.dwColorSpaceLowValue = 31775;
-					surface->SetColorKey(8, &key);
+					surface->SetColorKey(DDCKEY_SRCBLT, &key);
 				}
 				else {
 					for (int y = heightAbs; y > 0; y--) {

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -618,10 +618,14 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 				bitmapSrcPtr += rowSeek;
 				surfaceData = (MxU16*) ((MxU8*) surfaceData + newPitch);
 			}
+
 			surface->Unlock(ddsd.lpSurface);
+
 			if (p_transparent && surface) {
 				DDCOLORKEY key;
-				surface->SetColorKey(8, &key);
+				key.dwColorSpaceHighValue = 0;
+				key.dwColorSpaceLowValue = 0;
+				surface->SetColorKey(DDCKEY_SRCBLT, &key);
 			}
 			break;
 		}

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -599,21 +599,18 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 
 		MxU8* bitmapSrcPtr = p_bitmap->GetStart(0, 0);
 		MxU16* surfaceData = (MxU16*) ddsd.lpSurface;
-		MxU32 widthNormal = p_bitmap->GetBmiWidth();
-		MxU32 heightAbs = p_bitmap->GetBmiHeightAbs();
+		MxLong widthNormal = p_bitmap->GetBmiWidth();
+		MxLong heightAbs = p_bitmap->GetBmiHeightAbs();
 
-		// How many bytes are there for each row of the bitmap?
-		// (i.e. the image stride)
-		// If this is a bottom-up DIB, we will walk it in reverse.
-		// TODO: Same rounding trick as in MxBitmap
+		// TODO: Probably p_bitmap->GetAdjustedStride()
 		MxS32 rowSeek = p_bitmap->GetBmiStride();
 		if (p_bitmap->GetBmiHeader()->biCompression != BI_RGB_TOPDOWN && p_bitmap->GetBmiHeight() >= 0)
 			rowSeek = -rowSeek;
 
-		MxU32 newPitch = ddsd.lPitch;
+		MxLong newPitch = ddsd.lPitch;
 		switch (ddsd.ddpfPixelFormat.dwRGBBitCount) {
 		case 8: {
-			for (heightAbs > 0; heightAbs--;) {
+			for (MxS32 y = heightAbs; y > 0; y--) {
 				memcpy(surfaceData, bitmapSrcPtr, p_bitmap->GetBmiHeight());
 				bitmapSrcPtr += rowSeek;
 				surfaceData = (MxU16*) ((MxU8*) surfaceData + newPitch);
@@ -663,8 +660,8 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 					surface->SetColorKey(DDCKEY_SRCBLT, &key);
 				}
 				else {
-					for (int y = heightAbs; y > 0; y--) {
-						for (int x = widthNormal; x > 0; x--) {
+					for (MxS32 y = heightAbs; y > 0; y--) {
+						for (MxS32 x = widthNormal; x > 0; x--) {
 							*surfaceData++ = m_16bitPal[*bitmapSrcPtr++];
 						}
 


### PR DESCRIPTION
Currently it matches at 53.74%. With this function implemented (and if you remove Enable(FALSE) in MxStillPresenter::ParseExtra), the infocenter background gets drawn:
![image](https://github.com/isledecomp/isle/assets/106913236/5b7e2a7b-85c2-4c0e-86a1-e082c17d831a)