### PR TITLE
Remove unused functions from ISLE.EXE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,9 @@ if (MSVC_FOR_DECOMP)
   # They ensure a recompilation that can be byte/instruction accurate to the original binaries.
   if (ISLE_BUILD_APP)
     target_compile_options(isle PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    target_link_options(isle PRIVATE "/OPT:REF")
   endif()
+
   target_compile_options(lego1 PRIVATE "/MT$<$<CONFIG:Debug>:d>")
 
   set(CMAKE_CXX_FLAGS "/W3 /GX /D \"WIN32\" /D \"_WINDOWS\"")


### PR DESCRIPTION
This reduces the `ISLE.EXE` size closer to the original, by removing unused parts of linked libraries. It was discovered in the Matrix chat by @disinvite and @tahg that `/OPT:REF` needs to be explicitly turned back on when creating a build with debug symbols / PDB.