### PR TITLE
Roadmap tool to compare binary structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,8 +299,8 @@ set_property(TARGET lego1 PROPERTY SUFFIX ".DLL")
 if (ISLE_BUILD_APP)
   add_executable(isle WIN32
     ISLE/res/isle.rc
-    ISLE/isleapp.cpp
     ISLE/define.cpp
+    ISLE/isleapp.cpp
   )
 
   target_compile_definitions(isle PRIVATE ISLE_APP)

--- a/tools/isledecomp/isledecomp/bin.py
+++ b/tools/isledecomp/isledecomp/bin.py
@@ -1,6 +1,6 @@
 import logging
 import struct
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from dataclasses import dataclass
 from collections import namedtuple
 
@@ -364,6 +364,14 @@ class Bin:
         """Convenience function for converting section:offset pairs from cvdump
         into an absolute vaddr."""
         return self.get_section_offset_by_index(section) + offset
+
+    def get_relative_addr(self, addr: int) -> Tuple[int, int]:
+        """Convert an absolute address back into a (section, offset) pair."""
+        for i, section in enumerate(self.sections):
+            if section.contains_vaddr(addr):
+                return (i + 1, addr - section.virtual_address)
+
+        return (0, 0)
 
     def get_raw_addr(self, vaddr: int) -> int:
         """Returns the raw offset in the PE binary for the given virtual address."""

--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -409,6 +409,9 @@ class Compare:
 
     ## Public API
 
+    def get_all(self) -> List[MatchInfo]:
+        return self._db.get_all()
+
     def get_functions(self) -> List[MatchInfo]:
         return self._db.get_matches_by_type(SymbolType.FUNCTION)
 

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -82,6 +82,17 @@ class CompareDb:
 
         return [string for (string,) in cur.fetchall()]
 
+    def get_all(self) -> List[MatchInfo]:
+        cur = self._db.execute(
+            """SELECT compare_type, orig_addr, recomp_addr, name, size
+            FROM `symbols`
+            ORDER BY orig_addr NULLS LAST
+            """,
+        )
+        cur.row_factory = matchinfo_factory
+
+        return cur.fetchall()
+
     def get_matches(self) -> Optional[MatchInfo]:
         cur = self._db.execute(
             """SELECT compare_type, orig_addr, recomp_addr, name, size

--- a/tools/isledecomp/isledecomp/cvdump/runner.py
+++ b/tools/isledecomp/isledecomp/cvdump/runner.py
@@ -13,6 +13,7 @@ class DumpOpt(Enum):
     GLOBALS = 2
     PUBLICS = 3
     SECTION_CONTRIB = 4
+    MODULES = 5
 
 
 cvdump_opt_map = {
@@ -21,6 +22,7 @@ cvdump_opt_map = {
     DumpOpt.GLOBALS: "-g",
     DumpOpt.PUBLICS: "-p",
     DumpOpt.SECTION_CONTRIB: "-seccontrib",
+    DumpOpt.MODULES: "-m",
 }
 
 
@@ -47,6 +49,10 @@ class Cvdump:
 
     def section_contributions(self):
         self._options.add(DumpOpt.SECTION_CONTRIB)
+        return self
+
+    def modules(self):
+        self._options.add(DumpOpt.MODULES)
         return self
 
     def cmd_line(self) -> List[str]:

--- a/tools/roadmap/roadmap.py
+++ b/tools/roadmap/roadmap.py
@@ -1,0 +1,265 @@
+"""For all addresses matched by code annotations or recomp pdb,
+report how "far off" the recomp symbol is from its proper place
+in the original binary."""
+
+import os
+import argparse
+import logging
+from typing import List, Optional
+from collections import namedtuple
+from isledecomp import Bin as IsleBin
+from isledecomp.cvdump import Cvdump
+from isledecomp.compare import Compare as IsleCompare
+from isledecomp.types import SymbolType
+
+# Ignore all compare-db messages.
+logging.getLogger("isledecomp.compare").addHandler(logging.NullHandler())
+
+
+def or_blank(value) -> str:
+    """Helper for dealing with potential None values in text output."""
+    return "" if value is None else str(value)
+
+
+class ModuleMap:
+    """Load a subset of sections from the pdb to allow you to look up the
+    module number based on the recomp address."""
+
+    def __init__(self, pdb, binfile) -> None:
+        cvdump = Cvdump(pdb).section_contributions().modules().run()
+        self.module_lookup = {m.id: (m.lib, m.obj) for m in cvdump.modules}
+        self.section_contrib = [
+            (
+                binfile.get_abs_addr(sizeref.section, sizeref.offset),
+                sizeref.size,
+                sizeref.module,
+            )
+            for sizeref in cvdump.sizerefs
+            if binfile.is_valid_section(sizeref.section)
+        ]
+
+    def get_module(self, addr: int) -> Optional[str]:
+        for start, size, module_id in self.section_contrib:
+            if start <= addr < start + size:
+                if (module := self.module_lookup.get(module_id)) is not None:
+                    return module
+
+        return None
+
+
+def print_sections(sections):
+    print("    name |    start |   v.size | raw size")
+    print("---------|----------|----------|----------")
+    for sect in sections:
+        name = sect.name.decode("ascii").rstrip("\x00")
+        print(
+            f"{name:>8} | {sect.virtual_address:8x} | {sect.virtual_size:8x} | {sect.size_of_raw_data:8x}"
+        )
+    print()
+
+
+def match_type_abbreviation(mtype: Optional[SymbolType]) -> str:
+    """Return abbreviation of the given SymbolType name"""
+    if mtype is None:
+        return ""
+
+    return mtype.name.lower()[:3]
+
+
+RoadmapRow = namedtuple(
+    "RoadmapRow",
+    [
+        "orig_sect_ofs",
+        "recomp_sect_ofs",
+        "orig_addr",
+        "recomp_addr",
+        "displacement",
+        "sym_type",
+        "size",
+        "name",
+        "module",
+    ],
+)
+
+
+def print_text_report(results: List[RoadmapRow]):
+    """Print the result with original and recomp addresses."""
+    for row in results:
+        print(
+            "  ".join(
+                [
+                    f"{or_blank(row.orig_sect_ofs):14}",
+                    f"{or_blank(row.recomp_sect_ofs):14}",
+                    f"{or_blank(row.displacement):>8}",
+                    f"{row.sym_type:3}",
+                    f"{or_blank(row.size):6}",
+                    or_blank(row.name),
+                ]
+            )
+        )
+
+
+def print_diff_report(results: List[RoadmapRow]):
+    """Print only entries where we have the recomp address.
+    This is intended for generating a file to diff against.
+    The recomp addresses are always changing so we hide those."""
+    for row in results:
+        if row.orig_addr is None or row.recomp_addr is None:
+            continue
+
+        print(
+            "  ".join(
+                [
+                    f"{or_blank(row.orig_sect_ofs):14}",
+                    f"{or_blank(row.displacement):>8}",
+                    f"{row.sym_type:3}",
+                    f"{or_blank(row.size):6}",
+                    or_blank(row.name),
+                ]
+            )
+        )
+
+
+def export_to_csv(csv_file: str, results: List[RoadmapRow]):
+    with open(csv_file, "w+", encoding="utf-8") as f:
+        f.write(
+            "orig_sect_ofs,recomp_sect_ofs,orig_addr,recomp_addr,displacement,row_type,size,name,module\n"
+        )
+        for row in results:
+            f.write(",".join(map(or_blank, row)))
+            f.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Show all addresses from original and recomp."
+    )
+    parser.add_argument(
+        "original", metavar="original-binary", help="The original binary"
+    )
+    parser.add_argument(
+        "recompiled", metavar="recompiled-binary", help="The recompiled binary"
+    )
+    parser.add_argument(
+        "pdb", metavar="recompiled-pdb", help="The PDB of the recompiled binary"
+    )
+    parser.add_argument(
+        "decomp_dir", metavar="decomp-dir", help="The decompiled source tree"
+    )
+    parser.add_argument("--csv", metavar="<file>", help="If set, export to CSV")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Show recomp addresses in output"
+    )
+
+    (args, _) = parser.parse_known_args()
+
+    if not os.path.isfile(args.original):
+        parser.error(f"Original binary {args.original} does not exist")
+
+    if not os.path.isfile(args.recompiled):
+        parser.error(f"Recompiled binary {args.recompiled} does not exist")
+
+    if not os.path.isfile(args.pdb):
+        parser.error(f"Symbols PDB {args.pdb} does not exist")
+
+    if not os.path.isdir(args.decomp_dir):
+        parser.error(f"Source directory {args.decomp_dir} does not exist")
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    with IsleBin(args.original, find_str=True) as orig_bin, IsleBin(
+        args.recompiled
+    ) as recomp_bin:
+        engine = IsleCompare(orig_bin, recomp_bin, args.pdb, args.decomp_dir)
+
+        module_map = ModuleMap(args.pdb, recomp_bin)
+
+        def is_same_section(orig: int, recomp: int) -> bool:
+            """Compare the section name instead of the index.
+            LEGO1.dll adds extra sections for some reason. (Smacker library?)"""
+
+            try:
+                orig_name = orig_bin.sections[orig - 1].name
+                recomp_name = recomp_bin.sections[recomp - 1].name
+                return orig_name == recomp_name
+            except IndexError:
+                return False
+
+        def to_roadmap_row(match):
+            orig_sect = None
+            orig_ofs = None
+            orig_sect_ofs = None
+            recomp_sect = None
+            recomp_ofs = None
+            recomp_sect_ofs = None
+            orig_addr = None
+            recomp_addr = None
+            displacement = None
+            module_name = None
+
+            if match.recomp_addr is not None:
+                if (module_ref := module_map.get_module(match.recomp_addr)) is not None:
+                    (_, module_name) = module_ref
+
+            row_type = match_type_abbreviation(match.compare_type)
+            name = (
+                repr(match.name)
+                if match.compare_type == SymbolType.STRING
+                else match.name
+            )
+
+            if match.orig_addr is not None:
+                orig_addr = match.orig_addr
+                (orig_sect, orig_ofs) = orig_bin.get_relative_addr(match.orig_addr)
+                orig_sect_ofs = f"{orig_sect:04}:{orig_ofs:08x}"
+
+            if match.recomp_addr is not None:
+                recomp_addr = match.recomp_addr
+                (recomp_sect, recomp_ofs) = recomp_bin.get_relative_addr(
+                    match.recomp_addr
+                )
+                recomp_sect_ofs = f"{recomp_sect:04}:{recomp_ofs:08x}"
+
+            if (
+                orig_sect is not None
+                and recomp_sect is not None
+                and is_same_section(orig_sect, recomp_sect)
+            ):
+                displacement = recomp_ofs - orig_ofs
+
+            return RoadmapRow(
+                orig_sect_ofs,
+                recomp_sect_ofs,
+                orig_addr,
+                recomp_addr,
+                displacement,
+                row_type,
+                match.size,
+                name,
+                module_name,
+            )
+
+        results = list(map(to_roadmap_row, engine.get_all()))
+
+        if args.csv is None:
+            if args.verbose:
+                print("ORIG sections:")
+                print_sections(orig_bin.sections)
+
+                print("RECOMP sections:")
+                print_sections(recomp_bin.sections)
+
+                print_text_report(results)
+            else:
+                print_diff_report(results)
+
+        if args.csv is not None:
+            export_to_csv(args.csv, results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Our `reccmp` script provides the micro-level comparison of each symbol between original and recomp. We would also like to have the macro perspective to know:

1. What things are in each file?
2. Where are they?
3. How far off are those items (in the recomp) from where they should be?

To do that, I am introducing the `roadmap` script. This takes the same (basic) arguments as `reccmp` but only looks at the position of the elements rather than doing a comparison.

The default text output will show the original address (in `section:offset` format) of each item, followed by the number of bytes ahead or behind this same item can be found in the recomp. This displacement value is computed based on the section where the item lives, so we can still make a useful comparison with `LEGO1.dll` where the files are not yet of comparable size.

After that, we have a description of what symbol type this is (if it is known), the size in bytes (calculated from all available information) and the name (if we have one).

For example, from `ISLE`:
```
0001:000074e0        -16  fun  189     __except_handler3
0001:000075c0        -16  fun  103     _sprintf
0001:00007630        -16  fun  31      _abort
0001:00008110        -16  fun  96      __mtinit
0001:00008190        -16  fun  111     __getptd
0001:0000d5d0        -16  fun  6       _RtlUnwind@16
0002:00000018         64  vta  4       MxParam
0002:000000a0         64  dat  18      _szLibName
0002:00000140         12  str  15      'runtime error '
0002:00000154         12  str  14      'TLOSS error\r\n'
0002:00000164         12  str  13      'SING error\r\n'
0002:00000174         12  str  15      'DOMAIN error\r\n'
```

Adding `--verbose` will also show the recomp address, along with some section information before showing the results. That looks like this:

```
0001:00000000   0001:00000000          0  fun  411     IsleApp::IsleApp
0001:000001a0   0001:000001a0          0  fun  180     IsleApp::~IsleApp
0001:00000260   0001:00000260          0  fun  333     IsleApp::Close
0001:000003b0   0001:000003b0          0  fun  252     IsleApp::SetupLegoOmni
0001:000004b0   0001:000004b0          0  fun  124     MxOmniCreateParam::~MxOmniCreateParam
0001:00000530   0001:00000530          0  fun  7       MxParam::~MxParam
0001:00000540   0001:00000540          0  fun  31      MxParam::`scalar deleting destructor'
```

Verbose output also shows all the items found only in the recomp. These are either items that need an annotation, or (in the `LEGO1.dll` case) they are extraneous symbols that would be removed by adding `/OPT:REF` (see #476)

My thought with having two different text output modes is this: the recomp addresses are always changing, so if we wanted to have a CI action that compares the output for each pull request, it would be better to omit the recomp address to get a reasonable diff.

You can also add `--csv` to output the results as (you guessed it) a CSV. Some initial testing with Google Sheets showed that the section:offset strings can be misinterpreted as a time value. I would expect the same from Excel, but I don't have that here to test. If anyone finds this output useful (@tahg maybe?) then let me know if we should change this output to make the spreadsheet tools play nicely.

The CSV includes the module name for the given item. This would be too much to display on the terminal output, so it's CSV only for now. This should help show where things need to be rearranged in the CMakeLists.txt file. For example, I've found that swapping the order of `isleapp.cpp` and `define.cpp` puts the global variables of `ISLE` in a better spot, so I've added that with this PR.

HTML output coming in a later update.
