### PR TITLE
LegoWorld STL members

### DIFF
--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -3,6 +3,8 @@
 
 #include "mxvideopresenter.h"
 
+class AutoROI;
+
 // VTABLE: LEGO1 0x100d4e50
 // SIZE 0x6c (discovered through inline constructor at 0x10009ae6)
 class LegoModelPresenter : public MxVideoPresenter {
@@ -33,7 +35,7 @@ protected:
 	void Destroy(MxBool p_fromDestructor);
 
 private:
-	undefined4 m_unk0x64; // 0x64
+	AutoROI* m_unk0x64;   // 0x64
 	MxBool m_addedToView; // 0x68
 };
 

--- a/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
+++ b/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
@@ -48,6 +48,9 @@ public:
 // TEMPLATE: LEGO1 0x1001d3c0
 // MxPtrList<LegoPathController>::Destroy
 
+// TEMPLATE: LEGO1 0x1001d440
+// MxPtrList<LegoPathController>::~MxPtrList<LegoPathController>
+
 // SYNTHETIC: LEGO1 0x1001d490
 // MxCollection<LegoPathController *>::`scalar deleting destructor'
 
@@ -56,5 +59,8 @@ public:
 
 // SYNTHETIC: LEGO1 0x1001d5b0
 // MxPtrList<LegoPathController>::`scalar deleting destructor'
+
+// SYNTHETIC: LEGO1 0x1001d620
+// LegoPathControllerList::~LegoPathControllerList
 
 #endif // LEGOPATHCONTROLLERLIST_H

--- a/LEGO1/lego/legoomni/include/legounksavedatawriter.h
+++ b/LEGO1/lego/legoomni/include/legounksavedatawriter.h
@@ -4,6 +4,7 @@
 #include "decomp.h"
 #include "mxtypes.h"
 
+class AutoROI;
 class LegoROI;
 class LegoStream;
 
@@ -35,6 +36,7 @@ struct LegoSaveDataEntry3 {
 class LegoUnkSaveDataWriter {
 public:
 	MxResult WriteSaveData3(LegoStream* p_stream);
+	AutoROI* FUN_10083500(undefined4, undefined4);
 	void FUN_10083db0(LegoROI* p_roi);
 };
 

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -12,6 +12,12 @@
 class IslePathActor;
 class LegoPathBoundary;
 
+struct PresenterSetCompare {
+	int operator()(MxPresenter* const& p_a, MxPresenter* const& p_b) const { return p_a > p_b; }
+};
+
+typedef set<MxPresenter*, PresenterSetCompare> MxPresenterSet;
+
 // VTABLE: LEGO1 0x100d6280
 // SIZE 0xf8
 class LegoWorld : public LegoEntity {
@@ -71,15 +77,49 @@ protected:
 	LegoCameraController* m_cameraController; // 0x98
 	LegoEntityList* m_entityList;             // 0x9c
 	MxCoreList* m_coreList;                   // 0xa0
-	undefined m_unk0xa4[0x14];                // 0xa4
+	undefined m_unk0xa4;                      // 0xa4
+	MxPresenterSet m_set0xa8;                 // 0xa8
 	MxPresenterList m_list0xb8;               // 0xb8
-	undefined m_unk0xd0[0x1c];                // 0xd0
+	MxPresenterSet m_set0xd0;                 // 0xd0
+	list<AutoROI*> m_list0xe0;                // 0xe0
 	undefined4 m_unk0xec;                     // 0xec
 	undefined4 m_unk0xf0;                     // 0xf0
 	MxS16 m_unk0xf4;                          // 0xf4
 	MxBool m_worldStarted;                    // 0xf6
 	undefined m_unk0xf7;                      // 0xf7
 };
+
+// clang-format off
+// TEMPLATE: LEGO1 0x1001d780
+// _Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >::~_Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >
+
+// TEMPLATE: LEGO1 0x1001d850
+// _Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >::iterator::_Inc
+
+// TEMPLATE: LEGO1 0x1001d890
+// _Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >::erase
+
+// TEMPLATE: LEGO1 0x1001dcf0
+// _Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >::_Erase
+
+// TEMPLATE: LEGO1 0x1001dd30
+// _Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >::_Init
+
+// TEMPLATE: LEGO1 0x1001ddf0
+// list<AutoROI *,allocator<AutoROI *> >::~list<AutoROI *,allocator<AutoROI *> >
+
+// TEMPLATE: LEGO1 0x1001df50
+// List<AutoROI *>::~List<AutoROI *>
+
+// TEMPLATE: LEGO1 0x1001de60
+// list<AutoROI *,allocator<AutoROI *> >::_Buynode
+
+// TEMPLATE: LEGO1 0x1001de90
+// set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::~set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >
+
+// TEMPLATE: LEGO1 0x1001df00
+// Set<MxPresenter *,PresenterSetCompare>::~Set<MxPresenter *,PresenterSetCompare>
+// clang-format om
 
 // SYNTHETIC: LEGO1 0x1001eed0
 // MxPresenterListCursor::`scalar deleting destructor'
@@ -101,5 +141,8 @@ protected:
 
 // TEMPLATE: LEGO1 0x10020760
 // MxListCursor<MxPresenter *>::MxListCursor<MxPresenter *>
+
+// GLOBAL: LEGO1 0x100f11a0
+// _Tree<MxPresenter *,MxPresenter *,set<MxPresenter *,PresenterSetCompare,allocator<MxPresenter *> >::_Kfn,PresenterSetCompare,allocator<MxPresenter *> >::_Nil
 
 #endif // LEGOWORLD_H

--- a/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
@@ -1,8 +1,8 @@
-
 #include "legounksavedatawriter.h"
 
 #include "legogamestate.h"
 #include "legostream.h"
+#include "roi/legoroi.h"
 
 DECOMP_SIZE_ASSERT(LegoSaveDataEntry3, 0x108);
 
@@ -46,6 +46,14 @@ MxResult LegoUnkSaveDataWriter::WriteSaveData3(LegoStream* p_stream)
 		}
 	}
 	return result;
+}
+
+// STUB: LEGO1 0x10083500
+AutoROI* LegoUnkSaveDataWriter::FUN_10083500(undefined4, undefined4)
+{
+	// TODO
+	// involves an STL map with a _Nil node at 0x100fc508
+	return NULL;
 }
 
 // STUB: LEGO1 0x10083db0

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -17,12 +17,17 @@ DECOMP_SIZE_ASSERT(LegoEntityListCursor, 0x10)
 DECOMP_SIZE_ASSERT(MxCoreList, 0x18)
 DECOMP_SIZE_ASSERT(MxCoreListCursor, 0x10)
 
-// STUB: LEGO1 0x1001ca40
+// FUNCTION: LEGO1 0x1001ca40
 LegoWorld::LegoWorld() : m_list0x68(TRUE)
 {
-	// TODO
-	m_worldStarted = FALSE;
 	m_unk0xf4 = 4;
+	m_cameraController = NULL;
+	m_entityList = NULL;
+	m_coreList = NULL;
+	m_unk0xa4 = 0; // MxBool?
+	m_unk0xf0 = 0;
+	m_worldStarted = FALSE;
+
 	NotificationManager()->Register(this);
 }
 

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -11,6 +11,9 @@ class LegoEntity;
 // Note: There is an extra class between LegoROI and ViewROI,
 // maybe called "AutoROI". VTABLE 0x100dbe38
 
+// TODO: Set as superclass of LegoROI
+class AutoROI : public ViewROI {};
+
 // VTABLE: LEGO1 0x100dbea8
 // SIZE 0x10c
 class LegoROI : public ViewROI {

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -15,6 +15,9 @@ public:
 		m_elements[2] = p_z;
 	}
 
+	// SYNTHETIC: LEGO1 0x1001d170
+	// Mx3DPointFloat::Mx3DPointFloat
+
 	// FUNCTION: LEGO1 0x10003c10
 	virtual void operator=(const Vector3& p_impl) { EqualsImpl(p_impl.m_data); } // vtable+0x88
 

--- a/LEGO1/omni/include/mxpresenterlist.h
+++ b/LEGO1/omni/include/mxpresenterlist.h
@@ -68,4 +68,7 @@ public:
 // SYNTHETIC: LEGO1 0x1001d090
 // MxPtrList<MxPresenter>::`scalar deleting destructor'
 
+// SYNTHETIC: LEGO1 0x1001d100
+// MxPresenterList::~MxPresenterList
+
 #endif // MXPRESENTERLIST_H


### PR DESCRIPTION
`LegoWorld::LegoWorld` is now at 100% match with the addition of 3 STL members and filling in some annotations.

The two `<set>` members appear to contain pointers to `MxPresenter`. The key comparison is just looking at the pointer values, but I suppose if the goal is to have a unique list of presenters then that's valid.

The `<list>` at +0xe0 contains pointers to `AutoROI`, confirmed via the debugger. The only vtable I saw for the list elements matched what we have for `AutoROI`. It could be a generic `ViewROI*` list, too. I didn't want to insert the dependency in between `LegoROI` and `ViewROI` right now so it's just mocked up.

The `AutoROI` object comes from `LegoModelPresenter`. The function at `0x1007ff70` adds to the `+0xe0` list near the instruction `0x10080031`, where we take the `AutoROI` from `LegoModelPresenter +0x64`.

`0x100801b0` (aka `LegoModelPresenter::ParseExtra`) removes from the list by decrementing `LegoWorld +0xe8`. That function is also responsible for setting `LegoModelPresenter +0x64` from a value returned by `LegoUnkSaveDataWriter::FUN_10083500`.

I added this annotation for `Mx3DPointFloat`:

```
// SYNTHETIC: LEGO1 0x1001d170
// Mx3DPointFloat::Mx3DPointFloat
```

Is that truly a synthetic constructor or just MSVC not taking the `inline` suggestion for the constructor we do have?
