### PR TITLE
Implement/match LegoWorld::FUN_10021790

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install python libraries
       shell: bash
       run: |
-        pip install black pylint pytest -r tools/requirements.txt
+        pip install black==23 pylint==3 pytest==7 -r tools/requirements.txt
 
     - name: Run pylint and black
       shell: bash

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install python libraries
       shell: bash
       run: |
-        pip install black==23 pylint==3 pytest==7 -r tools/requirements.txt
+        pip install black==23.* pylint==3.* pytest==7.* -r tools/requirements.txt
 
     - name: Run pylint and black
       shell: bash

--- a/LEGO1/lego/legoomni/include/legoentitylist.h
+++ b/LEGO1/lego/legoomni/include/legoentitylist.h
@@ -86,7 +86,7 @@ public:
 // FUNCTION: LEGO1 0x1001f2b0
 // MxListCursor<LegoEntity *>::~MxListCursor<LegoEntity *>
 
-// FUNCTION: LEGO1 0x1001edc6
+// FUNCTION: LEGO1 0x1001f300
 // LegoEntityListCursor::~LegoEntityListCursor
 
 // TEMPLATE: LEGO1 0x100207d0

--- a/LEGO1/lego/legoomni/include/legoentitylist.h
+++ b/LEGO1/lego/legoomni/include/legoentitylist.h
@@ -89,4 +89,7 @@ public:
 // FUNCTION: LEGO1 0x1001edc6
 // LegoEntityListCursor::~LegoEntityListCursor
 
+// TEMPLATE: LEGO1 0x100207d0
+// MxListCursor<LegoEntity *>::MxListCursor<LegoEntity *>
+
 #endif // LEGOENTITYLIST_H

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -66,7 +66,7 @@ public:
 	void FUN_10073430();
 	MxS32 GetCurrPathInfo(LegoPathBoundary** p_path, MxS32& p_value);
 	MxPresenter* FindPresenter(const char* p_presenter, const char* p_name);
-	MxCore* FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId);
+	MxCore* FUN_10021790(const MxAtomId& p_atom, MxS32 p_entityId);
 
 	// SYNTHETIC: LEGO1 0x1001dee0
 	// LegoWorld::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -66,7 +66,7 @@ public:
 	void FUN_10073430();
 	MxS32 GetCurrPathInfo(LegoPathBoundary** p_path, MxS32& p_value);
 	MxPresenter* FindPresenter(const char* p_presenter, const char* p_name);
-	MxPresenter* FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId);
+	MxCore* FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId);
 
 	// SYNTHETIC: LEGO1 0x1001dee0
 	// LegoWorld::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -169,7 +169,7 @@ MxPresenter* LegoWorld::FindPresenter(const char* p_presenter, const char* p_nam
 }
 
 // FUNCTION: LEGO1 0x10021790
-MxCore* LegoWorld::FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId)
+MxCore* LegoWorld::FUN_10021790(const MxAtomId& p_atom, MxS32 p_entityId)
 {
 	LegoEntityListCursor entityCursor(m_entityList);
 	LegoEntity* entity;

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -203,8 +203,9 @@ MxCore* LegoWorld::FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId)
 
 		if (core->IsA("MxPresenter")) {
 			MxPresenter* presenter = (MxPresenter*) *it;
+			MxDSAction* action = presenter->GetAction();
 
-			if (presenter->GetAction()->GetAtomId() == p_atom && presenter->GetAction()->GetObjectId() == p_entityId)
+			if (action->GetAtomId() == p_atom && action->GetObjectId() == p_entityId)
 				return *it;
 		}
 	}

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -183,24 +183,29 @@ MxCore* LegoWorld::FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId)
 	MxPresenter* presenter;
 
 	while (presenterCursor0xb8.Next(presenter)) {
-		if (presenter->GetAction()->GetAtomId() == p_atom && presenter->GetAction()->GetObjectId() == p_entityId)
+		MxDSAction* action = presenter->GetAction();
+
+		if (action->GetAtomId() == p_atom && action->GetObjectId() == p_entityId)
 			return presenter;
 	}
 
 	MxPresenterListCursor presenterCursor0x80(&m_list0x80);
 
 	while (presenterCursor0x80.Next(presenter)) {
-		if (presenter->GetAction() && presenter->GetAction()->GetAtomId() == p_atom &&
-			presenter->GetAction()->GetObjectId() == p_entityId)
+		MxDSAction* action = presenter->GetAction();
+
+		if (action && action->GetAtomId() == p_atom && action->GetObjectId() == p_entityId)
 			return presenter;
 	}
 
 	for (MxPresenterSet::iterator it = m_set0xa8.begin(); it != m_set0xa8.end(); it++) {
 		MxCore* core = *it;
+
 		if (core->IsA("MxPresenter")) {
-			presenter = (MxPresenter*) *it;
+			MxPresenter* presenter = (MxPresenter*) *it;
+
 			if (presenter->GetAction()->GetAtomId() == p_atom && presenter->GetAction()->GetObjectId() == p_entityId)
-				return presenter;
+				return *it;
 		}
 	}
 

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -168,9 +168,42 @@ MxPresenter* LegoWorld::FindPresenter(const char* p_presenter, const char* p_nam
 	return NULL;
 }
 
-// STUB: LEGO1 0x10021790
-MxPresenter* LegoWorld::FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId)
+// FUNCTION: LEGO1 0x10021790
+MxCore* LegoWorld::FUN_10021790(MxAtomId& p_atom, MxS32 p_entityId)
 {
+	LegoEntityListCursor entityCursor(m_entityList);
+	LegoEntity* entity;
+
+	while (entityCursor.Next(entity)) {
+		if (entity->GetAtom() == p_atom && entity->GetEntityId() == p_entityId)
+			return entity;
+	}
+
+	MxPresenterListCursor presenterCursor0xb8(&m_list0xb8);
+	MxPresenter* presenter;
+
+	while (presenterCursor0xb8.Next(presenter)) {
+		if (presenter->GetAction()->GetAtomId() == p_atom && presenter->GetAction()->GetObjectId() == p_entityId)
+			return presenter;
+	}
+
+	MxPresenterListCursor presenterCursor0x80(&m_list0x80);
+
+	while (presenterCursor0x80.Next(presenter)) {
+		if (presenter->GetAction() && presenter->GetAction()->GetAtomId() == p_atom &&
+			presenter->GetAction()->GetObjectId() == p_entityId)
+			return presenter;
+	}
+
+	for (MxPresenterSet::iterator it = m_set0xa8.begin(); it != m_set0xa8.end(); it++) {
+		MxCore* core = *it;
+		if (core->IsA("MxPresenter")) {
+			presenter = (MxPresenter*) *it;
+			if (presenter->GetAction()->GetAtomId() == p_atom && presenter->GetAction()->GetObjectId() == p_entityId)
+				return presenter;
+		}
+	}
+
 	return NULL;
 }
 

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -365,22 +365,22 @@ void Infocenter::InitializeBitmaps()
 {
 	m_radio.Initialize(TRUE);
 
-	FUN_10021790(m_atom, c_leftArrowCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_rightArrowCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_infoCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_boatCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_raceCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_pizzaCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_gasCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_medCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_copCtl)->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_leftArrowCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_rightArrowCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_infoCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_boatCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_raceCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_pizzaCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_gasCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_medCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_copCtl))->Enable(TRUE);
 
-	FUN_10021790(m_atom, c_mamaCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_papaCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_pepperCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_nickCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_lauraCtl)->Enable(TRUE);
-	FUN_10021790(m_atom, c_radioCtl)->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_mamaCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_papaCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_pepperCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_nickCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_lauraCtl))->Enable(TRUE);
+	((MxPresenter*) FUN_10021790(m_atom, c_radioCtl))->Enable(TRUE);
 
 	m_mapAreas[0].m_presenter = (MxStillPresenter*) FindPresenter("MxStillPresenter", "Info_A_Bitmap");
 	m_mapAreas[0].m_unk0x08 = 391;


### PR DESCRIPTION
100% match.

The `m_set0xa8` container currently has `MxPresenter*` as its element type, which seems odd because this function has an explicit test if an element of it is a `MxPresenter`, which wouldn't be necessary if this container really had this type in it, so I'm assuming that it probably contains `MxCore*` since that's the only parent class left. We can leave it as-is for now though until we learn what its actual purpose is.