### PR TITLE
parser: Identify namespaces

### DIFF
--- a/tools/isledecomp/isledecomp/cvdump/demangler.py
+++ b/tools/isledecomp/isledecomp/cvdump/demangler.py
@@ -68,4 +68,9 @@ def demangle_vtable(symbol: str) -> str:
 
         return f"{class_name}<{generic}>"
 
+    # If we have two classes listed, it is a namespace hierarchy.
+    # @@6B@ is a common generic suffix for these vtable symbols.
+    if t[1] != "" and t[1] != "6B":
+        return t[1] + "::" + t[0]
+
     return t[0]

--- a/tools/isledecomp/tests/test_curly.py
+++ b/tools/isledecomp/tests/test_curly.py
@@ -1,0 +1,73 @@
+# nyuk nyuk nyuk
+import pytest
+from isledecomp.parser.parser import CurlyManager
+from isledecomp.parser.util import sanitize_code_line
+
+
+@pytest.fixture(name="curly")
+def fixture_curly():
+    return CurlyManager()
+
+
+def test_simple(curly):
+    curly.read_line("namespace Test {")
+    assert curly.get_prefix() == "Test"
+    curly.read_line("}")
+    assert curly.get_prefix() == ""
+
+
+def test_oneliner(curly):
+    """Should not go down into a scope for a class forward reference"""
+    curly.read_line("class LegoEntity;")
+    assert curly.get_prefix() == ""
+    # Now make sure that we still would not consider that class name
+    # even after reading the opening curly brace
+    curly.read_line("if (true) {")
+    assert curly.get_prefix() == ""
+
+
+def test_ignore_comments(curly):
+    curly.read_line("namespace Test {")
+    curly.read_line("// }")
+    assert curly.get_prefix() == "Test"
+
+
+@pytest.mark.xfail(reason="todo: need a real lexer")
+def test_ignore_multiline_comments(curly):
+    curly.read_line("namespace Test {")
+    curly.read_line("/*")
+    curly.read_line("}")
+    curly.read_line("*/")
+    assert curly.get_prefix() == "Test"
+    curly.read_line("}")
+    assert curly.get_prefix() == ""
+
+
+def test_nested(curly):
+    curly.read_line("namespace Test {")
+    curly.read_line("namespace Foo {")
+    assert curly.get_prefix() == "Test::Foo"
+    curly.read_line("}")
+    assert curly.get_prefix() == "Test"
+
+
+sanitize_cases = [
+    ("", ""),
+    ("   ", ""),
+    ("{", "{"),
+    ("// comments {", ""),
+    ("{ // why comment here", "{"),
+    ("/* comments */ {", "{"),
+    ('"curly in a string {"', '""'),
+    ('if (!strcmp("hello { there }", g_test)) {', 'if (!strcmp("", g_test)) {'),
+    ("'{'", "''"),
+    ("weird_function('\"', hello, '\"')", "weird_function('', hello, '')"),
+]
+
+
+@pytest.mark.parametrize("start, end", sanitize_cases)
+def test_sanitize(start: str, end: str):
+    """Make sure that we can remove curly braces in places where they should
+    not be considered as part of the semantic structure of the file.
+    i.e. inside strings or chars, and inside comments"""
+    assert sanitize_code_line(start) == end

--- a/tools/isledecomp/tests/test_demangler.py
+++ b/tools/isledecomp/tests/test_demangler.py
@@ -48,6 +48,7 @@ vtable_cases = [
     ("??_7LegoCarBuildAnimPresenter@@6B@", "LegoCarBuildAnimPresenter"),
     ("??_7?$MxCollection@PAVLegoWorld@@@@6B@", "MxCollection<LegoWorld *>"),
     ("??_7?$MxPtrList@VLegoPathController@@@@6B@", "MxPtrList<LegoPathController>"),
+    ("??_7Renderer@Tgl@@6B@", "Tgl::Renderer"),
 ]
 
 


### PR DESCRIPTION
This enhances our parser to identify a namespace. This can come from the actual keyword `namespace` or from a class or struct. This directly affects our parsing in two ways:

1. If an actual `namespace` is used, any global variables or any class vtables should include it. In the current code base, we have the `Tgl` namespace.
2. A static variable under a class takes on the class name as its namespace. For example, `MxOmni::g_instance`.

For those static variables, we can place the `// GLOBAL` marker inside the class above the declaration and this will work. In all cases where this would be useful, we already have the annotation above the fully qualified variable reference where its value is assigned. We had a bug with reading the full names, but this is now fixed. Match percentage should increase very slightly.

The aforementioned classes under `Tgl` _had_ been matching on their vtables because of another bug with demangling the symbol for the vtable. This is now fixed, so we will use the correct names.

This new feature comes courtesy of more wonky regular expressions that allow us to count the curly brackets and have a rough idea of whether we are inside of a namespace. The _better_ solution would be to use `libclang` or a similar library that is actually designed for parsing C++.

I spent some time checking to see whether we could interface with `libclang` directly, but I didn't like the performance I was getting. Reading the decomp annotations is part of `reccmp` so it's something people need to use frequently. Adding (at least) a 10 second overhead to that isn't really desirable. I'm speculating here, but I think the main performance problems are:

1. Clang needs to build the AST for whatever file it's looking at, which means it needs to pull in all required include files, including the MSVC ones that the parser doesn't need to see. Having that level of detail is certainly helpful, but if we could somehow access just the lexer/tokenizer that Clang is using, this would be enough to more confidently read the files and get what _we_ need from them.
2. It's not clear whether Clang can be configured to work with the standard library from MSVC 4.2. There are some compatibility options but each new switch seemed to just add more parsing warnings or errors. I think the processing time only increases when Clang finds something it doesn't expect, because it's pulling in even more information to try and resolve the problem.
3. I'm sure the Python to C interface adds overhead. The command line `clang.exe` seems faster to get the same result.

If we figure this out down the road, we have a battery of unit tests to describe the expected parsing behavior. I would imagine that `test_parser_statechange.py` will go away, though. We will still need some kind of state machine for reading the tokens from `libclang`, but there would no longer be a way to partially read a file, so no reason to expose the state outside the parser.