### PR TITLE
Implement/match MxStillPresenter::Clone

### DIFF
--- a/LEGO1/lego/legoomni/src/video/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legometerpresenter.cpp
@@ -41,7 +41,7 @@ LegoMeterPresenter::LegoMeterPresenter()
 	m_unk0x6c = 0;
 	m_unk0x84 = 0;
 	m_type = 1;
-	m_flags &= ~c_bit2;
+	SetBit1(FALSE);
 }
 
 // FUNCTION: LEGO1 0x10043780

--- a/LEGO1/omni/include/mxdisplaysurface.h
+++ b/LEGO1/omni/include/mxdisplaysurface.h
@@ -92,6 +92,7 @@ public:
 
 	void ClearScreen();
 	static LPDIRECTDRAWSURFACE CreateCursorSurface();
+	static LPDIRECTDRAWSURFACE FUN_100bbfb0(LPDIRECTDRAWSURFACE p_und);
 
 	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return this->m_ddSurface1; }
 	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }

--- a/LEGO1/omni/include/mxstillpresenter.h
+++ b/LEGO1/omni/include/mxstillpresenter.h
@@ -9,6 +9,7 @@
 class MxStillPresenter : public MxVideoPresenter {
 public:
 	MxStillPresenter() { m_bitmapInfo = NULL; }
+
 	// FUNCTION: LEGO1 0x10043550
 	virtual ~MxStillPresenter() override { Destroy(TRUE); }; // vtable+0x00
 

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -10,14 +10,6 @@
 // SIZE 0x64
 class MxVideoPresenter : public MxMediaPresenter {
 public:
-	enum {
-		c_bit1 = 0x01,
-		c_bit2 = 0x02,
-		c_bit3 = 0x04,
-		c_bit4 = 0x08,
-		c_bit5 = 0x10,
-	};
-
 	MxVideoPresenter() { Init(); }
 
 	// FUNCTION: LEGO1 0x1000c740
@@ -100,6 +92,18 @@ public:
 	inline MxS32 PrepareRects(MxRect32& p_rectDest, MxRect32& p_rectSrc);
 	inline MxBitmap* GetBitmap() { return m_bitmap; }
 
+	inline void SetBit0(BOOL p_e) { m_flags.m_bit0 = p_e; }
+	inline void SetBit1(BOOL p_e) { m_flags.m_bit1 = p_e; }
+	inline void SetBit2(BOOL p_e) { m_flags.m_bit2 = p_e; }
+	inline void SetBit3(BOOL p_e) { m_flags.m_bit3 = p_e; }
+	inline void SetBit4(BOOL p_e) { m_flags.m_bit4 = p_e; }
+
+	inline BYTE GetBit0() { return m_flags.m_bit0; }
+	inline BYTE GetBit1() { return m_flags.m_bit1; }
+	inline BYTE GetBit2() { return m_flags.m_bit2; }
+	inline BYTE GetBit3() { return m_flags.m_bit3; }
+	inline BYTE GetBit4() { return m_flags.m_bit4; }
+
 	// SYNTHETIC: LEGO1 0x1000c910
 	// MxVideoPresenter::`scalar deleting destructor'
 
@@ -113,7 +117,7 @@ protected:
 	AlphaMask* m_alpha;            // 0x54
 	LPDIRECTDRAWSURFACE m_unk0x58; // 0x58
 	MxS16 m_unk0x5c;               // 0x5c
-	MxU8 m_flags;                  // 0x5e
+	FlagBitfield m_flags;          // 0x5e
 	MxLong m_unk0x60;              // 0x60
 };
 

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -679,6 +679,13 @@ done:
 	return surface;
 }
 
+// STUB: LEGO1 0x100bbfb0
+LPDIRECTDRAWSURFACE MxDisplaySurface::FUN_100bbfb0(LPDIRECTDRAWSURFACE p_und)
+{
+	// TODO
+	return NULL;
+}
+
 // FUNCTION: LEGO1 0x100bc070
 LPDIRECTDRAWSURFACE MxDisplaySurface::CreateCursorSurface()
 {

--- a/LEGO1/omni/src/video/mxflcpresenter.cpp
+++ b/LEGO1/omni/src/video/mxflcpresenter.cpp
@@ -12,9 +12,9 @@ DECOMP_SIZE_ASSERT(MxFlcPresenter, 0x68);
 // FUNCTION: LEGO1 0x100b3310
 MxFlcPresenter::MxFlcPresenter()
 {
-	this->m_flcHeader = NULL;
-	this->m_flags &= ~c_bit2;
-	this->m_flags &= ~c_bit3;
+	m_flcHeader = NULL;
+	SetBit1(FALSE);
+	SetBit2(FALSE);
 }
 
 // FUNCTION: LEGO1 0x100b3420

--- a/LEGO1/omni/src/video/mxloopingflcpresenter.cpp
+++ b/LEGO1/omni/src/video/mxloopingflcpresenter.cpp
@@ -20,8 +20,8 @@ MxLoopingFlcPresenter::~MxLoopingFlcPresenter()
 void MxLoopingFlcPresenter::Init()
 {
 	this->m_elapsedDuration = 0;
-	this->m_flags &= ~c_bit2;
-	this->m_flags &= ~c_bit3;
+	SetBit1(FALSE);
+	SetBit2(FALSE);
 }
 
 // FUNCTION: LEGO1 0x100b4430

--- a/LEGO1/omni/src/video/mxloopingsmkpresenter.cpp
+++ b/LEGO1/omni/src/video/mxloopingsmkpresenter.cpp
@@ -20,9 +20,9 @@ MxLoopingSmkPresenter::~MxLoopingSmkPresenter()
 // FUNCTION: LEGO1 0x100b49b0
 void MxLoopingSmkPresenter::Init()
 {
-	this->m_elapsedDuration = 0;
-	this->m_flags &= ~c_bit2;
-	this->m_flags &= ~c_bit3;
+	m_elapsedDuration = 0;
+	SetBit1(FALSE);
+	SetBit2(FALSE);
 }
 
 // FUNCTION: LEGO1 0x100b49d0

--- a/LEGO1/omni/src/video/mxsmkpresenter.cpp
+++ b/LEGO1/omni/src/video/mxsmkpresenter.cpp
@@ -23,8 +23,8 @@ void MxSmkPresenter::Init()
 {
 	m_currentFrame = 0;
 	memset(&m_mxSmack, 0, sizeof(m_mxSmack));
-	m_flags &= ~c_bit2;
-	m_flags &= ~c_bit3;
+	SetBit1(FALSE);
+	SetBit2(FALSE);
 }
 
 // FUNCTION: LEGO1 0x100b3900

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -75,12 +75,12 @@ void MxStillPresenter::LoadFrame(MxStreamChunk* p_chunk)
 	MxRect32 rect(x, y, width + x, height + y);
 	MVideoManager()->InvalidateRect(rect);
 
-	if (m_flags & c_bit2) {
+	if (GetBit1()) {
 		undefined4 und = 0;
 		m_unk0x58 = MxOmni::GetInstance()->GetVideoManager()->GetDisplaySurface()->VTable0x44(
 			m_bitmap,
 			&und,
-			(m_flags & c_bit4) / 8,
+			GetBit3(),
 			m_action->GetFlags() & MxDSAction::c_bit4
 		);
 
@@ -91,9 +91,9 @@ void MxStillPresenter::LoadFrame(MxStreamChunk* p_chunk)
 		m_bitmap = NULL;
 
 		if (m_unk0x58 && und)
-			m_flags |= c_bit3;
+			SetBit2(TRUE);
 		else
-			m_flags &= ~c_bit3;
+			SetBit2(FALSE);
 	}
 }
 
@@ -186,7 +186,7 @@ void MxStillPresenter::ParseExtra()
 	MxPresenter::ParseExtra();
 
 	if (m_action->GetFlags() & MxDSAction::c_bit5)
-		m_flags |= c_bit4;
+		SetBit3(TRUE);
 
 	MxU32 len = m_action->GetExtraLength();
 
@@ -207,15 +207,52 @@ void MxStillPresenter::ParseExtra()
 	}
 
 	if (KeyValueStringParse(output, g_strBmpIsmap, buf)) {
-		m_flags |= c_bit5;
-		m_flags &= ~c_bit2;
-		m_flags &= ~c_bit3;
+		SetBit4(TRUE);
+		SetBit1(FALSE);
+		SetBit2(FALSE);
 	}
 }
 
-// STUB: LEGO1 0x100ba2c0
+// FUNCTION: LEGO1 0x100ba2c0
 MxStillPresenter* MxStillPresenter::Clone()
 {
-	// TODO
-	return NULL;
+	MxResult result = FAILURE;
+	MxStillPresenter* presenter = new MxStillPresenter;
+
+	if (presenter) {
+		if (presenter->AddToManager() == SUCCESS) {
+			MxDSAction* action = presenter->GetAction()->Clone();
+
+			if (action && presenter->StartAction(NULL, action) == SUCCESS) {
+				presenter->SetBit0(GetBit0());
+				presenter->SetBit1(GetBit1());
+				presenter->SetBit2(GetBit2());
+				presenter->SetBit3(GetBit3());
+				presenter->SetBit4(GetBit4());
+
+				if (m_bitmap) {
+					presenter->m_bitmap = new MxBitmap;
+
+					if (!presenter->m_bitmap || presenter->m_bitmap->ImportBitmap(m_bitmap) != SUCCESS)
+						goto done;
+				}
+
+				if (m_unk0x58)
+					presenter->m_unk0x58 = MxDisplaySurface::FUN_100bbfb0(m_unk0x58);
+
+				if (m_alpha)
+					presenter->m_alpha = new MxVideoPresenter::AlphaMask(*m_alpha);
+			}
+		}
+	}
+
+	result = SUCCESS;
+
+done:
+	if (result != SUCCESS) {
+		delete presenter;
+		presenter = NULL;
+	}
+
+	return presenter;
 }

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -242,11 +242,11 @@ MxStillPresenter* MxStillPresenter::Clone()
 
 				if (m_alpha)
 					presenter->m_alpha = new MxVideoPresenter::AlphaMask(*m_alpha);
+
+				result = SUCCESS;
 			}
 		}
 	}
-
-	result = SUCCESS;
 
 done:
 	if (result != SUCCESS) {

--- a/LEGO1/omni/src/video/mxvideopresenter.cpp
+++ b/LEGO1/omni/src/video/mxvideopresenter.cpp
@@ -117,16 +117,16 @@ void MxVideoPresenter::Init()
 	m_unk0x5c = 1;
 	m_unk0x58 = NULL;
 	m_unk0x60 = -1;
-	m_flags &= ~c_bit1;
+	SetBit0(FALSE);
 
 	if (MVideoManager() != NULL) {
 		MVideoManager();
-		m_flags |= c_bit2;
-		m_flags &= ~c_bit3;
+		SetBit1(TRUE);
+		SetBit2(FALSE);
 	}
 
-	m_flags &= ~c_bit4;
-	m_flags &= ~c_bit5;
+	SetBit3(FALSE);
+	SetBit4(FALSE);
 }
 
 // FUNCTION: LEGO1 0x100b27b0
@@ -138,8 +138,8 @@ void MxVideoPresenter::Destroy(MxBool p_fromDestructor)
 	if (m_unk0x58) {
 		m_unk0x58->Release();
 		m_unk0x58 = NULL;
-		m_flags &= ~c_bit2;
-		m_flags &= ~c_bit3;
+		SetBit1(FALSE);
+		SetBit2(FALSE);
 	}
 
 	if (MVideoManager() && (m_alpha || m_bitmap)) {
@@ -230,8 +230,7 @@ MxBool MxVideoPresenter::IsHit(MxS32 p_x, MxS32 p_y)
 		pixel = m_bitmap->GetBmiStride() * height + m_bitmap->GetBitmapData();
 	}
 
-	// DECOMP: m_flags is 1 byte, so no enum here
-	if (m_flags & 0x10)
+	if (GetBit4())
 		return (MxBool) *pixel;
 
 	if ((GetAction()->GetFlags() & MxDSAction::c_bit4) && *pixel == 0)
@@ -429,13 +428,13 @@ void MxVideoPresenter::StreamingTickle()
 			LoadFrame(m_currentChunk);
 			m_subscriber->DestroyChunk(m_currentChunk);
 			m_currentChunk = NULL;
-			m_flags |= c_bit1;
+			SetBit0(TRUE);
 
 			if (m_currentTickleState != e_streaming)
 				break;
 		}
 
-		if (m_flags & c_bit1)
+		if (GetBit0())
 			m_unk0x5c = 5;
 	}
 }
@@ -467,13 +466,13 @@ void MxVideoPresenter::RepeatingTickle()
 
 				LoadFrame(m_currentChunk);
 				m_currentChunk = NULL;
-				m_flags |= c_bit1;
+				SetBit0(TRUE);
 
 				if (m_currentTickleState != e_repeating)
 					break;
 			}
 
-			if (m_flags & c_bit1)
+			if (GetBit0())
 				m_unk0x5c = 5;
 		}
 	}


### PR DESCRIPTION
Match is at ~91%, the rest is compiler randomness/register swaps. The flags in `MxVideoPresenter` are of the `FlagBitfield` kind, similar to `MxVideoParamFlags`, so I've changed the rest of the code base to use it.