### PR TITLE
Pad all single-digit hexadecimal values with zero

### DIFF
--- a/LEGO1/lego/legoomni/include/act1state.h
+++ b/LEGO1/lego/legoomni/include/act1state.h
@@ -36,15 +36,15 @@ public:
 	// Act1State::`scalar deleting destructor'
 
 protected:
-	undefined m_unk0x8[0x10]; // 0x8
-	MxU32 m_unk0x18;          // 0x18
-	undefined2 m_unk0x1c;     // 0x1c
-	undefined m_unk0x1e;      // 0x1e
-	undefined m_unk0x1f;      // 0x1f
-	undefined m_unk0x20;      // 0x20
-	MxBool m_unk0x21;         // 0x21
-	undefined m_unk0x22;      // 0x22
-							  // TODO
+	undefined m_unk0x08[0x10]; // 0x08
+	MxU32 m_unk0x18;           // 0x18
+	undefined2 m_unk0x1c;      // 0x1c
+	undefined m_unk0x1e;       // 0x1e
+	undefined m_unk0x1f;       // 0x1f
+	undefined m_unk0x20;       // 0x20
+	MxBool m_unk0x21;          // 0x21
+	undefined m_unk0x22;       // 0x22
+							   // TODO
 };
 
 #endif // ACT1STATE_H

--- a/LEGO1/lego/legoomni/include/act2brick.h
+++ b/LEGO1/lego/legoomni/include/act2brick.h
@@ -8,9 +8,9 @@
 class Act2Brick : public LegoPathActor {
 public:
 	Act2Brick();
-	virtual ~Act2Brick() override; // vtable+0x0
+	virtual ~Act2Brick() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1007a360

--- a/LEGO1/lego/legoomni/include/act2policestation.h
+++ b/LEGO1/lego/legoomni/include/act2policestation.h
@@ -7,7 +7,7 @@
 // SIZE 0x68
 class Act2PoliceStation : public LegoEntity {
 public:
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1000e200
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/act3.h
+++ b/LEGO1/lego/legoomni/include/act3.h
@@ -11,8 +11,8 @@ public:
 
 	virtual ~Act3() override; // vtable+00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10072510
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/act3state.h
+++ b/LEGO1/lego/legoomni/include/act3state.h
@@ -4,7 +4,7 @@
 #include "legostate.h"
 
 // VTABLE: LEGO1 0x100d4fc8
-// SIZE 0xc
+// SIZE 0x0c
 class Act3State : public LegoState {
 public:
 	inline Act3State() { m_unk0x08 = 0; }

--- a/LEGO1/lego/legoomni/include/ambulancemissionstate.h
+++ b/LEGO1/lego/legoomni/include/ambulancemissionstate.h
@@ -46,18 +46,18 @@ public:
 	// AmbulanceMissionState::`scalar deleting destructor'
 
 protected:
-	undefined4 m_unk0x8; // 0x08
-	undefined4 m_unk0xc; // 0x0c
-	MxU16 m_unk0x10;     // 0x10
-	MxU16 m_unk0x12;     // 0x12
-	MxU16 m_unk0x14;     // 0x14
-	MxU16 m_unk0x16;     // 0x16
-	MxU16 m_unk0x18;     // 0x18
-	MxU16 m_color1;      // 0x1a
-	MxU16 m_color2;      // 0x1c
-	MxU16 m_color3;      // 0x1e
-	MxU16 m_color4;      // 0x20
-	MxU16 m_color5;      // 0x22
+	undefined4 m_unk0x08; // 0x08
+	undefined4 m_unk0x0c; // 0x0c
+	MxU16 m_unk0x10;      // 0x10
+	MxU16 m_unk0x12;      // 0x12
+	MxU16 m_unk0x14;      // 0x14
+	MxU16 m_unk0x16;      // 0x16
+	MxU16 m_unk0x18;      // 0x18
+	MxU16 m_color1;       // 0x1a
+	MxU16 m_color2;       // 0x1c
+	MxU16 m_color3;       // 0x1e
+	MxU16 m_color4;       // 0x20
+	MxU16 m_color5;       // 0x22
 };
 
 #endif // AMBULANCEMISSIONSTATE_H

--- a/LEGO1/lego/legoomni/include/animstate.h
+++ b/LEGO1/lego/legoomni/include/animstate.h
@@ -8,7 +8,7 @@
 class AnimState : public LegoState {
 public:
 	AnimState();
-	virtual ~AnimState() override; // vtable+0x0
+	virtual ~AnimState() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10065070
 	inline virtual const char* ClassName() const override // vtable+0x0c
@@ -30,8 +30,8 @@ public:
 	// AnimState::`scalar deleting destructor'
 
 private:
-	undefined4 m_unk0x8;  // 0x08
-	undefined4 m_unk0xc;  // 0x0c
+	undefined4 m_unk0x08; // 0x08
+	undefined4 m_unk0x0c; // 0x0c
 	void* m_unk0x10;      // 0x10
 	undefined4 m_unk0x14; // 0x14
 	void* m_unk0x18;      // 0x18

--- a/LEGO1/lego/legoomni/include/buildingentity.h
+++ b/LEGO1/lego/legoomni/include/buildingentity.h
@@ -8,9 +8,9 @@
 class BuildingEntity : public LegoEntity {
 public:
 	BuildingEntity();
-	virtual ~BuildingEntity() override; // vtable+0x0
+	virtual ~BuildingEntity() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10014f20
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/bumpbouy.h
+++ b/LEGO1/lego/legoomni/include/bumpbouy.h
@@ -7,7 +7,7 @@
 // VTABLE: LEGO1 0x100d6790
 class BumpBouy : public LegoAnimActor {
 public:
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100274e0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/elevatorbottom.h
+++ b/LEGO1/lego/legoomni/include/elevatorbottom.h
@@ -9,9 +9,9 @@
 class ElevatorBottom : public LegoWorld {
 public:
 	ElevatorBottom();
-	virtual ~ElevatorBottom() override; // vtable+0x0
+	virtual ~ElevatorBottom() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10017f20
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/gasstation.h
+++ b/LEGO1/lego/legoomni/include/gasstation.h
@@ -11,10 +11,10 @@
 class GasStation : public LegoWorld {
 public:
 	GasStation();
-	virtual ~GasStation() override; // vtable+0x0
+	virtual ~GasStation() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10004780
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/helicopter.h
+++ b/LEGO1/lego/legoomni/include/helicopter.h
@@ -12,7 +12,7 @@ public:
 	MxResult FUN_100040a0(Vector4& p_v, float p_f);
 
 private:
-	Mx4DPointFloat m_unk0x0;  // 0x0
+	Mx4DPointFloat m_unk0x00; // 0x00
 	Mx4DPointFloat m_unk0x18; // 0x18
 	undefined4 m_unk0x30;     // 0x30
 };
@@ -22,7 +22,7 @@ private:
 class Helicopter : public IslePathActor {
 public:
 	Helicopter();
-	virtual ~Helicopter() override; // vtable+0x0
+	virtual ~Helicopter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10003070
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/helicopterstate.h
+++ b/LEGO1/lego/legoomni/include/helicopterstate.h
@@ -5,7 +5,7 @@
 #include "legostate.h"
 
 // VTABLE: LEGO1 0x100d5418
-// SIZE 0xc
+// SIZE 0x0c
 class HelicopterState : public LegoState {
 public:
 	// FUNCTION: LEGO1 0x1000e0d0
@@ -27,18 +27,18 @@ public:
 	// FUNCTION: LEGO1 0x1000e0c0
 	virtual MxBool SetFlag() override
 	{
-		m_unk0x8 = 0;
+		m_unk0x08 = 0;
 		return TRUE;
 	}; // vtable+0x18
 
-	inline void SetUnknown8(MxU32 p_unk0x8) { m_unk0x8 = p_unk0x8; }
-	inline MxU32 GetUnkown8() { return m_unk0x8; }
+	inline void SetUnknown8(MxU32 p_unk0x08) { m_unk0x08 = p_unk0x08; }
+	inline MxU32 GetUnkown8() { return m_unk0x08; }
 
 	// SYNTHETIC: LEGO1 0x1000e190
 	// HelicopterState::`scalar deleting destructor'
 
 protected:
-	MxU32 m_unk0x8; // 0x8
+	MxU32 m_unk0x08; // 0x08
 };
 
 #endif // HELICOPTERSTATE_H

--- a/LEGO1/lego/legoomni/include/historybook.h
+++ b/LEGO1/lego/legoomni/include/historybook.h
@@ -8,9 +8,9 @@
 class HistoryBook : public LegoWorld {
 public:
 	HistoryBook();
-	virtual ~HistoryBook() override; // vtable+0x0
+	virtual ~HistoryBook() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10082390
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -9,7 +9,7 @@
 class Hospital : public LegoWorld {
 public:
 	Hospital();
-	virtual ~Hospital() override; // vtable+0x0
+	virtual ~Hospital() override; // vtable+0x00
 
 	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 	virtual MxResult Tickle() override;               // vtable+0x08

--- a/LEGO1/lego/legoomni/include/hospitalstate.h
+++ b/LEGO1/lego/legoomni/include/hospitalstate.h
@@ -30,13 +30,13 @@ public:
 	// HospitalState::`scalar deleting destructor'
 
 private:
-	undefined m_unk0x8[4]; // 0x8
-	undefined2 m_unk0xc;   // 0xc
-	undefined2 m_unk0xe;   // 0xe
-	undefined2 m_unk0x10;  // 0x10
-	undefined2 m_unk0x12;  // 0x12
-	undefined2 m_unk0x14;  // 0x14
-	undefined2 m_unk0x16;  // 0x16
+	undefined m_unk0x08[4]; // 0x08
+	undefined2 m_unk0x0c;   // 0x0c
+	undefined2 m_unk0x0e;   // 0x0e
+	undefined2 m_unk0x10;   // 0x10
+	undefined2 m_unk0x12;   // 0x12
+	undefined2 m_unk0x14;   // 0x14
+	undefined2 m_unk0x16;   // 0x16
 };
 
 #endif // HOSPITALSTATE_H

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -132,8 +132,8 @@ public:
 	Infocenter();
 	virtual ~Infocenter() override;
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1006eb40
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/infocenterdoor.h
+++ b/LEGO1/lego/legoomni/include/infocenterdoor.h
@@ -8,9 +8,9 @@
 class InfocenterDoor : public LegoWorld {
 public:
 	InfocenterDoor();
-	virtual ~InfocenterDoor(); // vtable+0x0
+	virtual ~InfocenterDoor(); // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100377b0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/isle.h
+++ b/LEGO1/lego/legoomni/include/isle.h
@@ -24,7 +24,7 @@ class Isle : public LegoWorld {
 public:
 	Isle();
 	virtual ~Isle() override;
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10030910
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/isleactor.h
+++ b/LEGO1/lego/legoomni/include/isleactor.h
@@ -6,7 +6,7 @@
 // VTABLE: LEGO1 0x100d5178
 class IsleActor : public LegoActor {
 public:
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1000e660
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/islepathactor.h
+++ b/LEGO1/lego/legoomni/include/islepathactor.h
@@ -15,9 +15,9 @@ public:
 	IslePathActor();
 
 	// FUNCTION: LEGO1 0x10002e10
-	inline virtual ~IslePathActor() override { IslePathActor::Destroy(TRUE); } // vtable+0x0
+	inline virtual ~IslePathActor() override { IslePathActor::Destroy(TRUE); } // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10002ea0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/jukebox.h
+++ b/LEGO1/lego/legoomni/include/jukebox.h
@@ -10,8 +10,8 @@ class JukeBox : public LegoWorld {
 public:
 	JukeBox();
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1005d6f0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/jukeboxentity.h
+++ b/LEGO1/lego/legoomni/include/jukeboxentity.h
@@ -8,9 +8,9 @@
 class JukeBoxEntity : public LegoEntity {
 public:
 	JukeBoxEntity();
-	virtual ~JukeBoxEntity() override; // vtable+0x0
+	virtual ~JukeBoxEntity() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10085cc0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -9,10 +9,10 @@
 class LegoAnimationManager : public MxCore {
 public:
 	LegoAnimationManager();
-	virtual ~LegoAnimationManager() override; // vtable+0x0
+	virtual ~LegoAnimationManager() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1005ec80
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -87,11 +87,11 @@ public:
 	virtual LegoTreeNodeData* CreateData() override;           // vtable+0x0c
 	virtual MxResult VTable0x10(LegoMemory* p_stream, MxS32);  // vtable+0x10
 
-	inline MxLong GetUnknown0x8() { return m_unk0x8; }
+	inline MxLong GetUnknown0x8() { return m_unk0x08; }
 
 private:
-	MxLong m_unk0x8;      // 0x08
-	undefined4 m_unk0xc;  // 0x0c
+	MxLong m_unk0x08;     // 0x08
+	undefined4 m_unk0x0c; // 0x0c
 	undefined4 m_unk0x10; // 0x10
 	undefined4 m_unk0x14; // 0x14
 };

--- a/LEGO1/lego/legoomni/include/legocachesound.h
+++ b/LEGO1/lego/legoomni/include/legocachesound.h
@@ -9,7 +9,7 @@
 class LegoCacheSound : public MxCore {
 public:
 	LegoCacheSound();
-	virtual ~LegoCacheSound() override; // vtable+0x0
+	virtual ~LegoCacheSound() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10006580
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legocameracontroller.h
+++ b/LEGO1/lego/legoomni/include/legocameracontroller.h
@@ -12,7 +12,7 @@
 class LegoCameraController : public LegoPointOfViewController {
 public:
 	LegoCameraController();
-	virtual ~LegoCameraController() override; // vtable+0x0
+	virtual ~LegoCameraController() override; // vtable+0x00
 
 	virtual MxLong Notify(MxParam& p_param) override; // vtable+04
 

--- a/LEGO1/lego/legoomni/include/legocarbuild.h
+++ b/LEGO1/lego/legoomni/include/legocarbuild.h
@@ -10,8 +10,8 @@ public:
 	LegoCarBuild();
 	virtual ~LegoCarBuild() override;
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10022940
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legocarbuildanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildanimpresenter.h
@@ -8,7 +8,7 @@
 class LegoCarBuildAnimPresenter : public LegoAnimPresenter {
 public:
 	LegoCarBuildAnimPresenter();
-	virtual ~LegoCarBuildAnimPresenter() override; // vtable+0x0
+	virtual ~LegoCarBuildAnimPresenter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10078510
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legocontrolmanager.h
+++ b/LEGO1/lego/legoomni/include/legocontrolmanager.h
@@ -40,9 +40,9 @@ private:
 class LegoControlManager : public MxCore {
 public:
 	LegoControlManager();
-	virtual ~LegoControlManager() override; // vtable+0x0
+	virtual ~LegoControlManager() override; // vtable+0x00
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10028cb0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -22,10 +22,10 @@ public:
 	// FUNCTION: LEGO1 0x1000c290
 	virtual ~LegoEntity() override { Destroy(TRUE); }
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1000c2f0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0064
 		return "LegoEntity";

--- a/LEGO1/lego/legoomni/include/legoentitypresenter.h
+++ b/LEGO1/lego/legoomni/include/legoentitypresenter.h
@@ -10,10 +10,10 @@ class LegoEntity;
 class LegoEntityPresenter : public MxCompositePresenter {
 public:
 	LegoEntityPresenter();
-	virtual ~LegoEntityPresenter() override; // vtable+0x0
+	virtual ~LegoEntityPresenter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100534b0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f06b8
 		return "LegoEntityPresenter";

--- a/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
@@ -18,7 +18,7 @@ public:
 			new LegoEventNotificationParam(m_type, m_sender, m_modifier, m_x, m_y, m_key);
 		clone->m_roi = m_roi;
 		return clone;
-	}; // vtable+0x4
+	}; // vtable+0x04
 
 	inline LegoEventNotificationParam() : MxNotificationParam(c_notificationType0, NULL) {}
 	inline LegoEventNotificationParam(

--- a/LEGO1/lego/legoomni/include/legoextraactor.h
+++ b/LEGO1/lego/legoomni/include/legoextraactor.h
@@ -7,7 +7,7 @@
 class LegoExtraActor : public LegoAnimActor {
 public:
 	// FUNCTION: LEGO1 0x1002b7a0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f3204
 		return "LegoExtraActor";

--- a/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
@@ -11,7 +11,7 @@ public:
 	LegoFlcTexturePresenter();
 
 	// FUNCTION: LEGO1 0x1005def0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0634
 		return "LegoFlcTexturePresenter";

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -35,7 +35,7 @@ public:
 	void FUN_1003a720(MxU32);
 	void HandleAction(MxU32);
 
-	inline MxU8 GetUnknownC() { return m_unk0xc; }
+	inline MxU8 GetUnknownC() { return m_unk0x0c; }
 	inline MxU32 GetUnknown10() { return m_unk0x10; }
 	inline MxS32 GetCurrentAct() { return m_currentAct; }
 	inline undefined4 GetUnknown424() { return m_unk0x424; }
@@ -61,10 +61,10 @@ private:
 	MxS32 ReadVariable(LegoStorage* p_stream, MxVariableTable* p_to);
 	void SetROIHandlerFunction();
 
-	char* m_savePath;                           // 0x0
-	MxS16 m_stateCount;                         // 0x4
-	LegoState** m_stateArray;                   // 0x8
-	MxU8 m_unk0xc;                              // 0xc
+	char* m_savePath;                           // 0x00
+	MxS16 m_stateCount;                         // 0x04
+	LegoState** m_stateArray;                   // 0x08
+	MxU8 m_unk0x0c;                             // 0x0c
 	MxU32 m_unk0x10;                            // 0x10
 	MxS32 m_currentAct;                         // 0x14
 	LegoBackgroundColor* m_backgroundColor;     // 0x18

--- a/LEGO1/lego/legoomni/include/legohideanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legohideanimpresenter.h
@@ -12,7 +12,7 @@ public:
 	virtual ~LegoHideAnimPresenter() override;
 
 	// FUNCTION: LEGO1 0x1006d880
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f06cc
 		return "LegoHideAnimPresenter";

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -75,7 +75,7 @@ public:
 	void Register(MxCore*);
 	void UnRegister(MxCore*);
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1005b8c0
 	virtual MxResult PutData() override { return SUCCESS; }; // vtable+0x4c

--- a/LEGO1/lego/legoomni/include/legojetski.h
+++ b/LEGO1/lego/legoomni/include/legojetski.h
@@ -9,7 +9,7 @@ public:
 	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10013e80
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f053c
 		return "LegoJetski";

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -7,7 +7,7 @@
 class LegoJetskiRaceActor : public LegoCarRaceActor {
 public:
 	// FUNCTION: LEGO1 0x10081d80
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0554
 		return "LegoJetskiRaceActor";

--- a/LEGO1/lego/legoomni/include/legoloadcachesoundpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoloadcachesoundpresenter.h
@@ -14,7 +14,7 @@ public:
 	virtual ~LegoLoadCacheSoundPresenter() override;
 
 	// FUNCTION: LEGO1 0x10018450
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f05a0
 		return "LegoLoadCacheSoundPresenter";

--- a/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
@@ -11,7 +11,7 @@ public:
 	virtual ~LegoLocomotionAnimPresenter() override;
 
 	// FUNCTION: LEGO1 0x1006ce50
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f06e4
 		return "LegoLocomotionAnimPresenter";

--- a/LEGO1/lego/legoomni/include/legoloopinganimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoloopinganimpresenter.h
@@ -8,7 +8,7 @@
 class LegoLoopingAnimPresenter : public LegoAnimPresenter {
 public:
 	// FUNCTION: LEGO1 0x1000c9a0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0700
 		return "LegoLoopingAnimPresenter";

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -12,7 +12,7 @@ public:
 	static void configureLegoModelPresenter(MxS32 p_modelPresenterConfig);
 
 	// FUNCTION: LEGO1 0x1000ccb0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f067c
 		return "LegoModelPresenter";

--- a/LEGO1/lego/legoomni/include/legonavcontroller.h
+++ b/LEGO1/lego/legoomni/include/legonavcontroller.h
@@ -37,11 +37,11 @@ public:
 	);
 
 	LegoNavController();
-	virtual ~LegoNavController() override;            // vtable+0x0
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual ~LegoNavController() override;            // vtable+0x00
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10054b80
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f66d8
 		return "LegoNavController";

--- a/LEGO1/lego/legoomni/include/legopalettepresenter.h
+++ b/LEGO1/lego/legoomni/include/legopalettepresenter.h
@@ -10,10 +10,10 @@
 class LegoPalettePresenter : public MxVideoPresenter {
 public:
 	LegoPalettePresenter();
-	virtual ~LegoPalettePresenter() override; // vtable+0x0
+	virtual ~LegoPalettePresenter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10079f30
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f061c
 		return "LegoPalettePresenter";

--- a/LEGO1/lego/legoomni/include/legopartpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopartpresenter.h
@@ -8,7 +8,7 @@
 class LegoPartPresenter : public MxMediaPresenter {
 public:
 	// FUNCTION: LEGO1 0x1000cf70
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f05d8
 		return "LegoPartPresenter";

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -13,7 +13,7 @@ public:
 	virtual ~LegoPathActor() override;
 
 	// FUNCTION: LEGO1 0x1000c430
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0114
 		return "LegoPathActor";

--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -13,7 +13,7 @@ public:
 	virtual MxResult Tickle() override; // vtable+08
 
 	// FUNCTION: LEGO1 0x10045110
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f11b8
 		return "LegoPathController";

--- a/LEGO1/lego/legoomni/include/legopathpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopathpresenter.h
@@ -11,7 +11,7 @@ public:
 	virtual ~LegoPathPresenter() override;
 
 	// FUNCTION: LEGO1 0x100449a0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0690
 		return "LegoPathPresenter";

--- a/LEGO1/lego/legoomni/include/legophonemepresenter.h
+++ b/LEGO1/lego/legoomni/include/legophonemepresenter.h
@@ -11,10 +11,10 @@
 class LegoPhonemePresenter : public MxFlcPresenter {
 public:
 	LegoPhonemePresenter();
-	virtual ~LegoPhonemePresenter() override; // vtable+0x0
+	virtual ~LegoPhonemePresenter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x1004e310
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f064c
 		return "LegoPhonemePresenter";

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -9,12 +9,12 @@
 class LegoPlantManager : public MxCore {
 public:
 	LegoPlantManager();
-	virtual ~LegoPlantManager() override; // vtable+0x0
+	virtual ~LegoPlantManager() override; // vtable+0x00
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10026290
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f318c
 		return "LegoPlantManager";

--- a/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
@@ -30,10 +30,10 @@ public:
 	virtual void RightUp(int, int);   // vtable+0x28
 
 private:
-	BOOL m_isButtonDown; // 0x08
-	undefined4 m_unk0xc; // 0x0c
-	MxDouble m_buttonX;  // 0x10
-	MxDouble m_buttonY;  // 0x18
+	BOOL m_isButtonDown;  // 0x08
+	undefined4 m_unk0x0c; // 0x0c
+	MxDouble m_buttonX;   // 0x10
+	MxDouble m_buttonY;   // 0x18
 };
 
 // SYNTHETIC: LEGO1 0x100655b0

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -11,12 +11,12 @@
 class LegoRace : public LegoWorld {
 public:
 	LegoRace();
-	virtual ~LegoRace() override; // vtable+0x0
+	virtual ~LegoRace() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10015ba0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f07c4
 		return "LegoRace";

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -8,7 +8,7 @@
 class LegoRaceActor : public LegoAnimActor {
 public:
 	// FUNCTION: LEGO1 0x10014af0
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0bf4
 		return "LegoRaceActor";

--- a/LEGO1/lego/legoomni/include/legoracecar.h
+++ b/LEGO1/lego/legoomni/include/legoracecar.h
@@ -11,7 +11,7 @@ public:
 	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10014290
-	inline const char* ClassName() const override // vtable+0xc
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0548
 		return "LegoRaceCar";

--- a/LEGO1/lego/legoomni/include/legovideomanager.h
+++ b/LEGO1/lego/legoomni/include/legovideomanager.h
@@ -25,7 +25,7 @@ public:
 	void EnableFullScreenMovie(MxBool p_enable, MxBool p_scale);
 	void MoveCursor(MxS32 p_cursorX, MxS32 p_cursorY);
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 	virtual void Destroy() override;    // vtable+0x18
 	virtual MxResult Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread)
 		override;                                                                          // vtable+0x2c

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -33,10 +33,10 @@ public:
 	};
 
 	LegoWorld();
-	virtual ~LegoWorld() override; // vtable+0x0
+	virtual ~LegoWorld() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1001d690
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/legoworldpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoworldpresenter.h
@@ -8,7 +8,7 @@
 class LegoWorldPresenter : public LegoEntityPresenter {
 public:
 	LegoWorldPresenter();
-	virtual ~LegoWorldPresenter() override; // vtable+0x0
+	virtual ~LegoWorldPresenter() override; // vtable+0x00
 
 	static void configureLegoWorldPresenter(MxS32 p_legoWorldPresenterQuality);
 

--- a/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
+++ b/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
@@ -54,8 +54,8 @@ private:
 	MxResult OpenMusic(MxAtomId& p_script);
 	void DestroyMusic();
 
-	MxBool m_musicEnabled; // 0x8
-	MxDSAction m_action1;  // 0xc
+	MxBool m_musicEnabled; // 0x08
+	MxDSAction m_action1;  // 0x0c
 	MxAudioPresenter* m_unk0xa0;
 	MxDSAction m_action2; // 0xa4
 	MxAudioPresenter* m_unk0x138;

--- a/LEGO1/lego/legoomni/include/mxtransitionmanager.h
+++ b/LEGO1/lego/legoomni/include/mxtransitionmanager.h
@@ -11,11 +11,11 @@
 class MxTransitionManager : public MxCore {
 public:
 	MxTransitionManager();
-	virtual ~MxTransitionManager() override; // vtable+0x0
+	virtual ~MxTransitionManager() override; // vtable+0x00
 
 	void SetWaitIndicator(MxVideoPresenter* p_waitIndicator);
 
-	virtual MxResult Tickle(); // vtable+0x8
+	virtual MxResult Tickle(); // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1004b950
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/pizza.h
+++ b/LEGO1/lego/legoomni/include/pizza.h
@@ -15,10 +15,10 @@ public:
 	Pizza();
 	virtual ~Pizza() override;
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10037f90
-	inline const char* ClassName() const // vtable+0xc
+	inline const char* ClassName() const // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f038c
 		return "Pizza";

--- a/LEGO1/lego/legoomni/include/pizzamissionstate.h
+++ b/LEGO1/lego/legoomni/include/pizzamissionstate.h
@@ -6,9 +6,9 @@
 // SIZE 0x20
 struct PizzaMissionStateEntry {
 public:
-	undefined2 m_unk0x0;
+	undefined2 m_unk0x00;
 	MxU8 m_id;
-	undefined m_unk0x3[0x15];
+	undefined m_unk0x03[0x15];
 	MxU16 m_color;
 	undefined m_unk0x18[6];
 };
@@ -41,8 +41,8 @@ private:
 	PizzaMissionStateEntry* GetState(MxU8 p_id);
 
 protected:
-	undefined4 m_unk0x8;               // 0x08
-	undefined4 m_unk0xc;               // 0x0c
+	undefined4 m_unk0x08;              // 0x08
+	undefined4 m_unk0x0c;              // 0x0c
 	PizzaMissionStateEntry m_state[5]; // 0x10
 };
 

--- a/LEGO1/lego/legoomni/include/police.h
+++ b/LEGO1/lego/legoomni/include/police.h
@@ -13,12 +13,12 @@
 class Police : public LegoWorld {
 public:
 	Police();
-	virtual ~Police() override; // vtable+0x0
+	virtual ~Police() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1005e1e0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0450
 		return "Police";

--- a/LEGO1/lego/legoomni/include/policeentity.h
+++ b/LEGO1/lego/legoomni/include/policeentity.h
@@ -8,7 +8,7 @@
 class PoliceEntity : public BuildingEntity {
 public:
 	// FUNCTION: LEGO1 0x1000ed60
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0328
 		return "PoliceEntity";

--- a/LEGO1/lego/legoomni/include/policestate.h
+++ b/LEGO1/lego/legoomni/include/policestate.h
@@ -30,8 +30,8 @@ public:
 	// PoliceState::`scalar deleting destructor'
 
 private:
-	undefined4 m_unk0x8; // 0x8
-	undefined4 m_unk0xc; // 0xc
+	undefined4 m_unk0x08; // 0x08
+	undefined4 m_unk0x0c; // 0x0c
 };
 
 #endif // POLICESTATE_H

--- a/LEGO1/lego/legoomni/include/racecar.h
+++ b/LEGO1/lego/legoomni/include/racecar.h
@@ -9,7 +9,7 @@
 class RaceCar : public IslePathActor {
 public:
 	RaceCar();
-	virtual ~RaceCar() override; // vtable+0x0
+	virtual ~RaceCar() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10028270
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/racestate.h
+++ b/LEGO1/lego/legoomni/include/racestate.h
@@ -6,8 +6,8 @@
 struct RaceStateEntry {
 public:
 	MxU8 m_id;
-	undefined m_unk0x1[1];
-	MxU16 m_unk0x2;
+	undefined m_unk0x01[1];
+	MxU16 m_unk0x02;
 	MxU16 m_color;
 };
 

--- a/LEGO1/lego/legoomni/include/radio.h
+++ b/LEGO1/lego/legoomni/include/radio.h
@@ -32,7 +32,7 @@ public:
 
 private:
 	RadioState* m_state; // 0x08
-	MxBool m_unk0xc;     // 0x0c
+	MxBool m_unk0x0c;    // 0x0c
 
 	void CreateRadioState();
 };

--- a/LEGO1/lego/legoomni/include/registrationbook.h
+++ b/LEGO1/lego/legoomni/include/registrationbook.h
@@ -8,10 +8,10 @@
 class RegistrationBook : public LegoWorld {
 public:
 	RegistrationBook();
-	virtual ~RegistrationBook() override; // vtable+0x0
+	virtual ~RegistrationBook() override; // vtable+0x00
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
-	virtual MxResult Tickle() override;               // vtable+0x8
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
+	virtual MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10076e10
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/score.h
+++ b/LEGO1/lego/legoomni/include/score.h
@@ -12,8 +12,8 @@
 class Score : public LegoWorld {
 public:
 	Score();
-	virtual ~Score() override;                        // vtable+0x0
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual ~Score() override;                        // vtable+0x00
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100010c0
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/scorestate.h
+++ b/LEGO1/lego/legoomni/include/scorestate.h
@@ -4,7 +4,7 @@
 #include "legostate.h"
 
 // VTABLE: LEGO1 0x100d53f8
-// SIZE 0xc
+// SIZE 0x0c
 class ScoreState : public LegoState {
 public:
 	// FUNCTION: LEGO1 0x1000de40

--- a/LEGO1/lego/legoomni/src/build/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/build/helicopter.cpp
@@ -342,7 +342,7 @@ MxResult HelicopterSubclass::FUN_100040a0(Vector4& p_v, float p_f)
 {
 	MxU32 state = m_unk0x30;
 	if (state == 1) {
-		p_v.EqualsImpl(m_unk0x0.GetData());
+		p_v.EqualsImpl(m_unk0x00.GetData());
 		p_v[3] = acos(p_v[3]) * (1 - p_f) * 2.0;
 		return p_v.NormalizeQuaternion();
 	}
@@ -352,7 +352,7 @@ MxResult HelicopterSubclass::FUN_100040a0(Vector4& p_v, float p_f)
 		return p_v.NormalizeQuaternion();
 	}
 	else if (state == 3) {
-		double d1 = p_v.Dot(&m_unk0x0, &m_unk0x18), d2;
+		double d1 = p_v.Dot(&m_unk0x00, &m_unk0x18), d2;
 		if (d1 + 1 > 0.00001) {
 			if (1 - d1 > 0.00001) {
 				double d = acos(d1);
@@ -365,18 +365,18 @@ MxResult HelicopterSubclass::FUN_100040a0(Vector4& p_v, float p_f)
 				d2 = p_f;
 			}
 			for (MxS32 i = 0; i < 4; i++) {
-				p_v[i] = m_unk0x18[i] * d2 + m_unk0x0[i] * d1;
+				p_v[i] = m_unk0x18[i] * d2 + m_unk0x00[i] * d1;
 			}
 			return SUCCESS;
 		}
-		p_v[0] = -m_unk0x0[1];
-		p_v[1] = m_unk0x0[1];
-		p_v[2] = -m_unk0x0[3];
-		p_v[3] = m_unk0x0[2];
+		p_v[0] = -m_unk0x00[1];
+		p_v[1] = m_unk0x00[1];
+		p_v[2] = -m_unk0x00[3];
+		p_v[3] = m_unk0x00[2];
 		d1 = sin((1 - p_f) * 1.570796326794895);
 		d2 = sin(p_f * 1.570796326794895);
 		for (MxS32 i = 0; i < 3; i++) {
-			p_v[i] = m_unk0x0[i] * d1 + p_v[i] * d2;
+			p_v[i] = m_unk0x00[i] * d1 + p_v[i] * d2;
 		}
 		return SUCCESS;
 	}

--- a/LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
+++ b/LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
@@ -3,7 +3,7 @@
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(LegoVehicleBuildState, 0x50); // 1000acd7
-DECOMP_SIZE_ASSERT(LegoVehicleBuildState::UnkStruct, 0xc);
+DECOMP_SIZE_ASSERT(LegoVehicleBuildState::UnkStruct, 0x0c);
 
 // FUNCTION: LEGO1 0x10017c00
 LegoVehicleBuildState::UnkStruct::UnkStruct()

--- a/LEGO1/lego/legoomni/src/common/animstate.cpp
+++ b/LEGO1/lego/legoomni/src/common/animstate.cpp
@@ -5,7 +5,7 @@ DECOMP_SIZE_ASSERT(AnimState, 0x1c);
 // FUNCTION: LEGO1 0x10064ff0
 AnimState::AnimState()
 {
-	m_unk0xc = 0;
+	m_unk0x0c = 0;
 	m_unk0x10 = NULL;
 	m_unk0x14 = 0;
 	m_unk0x18 = NULL;

--- a/LEGO1/lego/legoomni/src/common/gifmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/gifmanager.cpp
@@ -47,7 +47,7 @@ void GifManager::FUN_10099cc0(GifData* p_data)
 	for (GifList::iterator it = m_list.begin(); it != m_list.end(); it++) {
 #endif
 		if (*it == p_data) {
-			// TODO: This is wrong, but what is at +0xc on the iterator?
+			// TODO: This is wrong, but what is at +0x0c on the iterator?
 			*it = NULL;
 
 			if (p_data->m_texture->Release() == TRUE) {

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -67,7 +67,7 @@ LegoGameState::LegoGameState()
 	SetROIHandlerFunction();
 
 	this->m_stateCount = 0;
-	this->m_unk0xc = 0;
+	this->m_unk0x0c = 0;
 	this->m_savePath = NULL;
 	this->m_unk0x424 = 0;
 	this->m_prevArea = 0;
@@ -131,7 +131,7 @@ MxResult LegoGameState::Save(MxULong p_slot)
 			fileStream.Write(&maybeVersion, 4);
 			fileStream.Write(&m_unk0x24, 2);
 			fileStream.Write(&m_unk0x10, 2);
-			fileStream.Write(&m_unk0xc, 1);
+			fileStream.Write(&m_unk0x0c, 1);
 
 			for (MxS32 i = 0; i < sizeof(g_colorSaveData) / sizeof(g_colorSaveData[0]); ++i) {
 				if (WriteVariable(&fileStream, variableTable, g_colorSaveData[i].m_targetName) == FAILURE)

--- a/LEGO1/lego/legoomni/src/hospital/ambulancemissionstate.cpp
+++ b/LEGO1/lego/legoomni/src/hospital/ambulancemissionstate.cpp
@@ -8,9 +8,9 @@ AmbulanceMissionState::AmbulanceMissionState()
 	m_unk0x10 = 0;
 	m_unk0x12 = 0;
 	m_unk0x14 = 0;
-	m_unk0x8 = 0;
+	m_unk0x08 = 0;
 	m_unk0x16 = 0;
-	m_unk0xc = 0;
+	m_unk0x0c = 0;
 	m_unk0x18 = 0;
 	m_color1 = 0;
 	m_color2 = 0;

--- a/LEGO1/lego/legoomni/src/hospital/hospitalstate.cpp
+++ b/LEGO1/lego/legoomni/src/hospital/hospitalstate.cpp
@@ -5,8 +5,8 @@ DECOMP_SIZE_ASSERT(HospitalState, 0x18)
 // FUNCTION: LEGO1 0x10076370
 HospitalState::HospitalState()
 {
-	this->m_unk0xc = 0;
-	this->m_unk0xe = 0;
+	this->m_unk0x0c = 0;
+	this->m_unk0x0e = 0;
 	this->m_unk0x10 = 0;
 	this->m_unk0x12 = 0;
 	this->m_unk0x14 = 0;

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -133,7 +133,7 @@ MxLong Infocenter::Notify(MxParam& p_param)
 			StopBookAnimation();
 			m_bookAnimationTimer = 0;
 
-			if (m_infocenterState->GetUnknown0x74() == 0xc) {
+			if (m_infocenterState->GetUnknown0x74() == 0x0c) {
 				StartCredits();
 				m_infocenterState->SetUnknown0x74(0xd);
 			}

--- a/LEGO1/lego/legoomni/src/infocenter/score.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/score.cpp
@@ -303,12 +303,12 @@ void Score::FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color)
 	data[0] = 0x11;
 	data[17] = 0x28;
 	data[18] = 0x28;
-	data[1] = 0xf;
+	data[1] = 0x0f;
 	MxU32 size = data[p_x + 14];
 	MxU8* ptr = data[p_x + 4] + data[p_y + 9] + m_surface;
 	MxS32 count = data[p_y + 19];
-	data[2] = 0x8;
-	data[3] = 0x5;
+	data[2] = 0x08;
+	data[3] = 0x05;
 	MxU32 value = data[p_color];
 	for (; count > 0; count--) {
 		memset(ptr++, value, size);

--- a/LEGO1/lego/legoomni/src/isle/radio.cpp
+++ b/LEGO1/lego/legoomni/src/isle/radio.cpp
@@ -13,7 +13,7 @@ Radio::Radio()
 	NotificationManager()->Register(this);
 	ControlManager()->Register(this);
 
-	m_unk0xc = TRUE;
+	m_unk0x0c = TRUE;
 	CreateRadioState();
 }
 
@@ -33,8 +33,8 @@ MxLong Radio::Notify(MxParam& p_param)
 // FUNCTION: LEGO1 0x1002cdc0
 void Radio::Initialize(MxBool p_und)
 {
-	if (m_unk0xc != p_und) {
-		m_unk0xc = p_und;
+	if (m_unk0x0c != p_und) {
+		m_unk0x0c = p_und;
 		CreateRadioState();
 	}
 }

--- a/LEGO1/lego/legoomni/src/police/policestate.cpp
+++ b/LEGO1/lego/legoomni/src/police/policestate.cpp
@@ -22,8 +22,8 @@ MxResult PoliceState::VTable0x1c(LegoFile* p_legoFile)
 		p_legoFile->Read(&m_unk0x08, sizeof(m_unk0x08));
 	}
 	else {
-		undefined4 unk0x8 = m_unk0x08;
-		p_legoFile->Write(&unk0x8, sizeof(m_unk0x08));
+		undefined4 unk0x08 = m_unk0x08;
+		p_legoFile->Write(&unk0x08, sizeof(m_unk0x08));
 	}
 
 	return SUCCESS;

--- a/LEGO1/lego/legoomni/src/police/policestate.cpp
+++ b/LEGO1/lego/legoomni/src/police/policestate.cpp
@@ -7,8 +7,8 @@ DECOMP_SIZE_ASSERT(PoliceState, 0x10)
 // FUNCTION: LEGO1 0x1005e7c0
 PoliceState::PoliceState()
 {
-	m_unk0xc = 0;
-	m_unk0x8 = (rand() % 2 == 0) ? 501 : 500;
+	m_unk0x0c = 0;
+	m_unk0x08 = (rand() % 2 == 0) ? 501 : 500;
 }
 
 // FUNCTION: LEGO1 0x1005e990
@@ -19,11 +19,11 @@ MxResult PoliceState::VTable0x1c(LegoFile* p_legoFile)
 	}
 
 	if (p_legoFile->IsReadMode()) {
-		p_legoFile->Read(&m_unk0x8, sizeof(m_unk0x8));
+		p_legoFile->Read(&m_unk0x08, sizeof(m_unk0x08));
 	}
 	else {
-		undefined4 unk0x8 = m_unk0x8;
-		p_legoFile->Write(&unk0x8, sizeof(m_unk0x8));
+		undefined4 unk0x8 = m_unk0x08;
+		p_legoFile->Write(&unk0x8, sizeof(m_unk0x08));
 	}
 
 	return SUCCESS;

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -202,8 +202,8 @@ void LegoAnimPresenter::EndAction()
 // FUNCTION: LEGO1 0x100a0b30
 LegoAnimClass::LegoAnimClass()
 {
-	m_unk0x8 = 0;
-	m_unk0xc = 0;
+	m_unk0x08 = 0;
+	m_unk0x0c = 0;
 	m_unk0x10 = 0;
 	m_unk0x14 = 0;
 }

--- a/LEGO1/lego/sources/misc/legoimage.cpp
+++ b/LEGO1/lego/sources/misc/legoimage.cpp
@@ -4,7 +4,7 @@
 #include "legostorage.h"
 #include "memory.h"
 
-DECOMP_SIZE_ASSERT(LegoPaletteEntry, 0x3);
+DECOMP_SIZE_ASSERT(LegoPaletteEntry, 0x03);
 DECOMP_SIZE_ASSERT(LegoImage, 0x310);
 
 // FUNCTION: LEGO1 0x100994c0

--- a/LEGO1/lego/sources/misc/legoimage.h
+++ b/LEGO1/lego/sources/misc/legoimage.h
@@ -5,7 +5,7 @@
 
 class LegoStorage;
 
-// SIZE 0x3
+// SIZE 0x03
 class LegoPaletteEntry {
 public:
 	LegoPaletteEntry();

--- a/LEGO1/lego/sources/misc/legostorage.cpp
+++ b/LEGO1/lego/sources/misc/legostorage.cpp
@@ -5,9 +5,9 @@
 #include <memory.h>
 #include <string.h>
 
-DECOMP_SIZE_ASSERT(LegoStorage, 0x8);
+DECOMP_SIZE_ASSERT(LegoStorage, 0x08);
 DECOMP_SIZE_ASSERT(LegoMemory, 0x10);
-DECOMP_SIZE_ASSERT(LegoFile, 0xc);
+DECOMP_SIZE_ASSERT(LegoFile, 0x0c);
 
 // FUNCTION: LEGO1 0x10099080
 LegoMemory::LegoMemory(void* p_buffer) : LegoStorage()

--- a/LEGO1/lego/sources/misc/legotexture.cpp
+++ b/LEGO1/lego/sources/misc/legotexture.cpp
@@ -4,7 +4,7 @@
 #include "legoimage.h"
 #include "legostorage.h"
 
-DECOMP_SIZE_ASSERT(LegoTexture, 0x4);
+DECOMP_SIZE_ASSERT(LegoTexture, 0x04);
 
 // FUNCTION: LEGO1 0x10098fb0
 LegoTexture::LegoTexture()

--- a/LEGO1/lego/sources/misc/legotree.h
+++ b/LEGO1/lego/sources/misc/legotree.h
@@ -9,17 +9,17 @@
 class LegoStorage;
 
 // VTABLE: LEGO1 0x100db778
-// SIZE 0x4
+// SIZE 0x04
 class LegoTreeNodeData {
 public:
 	LegoTreeNodeData() {}
 	virtual ~LegoTreeNodeData() {}
 
 	// FUNCTION: LEGO1 0x10099fe0
-	virtual LegoResult Read(LegoStorage* p_storage) { return SUCCESS; } // vtable+0x4
+	virtual LegoResult Read(LegoStorage* p_storage) { return SUCCESS; } // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10099ff0
-	virtual LegoResult Write(LegoStorage* p_storage) { return SUCCESS; } // vtable+0x8
+	virtual LegoResult Write(LegoStorage* p_storage) { return SUCCESS; } // vtable+0x08
 
 	// SYNTHETIC: LEGO1 0x1009a000
 	// LegoTreeNodeData::`scalar deleting destructor'
@@ -44,21 +44,21 @@ public:
 	// LegoTreeNode::`scalar deleting destructor'
 
 protected:
-	LegoTreeNodeData* m_data;  // 0x4
-	LegoU32 m_numChildren;     // 0x8
-	LegoTreeNode** m_children; // 0xc
+	LegoTreeNodeData* m_data;  // 0x04
+	LegoU32 m_numChildren;     // 0x08
+	LegoTreeNode** m_children; // 0x0c
 };
 
 // VTABLE: LEGO1 0x100db768
-// SIZE 0x8
+// SIZE 0x08
 class LegoTree {
 public:
 	LegoTree();
 	virtual ~LegoTree();
 	LegoTreeNode* GetRoot() { return m_root; }
 	void SetRoot(LegoTreeNode* p_root) { m_root = p_root; }
-	virtual LegoResult Read(LegoStorage* p_storage);  // vtable+0x4
-	virtual LegoResult Write(LegoStorage* p_storage); // vtable+0x8
+	virtual LegoResult Read(LegoStorage* p_storage);  // vtable+0x04
+	virtual LegoResult Write(LegoStorage* p_storage); // vtable+0x08
 
 	// SYNTHETIC: LEGO1 0x10099de0
 	// LegoTree::`scalar deleting destructor'
@@ -69,9 +69,9 @@ protected:
 	void Delete(LegoTreeNode* p_node);
 
 	// FUNCTION: LEGO1 0x10099f70
-	virtual LegoTreeNodeData* CreateData() { return new LegoTreeNodeData(); } // vtable+0xc
+	virtual LegoTreeNodeData* CreateData() { return new LegoTreeNodeData(); } // vtable+0x0c
 
-	LegoTreeNode* m_root; // 0x4
+	LegoTreeNode* m_root; // 0x04
 };
 
 #endif // __LEGOTREE_H

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -19,7 +19,7 @@ class LegoROI : public ViewROI {
 public:
 	LegoROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList, int p_time);
 
-	virtual float IntrinsicImportance() const override; // vtable+0x4
+	virtual float IntrinsicImportance() const override; // vtable+0x04
 	// Note: Actually part of parent class (doesn't exist yet)
 	virtual void UpdateWorldBoundingVolumes() override; // vtable+0x18
 

--- a/LEGO1/omni/include/mxactionnotificationparam.h
+++ b/LEGO1/omni/include/mxactionnotificationparam.h
@@ -47,12 +47,12 @@ public:
 	virtual MxNotificationParam* Clone() override
 	{
 		return new MxActionNotificationParam(this->m_type, this->m_sender, this->m_action, this->m_realloc);
-	}; // vtable+0x4
+	}; // vtable+0x04
 
 	inline MxDSAction* GetAction() { return m_action; }
 
 protected:
-	MxDSAction* m_action; // 0xc
+	MxDSAction* m_action; // 0x0c
 	MxBool m_realloc;     // 0x10
 };
 
@@ -70,7 +70,7 @@ public:
 	{
 	}
 
-	virtual MxNotificationParam* Clone() override; // vtable+0x4
+	virtual MxNotificationParam* Clone() override; // vtable+0x04
 };
 
 // VTABLE: LEGO1 0x100d8358
@@ -96,7 +96,7 @@ public:
 			this->m_action,
 			this->m_realloc
 		);
-	}; // vtable+0x4
+	}; // vtable+0x04
 };
 
 // VTABLE: LEGO1 0x100dc208
@@ -109,7 +109,7 @@ public:
 		m_unk0x14 = p_unk0x14;
 	}
 
-	virtual MxNotificationParam* Clone() override; // vtable+0x4
+	virtual MxNotificationParam* Clone() override; // vtable+0x04
 
 private:
 	MxPresenter* m_unk0x14; // 0x14

--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -134,8 +134,8 @@ public:
 private:
 	MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);
 
-	MxBITMAPINFO* m_info;          // 0x8
-	BITMAPINFOHEADER* m_bmiHeader; // 0xc
+	MxBITMAPINFO* m_info;          // 0x08
+	BITMAPINFOHEADER* m_bmiHeader; // 0x0c
 	RGBQUAD* m_paletteData;        // 0x10
 	MxU8* m_data;                  // 0x14
 	MxBool m_isHighColor;          // 0x18

--- a/LEGO1/omni/include/mxcollection.h
+++ b/LEGO1/omni/include/mxcollection.h
@@ -20,8 +20,8 @@ public:
 	virtual MxS8 Compare(T, T) { return 0; }
 
 protected:
-	MxU32 m_count;                 // 0x8
-	void (*m_customDestructor)(T); // 0xc
+	MxU32 m_count;                 // 0x08
+	void (*m_customDestructor)(T); // 0x0c
 };
 
 #endif // MXCOLLECTION_H

--- a/LEGO1/omni/include/mxcompositepresenter.h
+++ b/LEGO1/omni/include/mxcompositepresenter.h
@@ -12,7 +12,7 @@ class MxCompositePresenterList : public list<MxPresenter*> {};
 class MxCompositePresenter : public MxPresenter {
 public:
 	MxCompositePresenter();
-	virtual ~MxCompositePresenter() override; // vtable+0x0
+	virtual ~MxCompositePresenter() override; // vtable+0x00
 
 	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 

--- a/LEGO1/omni/include/mxcore.h
+++ b/LEGO1/omni/include/mxcore.h
@@ -9,7 +9,7 @@
 class MxParam;
 
 // VTABLE: LEGO1 0x100dc0f8
-// SIZE 0x8
+// SIZE 0x08
 class MxCore {
 public:
 	MxCore();

--- a/LEGO1/omni/include/mxdiskstreamcontroller.h
+++ b/LEGO1/omni/include/mxdiskstreamcontroller.h
@@ -17,7 +17,7 @@ public:
 	MxDiskStreamController();
 	virtual ~MxDiskStreamController() override;
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x100c7360
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/omni/include/mxdschunk.h
+++ b/LEGO1/omni/include/mxdschunk.h
@@ -61,8 +61,8 @@ public:
 	// MxDSChunk::`scalar deleting destructor'
 
 protected:
-	MxU16 m_flags;    // 0x8
-	MxU32 m_objectId; // 0xc
+	MxU16 m_flags;    // 0x08
+	MxU32 m_objectId; // 0x0c
 	MxLong m_time;    // 0x10
 	MxU32 m_length;   // 0x14
 	MxU8* m_data;     // 0x18

--- a/LEGO1/omni/include/mxdsfile.h
+++ b/LEGO1/omni/include/mxdsfile.h
@@ -12,7 +12,7 @@
 class MxDSFile : public MxDSSource {
 public:
 	MxDSFile(const char* p_filename, MxULong p_skipReadingChunks);
-	virtual ~MxDSFile(); // vtable+0x0
+	virtual ~MxDSFile(); // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100c0120
 	inline virtual const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -68,8 +68,8 @@ public:
 	// MxDSObject::`scalar deleting destructor'
 
 private:
-	MxU32 m_sizeOnDisk;     // 0x8
-	MxU16 m_type;           // 0xc
+	MxU32 m_sizeOnDisk;     // 0x08
+	MxU16 m_type;           // 0x0c
 	char* m_sourceName;     // 0x10
 	undefined4 m_unk0x14;   // 0x14
 	char* m_objectName;     // 0x18

--- a/LEGO1/omni/include/mxentity.h
+++ b/LEGO1/omni/include/mxentity.h
@@ -18,7 +18,7 @@ public:
 	virtual ~MxEntity() override{};
 
 	// FUNCTION: LEGO1 0x1000c180
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0070
 		return "MxEntity";
@@ -52,8 +52,8 @@ public:
 	// MxEntity::`scalar deleting destructor'
 
 protected:
-	MxS32 m_mxEntityId; // 0x8
-	MxAtomId m_atom;    // 0xc
+	MxS32 m_mxEntityId; // 0x08
+	MxAtomId m_atom;    // 0x0c
 };
 
 #endif // MXENTITY_H

--- a/LEGO1/omni/include/mxeventpresenter.h
+++ b/LEGO1/omni/include/mxeventpresenter.h
@@ -12,7 +12,7 @@ public:
 	virtual ~MxEventPresenter() override;
 
 	// FUNCTION: LEGO1 0x100c2c30
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101dcc
 		return "MxEventPresenter";

--- a/LEGO1/omni/include/mxflcpresenter.h
+++ b/LEGO1/omni/include/mxflcpresenter.h
@@ -20,7 +20,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100b33f0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f43c8
 		return "MxFlcPresenter";

--- a/LEGO1/omni/include/mxloopingflcpresenter.h
+++ b/LEGO1/omni/include/mxloopingflcpresenter.h
@@ -12,7 +12,7 @@ public:
 	virtual ~MxLoopingFlcPresenter() override;
 
 	// FUNCTION: LEGO1 0x100b4380
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e20
 		return "MxLoopingFlcPresenter";

--- a/LEGO1/omni/include/mxloopingmidipresenter.h
+++ b/LEGO1/omni/include/mxloopingmidipresenter.h
@@ -8,7 +8,7 @@
 class MxLoopingMIDIPresenter : public MxMIDIPresenter {
 public:
 	// FUNCTION: LEGO1 0x100b1830
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101de0
 		return "MxLoopingMIDIPresenter";

--- a/LEGO1/omni/include/mxloopingsmkpresenter.h
+++ b/LEGO1/omni/include/mxloopingsmkpresenter.h
@@ -9,10 +9,10 @@
 class MxLoopingSmkPresenter : public MxSmkPresenter {
 public:
 	MxLoopingSmkPresenter();
-	virtual ~MxLoopingSmkPresenter() override; // vtable+0x0
+	virtual ~MxLoopingSmkPresenter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100b4920
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e08
 		return "MxLoopingSmkPresenter";

--- a/LEGO1/omni/include/mxmediamanager.h
+++ b/LEGO1/omni/include/mxmediamanager.h
@@ -27,8 +27,8 @@ public:
 	// MxMediaManager::`scalar deleting destructor'
 
 protected:
-	MxPresenterList* m_presenters;       // 0x8
-	MxThread* m_thread;                  // 0xc
+	MxPresenterList* m_presenters;       // 0x08
+	MxThread* m_thread;                  // 0x0c
 	MxCriticalSection m_criticalSection; // 0x10
 };
 

--- a/LEGO1/omni/include/mxmediapresenter.h
+++ b/LEGO1/omni/include/mxmediapresenter.h
@@ -15,10 +15,10 @@ public:
 	// FUNCTION: LEGO1 0x1000c550
 	virtual ~MxMediaPresenter() override { Destroy(TRUE); };
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1000c5c0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f074c
 		return "MxMediaPresenter";

--- a/LEGO1/omni/include/mxmidipresenter.h
+++ b/LEGO1/omni/include/mxmidipresenter.h
@@ -12,7 +12,7 @@ public:
 	virtual ~MxMIDIPresenter() override;
 
 	// FUNCTION: LEGO1 0x100c2650
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101df8
 		return "MxMIDIPresenter";

--- a/LEGO1/omni/include/mxmusicpresenter.h
+++ b/LEGO1/omni/include/mxmusicpresenter.h
@@ -11,7 +11,7 @@ public:
 	virtual ~MxMusicPresenter() override;
 
 	// FUNCTION: LEGO1 0x100c23a0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e48
 		return "MxMusicPresenter";

--- a/LEGO1/omni/include/mxnextactiondatastart.h
+++ b/LEGO1/omni/include/mxnextactiondatastart.h
@@ -16,7 +16,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c1900
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025a0
 		return "MxNextActionDataStart";

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -16,8 +16,8 @@ public:
 	inline MxNotificationParam* GetParam() { return m_param; }
 
 private:
-	MxCore* m_target;             // 0x0
-	MxNotificationParam* m_param; // 0x4
+	MxCore* m_target;             // 0x00
+	MxNotificationParam* m_param; // 0x04
 };
 
 class MxIdList : public list<MxU32> {};
@@ -27,8 +27,8 @@ class MxNotificationPtrList : public list<MxNotification*> {};
 // VTABLE: LEGO1 0x100dc078
 class MxNotificationManager : public MxCore {
 private:
-	MxNotificationPtrList* m_queue;    // 0x8
-	MxNotificationPtrList* m_sendList; // 0xc
+	MxNotificationPtrList* m_queue;    // 0x08
+	MxNotificationPtrList* m_sendList; // 0x0c
 	MxCriticalSection m_lock;          // 0x10
 	MxS32 m_unk0x2c;                   // 0x2c
 	MxIdList m_listenerIds;            // 0x30
@@ -36,9 +36,9 @@ private:
 
 public:
 	MxNotificationManager();
-	virtual ~MxNotificationManager(); // vtable+0x0 (scalar deleting destructor)
+	virtual ~MxNotificationManager(); // vtable+0x00 (scalar deleting destructor)
 
-	virtual MxResult Tickle(); // vtable+0x8
+	virtual MxResult Tickle(); // vtable+0x08
 	// TODO: Where does this method come from?
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x14
 	void Register(MxCore* p_listener);

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -42,7 +42,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10010390
-	virtual MxNotificationParam* Clone() { return new MxNotificationParam(m_type, m_sender); }; // vtable+0x4
+	virtual MxNotificationParam* Clone() { return new MxNotificationParam(m_type, m_sender); }; // vtable+0x04
 
 	inline NotificationId GetNotification() const { return m_type; }
 	inline MxCore* GetSender() const { return m_sender; }

--- a/LEGO1/omni/include/mxobjectfactory.h
+++ b/LEGO1/omni/include/mxobjectfactory.h
@@ -24,7 +24,7 @@ public:
 	MxObjectFactory();
 
 	// FUNCTION: LEGO1 0x10008f70
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0730
 		return "MxObjectFactory";

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -79,7 +79,7 @@ public:
 protected:
 	static MxOmni* g_instance;
 
-	MxString m_mediaPath;                         // 0x8
+	MxString m_mediaPath;                         // 0x08
 	HWND m_windowHandle;                          // 0x18
 	MxObjectFactory* m_objectFactory;             // 0x1C
 	MxVariableTable* m_variableTable;             // 0x20

--- a/LEGO1/omni/include/mxpalette.h
+++ b/LEGO1/omni/include/mxpalette.h
@@ -33,7 +33,7 @@ public:
 
 private:
 	LPDIRECTDRAWPALETTE m_palette;
-	PALETTEENTRY m_entries[256]; // 0xc
+	PALETTEENTRY m_entries[256]; // 0x0c
 	MxBool m_overrideSkyColor;   // 0x40c
 	PALETTEENTRY m_skyColor;     // 0x40d
 };

--- a/LEGO1/omni/include/mxpresenter.h
+++ b/LEGO1/omni/include/mxpresenter.h
@@ -34,7 +34,7 @@ public:
 	virtual MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1000bfe0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0740
 		return "MxPresenter";
@@ -127,7 +127,7 @@ public:
 protected:
 	void Init();
 
-	TickleState m_currentTickleState;           // 0x8
+	TickleState m_currentTickleState;           // 0x08
 	MxU32 m_previousTickleStates;               // 0x0c
 	MxPoint32 m_location;                       // 0x10
 	MxS32 m_displayZ;                           // 0x18

--- a/LEGO1/omni/include/mxramstreamcontroller.h
+++ b/LEGO1/omni/include/mxramstreamcontroller.h
@@ -12,7 +12,7 @@ public:
 	inline MxRAMStreamController() {}
 
 	// FUNCTION: LEGO1 0x100b9430
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102118
 		return "MxRAMStreamController";

--- a/LEGO1/omni/include/mxramstreamprovider.h
+++ b/LEGO1/omni/include/mxramstreamprovider.h
@@ -11,7 +11,7 @@ public:
 	virtual ~MxRAMStreamProvider() override;
 
 	// FUNCTION: LEGO1 0x100d0970
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102864
 		return "MxRAMStreamProvider";

--- a/LEGO1/omni/include/mxsmkpresenter.h
+++ b/LEGO1/omni/include/mxsmkpresenter.h
@@ -13,7 +13,7 @@ public:
 	virtual ~MxSmkPresenter() override;
 
 	// FUNCTION: LEGO1 0x100b3730
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e38
 		return "MxSmkPresenter";

--- a/LEGO1/omni/include/mxsoundmanager.h
+++ b/LEGO1/omni/include/mxsoundmanager.h
@@ -12,7 +12,7 @@
 class MxSoundManager : public MxAudioManager {
 public:
 	MxSoundManager();
-	virtual ~MxSoundManager() override; // vtable+0x0
+	virtual ~MxSoundManager() override; // vtable+0x00
 
 	virtual void Destroy() override;                                     // vtable+0x18
 	virtual void SetVolume(MxS32 p_volume) override;                     // vtable+0x2c

--- a/LEGO1/omni/include/mxstillpresenter.h
+++ b/LEGO1/omni/include/mxstillpresenter.h
@@ -14,7 +14,7 @@ public:
 	virtual ~MxStillPresenter() override { Destroy(TRUE); }; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100435c0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0184
 		return "MxStillPresenter";

--- a/LEGO1/omni/include/mxstreamchunk.h
+++ b/LEGO1/omni/include/mxstreamchunk.h
@@ -15,7 +15,7 @@ public:
 	virtual ~MxStreamChunk() override;
 
 	// FUNCTION: LEGO1 0x100b1fe0
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e5c
 		return "MxStreamChunk";

--- a/LEGO1/omni/include/mxstreamcontroller.h
+++ b/LEGO1/omni/include/mxstreamcontroller.h
@@ -19,10 +19,10 @@ class MxDSStreamingAction;
 class MxStreamController : public MxCore {
 public:
 	MxStreamController();
-	virtual ~MxStreamController() override; // vtable+0x0
+	virtual ~MxStreamController() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100c0f10
-	inline virtual const char* ClassName() const override // vtable+0xc
+	inline virtual const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102130
 		return "MxStreamController";
@@ -60,7 +60,7 @@ public:
 	inline MxStreamListMxDSSubscriber& GetSubscriberList() { return m_subscriberList; };
 
 protected:
-	MxCriticalSection m_criticalSection;                // 0x8
+	MxCriticalSection m_criticalSection;                // 0x08
 	MxAtomId m_atom;                                    // 0x24
 	MxStreamProvider* m_provider;                       // 0x28
 	undefined4* m_unk0x2c;                              // 0x2c

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -76,12 +76,12 @@ public:
 	};
 
 	MxStreamer();
-	virtual ~MxStreamer() override; // vtable+0x0
+	virtual ~MxStreamer() override; // vtable+0x00
 
 	MxStreamController* Open(const char* p_name, MxU16 p_openMode);
 	MxLong Close(const char* p_name);
 
-	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x4
+	virtual MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100b9000
 	inline virtual const char* ClassName() const override // vtable+0x0c
@@ -109,7 +109,7 @@ public:
 	inline const MxStreamerSubClass3& GetSubclass2() { return m_subclass2; }
 
 private:
-	list<MxStreamController*> m_openStreams; // 0x8
+	list<MxStreamController*> m_openStreams; // 0x08
 	MxStreamerSubClass2 m_subclass1;         // 0x14
 	MxStreamerSubClass3 m_subclass2;         // 0x20
 };

--- a/LEGO1/omni/include/mxstreamlist.h
+++ b/LEGO1/omni/include/mxstreamlist.h
@@ -20,7 +20,7 @@ public:
 	}
 };
 
-// SIZE 0xc
+// SIZE 0x0c
 class MxStreamListMxDSAction : public MxStreamList<MxDSAction*> {
 public:
 	MxDSAction* Find(MxDSAction* p_action, MxBool p_delete);
@@ -38,14 +38,14 @@ public:
 	}
 };
 
-// SIZE 0xc
+// SIZE 0x0c
 class MxStreamListMxNextActionDataStart : public MxStreamList<MxNextActionDataStart*> {
 public:
 	MxNextActionDataStart* Find(MxU32 p_id, MxS16 p_value);
 	MxNextActionDataStart* FindAndErase(MxU32 p_id, MxS16 p_value);
 };
 
-// SIZE 0xc
+// SIZE 0x0c
 class MxStreamListMxDSSubscriber : public MxStreamList<MxDSSubscriber*> {
 public:
 	MxDSSubscriber* Find(MxDSObject* p_object);

--- a/LEGO1/omni/include/mxticklemanager.h
+++ b/LEGO1/omni/include/mxticklemanager.h
@@ -24,10 +24,10 @@ public:
 	inline void SetFlags(MxU16 p_flags) { m_flags = p_flags; }
 
 private:
-	MxCore* m_client;        // 0x0
-	MxTime m_interval;       // 0x4
-	MxTime m_lastUpdateTime; // 0x8
-	MxU16 m_flags;           // 0xc
+	MxCore* m_client;        // 0x00
+	MxTime m_interval;       // 0x04
+	MxTime m_lastUpdateTime; // 0x08
+	MxU16 m_flags;           // 0x0c
 };
 
 typedef list<MxTickleClient*> MxTickleClientPtrList;
@@ -36,9 +36,9 @@ typedef list<MxTickleClient*> MxTickleClientPtrList;
 class MxTickleManager : public MxCore {
 public:
 	inline MxTickleManager() {}
-	virtual ~MxTickleManager(); // vtable+0x0 (scalar deleting destructor)
+	virtual ~MxTickleManager(); // vtable+0x00 (scalar deleting destructor)
 
-	virtual MxResult Tickle();                                                 // vtable+0x8
+	virtual MxResult Tickle();                                                 // vtable+0x08
 	virtual void RegisterClient(MxCore* p_client, MxTime p_interval);          // vtable+0x14
 	virtual void UnregisterClient(MxCore* p_client);                           // vtable+0x18
 	virtual void SetClientTickleInterval(MxCore* p_client, MxTime p_interval); // vtable+0x1c
@@ -48,7 +48,7 @@ public:
 	// MxTickleManager::`scalar deleting destructor'
 
 private:
-	MxTickleClientPtrList m_clients; // 0x8
+	MxTickleClientPtrList m_clients; // 0x08
 };
 
 #define TICKLE_MANAGER_NOT_FOUND 0x80000000

--- a/LEGO1/omni/include/mxtype18notificationparam.h
+++ b/LEGO1/omni/include/mxtype18notificationparam.h
@@ -8,7 +8,7 @@
 // SIZE 0x10
 class MxType18NotificationParam : public MxNotificationParam {
 protected:
-	undefined4 m_unk0xc; // 0xc
+	undefined4 m_unk0x0c; // 0x0c
 };
 
 #endif // MXTYPE18NOTIFICATIONPARAM_H

--- a/LEGO1/omni/include/mxtype19notificationparam.h
+++ b/LEGO1/omni/include/mxtype19notificationparam.h
@@ -8,8 +8,8 @@
 // SIZE 0x10
 class MxType19NotificationParam : public MxNotificationParam {
 protected:
-	MxU16 m_unk0xc; // 0xc
-	MxU8 m_unk0xe;  // 0xe
+	MxU16 m_unk0x0c; // 0x0c
+	MxU8 m_unk0x0e;  // 0x0e
 };
 
 #endif // MXTYPE19NOTIFICATIONPARAM_H

--- a/LEGO1/omni/include/mxvideomanager.h
+++ b/LEGO1/omni/include/mxvideomanager.h
@@ -16,7 +16,7 @@ public:
 	MxVideoManager();
 	virtual ~MxVideoManager() override;
 
-	virtual MxResult Tickle() override; // vtable+0x8
+	virtual MxResult Tickle() override; // vtable+0x08
 	virtual void Destroy() override;    // vtable+0x18
 	virtual MxResult VTable0x28(
 		MxVideoParam& p_videoParam,

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -13,7 +13,7 @@ public:
 	MxVideoPresenter() { Init(); }
 
 	// FUNCTION: LEGO1 0x1000c740
-	virtual ~MxVideoPresenter() override { Destroy(TRUE); }; // vtable+0x0
+	virtual ~MxVideoPresenter() override { Destroy(TRUE); }; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x1000c820
 	inline virtual const char* ClassName() const override // vtable+0x0c
@@ -73,7 +73,7 @@ public:
 	virtual MxS32 GetHeight() { return m_alpha ? m_alpha->m_height : m_bitmap->GetBmiHeightAbs(); }; // vtable+0x84
 
 	// VTABLE: LEGO1 0x100dc2bc
-	// SIZE 0xc
+	// SIZE 0x0c
 	struct AlphaMask {
 		MxU8* m_bitmask;
 		MxU16 m_width;

--- a/LEGO1/omni/src/common/mxticklemanager.cpp
+++ b/LEGO1/omni/src/common/mxticklemanager.cpp
@@ -5,7 +5,7 @@
 #include "mxtimer.h"
 #include "mxtypes.h"
 
-#define TICKLE_MANAGER_FLAG_DESTROY 0x1
+#define TICKLE_MANAGER_FLAG_DESTROY 0x01
 
 DECOMP_SIZE_ASSERT(MxTickleClient, 0x10);
 DECOMP_SIZE_ASSERT(MxTickleManager, 0x14);

--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -8,7 +8,7 @@
 #include "mxticklemanager.h"
 #include "mxtypes.h"
 
-DECOMP_SIZE_ASSERT(MxNotification, 0x8);
+DECOMP_SIZE_ASSERT(MxNotification, 0x08);
 DECOMP_SIZE_ASSERT(MxNotificationManager, 0x40);
 
 // FUNCTION: LEGO1 0x100ac220

--- a/LEGO1/omni/src/notify/mxnotificationparam.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationparam.cpp
@@ -2,4 +2,4 @@
 
 #include "decomp.h"
 
-DECOMP_SIZE_ASSERT(MxNotificationParam, 0xc);
+DECOMP_SIZE_ASSERT(MxNotificationParam, 0x0c);

--- a/LEGO1/omni/src/stream/mxdschunk.cpp
+++ b/LEGO1/omni/src/stream/mxdschunk.cpp
@@ -22,5 +22,5 @@ MxDSChunk::~MxDSChunk()
 // FUNCTION: LEGO1 0x100be1e0
 MxU32 MxDSChunk::GetHeaderSize()
 {
-	return 0xe;
+	return 0x0e;
 }

--- a/LEGO1/omni/src/stream/mxdsfile.cpp
+++ b/LEGO1/omni/src/stream/mxdsfile.cpp
@@ -62,7 +62,7 @@ MxLong MxDSFile::ReadChunks()
 		return -1;
 	}
 
-	m_io.Read(&m_header, 0xc);
+	m_io.Read(&m_header, 0x0c);
 	if ((m_header.m_majorVersion == SI_MAJOR_VERSION) && (m_header.m_minorVersion == SI_MINOR_VERSION)) {
 		childChunk.ckid = FOURCC('M', 'x', 'O', 'f');
 		if (m_io.Descend(&childChunk, &topChunk, 0) != 0) {

--- a/LEGO1/omni/src/stream/mxstreamlist.cpp
+++ b/LEGO1/omni/src/stream/mxstreamlist.cpp
@@ -1,9 +1,9 @@
 #include "mxstreamlist.h"
 
 // Wrappers around STL list that are used by the MxStream* classes.
-DECOMP_SIZE_ASSERT(MxStreamListMxDSAction, 0xc);
-DECOMP_SIZE_ASSERT(MxStreamListMxNextActionDataStart, 0xc);
-DECOMP_SIZE_ASSERT(MxStreamListMxDSSubscriber, 0xc);
+DECOMP_SIZE_ASSERT(MxStreamListMxDSAction, 0x0c);
+DECOMP_SIZE_ASSERT(MxStreamListMxNextActionDataStart, 0x0c);
+DECOMP_SIZE_ASSERT(MxStreamListMxDSSubscriber, 0x0c);
 
 // FUNCTION: LEGO1 0x100b8450
 MxDSSubscriber* MxStreamListMxDSSubscriber::Find(MxDSObject* p_object)

--- a/LEGO1/omni/src/video/mxvideopresenter.cpp
+++ b/LEGO1/omni/src/video/mxvideopresenter.cpp
@@ -6,7 +6,7 @@
 #include "mxvideomanager.h"
 
 DECOMP_SIZE_ASSERT(MxVideoPresenter, 0x64);
-DECOMP_SIZE_ASSERT(MxVideoPresenter::AlphaMask, 0xc);
+DECOMP_SIZE_ASSERT(MxVideoPresenter::AlphaMask, 0x0c);
 
 // FUNCTION: LEGO1 0x100b24f0
 MxVideoPresenter::AlphaMask::AlphaMask(const MxBitmap& p_bitmap)

--- a/LEGO1/realtime/matrix.cpp
+++ b/LEGO1/realtime/matrix.cpp
@@ -2,4 +2,4 @@
 
 #include "decomp.h"
 
-DECOMP_SIZE_ASSERT(Matrix4, 0x8);
+DECOMP_SIZE_ASSERT(Matrix4, 0x08);

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -10,7 +10,7 @@ struct UnknownMatrixType {
 };
 
 // VTABLE: LEGO1 0x100d4350
-// SIZE 0x8
+// SIZE 0x08
 class Matrix4 {
 public:
 	inline Matrix4(float (*p_data)[4]) { SetData(p_data); }

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -16,8 +16,8 @@ public:
 
 	OrientableROI();
 
-	virtual const float* GetWorldVelocity() const override;                // vtable+0x8
-	virtual const BoundingBox& GetWorldBoundingBox() const override;       // vtable+0xc
+	virtual const float* GetWorldVelocity() const override;                // vtable+0x08
+	virtual const BoundingBox& GetWorldBoundingBox() const override;       // vtable+0x0c
 	virtual const BoundingSphere& GetWorldBoundingSphere() const override; // vtable+0x10
 	// FUNCTION: LEGO1 0x100a5db0
 	virtual void VTable0x14() { VTable0x1c(); }                 // vtable+0x14

--- a/LEGO1/realtime/roi.h
+++ b/LEGO1/realtime/roi.h
@@ -49,9 +49,9 @@ class LODObject {
 public:
 	// LODObject();
 	virtual ~LODObject() {}
-	virtual float Cost(float pixels_covered) const = 0; // vtable+0x4
-	virtual float AveragePolyArea() const = 0;          // vtable+0x8
-	virtual int NVerts() const = 0;                     // vtable+0xc
+	virtual float Cost(float pixels_covered) const = 0; // vtable+0x04
+	virtual float AveragePolyArea() const = 0;          // vtable+0x08
+	virtual int NVerts() const = 0;                     // vtable+0x0c
 };
 
 /*
@@ -81,7 +81,7 @@ public:
 	{
 		m_comp = 0;
 		m_lods = 0;
-		m_unk0xc = 1;
+		m_unk0x0c = 1;
 	}
 	virtual ~ROI()
 	{
@@ -89,9 +89,9 @@ public:
 		assert(!m_comp);
 		assert(!m_lods);
 	}
-	virtual float IntrinsicImportance() const = 0;                    // vtable+0x4
-	virtual const float* GetWorldVelocity() const = 0;                // vtable+0x8
-	virtual const BoundingBox& GetWorldBoundingBox() const = 0;       // vtable+0xc
+	virtual float IntrinsicImportance() const = 0;                    // vtable+0x04
+	virtual const float* GetWorldVelocity() const = 0;                // vtable+0x08
+	virtual const BoundingBox& GetWorldBoundingBox() const = 0;       // vtable+0x0c
 	virtual const BoundingSphere& GetWorldBoundingSphere() const = 0; // vtable+0x10
 
 	const LODListBase* GetLODs() const { return m_lods; }
@@ -103,15 +103,15 @@ public:
 	int GetLODCount() const { return m_lods ? m_lods->Size() : 0; }
 	const CompoundObject* GetComp() const { return m_comp; }
 
-	inline undefined GetUnk0x0c() { return m_unk0xc; }
+	inline undefined GetUnk0x0c() { return m_unk0x0c; }
 
 	// SYNTHETIC: LEGO1 0x100a5d60
 	// ROI::`scalar deleting destructor'
 
 protected:
-	CompoundObject* m_comp; // 0x4
-	LODListBase* m_lods;    // 0x8
-	undefined m_unk0xc;     // 0xc
+	CompoundObject* m_comp; // 0x04
+	LODListBase* m_lods;    // 0x08
+	undefined m_unk0x0c;    // 0x0c
 };
 
 // SYNTHETIC: LEGO1 0x100a5d50

--- a/LEGO1/realtime/vector.cpp
+++ b/LEGO1/realtime/vector.cpp
@@ -2,6 +2,6 @@
 
 #include "decomp.h"
 
-DECOMP_SIZE_ASSERT(Vector2, 0x8);
-DECOMP_SIZE_ASSERT(Vector3, 0x8);
-DECOMP_SIZE_ASSERT(Vector4, 0x8);
+DECOMP_SIZE_ASSERT(Vector2, 0x08);
+DECOMP_SIZE_ASSERT(Vector3, 0x08);
+DECOMP_SIZE_ASSERT(Vector4, 0x08);

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -263,7 +263,7 @@ public:
 };
 
 // VTABLE: LEGO1 0x100d45a0
-// SIZE 0x8
+// SIZE 0x08
 class Vector4 : public Vector3 {
 public:
 	inline Vector4(float* p_data) : Vector3(p_data) {}

--- a/LEGO1/tgl/d3drm/camera.cpp
+++ b/LEGO1/tgl/d3drm/camera.cpp
@@ -2,8 +2,8 @@
 
 using namespace TglImpl;
 
-DECOMP_SIZE_ASSERT(Camera, 0x4);
-DECOMP_SIZE_ASSERT(CameraImpl, 0x8);
+DECOMP_SIZE_ASSERT(Camera, 0x04);
+DECOMP_SIZE_ASSERT(CameraImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a36f0
 void* CameraImpl::ImplementationDataPtr()

--- a/LEGO1/tgl/d3drm/light.cpp
+++ b/LEGO1/tgl/d3drm/light.cpp
@@ -2,8 +2,8 @@
 
 using namespace TglImpl;
 
-DECOMP_SIZE_ASSERT(Light, 0x4);
-DECOMP_SIZE_ASSERT(LightImpl, 0x8);
+DECOMP_SIZE_ASSERT(Light, 0x04);
+DECOMP_SIZE_ASSERT(LightImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a3770
 void* LightImpl::ImplementationDataPtr()

--- a/LEGO1/tgl/d3drm/mesh.cpp
+++ b/LEGO1/tgl/d3drm/mesh.cpp
@@ -4,8 +4,8 @@ using namespace TglImpl;
 
 DECOMP_SIZE_ASSERT(D3DRMVERTEX, 0x24);
 
-DECOMP_SIZE_ASSERT(Mesh, 0x4);
-DECOMP_SIZE_ASSERT(MeshImpl, 0x8);
+DECOMP_SIZE_ASSERT(Mesh, 0x04);
+DECOMP_SIZE_ASSERT(MeshImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a3ed0
 void* MeshImpl::ImplementationDataPtr()

--- a/LEGO1/tgl/d3drm/unk.cpp
+++ b/LEGO1/tgl/d3drm/unk.cpp
@@ -2,8 +2,8 @@
 
 using namespace TglImpl;
 
-DECOMP_SIZE_ASSERT(Unk, 0x4);
-DECOMP_SIZE_ASSERT(UnkImpl, 0x8);
+DECOMP_SIZE_ASSERT(Unk, 0x04);
+DECOMP_SIZE_ASSERT(UnkImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a3830
 void* UnkImpl::ImplementationDataPtr()


### PR DESCRIPTION
This cleans up uses of single digit hex values such as `0x4`, `0xc` etc. and pads them with a zero:

![Untitled](https://github.com/isledecomp/isle/assets/1135351/16c6f1d2-a4fc-4e97-bf97-3473e8a7ca50)

This is mainly for readability and consistency purposes. The substitution regex that fixes up all the occurences - as far as I can tell- is as follows (could be added to the decomp linter @disinvite):

`(\s|_unk|\+|VTable|Unknown|Unk)0x([a-f0-9])($|;|\s|\)|\.|,|\[)` replace with `$10x0$2$3`