### PR TITLE
roadmap: Suggest order of modules

### DIFF
--- a/tools/roadmap/roadmap.py
+++ b/tools/roadmap/roadmap.py
@@ -56,10 +56,17 @@ class ModuleMap:
 
     def get_module(self, addr: int) -> Optional[str]:
         i = bisect.bisect_left(self.contrib_starts, addr)
+        # If the addr matches the section contribution start, we are in the
+        # right spot. Otherwise, we need to subtract one here.
+        # We don't want the insertion point given by bisect, but the
+        # section contribution that contains the address.
 
-        # Clamp to final section contribution for a very high address
-        if i >= len(self.section_contrib):
-            i = len(self.section_contrib) - 1
+        (potential_start, _, __) = self.section_contrib[i]
+        if potential_start != addr:
+            i -= 1
+
+        # Safety catch: clamp to range of indices from section_contrib.
+        i = max(0, min(i, len(self.section_contrib) - 1))
 
         (start, size, module_id) = self.section_contrib[i]
         if start <= addr < start + size:

--- a/tools/roadmap/roadmap.py
+++ b/tools/roadmap/roadmap.py
@@ -264,7 +264,7 @@ def suggest_order(results: List[RoadmapRow], module_map: ModuleMap, match_type: 
     # Now display the order of all libaries in the final file.
     library_order = {}
 
-    for module, start in dc.earliest.items():
+    for start, module in computed_order:
         lib = module_map.get_lib_for_module(module)
         if lib is None:
             lib = get_cmakefiles_prefix(module)
@@ -272,7 +272,7 @@ def suggest_order(results: List[RoadmapRow], module_map: ModuleMap, match_type: 
         if start < library_order.get(lib, 0xFFFFFFFFF):
             library_order[lib] = start
 
-    print("Library order (earliest address shown):")
+    print("Library order (average address shown):")
     for lib, start in sorted(library_order.items(), key=lambda x: x[1]):
         # Strip off any OS path for brevity
         if not lib.startswith("CMakeFiles"):


### PR DESCRIPTION
This adds a new command line option `--order` to the `roadmap` tool that will suggest the order of modules (i.e. translation units). This is broken out by build target, so for `LEGO1` each library will show its own list of modules.

By default, we are looking for functions from each module and where they first appear in the binary. We also show the average displacement for each function from that module (i.e. how far off it is in the recomp from where it should be.) `Score::Score` is the first function from `LEGO1` so naturally the `score.cpp` module appears first in the list. You can provide an argument to `--order` to pick which symbol type you want to look at. For example: `--order vtable` will look at only vtables.

*Caution:* This will _only_ show modules that are currently used in the final binary. You should not copy the list from `roadmap` directly into `CMakeLists.txt` because this will omit any modules that are not referenced yet. Some modules are marked "no suggestion", which means that it is being used, but provides no symbols matching the type that you chose. To give an example, `LEGO1/realtime/matrix.cpp` is included in the list, but no symbols from the .obj file are used in `LEGO1` at the moment.

If we think it's worth applying the results directly to `CMakeLists.txt` now, we can do that. I think combining the results from checking functions _and_ vtables would be a good starting point.