### PR TITLE
cmake+ci: run clang-tidy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,20 @@ jobs:
       matrix:
         toolchain:
         - { name: 'MSVC',           shell: 'sh',        setup-cmake: true, setup-ninja: true, setup-msvc: true }
-        - { name: 'msys2 mingw32',  shell: 'msys2 {0}', setup-msys2: true }
+        - { name: 'msys2 mingw32',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true }
+        - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true }
 
     steps:
       - name: Set up MSYS2
-        if: matrix.toolchain.setup-msys2
+        if: ${{ !!matrix.toolchain.msystem }}
         uses: msys2/setup-msys2@v2
         with:
-          msystem: mingw32
+          msystem: ${{ matrix.toolchain.msystem }}
           install: >-
-            mingw-w64-i686-cc
-            mingw-w64-i686-cmake
-            mingw-w64-i686-ninja
+            ${{ matrix.toolchain.msys-env }}-cc
+            ${{ matrix.toolchain.msys-env }}-cmake
+            ${{ matrix.toolchain.msys-env }}-ninja
+            ${{ matrix.toolchain.msys-env }}-clang-tools-extra
 
       - name: Setup cmake
         if: matrix.toolchain.setup-cmake
@@ -45,7 +47,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja -Werror=dev
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja -Werror=dev -DENABLE_CLANG_TIDY=${{ !!matrix.toolchain.clang-tidy }}
           cmake --build build
 
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(isle CXX)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+option(ENABLE_CLANG_TIDY "Enable clang-tidy")
+if (ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_BIN NAMES "clang-tidy")
+    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_BIN}")
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_BIN}")
+endif()
+
 math(EXPR bits "8 * ${CMAKE_SIZEOF_VOID_P}")
 message(STATUS "Building ${bits}-bit LEGO Island")
 if (NOT bits EQUAL 32)


### PR DESCRIPTION
This adds a `ENABLE_CLANG_TIDY` cmake option  that will let cmake drive clang-tidy.
CMake also does `set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)` unconditionally, so you (or your ide) can always run `clang-tidy` manually without worrying about cmake.

I've also added a job for building isle with clang. It fails for a dumb reason:
```
[241/243] Linking CXX shared library LEGO1.DLL
FAILED: LEGO1.DLL libLEGO1.dll.a 
C:\Windows\system32\cmd.exe /C "cd . && D:\a\_temp\msys64\clang32\bin\c++.exe -g  D:\a\isle\isle\LEGO1\LegoOmni.mingw.def -shared -o LEGO1.DLL -Wl,--out-implib,libLEGO1.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles\lego1.rsp  && cd ."
ld.lld: error: unknown directive: DESCRIPTION
```
I cannot find `DESCRIPTION` in the [Module-Definition (.Def) Files documentation](https://learn.microsoft.com/en-us/cpp/build/reference/module-definition-dot-def-files). So let's remove it?

I have not added a `.clang-tidy` yet in the root folder. You probably want to disable some checks in there.