### PR TITLE
Match MxDSFile scalar ddtor, add annotations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,8 @@ if (ISLE_BUILD_APP)
     ISLE/define.cpp
   )
 
+  target_compile_definitions(isle PRIVATE ISLE_APP)
+
   # Use internal DirectX 5 if required
   target_link_libraries(isle PRIVATE $<$<BOOL:${ISLE_USE_DX5}>:DirectX5::DirectX5>)
 

--- a/LEGO1/omni/include/mxdsfile.h
+++ b/LEGO1/omni/include/mxdsfile.h
@@ -9,10 +9,19 @@
 #include <windows.h>
 
 // VTABLE: LEGO1 0x100dc890
+// SIZE 0x7c
 class MxDSFile : public MxDSSource {
 public:
 	MxDSFile(const char* p_filename, MxULong p_skipReadingChunks);
-	~MxDSFile() override; // vtable+0x00
+
+#ifdef ISLE_APP
+	~MxDSFile() override { Close(); }
+#else
+	// We have to explicitly use dllexport, otherwise this function cannot be exported,
+	// since it is inlined everywhere in LEGO1.DLL
+	// FUNCTION: LEGO1 0x100bfed0
+	__declspec(dllexport) ~MxDSFile() override { Close(); }
+#endif
 
 	// FUNCTION: LEGO1 0x100c0120
 	inline const char* ClassName() const override // vtable+0x0c
@@ -41,25 +50,27 @@ public:
 	// SYNTHETIC: LEGO1 0x100c01e0
 	// MxDSFile::`scalar deleting destructor'
 
-private:
-	MxLong ReadChunks();
+	// SIZE 0x0c
 	struct ChunkHeader {
 		ChunkHeader() : m_majorVersion(0), m_minorVersion(0), m_bufferSize(0), m_streamBuffersNum(0) {}
 
-		MxU16 m_majorVersion;
-		MxU16 m_minorVersion;
-		MxULong m_bufferSize;
-		MxS16 m_streamBuffersNum;
-		MxS16 m_reserved;
+		MxU16 m_majorVersion;     // 0x00
+		MxU16 m_minorVersion;     // 0x02
+		MxULong m_bufferSize;     // 0x04
+		MxS16 m_streamBuffersNum; // 0x08
+		MxS16 m_reserved;         // 0x0a
 	};
 
-	MxString m_filename;
-	MXIOINFO m_io;
-	ChunkHeader m_header;
+private:
+	MxLong ReadChunks();
+
+	MxString m_filename;  // 0x14
+	MXIOINFO m_io;        // 0x24
+	ChunkHeader m_header; // 0x6c
 
 	// If false, read chunks immediately on open, otherwise
 	// skip reading chunks until ReadChunks is explicitly called.
-	MxULong m_skipReadingChunks;
+	MxULong m_skipReadingChunks; // 0x78
 };
 
 #endif // MXDSFILE_H

--- a/LEGO1/omni/include/mxioinfo.h
+++ b/LEGO1/omni/include/mxioinfo.h
@@ -9,6 +9,7 @@
 #include <mmsystem.h>
 // clang-format on
 
+// SIZE 0x48
 class MXIOINFO {
 public:
 	MXIOINFO();

--- a/LEGO1/omni/src/stream/mxdsfile.cpp
+++ b/LEGO1/omni/src/stream/mxdsfile.cpp
@@ -1,15 +1,14 @@
 #include "mxdsfile.h"
 
+#include "decomp.h"
+
 #include <stdio.h>
 
 #define SI_MAJOR_VERSION 2
 #define SI_MINOR_VERSION 2
 
-// FUNCTION: LEGO1 0x100bfed0
-MxDSFile::~MxDSFile()
-{
-	Close();
-}
+DECOMP_SIZE_ASSERT(MxDSFile::ChunkHeader, 0x0c)
+DECOMP_SIZE_ASSERT(MxDSFile, 0x7c)
 
 // FUNCTION: LEGO1 0x100cc4b0
 MxDSFile::MxDSFile(const char* p_filename, MxULong p_skipReadingChunks)
@@ -37,10 +36,10 @@ MxLong MxDSFile::Open(MxULong p_uStyle)
 	}
 
 	if (longResult != 0) {
-		Close(); // vtable + 0x18
+		Close();
 	}
 	else {
-		Seek(0, 0); // vtable + 0x24
+		Seek(0, 0);
 	}
 
 	return longResult;


### PR DESCRIPTION
The destructor of `MxDSFile` is actually inlined everywhere, but it needs to be exported. The workaround is to use `dllexport` directly on the destructor, but only when we compile the DLL. This is necessary to match the scalar ddtor. Also added annotations.