### PR TITLE
Starting removing `this->` from `LEGO1/lego/legoomni/`

### DIFF
--- a/LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
@@ -21,15 +21,15 @@ LegoLoadCacheSoundPresenter::~LegoLoadCacheSoundPresenter()
 // FUNCTION: LEGO1 0x100184e0
 void LegoLoadCacheSoundPresenter::Init()
 {
-	this->m_unk0x70 = NULL;
-	this->m_unk0x78 = 0;
-	this->m_unk0x7c = 0;
+	m_unk0x70 = NULL;
+	m_unk0x78 = 0;
+	m_unk0x7c = 0;
 }
 
 // FUNCTION: LEGO1 0x100184f0
 void LegoLoadCacheSoundPresenter::Destroy(MxBool p_fromDestructor)
 {
-	delete[] this->m_unk0x70;
+	delete[] m_unk0x70;
 	MxWavePresenter::Destroy(p_fromDestructor);
 }
 

--- a/LEGO1/lego/legoomni/src/build/dunebuggy.cpp
+++ b/LEGO1/lego/legoomni/src/build/dunebuggy.cpp
@@ -7,8 +7,8 @@ DECOMP_SIZE_ASSERT(DuneBuggy, 0x16c);
 // FUNCTION: LEGO1 0x10067bb0
 DuneBuggy::DuneBuggy()
 {
-	this->m_unk0x13c = 25.0;
-	this->m_unk0x164 = 1.0;
+	m_unk0x13c = 25.0;
+	m_unk0x164 = 1.0;
 }
 
 // STUB: LEGO1 0x10067e30

--- a/LEGO1/lego/legoomni/src/build/jetski.cpp
+++ b/LEGO1/lego/legoomni/src/build/jetski.cpp
@@ -5,9 +5,9 @@ DECOMP_SIZE_ASSERT(Jetski, 0x164);
 // FUNCTION: LEGO1 0x1007e3b0
 Jetski::Jetski()
 {
-	this->m_unk0x13c = 25.0;
-	this->m_unk0x150 = 2.0;
-	this->m_unk0x148 = 1;
+	m_unk0x13c = 25.0;
+	m_unk0x150 = 2.0;
+	m_unk0x148 = 1;
 }
 
 // STUB: LEGO1 0x1007e630

--- a/LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
+++ b/LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
@@ -7,11 +7,11 @@ DECOMP_SIZE_ASSERT(LegoVehicleBuildState, 0x50)
 // FUNCTION: LEGO1 0x10025f30
 LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
 {
-	this->m_className = p_classType;
-	this->m_unk0x4c = 0;
-	this->m_unk0x4d = 0;
-	this->m_unk0x4e = 0;
-	this->m_placedPartCount = 0;
+	m_className = p_classType;
+	m_unk0x4c = 0;
+	m_unk0x4d = 0;
+	m_unk0x4e = 0;
+	m_placedPartCount = 0;
 }
 
 // STUB: LEGO1 0x10026120


### PR DESCRIPTION
This PR does:
- Removing all unnecessary `this->` keywords from folder `LEGO1/lego/legoomni/audio/`
- Removing all unnecessary `this->` keywords from folder `LEGO1/lego/legoomni/build/`