### PR TITLE
Match static function variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,8 +415,8 @@ set_property(TARGET lego1 PROPERTY SUFFIX ".DLL")
 if (ISLE_BUILD_APP)
   add_executable(isle WIN32
     ISLE/res/isle.rc
-    ISLE/isleapp.cpp
     ISLE/define.cpp
+    ISLE/isleapp.cpp
   )
 
   target_compile_definitions(isle PRIVATE ISLE_APP)

--- a/ISLE/define.cpp
+++ b/ISLE/define.cpp
@@ -32,9 +32,3 @@ int g_targetDepth = 16;
 
 // GLOBAL: ISLE 0x410064
 int g_reqEnableRMDevice = 0;
-
-// GLOBAL: ISLE 0x4101bc
-int g_startupDelay = 200;
-
-// GLOBAL: ISLE 0x4101c0
-MxLong g_lastFrameTime = 0;

--- a/ISLE/define.h
+++ b/ISLE/define.h
@@ -21,7 +21,5 @@ extern int g_targetWidth;
 extern int g_targetHeight;
 extern int g_targetDepth;
 extern int g_reqEnableRMDevice;
-extern int g_startupDelay;
-extern MxLong g_lastFrameTime;
 
 #endif // DEFINE_H

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -765,6 +765,12 @@ void IsleApp::LoadConfig()
 // FUNCTION: ISLE 0x402c20
 inline void IsleApp::Tick(BOOL sleepIfNotNextFrame)
 {
+	// GLOBAL: ISLE 0x4101c0
+	static MxLong g_lastFrameTime = 0;
+
+	// GLOBAL: ISLE 0x4101bc
+	static int g_startupDelay = 200;
+
 	if (!this->m_windowActive) {
 		Sleep(0);
 		return;

--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -134,7 +134,9 @@ class Compare:
                 except UnicodeDecodeError:
                     pass
 
-            self._db.set_recomp_symbol(addr, sym.node_type, sym.name(), sym.size())
+            self._db.set_recomp_symbol(
+                addr, sym.node_type, sym.name(), sym.decorated_name, sym.size()
+            )
 
         for lineref in cv.lines:
             addr = self.recomp_bin.get_abs_addr(lineref.section, lineref.offset)
@@ -168,7 +170,12 @@ class Compare:
                 self._db.skip_compare(fun.offset)
 
         for var in codebase.iter_variables():
-            self._db.match_variable(var.offset, var.name)
+            if var.is_static and var.parent_function is not None:
+                self._db.match_static_variable(
+                    var.offset, var.name, var.parent_function
+                )
+            else:
+                self._db.match_variable(var.offset, var.name)
 
         for tbl in codebase.iter_vtables():
             self._db.match_vtable(tbl.offset, tbl.name)

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -12,6 +12,7 @@ _SETUP_SQL = """
         orig_addr int,
         recomp_addr int,
         name text,
+        decorated_name text,
         size int,
         should_skip int default(FALSE)
     );
@@ -65,12 +66,13 @@ class CompareDb:
         addr: int,
         compare_type: Optional[SymbolType],
         name: Optional[str],
+        decorated_name: Optional[str],
         size: Optional[int],
     ):
         compare_value = compare_type.value if compare_type is not None else None
         self._db.execute(
-            "INSERT INTO `symbols` (recomp_addr, compare_type, name, size) VALUES (?,?,?,?)",
-            (addr, compare_value, name, size),
+            "INSERT INTO `symbols` (recomp_addr, compare_type, name, decorated_name, size) VALUES (?,?,?,?,?)",
+            (addr, compare_value, name, decorated_name, size),
         )
 
     def get_unmatched_strings(self) -> List[str]:
@@ -211,6 +213,56 @@ class CompareDb:
         did_match = self._match_on(SymbolType.VTABLE, addr, name)
         if not did_match:
             logger.error("Failed to find vtable for class: %s", name)
+
+        return did_match
+
+    def match_static_variable(self, addr: int, name: str, function_addr: int) -> bool:
+        """Matching a static function variable by combining the variable name
+        with the decorated (mangled) name of its parent function."""
+
+        cur = self._db.execute(
+            """SELECT name, decorated_name
+            FROM `symbols`
+            WHERE orig_addr = ?""",
+            (function_addr,),
+        )
+
+        if (result := cur.fetchone()) is None:
+            logger.error("No function for static variable: %s", name)
+            return False
+
+        # Get the friendly name for the "failed to match" error message
+        (function_name, decorated_name) = result
+
+        # Now we have to combine the variable name (read from the marker)
+        # and the decorated name of the enclosing function (the above variable)
+        # into a LIKE clause and try to match.
+        # For example, the variable "g_startupDelay" from function "IsleApp::Tick"
+        # has symbol: "?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA"
+        # The function's decorated name is: "?Tick@IsleApp@@QAEXH@Z"
+        cur = self._db.execute(
+            """UPDATE `symbols`
+            SET orig_addr = ?
+            WHERE name LIKE '%' || ? || '%' || ? || '%'
+            AND orig_addr IS NULL
+            AND (compare_type = ? OR compare_type = ? OR compare_type IS NULL)""",
+            (
+                addr,
+                name,
+                decorated_name,
+                SymbolType.DATA.value,
+                SymbolType.POINTER.value,
+            ),
+        )
+
+        did_match = cur.rowcount > 0
+
+        if not did_match:
+            logger.error(
+                "Failed to match static variable %s from function %s",
+                name,
+                function_name,
+            )
 
         return did_match
 

--- a/tools/isledecomp/isledecomp/parser/error.py
+++ b/tools/isledecomp/isledecomp/parser/error.py
@@ -47,6 +47,10 @@ class ParserError(Enum):
     # to ignore things like string literal that are not variables.
     GLOBAL_NOT_VARIABLE = 111
 
+    # WARN: A marked static variable inside a function needs to have its
+    # function marked too, and in the same module.
+    ORPHANED_STATIC_VARIABLE = 112
+
     # This code or higher is an error, not a warning
     DECOMP_ERROR_START = 200
 

--- a/tools/isledecomp/isledecomp/parser/node.py
+++ b/tools/isledecomp/isledecomp/parser/node.py
@@ -50,6 +50,7 @@ class ParserFunction(ParserSymbol):
 @dataclass
 class ParserVariable(ParserSymbol):
     is_static: bool = False
+    parent_function: Optional[int] = None
 
 
 @dataclass


### PR DESCRIPTION
After some analysis with the `roadmap` tool on `ISLE`, I came to the conclusion that two global variables `g_lastFrameTime` and `g_startupDelay` used only in the `IsleApp::Tick` function are actually static variables _from_ that function.

Before:
```
0003:0000005c          0  dat  4       g_targetHeight
0003:00000060          0  dat  4       g_targetDepth
0003:00000064          0  dat  4       g_reqEnableRMDevice
// omitted
0003:0000011c          8  str  19      'LEGO® Island Error'
0003:00000130          8  str  120     '"LEGO® Island" is not detecting...
0003:000001a8          8  str  18      'Lego Island Error'
0003:000001bc       -340  dat  4       g_startupDelay
0003:000001c0       -340  dat  4       g_lastFrameTime
0003:000001c4          0  str  24      'Lego Island MainNoM App'
```

To explain the output from `roadmap`, the items are ordered as they appear in the original, with the address from original shown in section:offset format. The first three global variables listed are exactly where they should be. They have the same offset in the `.data` section in both original and recomp. The strings that follow are ahead in the recomp by 8 bytes, and then we have the two aforementioned variables. These two are quite a ways behind where they should be.

After making those variables static (and reversing their order):
```
0003:0000005c          0  dat  4       g_targetHeight
0003:00000060          0  dat  4       g_targetDepth
0003:00000064          0  dat  4       g_reqEnableRMDevice
// omitted
0003:0000011c          0  str  19      'LEGO® Island Error'
0003:00000130          0  str  120     '"LEGO® Island" is not detecting...
0003:000001a8          0  str  18      'Lego Island Error'
0003:000001bc          0       4       ?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA
0003:000001c0          0       4       ?g_lastFrameTime@?1??Tick@IsleApp@@QAEXH@Z@4JA
0003:000001c4          0  str  24      'Lego Island MainNoM App'
```

The offsets line up exactly.

The challenge with matching these static function variables is that they are not public, per se. If the symbols appear in `cvdump` at all, you get the mangled name only (as you see above). My approach to solving this is:

1. The parser can identify a static function variable when it sees a `// GLOBAL` marker. This is based on context, meaning that we don't know whether we are in a function unless the `// FUNCTION` marker has just been parsed. Since our goal is to annotate all functions, while this is a limitation of the parser it is a solvable one. (`libclang` would eliminate this problem.)
2. Since we know which function we are in when we report a static function variable, capture the function's original address too.
3. When it's time to match up this variable, check the database for the function address and find the decorated name for that function. Try to match on the variable based on a combination of the variable name and the decorated function name.

This works well, but it all depends on the variable appearing in `cvdump`. This is not the case for `g_isInsideError` from `MxDirectDraw::Error` and I'm not sure why. Like `IsleApp::Tick`, it is a public function of its class.