### PR TITLE
Children classes of LegoWorld's VTable0x5c function

### DIFF
--- a/LEGO1/lego/legoomni/src/act2/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/act2/legoact2.cpp
@@ -1,10 +1,9 @@
 #include "legoact2.h"
 
-// STUB: LEGO1 0x1004fe10
+// FUNCTION: LEGO1 0x1004fe10
 MxBool LegoAct2::VTable0x5c()
 {
-	// TODO
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x1004ff20

--- a/LEGO1/lego/legoomni/src/act3/act3.cpp
+++ b/LEGO1/lego/legoomni/src/act3/act3.cpp
@@ -8,11 +8,10 @@ Act3::Act3()
 	// TODO
 }
 
-// STUB: LEGO1 0x10072500
+// FUNCTION: LEGO1 0x10072500
 MxBool Act3::VTable0x5c()
 {
-	// TODO
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x100726a0

--- a/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
@@ -6,11 +6,10 @@ LegoCarBuild::LegoCarBuild()
 	// TODO
 }
 
-// STUB: LEGO1 0x10022930
+// FUNCTION: LEGO1 0x10022930
 MxBool LegoCarBuild::VTable0x5c()
 {
-	// TODO
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x10022a80

--- a/LEGO1/lego/legoomni/src/gasstation/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/gasstation/gasstation.cpp
@@ -19,11 +19,10 @@ GasStation::GasStation()
 	NotificationManager()->Register(this);
 }
 
-// STUB: LEGO1 0x10004770
+// FUNCTION: LEGO1 0x10004770
 MxBool GasStation::VTable0x5c()
 {
-	// TODO
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x100048c0

--- a/LEGO1/lego/legoomni/src/hospital/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/hospital/hospital.cpp
@@ -23,11 +23,10 @@ Hospital::Hospital()
 	NotificationManager()->Register(this);
 }
 
-// STUB: LEGO1 0x100746a0
+// FUNCTION: LEGO1 0x100746a0
 MxBool Hospital::VTable0x5c()
 {
-	// TODO
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x100747f0

--- a/LEGO1/lego/legoomni/src/isle/jukebox.cpp
+++ b/LEGO1/lego/legoomni/src/isle/jukebox.cpp
@@ -13,11 +13,10 @@ JukeBox::JukeBox()
 	NotificationManager()->Register(this);
 }
 
-// STUB: LEGO1 0x1005d6e0
+// FUNCTION: LEGO1 0x1005d6e0
 MxBool JukeBox::VTable0x5c()
 {
-	// TODO
-	return FALSE;
+	return TRUE;
 }
 
 // STUB: LEGO1 0x1005d8d0


### PR DESCRIPTION
I noticed that it wasn't just Police, a lot of other classes seem to just have this. I think the purpose of `VTable0x5C` is just a function for in a few use cases the devs to ask 'is this a child of the LegoWorld' class without needing to go through IsA, which would probably save runtime. I didn't rename VTable0x5C, I just matched the functions. A match is a match.

I really do think the purpose of these functions are for the LegoWorldPresenter destructor to know not to destroy the entire world but [just the entities,](https://github.com/isledecomp/isle/blob/917485247ba6dcd1db8ba77b4b81ee9ab5a25fe8/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp#L44) but I dont know.