### PR TITLE
Add CONFIG.EXE to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a **work-in-progress** decompilation of LEGO Island (Version 1.1, Englis
 
 ## Status
 
-<img src="https://legoisland.org/progress/ISLEPROGRESS.SVG" width="50%"><img src="https://legoisland.org/progress/LEGO1PROGRESS.SVG" width="50%">
+<img src="https://legoisland.org/progress/CONFIGPROGRESS.SVG" width="33%"><img src="https://legoisland.org/progress/ISLEPROGRESS.SVG" width="33%"><img src="https://legoisland.org/progress/LEGO1PROGRESS.SVG" width="33%">
 
 Currently, `ISLE.EXE` is completely decompiled and behaves identically to the original. A handful of stubborn instructions are not yet matching; however, we anticipate they will as more of the overall codebase is implemented.
 


### PR DESCRIPTION
Currently I have only added the SVG, however we could add text explaining the purpose of CONFIG.EXE.

There are a few ways of displaying it, I have gone with this one:
<img src="https://legoisland.org/progress/CONFIGPROGRESS.SVG" width="33%" alt="config-"><img src="https://legoisland.org/progress/ISLEPROGRESS.SVG" width="33%" alt="isle-"><img src="https://legoisland.org/progress/LEGO1PROGRESS.SVG" width="33%" alt="lego1">
Though we could also use:
<img src="https://legoisland.org/progress/ISLEPROGRESS.SVG" width="33%" alt="isle-"><img src="https://legoisland.org/progress/CONFIGPROGRESS.SVG" width="33%" alt="config-"><img src="https://legoisland.org/progress/LEGO1PROGRESS.SVG" width="33%" alt="lego1">
Or:
<img src="https://legoisland.org/progress/ISLEPROGRESS.SVG" width="33%" alt="isle-"><img src="https://legoisland.org/progress/LEGO1PROGRESS.SVG" width="33%" alt="lego1-"><img src="https://legoisland.org/progress/CONFIGPROGRESS.SVG" width="33%" alt="config">
There are also more possibilities, but I'm only showing a few of them.