### PR TITLE
Introduce and use enum for acts

### DIFF
--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -20,8 +20,16 @@ struct ColorStringStruct {
 // SIZE 0x430
 class LegoGameState {
 public:
+	enum Act {
+		e_actNotFound = -1,
+		e_act1 = 0,
+		e_act2 = 1,
+		e_act3 = 2
+	};
+
 	LegoGameState();
 	~LegoGameState();
+
 	MxResult Load(MxULong);
 	MxResult Save(MxULong);
 	void SerializePlayersInfo(MxS16);
@@ -36,8 +44,8 @@ public:
 	void SwitchArea(MxU32 p_area);
 
 	inline MxU8 GetUnknownC() { return m_unk0x0c; }
-	inline MxU32 GetUnknown10() { return m_unk0x10; }
-	inline MxS32 GetCurrentAct() { return m_currentAct; }
+	inline Act GetCurrentAct() { return m_currentAct; }
+	inline Act GetLoadedAct() { return m_loadedAct; }
 	inline MxU32 GetCurrentArea() { return m_currentArea; }
 	inline MxU32 GetPreviousArea() { return m_previousArea; }
 	inline MxU32 GetUnknown0x42c() { return m_unk0x42c; }
@@ -48,8 +56,8 @@ public:
 	inline void SetUnknown0x0c(MxU8 p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
 	inline void SetUnknown0x42c(undefined4 p_unk0x42c) { m_unk0x42c = p_unk0x42c; }
 
-	void FUN_1003cea0(undefined4 p_state);
-	void FUN_1003ceb0();
+	void SetCurrentAct(Act p_currentAct);
+	void FindLoadedAct();
 	void FUN_10039780(MxU8);
 	void FUN_10039940();
 
@@ -72,8 +80,8 @@ private:
 	MxS16 m_stateCount;                         // 0x04
 	LegoState** m_stateArray;                   // 0x08
 	MxU8 m_unk0x0c;                             // 0x0c
-	MxU32 m_unk0x10;                            // 0x10
-	MxS32 m_currentAct;                         // 0x14
+	Act m_currentAct;                           // 0x10
+	Act m_loadedAct;                            // 0x14
 	LegoBackgroundColor* m_backgroundColor;     // 0x18
 	LegoBackgroundColor* m_tempBackgroundColor; // 0x1c
 	LegoFullScreenMovie* m_fullScreenMovie;     // 0x20

--- a/LEGO1/lego/legoomni/src/build/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/build/helicopter.cpp
@@ -59,11 +59,13 @@ void Helicopter::GetState()
 // FUNCTION: LEGO1 0x10003360
 void Helicopter::VTable0xe4()
 {
-	if (!GameState()->GetCurrentAct()) {
+	if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 		VTable0xe8(0x28, TRUE, 7);
 	}
+
 	IslePathActor::VTable0xe4();
-	if (!GameState()->GetCurrentAct()) {
+
+	if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 		GameState()->SetCurrentArea(0x3c);
 		if (CurrentVehicle()) {
 			if (CurrentVehicle()->IsA("IslePathActor")) {
@@ -71,6 +73,7 @@ void Helicopter::VTable0xe4()
 			}
 		}
 	}
+
 	m_state->SetUnknown8(0);
 	FUN_1003ee00(m_script, 0x16);
 	FUN_1003ee00(m_script, 0x17);
@@ -92,17 +95,21 @@ MxU32 Helicopter::VTable0xcc()
 	if (!FUN_1003ef60()) {
 		return 1;
 	}
+
 	if (!m_world) {
 		m_world = CurrentWorld();
 	}
+
 	AnimationManager()->FUN_1005f6d0(FALSE);
+
 	if (CurrentVehicle()) {
 		if (CurrentVehicle()->VTable0x60() != GameState()->GetUnknownC()) {
 			CurrentVehicle()->VTable0xe4();
 		}
 	}
+
 	switch (GameState()->GetCurrentAct()) {
-	case 0:
+	case LegoGameState::e_act1:
 		m_script = *g_isleScript;
 		AnimationManager()->FUN_10064670(FALSE);
 		VTable0xe8(0x29, TRUE, 7);
@@ -112,13 +119,14 @@ MxU32 Helicopter::VTable0xcc()
 		SetUnknownDC(4);
 		PlayMusic(JukeBox::e_jail);
 		break;
-	case 1:
+	case LegoGameState::e_act2:
 		m_script = *g_act2mainScript;
 		break;
-	case 2:
+	case LegoGameState::e_act3:
 		m_script = *g_act3Script;
 		break;
 	}
+
 	VTable0xe0();
 	InvokeAction(Extra::ActionType::e_start, m_script, 0x15, NULL);
 	GetCurrentAction().SetObjectId(-1);
@@ -131,17 +139,19 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 {
 	MxU32 ret = 0;
 	MxAtomId script;
+
 	switch (GameState()->GetCurrentAct()) {
-	case 0:
+	case LegoGameState::e_act1:
 		script = *g_isleScript;
 		break;
-	case 1:
+	case LegoGameState::e_act2:
 		script = *g_act2mainScript;
 		break;
-	case 2:
+	case LegoGameState::e_act3:
 		script = *g_act3Script;
 		break;
 	}
+
 	if (p_param.GetUnknown0x28() == 1) {
 		switch (p_param.GetClickedObjectId()) {
 		case 0x17:
@@ -217,7 +227,7 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 			ret = 1;
 			break;
 		case 0x1c:
-			if (GameState()->GetCurrentAct() == 0) {
+			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				((Isle*) CurrentWorld())->SetUnknown13c(2);
 				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 				VTable0xe4();
@@ -239,7 +249,7 @@ MxU32 Helicopter::VTable0xd8(MxType18NotificationParam& p_param)
 
 	switch (m_state->GetUnkown8()) {
 	case 1: {
-		if (GameState()->GetCurrentAct() == 0) {
+		if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 			((Act1State*) GameState()->GetState("Act1State"))->SetUnknown18(4);
 			VTable0xe8(0x2a, TRUE, 7);
 		}
@@ -276,7 +286,7 @@ MxU32 Helicopter::VTable0xd8(MxType18NotificationParam& p_param)
 		at[1] = 1.25;
 		m_world->GetCamera()->SetWorldTransform(at, dir, up);
 
-		if (GameState()->GetCurrentAct() == 0) {
+		if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 			((Act1State*) GameState()->GetState("Act1State"))->SetUnknown18(0);
 			VTable0xe8(0x29, TRUE, 7);
 		}

--- a/LEGO1/lego/legoomni/src/build/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/build/helicopter.cpp
@@ -59,11 +59,11 @@ void Helicopter::GetState()
 // FUNCTION: LEGO1 0x10003360
 void Helicopter::VTable0xe4()
 {
-	if (!GameState()->GetUnknown10()) {
+	if (!GameState()->GetCurrentAct()) {
 		VTable0xe8(0x28, TRUE, 7);
 	}
 	IslePathActor::VTable0xe4();
-	if (!GameState()->GetUnknown10()) {
+	if (!GameState()->GetCurrentAct()) {
 		GameState()->SetCurrentArea(0x3c);
 		if (CurrentVehicle()) {
 			if (CurrentVehicle()->IsA("IslePathActor")) {
@@ -101,7 +101,7 @@ MxU32 Helicopter::VTable0xcc()
 			CurrentVehicle()->VTable0xe4();
 		}
 	}
-	switch (GameState()->GetUnknown10()) {
+	switch (GameState()->GetCurrentAct()) {
 	case 0:
 		m_script = *g_isleScript;
 		AnimationManager()->FUN_10064670(FALSE);
@@ -131,7 +131,7 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 {
 	MxU32 ret = 0;
 	MxAtomId script;
-	switch (GameState()->GetUnknown10()) {
+	switch (GameState()->GetCurrentAct()) {
 	case 0:
 		script = *g_isleScript;
 		break;
@@ -217,7 +217,7 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 			ret = 1;
 			break;
 		case 0x1c:
-			if (GameState()->GetUnknown10() == 0) {
+			if (GameState()->GetCurrentAct() == 0) {
 				((Isle*) CurrentWorld())->SetUnknown13c(2);
 				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 				VTable0xe4();
@@ -239,7 +239,7 @@ MxU32 Helicopter::VTable0xd8(MxType18NotificationParam& p_param)
 
 	switch (m_state->GetUnkown8()) {
 	case 1: {
-		if (GameState()->GetUnknown10() == 0) {
+		if (GameState()->GetCurrentAct() == 0) {
 			((Act1State*) GameState()->GetState("Act1State"))->SetUnknown18(4);
 			VTable0xe8(0x2a, TRUE, 7);
 		}
@@ -276,7 +276,7 @@ MxU32 Helicopter::VTable0xd8(MxType18NotificationParam& p_param)
 		at[1] = 1.25;
 		m_world->GetCamera()->SetWorldTransform(at, dir, up);
 
-		if (GameState()->GetUnknown10() == 0) {
+		if (GameState()->GetCurrentAct() == 0) {
 			((Act1State*) GameState()->GetState("Act1State"))->SetUnknown18(0);
 			VTable0xe8(0x29, TRUE, 7);
 		}

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -74,7 +74,7 @@ LegoGameState::LegoGameState()
 	this->m_previousArea = 0;
 	this->m_unk0x42c = 0;
 	this->m_isDirty = FALSE;
-	this->m_currentAct = -1;
+	this->m_loadedAct = e_actNotFound;
 
 	m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
 	VariableTable()->SetVariable(m_backgroundColor);
@@ -139,7 +139,7 @@ MxResult LegoGameState::Save(MxULong p_slot)
 			MxU32 maybeVersion = 0x1000C;
 			fileStream.Write(&maybeVersion, 4);
 			fileStream.Write(&m_unk0x24, 2);
-			fileStream.Write(&m_unk0x10, 2);
+			fileStream.Write(&m_currentAct, 2);
 			fileStream.Write(&m_unk0x0c, 1);
 
 			for (MxS32 i = 0; i < sizeof(g_colorSaveData) / sizeof(g_colorSaveData[0]); ++i) {
@@ -717,24 +717,24 @@ void LegoGameState::SerializeScoreHistory(MxS16 p_flags)
 }
 
 // FUNCTION: LEGO1 0x1003cea0
-void LegoGameState::FUN_1003cea0(undefined4 p_state)
+void LegoGameState::SetCurrentAct(Act p_currentAct)
 {
-	m_unk0x10 = p_state;
+	m_currentAct = p_currentAct;
 }
 
 // FUNCTION: LEGO1 0x1003ceb0
-void LegoGameState::FUN_1003ceb0()
+void LegoGameState::FindLoadedAct()
 {
 	if (FindWorld(*g_isleScript, 0)) {
-		m_currentAct = 0;
+		m_loadedAct = e_act1;
 	}
 	else if (FindWorld(*g_act2mainScript, 0)) {
-		m_currentAct = 1;
+		m_loadedAct = e_act2;
 	}
 	else if (FindWorld(*g_act3Script, 0)) {
-		m_currentAct = 2;
+		m_loadedAct = e_act3;
 	}
 	else {
-		m_currentAct = -1;
+		m_loadedAct = e_actNotFound;
 	}
 }

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -302,7 +302,7 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 		break;
 	case 5:
 		if (action->GetObjectId() == m_currentInfomainScript) {
-			if (GameState()->GetUnknown10() != 2 && m_selectedCharacter != e_noCharacter) {
+			if (GameState()->GetCurrentAct() != LegoGameState::e_act3 && m_selectedCharacter != e_noCharacter) {
 				GameState()->FUN_10039780(m_selectedCharacter);
 			}
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
@@ -343,8 +343,8 @@ void Infocenter::ReadyWorld()
 	MxStillPresenter* bg = (MxStillPresenter*) Find("MxStillPresenter", "Background_Bitmap");
 	MxStillPresenter* bgRed = (MxStillPresenter*) Find("MxStillPresenter", "BackgroundRed_Bitmap");
 
-	switch (GameState()->GetUnknown10()) {
-	case 0:
+	switch (GameState()->GetCurrentAct()) {
+	case LegoGameState::e_act1:
 		bg->Enable(TRUE);
 		InitializeBitmaps();
 
@@ -368,7 +368,7 @@ void Infocenter::ReadyWorld()
 			PlayMusic(JukeBox::e_informationCenter);
 
 			InfomainScript script =
-				(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetUnknown10()].Next();
+				(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetCurrentAct()].Next();
 			PlayAction(script);
 
 			if (script == c_returnBackGuidanceDialogue2) {
@@ -402,7 +402,7 @@ void Infocenter::ReadyWorld()
 			break;
 		}
 		return;
-	case 1: {
+	case LegoGameState::e_act2: {
 		if (m_infocenterState->GetUnknown0x74() == 8) {
 			PlayMusic(JukeBox::e_informationCenter);
 			bgRed->Enable(TRUE);
@@ -412,7 +412,7 @@ void Infocenter::ReadyWorld()
 		}
 
 		LegoAct2State* state = (LegoAct2State*) GameState()->GetState("LegoAct2State");
-		GameState()->FUN_1003ceb0();
+		GameState()->FindLoadedAct();
 
 		if (state && state->GetUnknown0x08() == 0x68) {
 			bg->Enable(TRUE);
@@ -424,7 +424,7 @@ void Infocenter::ReadyWorld()
 		if (m_infocenterState->GetUnknown0x74() == 4) {
 			bgRed->Enable(TRUE);
 
-			if (GameState()->GetUnknown10() == GameState()->GetCurrentAct()) {
+			if (GameState()->GetCurrentAct() == GameState()->GetLoadedAct()) {
 				GameState()->SetCurrentArea(0x2e);
 				GameState()->StopArea(0x2e);
 				GameState()->SetCurrentArea(0x02);
@@ -434,7 +434,7 @@ void Infocenter::ReadyWorld()
 			m_transitionDestination = 0x2e;
 
 			InfomainScript script =
-				(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetUnknown10()].Next();
+				(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetCurrentAct()].Next();
 			PlayAction(script);
 
 			InputManager()->DisableInputProcessing();
@@ -444,12 +444,12 @@ void Infocenter::ReadyWorld()
 
 		PlayMusic(JukeBox::e_informationCenter);
 		InfomainScript script =
-			(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetUnknown10()].Next();
+			(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetCurrentAct()].Next();
 		PlayAction(script);
 		bgRed->Enable(TRUE);
 		break;
 	}
-	case 2: {
+	case LegoGameState::e_act3: {
 		if (m_infocenterState->GetUnknown0x74() == 8) {
 			PlayMusic(JukeBox::e_informationCenter);
 			bgRed->Enable(TRUE);
@@ -459,7 +459,7 @@ void Infocenter::ReadyWorld()
 		}
 
 		Act3State* state = (Act3State*) GameState()->GetState("Act3State");
-		GameState()->FUN_1003ceb0();
+		GameState()->FindLoadedAct();
 
 		if (state) {
 			if (state->GetUnknown0x08() == 3) {
@@ -480,7 +480,7 @@ void Infocenter::ReadyWorld()
 		if (m_infocenterState->GetUnknown0x74() == 4) {
 			bgRed->Enable(TRUE);
 
-			if (GameState()->GetUnknown10() == GameState()->GetCurrentAct()) {
+			if (GameState()->GetCurrentAct() == GameState()->GetLoadedAct()) {
 				GameState()->SetCurrentArea(0x2f);
 				GameState()->StopArea(0x2f);
 				GameState()->SetCurrentArea(0x02);
@@ -490,7 +490,7 @@ void Infocenter::ReadyWorld()
 			m_transitionDestination = 0x2f;
 
 			InfomainScript script =
-				(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetUnknown10()].Next();
+				(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetCurrentAct()].Next();
 			PlayAction(script);
 
 			InputManager()->DisableInputProcessing();
@@ -500,7 +500,7 @@ void Infocenter::ReadyWorld()
 
 		PlayMusic(JukeBox::e_informationCenter);
 		InfomainScript script =
-			(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetUnknown10()].Next();
+			(InfomainScript) m_infocenterState->GetUnknown0x20()[GameState()->GetCurrentAct()].Next();
 		PlayAction(script);
 		bgRed->Enable(TRUE);
 		break;
@@ -800,7 +800,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 		if (m_infocenterState->GetUnknown0x74() == 5) {
 			InfomainScript dialogueToPlay;
 
-			if (GameState()->GetUnknown10() == 0) {
+			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				if (m_infocenterState->GetInfocenterBufferElement(0) == NULL) {
 					m_infocenterState->SetUnknown0x74(2);
 					m_transitionDestination = 0;
@@ -830,7 +830,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 						break;
 					default:
 						dialogueToPlay =
-							(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetUnknown10()].Next();
+							(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetCurrentAct()].Next();
 						break;
 					}
 
@@ -840,7 +840,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 			}
 			else {
 				dialogueToPlay =
-					(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetUnknown10()].Next();
+					(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetCurrentAct()].Next();
 			}
 
 			PlayAction(dialogueToPlay);
@@ -870,7 +870,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			m_infocenterState->SetUnknown0x74(14);
 			StopCurrentAction();
 
-			if (GameState()->GetUnknown10() == 0) {
+			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
 				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 				m_transitionDestination = 5;
@@ -885,7 +885,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			m_infocenterState->SetUnknown0x74(14);
 			StopCurrentAction();
 
-			if (GameState()->GetUnknown10() == 0) {
+			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
 				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 				m_transitionDestination = 13;
@@ -933,8 +933,8 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			m_radio.Stop();
 			break;
 		case c_bigInfoCtl:
-			switch (state->GetUnknown10()) {
-			case 0:
+			switch (state->GetCurrentAct()) {
+			case LegoGameState::e_act1:
 				switch (state->GetPreviousArea()) {
 				case 3:
 				case 12:
@@ -942,7 +942,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 					m_infocenterState->SetUnknown0x74(5);
 					m_transitionDestination = state->GetPreviousArea();
 					actionToPlay =
-						(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetUnknown10()].Next();
+						(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetCurrentAct()].Next();
 					m_radio.Stop();
 					InputManager()->DisableInputProcessing();
 					InputManager()->SetUnknown336(TRUE);
@@ -953,7 +953,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 							m_infocenterState->SetUnknown0x74(5);
 							m_transitionDestination = state->GetPreviousArea();
 							actionToPlay =
-								(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetUnknown10()].Next(
+								(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetCurrentAct()].Next(
 								);
 							m_radio.Stop();
 							InputManager()->DisableInputProcessing();
@@ -967,17 +967,19 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 					break;
 				}
 				break;
-			case 1:
+			case LegoGameState::e_act2:
 				m_infocenterState->SetUnknown0x74(5);
 				m_transitionDestination = 0x2e;
-				actionToPlay = (InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetUnknown10()].Next();
+				actionToPlay =
+					(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetCurrentAct()].Next();
 				InputManager()->DisableInputProcessing();
 				InputManager()->SetUnknown336(TRUE);
 				break;
-			case 2:
+			case LegoGameState::e_act3:
 				m_infocenterState->SetUnknown0x74(5);
 				m_transitionDestination = 0x2f;
-				actionToPlay = (InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetUnknown10()].Next();
+				actionToPlay =
+					(InfomainScript) m_infocenterState->GetUnknown0x44()[GameState()->GetCurrentAct()].Next();
 				InputManager()->DisableInputProcessing();
 				InputManager()->SetUnknown336(TRUE);
 				break;
@@ -986,7 +988,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 		case c_bookCtl:
 			m_transitionDestination = 12;
 			m_infocenterState->SetUnknown0x74(4);
-			actionToPlay = GameState()->GetUnknown10() ? c_goToRegBookRed : c_goToRegBook;
+			actionToPlay = GameState()->GetCurrentAct() != LegoGameState::e_act1 ? c_goToRegBookRed : c_goToRegBook;
 			m_radio.Stop();
 			GameState()->SetUnknown0x42c(GameState()->GetPreviousArea());
 			InputManager()->DisableInputProcessing();
@@ -1044,7 +1046,7 @@ MxLong Infocenter::HandleNotification0(MxNotificationParam& p_param)
 			m_infoManDialogueTimer = 0;
 
 			InfomainScript objectId;
-			if (GameState()->GetUnknown10()) {
+			if (GameState()->GetCurrentAct() != LegoGameState::e_act1) {
 				objectId = (InfomainScript) m_infocenterState->GetUnknown0x14().Next();
 			}
 			else {
@@ -1270,11 +1272,11 @@ void Infocenter::UpdateFrameHot(MxBool p_display)
 // FUNCTION: LEGO1 0x10070e90
 void Infocenter::Reset()
 {
-	switch (GameState()->GetUnknown10()) {
-	case 1:
+	switch (GameState()->GetCurrentAct()) {
+	case LegoGameState::e_act2:
 		Lego()->RemoveWorld(*g_act2mainScript, 0);
 		break;
-	case 2:
+	case LegoGameState::e_act3:
 		Lego()->RemoveWorld(*g_act3Script, 0);
 		break;
 	}
@@ -1283,7 +1285,7 @@ void Infocenter::Reset()
 	BuildingManager()->FUN_10030590();
 	AnimationManager()->FUN_1005ee80(FALSE);
 	UnkSaveDataWriter()->FUN_100832a0();
-	GameState()->FUN_1003cea0(0);
+	GameState()->SetCurrentAct(LegoGameState::e_act1);
 	GameState()->SetPreviousArea(0);
 	GameState()->SetUnknown0x42c(0);
 

--- a/LEGO1/lego/legoomni/src/isle/isle.cpp
+++ b/LEGO1/lego/legoomni/src/isle/isle.cpp
@@ -56,7 +56,7 @@ Isle::~Isle()
 // FUNCTION: LEGO1 0x10030b20
 MxResult Isle::Create(MxDSAction& p_dsAction)
 {
-	GameState()->FUN_1003ceb0();
+	GameState()->FindLoadedAct();
 
 	MxResult result = LegoWorld::Create(p_dsAction);
 	if (result == SUCCESS) {
@@ -64,14 +64,14 @@ MxResult Isle::Create(MxDSAction& p_dsAction)
 		InputManager()->SetWorld(this);
 		GameState()->StopArea();
 
-		switch (GameState()->GetCurrentAct()) {
-		case 1:
+		switch (GameState()->GetLoadedAct()) {
+		case LegoGameState::e_act2:
 			GameState()->StopArea(0x2e);
 			break;
-		case 2:
+		case LegoGameState::e_act3:
 			GameState()->StopArea(0x2e);
 			break;
-		case -1:
+		case LegoGameState::e_actNotFound:
 			m_unk0x13c = 2;
 		}
 
@@ -162,7 +162,7 @@ void Isle::ReadyWorld()
 		m_act1state->SetUnknown18(0);
 		m_act1state->SetUnknown21(0);
 	}
-	else if (GameState()->GetCurrentAct()) {
+	else if (GameState()->GetLoadedAct()) {
 		FUN_1003ef00(TRUE);
 		FUN_10032620();
 		m_act1state->FUN_10034d00();

--- a/LEGO1/lego/legoomni/src/main/legoomni.cpp
+++ b/LEGO1/lego/legoomni/src/main/legoomni.cpp
@@ -588,7 +588,7 @@ MxResult LegoOmni::Create(MxOmniCreateParam& p_param)
 				if (m_transitionManager->GetDDrawSurfaceFromVideoManager() == SUCCESS) {
 					m_notificationManager->Register(this);
 					SetAppCursor(1);
-					m_gameState->FUN_1003cea0(0);
+					m_gameState->SetCurrentAct(LegoGameState::e_act1);
 					return SUCCESS;
 				}
 			}

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -44,8 +44,6 @@ undefined4 LegoModelPresenter::LoadModel(MxStreamChunk* p_chunk)
 // FUNCTION: LEGO1 0x10080050
 void LegoModelPresenter::ReadyTickle()
 {
-	ProgressTickleState(e_starting);
-	return;
 	if (m_compositePresenter != NULL && m_compositePresenter->IsA("LegoEntityPresenter") &&
 		m_compositePresenter->GetCurrentTickleState() <= e_ready) {
 		return;

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -44,6 +44,8 @@ undefined4 LegoModelPresenter::LoadModel(MxStreamChunk* p_chunk)
 // FUNCTION: LEGO1 0x10080050
 void LegoModelPresenter::ReadyTickle()
 {
+	ProgressTickleState(e_starting);
+	return;
 	if (m_compositePresenter != NULL && m_compositePresenter->IsA("LegoEntityPresenter") &&
 		m_compositePresenter->GetCurrentTickleState() <= e_ready) {
 		return;


### PR DESCRIPTION
This adds an enum for the 3 acts, replacing some magic values across the code base.

Note that I've also renamed the previous `GetCurrentAct` to `GetLoadedAct`, and `GetUnknown10` to `GetCurrentAct`. The `GetLoadedAct` function is to determine which of the act scripts/world is currently loaded, not the one that is meant to be active/current.