### PR TITLE
Add LegoGameState::Area enum

### DIFF
--- a/LEGO1/lego/legoomni/include/elevatorbottom.h
+++ b/LEGO1/lego/legoomni/include/elevatorbottom.h
@@ -2,6 +2,7 @@
 #define ELEVATORBOTTOM_H
 
 #include "decomp.h"
+#include "legogamestate.h"
 #include "legoworld.h"
 
 class LegoControlManagerEvent;
@@ -41,7 +42,7 @@ public:
 	// ElevatorBottom::`scalar deleting destructor'
 
 private:
-	undefined4 m_unk0xf8; // 0xf8
+	LegoGameState::Area m_unk0xf8; // 0xf8
 
 	MxLong HandleClick(LegoControlManagerEvent& p_param);
 };

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -1,6 +1,7 @@
 #ifndef INFOCENTER_H
 #define INFOCENTER_H
 
+#include "legogamestate.h"
 #include "legoworld.h"
 #include "mxrect32.h"
 #include "radio.h"
@@ -229,20 +230,20 @@ private:
 	void PlayBookAnimation();
 	void StopBookAnimation();
 
-	InfomainScript m_currentInfomainScript; // 0xf8
-	MxS16 m_selectedCharacter;              // 0xfc
-	InfocenterState* m_infocenterState;     // 0x100
-	undefined4 m_transitionDestination;     // 0x104
-	Cutscene m_currentCutscene;             // 0x108
-	Radio m_radio;                          // 0x10c
-	MxStillPresenter* m_unk0x11c;           // 0x11c
-	InfocenterMapEntry m_mapAreas[7];       // 0x120
-	MxS16 m_unk0x1c8;                       // 0x1c8
-	MxStillPresenter* m_frameHotBitmap;     // 0x1cc
-	MxS16 m_infoManDialogueTimer;           // 0x1d0
-	MxS16 m_bookAnimationTimer;             // 0x1d2
-	MxU16 m_unk0x1d4;                       // 0x1d4
-	MxS16 m_unk0x1d6;                       // 0x1d6
+	InfomainScript m_currentInfomainScript;      // 0xf8
+	MxS16 m_selectedCharacter;                   // 0xfc
+	InfocenterState* m_infocenterState;          // 0x100
+	LegoGameState::Area m_transitionDestination; // 0x104
+	Cutscene m_currentCutscene;                  // 0x108
+	Radio m_radio;                               // 0x10c
+	MxStillPresenter* m_unk0x11c;                // 0x11c
+	InfocenterMapEntry m_mapAreas[7];            // 0x120
+	MxS16 m_unk0x1c8;                            // 0x1c8
+	MxStillPresenter* m_frameHotBitmap;          // 0x1cc
+	MxS16 m_infoManDialogueTimer;                // 0x1d0
+	MxS16 m_bookAnimationTimer;                  // 0x1d2
+	MxU16 m_unk0x1d4;                            // 0x1d4
+	MxS16 m_unk0x1d6;                            // 0x1d6
 };
 
 #endif // INFOCENTER_H

--- a/LEGO1/lego/legoomni/include/infocenterdoor.h
+++ b/LEGO1/lego/legoomni/include/infocenterdoor.h
@@ -1,6 +1,7 @@
 #ifndef INFOCENTERDOOR_H
 #define INFOCENTERDOOR_H
 
+#include "legogamestate.h"
 #include "legoworld.h"
 
 class LegoControlManagerEvent;
@@ -40,7 +41,7 @@ public:
 	// InfocenterDoor::`scalar deleting destructor'
 
 private:
-	MxS32 m_unk0xf8; // 0xf8
+	LegoGameState::Area m_unk0xf8; // 0xf8
 
 	MxLong HandleClick(LegoControlManagerEvent& p_param);
 };

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -22,9 +22,68 @@ class LegoGameState {
 public:
 	enum Act {
 		e_actNotFound = -1,
-		e_act1 = 0,
-		e_act2 = 1,
-		e_act3 = 2
+		e_act1,
+		e_act2,
+		e_act3
+	};
+
+	enum Area {
+		e_noArea = 0,
+		e_previousArea = 0,
+		e_isle,
+		e_infomain,
+		e_infodoor,
+		e_unk4,
+		e_elevbott,
+		e_unk6,
+		e_unk7,
+		e_unk8,
+		e_unk9,
+		e_unk10,
+		e_unk11,
+		e_regbook,
+		e_infoscor,
+		e_jetrace,
+		e_unk15,
+		e_unk16,
+		e_unk17,
+		e_carrace,
+		e_unk19,
+		e_unk20,
+		e_unk21,
+		e_unk22,
+
+		e_unk25 = 25,
+		e_garage,
+		e_unk27,
+
+		e_unk29 = 29,
+		e_hospital,
+		e_unk31,
+		e_unk32,
+
+		e_police = 34,
+		e_unk35,
+		e_copter,
+		e_dunecar,
+		e_jetski,
+		e_racecar,
+
+		e_act2main = 46,
+		e_act3script,
+
+		e_jukeboxw = 53,
+
+		e_histbook = 56,
+		e_unk57,
+		e_unk58,
+		e_unk59,
+		e_unk60,
+		e_unk61,
+
+		e_unk64 = 64,
+
+		e_unk66 = 66
 	};
 
 	LegoGameState();
@@ -40,21 +99,21 @@ public:
 	LegoState* CreateState(const char* p_stateName);
 
 	void GetFileSavePath(MxString* p_outPath, MxULong p_slotn);
-	void StopArea(MxU32 p_area = 0);
-	void SwitchArea(MxU32 p_area);
+	void StopArea(Area p_area);
+	void SwitchArea(Area p_area);
 
 	inline MxU8 GetUnknownC() { return m_unk0x0c; }
 	inline Act GetCurrentAct() { return m_currentAct; }
 	inline Act GetLoadedAct() { return m_loadedAct; }
-	inline MxU32 GetCurrentArea() { return m_currentArea; }
-	inline MxU32 GetPreviousArea() { return m_previousArea; }
-	inline MxU32 GetUnknown0x42c() { return m_unk0x42c; }
+	inline Area GetCurrentArea() { return m_currentArea; }
+	inline Area GetPreviousArea() { return m_previousArea; }
+	inline Area GetUnknown0x42c() { return m_unk0x42c; }
 
 	inline void SetDirty(MxBool p_dirty) { m_isDirty = p_dirty; }
-	inline void SetCurrentArea(MxU32 p_currentArea) { m_currentArea = p_currentArea; }
-	inline void SetPreviousArea(MxU32 p_previousArea) { m_previousArea = p_previousArea; }
+	inline void SetCurrentArea(Area p_currentArea) { m_currentArea = p_currentArea; }
+	inline void SetPreviousArea(Area p_previousArea) { m_previousArea = p_previousArea; }
 	inline void SetUnknown0x0c(MxU8 p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
-	inline void SetUnknown0x42c(undefined4 p_unk0x42c) { m_unk0x42c = p_unk0x42c; }
+	inline void SetUnknown0x42c(Area p_unk0x42c) { m_unk0x42c = p_unk0x42c; }
 
 	void SetCurrentAct(Act p_currentAct);
 	void FindLoadedAct();
@@ -90,9 +149,9 @@ private:
 	ScoreStruct m_unk0xa6;                      // 0xa6
 	undefined m_unk0x41a[8];                    // 0x41a - might be part of the structure at 0xa6
 	MxBool m_isDirty;                           // 0x420
-	MxU32 m_currentArea;                        // 0x424
-	MxU32 m_previousArea;                       // 0x428
-	undefined4 m_unk0x42c;                      // 0x42c
+	Area m_currentArea;                         // 0x424
+	Area m_previousArea;                        // 0x428
+	Area m_unk0x42c;                            // 0x42c
 };
 
 MxBool ROIHandlerFunction(char* p_input, char* p_output, MxU32 p_copyLen);

--- a/LEGO1/lego/legoomni/include/police.h
+++ b/LEGO1/lego/legoomni/include/police.h
@@ -2,6 +2,7 @@
 #define POLICE_H
 
 #include "decomp.h"
+#include "legogamestate.h"
 #include "legoworld.h"
 #include "mxdsaction.h"
 #include "policestate.h"
@@ -44,9 +45,9 @@ private:
 	MxLong HandleEndAction(MxEndActionNotificationParam& p_param);
 	MxLong HandleKeyPress(LegoEventNotificationParam& p_param);
 
-	Radio m_radio;                      // 0xf8
-	PoliceState* m_policeState;         // 0x108
-	undefined4 m_transitionDestination; // 0x10c
+	Radio m_radio;                               // 0xf8
+	PoliceState* m_policeState;                  // 0x108
+	LegoGameState::Area m_transitionDestination; // 0x10c
 };
 
 #endif // POLICE_H

--- a/LEGO1/lego/legoomni/include/score.h
+++ b/LEGO1/lego/legoomni/include/score.h
@@ -3,6 +3,7 @@
 
 #include "legocontrolmanager.h"
 #include "legoeventnotificationparam.h"
+#include "legogamestate.h"
 #include "legoworld.h"
 #include "mxactionnotificationparam.h"
 #include "scorestate.h"
@@ -43,7 +44,7 @@ public:
 	void FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color);
 
 protected:
-	undefined4 m_unk0xf8;
+	LegoGameState::Area m_unk0xf8;
 	ScoreState* m_state;
 	MxU8* m_surface;
 

--- a/LEGO1/lego/legoomni/src/build/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/build/helicopter.cpp
@@ -66,7 +66,7 @@ void Helicopter::VTable0xe4()
 	IslePathActor::VTable0xe4();
 
 	if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
-		GameState()->SetCurrentArea(0x3c);
+		GameState()->SetCurrentArea(LegoGameState::e_unk60);
 		if (CurrentVehicle()) {
 			if (CurrentVehicle()->IsA("IslePathActor")) {
 				((IslePathActor*) CurrentVehicle())->VTable0xe8(0x37, TRUE, 7);
@@ -163,7 +163,7 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 				break;
 			}
 			VTable0xe4();
-			GameState()->SetCurrentArea(0x42);
+			GameState()->SetCurrentArea(LegoGameState::e_unk66);
 			ret = 1;
 			break;
 		case 0x18: {

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -70,9 +70,9 @@ LegoGameState::LegoGameState()
 	this->m_stateCount = 0;
 	this->m_unk0x0c = 0;
 	this->m_savePath = NULL;
-	this->m_currentArea = 0;
-	this->m_previousArea = 0;
-	this->m_unk0x42c = 0;
+	this->m_currentArea = e_noArea;
+	this->m_previousArea = e_noArea;
+	this->m_unk0x42c = e_noArea;
 	this->m_isDirty = FALSE;
 	this->m_loadedAct = e_actNotFound;
 
@@ -273,32 +273,32 @@ void LegoGameState::SerializePlayersInfo(MxS16)
 }
 
 // FUNCTION: LEGO1 0x1003a720
-void LegoGameState::StopArea(MxU32 p_area)
+void LegoGameState::StopArea(Area p_area)
 {
-	if (p_area == 0) {
+	if (p_area == e_previousArea) {
 		p_area = m_previousArea;
 	}
 
 	switch (p_area) {
-	case 1:
+	case e_isle:
 		InvokeAction(Extra::e_stop, *g_isleScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_isleScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_sndAnimScript, 0, NULL);
 		break;
-	case 2:
+	case e_infomain:
 		InvokeAction(Extra::e_stop, *g_infomainScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_infomainScript, 0, NULL);
 		break;
-	case 3:
+	case e_infodoor:
 		InvokeAction(Extra::e_stop, *g_infodoorScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_infodoorScript, 0, NULL);
 		break;
-	case 5:
+	case e_elevbott:
 		InvokeAction(Extra::e_stop, *g_elevbottScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_elevbottScript, 0, NULL);
 		break;
-	case 6:
-	case 7:
+	case e_unk6:
+	case e_unk7:
 		RemoveFromWorld(*g_isleScript, 0x41b, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 1052, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x41d, *g_isleScript, 0);
@@ -311,17 +311,17 @@ void LegoGameState::StopArea(MxU32 p_area)
 		RemoveFromWorld(*g_isleScript, 0x42a, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x42b, *g_isleScript, 0);
 		break;
-	case 8:
+	case e_unk8:
 		RemoveFromWorld(*g_isleScript, 0x45b, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x45c, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x45d, *g_isleScript, 0);
 		break;
-	case 9:
+	case e_unk9:
 		RemoveFromWorld(*g_isleScript, 0x475, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x476, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x477, *g_isleScript, 0);
 		break;
-	case 10:
+	case e_unk10:
 		RemoveFromWorld(*g_isleScript, 0x45f, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x460, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x461, *g_isleScript, 0);
@@ -343,92 +343,92 @@ void LegoGameState::StopArea(MxU32 p_area)
 		RemoveFromWorld(*g_isleScript, 0x472, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x12, *g_isleScript, 0);
 		break;
-	case 0xb:
+	case e_unk11:
 		RemoveFromWorld(*g_isleScript, 0x47a, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x47b, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x47c, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x47d, *g_isleScript, 0);
 		break;
-	case 0xc:
+	case e_regbook:
 		InvokeAction(Extra::e_stop, *g_regbookScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_regbookScript, 0, NULL);
 		break;
-	case 0xd:
+	case e_infoscor:
 		InvokeAction(Extra::e_stop, *g_infoscorScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_infoscorScript, 0, NULL);
 		break;
-	case 0xe:
+	case e_jetrace:
 		InvokeAction(Extra::e_stop, *g_jetraceScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_jetraceScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_jetracerScript, 0, NULL);
 		break;
-	case 0x12:
+	case e_carrace:
 		InvokeAction(Extra::e_stop, *g_carraceScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_carraceScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_carracerScript, 0, NULL);
 		break;
-	case 0x1a:
+	case e_garage:
 		Lego()->RemoveWorld(*g_garageScript, 0);
 		InvokeAction(Extra::e_stop, *g_garageScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_garageScript, 0, NULL);
 		break;
-	case 0x1b:
+	case e_unk27:
 		RemoveFromWorld(*g_isleScript, 0x489, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x48a, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x48b, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x48c, *g_isleScript, 0);
 		break;
-	case 0x1e:
+	case e_hospital:
 		InvokeAction(Extra::e_stop, *g_hospitalScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_hospitalScript, 0, NULL);
 		break;
-	case 0x22:
+	case e_police:
 		InvokeAction(Extra::e_stop, *g_policeScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_policeScript, 0, NULL);
 		break;
-	case 0x23:
+	case e_unk35:
 		RemoveFromWorld(*g_isleScript, 0x47f, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x480, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x481, *g_isleScript, 0);
 		RemoveFromWorld(*g_isleScript, 0x482, *g_isleScript, 0);
 		break;
-	case 0x24:
+	case e_copter:
 		InvokeAction(Extra::e_stop, *g_jukeboxScript, 0x2f, NULL);
 		InvokeAction(Extra::e_stop, *g_copterScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_copterScript, 0, NULL);
 		break;
-	case 0x25:
+	case e_dunecar:
 		InvokeAction(Extra::e_stop, *g_jukeboxScript, 0x31, NULL);
 		InvokeAction(Extra::e_stop, *g_dunecarScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_dunecarScript, 0, NULL);
 		break;
-	case 0x26:
+	case e_jetski:
 		InvokeAction(Extra::e_stop, *g_jukeboxScript, 0x33, NULL);
 		InvokeAction(Extra::e_stop, *g_jetskiScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_jetskiScript, 0, NULL);
 		break;
-	case 0x27:
+	case e_racecar:
 		InvokeAction(Extra::e_stop, *g_jukeboxScript, 0x35, NULL);
 		InvokeAction(Extra::e_stop, *g_racecarScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_racecarScript, 0, NULL);
 		break;
-	case 0x2e:
+	case e_act2main:
 		if (m_currentArea != 2) {
 			InvokeAction(Extra::e_stop, *g_act2mainScript, 0, NULL);
 			InvokeAction(Extra::e_close, *g_act2mainScript, 0, NULL);
 		}
 		break;
-	case 0x2f:
+	case e_act3script:
 		if (m_currentArea != 2) {
 			InvokeAction(Extra::e_stop, *g_act3Script, 0, NULL);
 			InvokeAction(Extra::e_close, *g_act3Script, 0, NULL);
 		}
 		break;
-	case 0x35:
+	case e_jukeboxw:
 		InvokeAction(Extra::e_stop, *g_jukeboxwScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_jukeboxwScript, 0, NULL);
 		break;
-	case 0x38:
+	case e_histbook:
 		InvokeAction(Extra::e_disable, *g_histbookScript, 0, NULL);
 		InvokeAction(Extra::e_stop, *g_histbookScript, 0, NULL);
 		InvokeAction(Extra::e_close, *g_histbookScript, 0, NULL);
@@ -437,7 +437,7 @@ void LegoGameState::StopArea(MxU32 p_area)
 }
 
 // FUNCTION: LEGO1 0x1003b060
-void LegoGameState::SwitchArea(MxU32 p_area)
+void LegoGameState::SwitchArea(Area p_area)
 {
 	m_previousArea = m_currentArea;
 	m_currentArea = p_area;
@@ -450,36 +450,36 @@ void LegoGameState::SwitchArea(MxU32 p_area)
 	LegoWorld* world;
 
 	switch (p_area) {
-	case 1:
+	case e_isle:
 		InvokeAction(Extra::ActionType::e_opendisk, *g_isleScript, 0, NULL);
 		break;
-	case 2:
+	case e_infomain:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_opendisk, *g_infomainScript, 0, NULL);
 		break;
-	case 3:
+	case e_infodoor:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_opendisk, *g_infodoorScript, 0, NULL);
 		break;
-	case 4:
-	case 0xf:
-	case 0x10:
-	case 0x11:
-	case 0x13:
-	case 0x14:
-	case 0x15:
-	case 0x16:
-	case 0x19:
-	case 0x1d:
-	case 0x1f:
-	case 0x20:
-	case 0x39:
-	case 0x3a:
-	case 0x3b:
-	case 0x3c:
-	case 0x3d:
-	case 0x40:
-	case 0x42:
+	case e_unk4:
+	case e_unk15:
+	case e_unk16:
+	case e_unk17:
+	case e_unk19:
+	case e_unk20:
+	case e_unk21:
+	case e_unk22:
+	case e_unk25:
+	case e_unk29:
+	case e_unk31:
+	case e_unk32:
+	case e_unk57:
+	case e_unk58:
+	case e_unk59:
+	case e_unk60:
+	case e_unk61:
+	case e_unk64:
+	case e_unk66:
 		world = FindWorld(*g_isleScript, 0);
 		if (world != NULL) {
 			if (world->GetUnknown0xd0().empty()) {
@@ -499,11 +499,11 @@ void LegoGameState::SwitchArea(MxU32 p_area)
 		}
 		InvokeAction(Extra::ActionType::e_opendisk, *g_isleScript, 0, NULL);
 		break;
-	case 5:
+	case e_elevbott:
 		InvokeAction(Extra::ActionType::e_opendisk, *g_elevbottScript, 0, NULL);
 		break;
-	case 6:
-	case 7:
+	case e_unk6:
+	case e_unk7:
 		world = FindWorld(*g_isleScript, 0);
 
 		if (world == NULL) {
@@ -521,30 +521,30 @@ void LegoGameState::SwitchArea(MxU32 p_area)
 		}
 		InvokeAction(Extra::ActionType::e_start, *g_isleScript, 1050, NULL);
 		break;
-	case 8:
+	case e_unk8:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_start, *g_isleScript, 1114, NULL);
 		break;
-	case 9:
+	case e_unk9:
 		InvokeAction(Extra::ActionType::e_start, *g_isleScript, 1140, NULL);
 		break;
-	case 10:
+	case e_unk10:
 		InvokeAction(Extra::ActionType::e_start, *g_isleScript, 1118, NULL);
 		break;
-	case 11:
+	case e_unk11:
 		InvokeAction(Extra::ActionType::e_start, *g_isleScript, 1145, NULL);
 		break;
-	case 12:
+	case e_regbook:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_opendisk, *g_regbookScript, 0, NULL);
 		break;
-	case 13:
+	case e_infoscor:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_opendisk, *g_infoscorScript, 0, NULL);
 		break;
-	case 14:
-		if (m_previousArea == 2) {
-			m_currentArea = 15;
+	case e_jetrace:
+		if (m_previousArea == e_infomain) {
+			m_currentArea = e_unk15;
 
 			world = FindWorld(*g_isleScript, 0);
 			if (world != NULL) {
@@ -571,9 +571,9 @@ void LegoGameState::SwitchArea(MxU32 p_area)
 
 		InvokeAction(Extra::ActionType::e_opendisk, *g_jetraceScript, 0, NULL);
 		break;
-	case 18:
-		if (m_previousArea == 2) {
-			m_currentArea = 19;
+	case e_carrace:
+		if (m_previousArea == e_infomain) {
+			m_currentArea = e_unk19;
 
 			world = FindWorld(*g_isleScript, 0);
 			if (world != NULL) {
@@ -596,13 +596,13 @@ void LegoGameState::SwitchArea(MxU32 p_area)
 
 		InvokeAction(Extra::ActionType::e_opendisk, *g_carraceScript, 0, NULL);
 		break;
-	case 26:
+	case e_garage:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_opendisk, *g_garageScript, 0, NULL);
 		break;
 
 	// TODO: implement other cases
-	case 56:
+	case e_histbook:
 		VideoManager()->SetUnk0x554(TRUE);
 		InvokeAction(Extra::ActionType::e_opendisk, *g_histbookScript, 0, NULL);
 		break;

--- a/LEGO1/lego/legoomni/src/infocenter/elevatorbottom.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/elevatorbottom.cpp
@@ -20,7 +20,7 @@ const char* g_cameraLoc = "CAMERA_LOCATION";
 ElevatorBottom::ElevatorBottom()
 {
 	NotificationManager()->Register(this);
-	this->m_unk0xf8 = 0;
+	this->m_unk0xf8 = LegoGameState::e_noArea;
 }
 
 // FUNCTION: LEGO1 0x10018060
@@ -44,8 +44,8 @@ MxResult ElevatorBottom::Create(MxDSAction& p_dsAction)
 
 	SetIsWorldActive(FALSE);
 
-	GameState()->SetCurrentArea(5);
-	GameState()->StopArea();
+	GameState()->SetCurrentArea(LegoGameState::e_elevbott);
+	GameState()->StopArea(LegoGameState::e_previousArea);
 
 	return result;
 }
@@ -86,12 +86,12 @@ MxLong ElevatorBottom::HandleClick(LegoControlManagerEvent& p_param)
 	if (p_param.GetUnknown0x28() == 1) {
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
-			m_unk0xf8 = 3;
+			m_unk0xf8 = LegoGameState::e_infodoor;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 2:
-			m_unk0xf8 = 2;
+			m_unk0xf8 = LegoGameState::e_infomain;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 			result = 1;
 			break;
@@ -104,7 +104,7 @@ MxLong ElevatorBottom::HandleClick(LegoControlManagerEvent& p_param)
 			}
 
 			state->SetUnknown1c(1);
-			m_unk0xf8 = 6;
+			m_unk0xf8 = LegoGameState::e_unk6;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 			VariableTable()->SetVariable(g_cameraLoc, "LCAMZI1,90");
 			result = 1;
@@ -135,6 +135,6 @@ void ElevatorBottom::Enable(MxBool p_enable)
 MxBool ElevatorBottom::VTable0x64()
 {
 	DeleteObjects(&m_atom, 500, 999);
-	m_unk0xf8 = 2;
+	m_unk0xf8 = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -39,7 +39,7 @@ Infocenter::Infocenter()
 	m_unk0x11c = NULL;
 	m_infocenterState = NULL;
 	m_frameHotBitmap = NULL;
-	m_transitionDestination = 0;
+	m_transitionDestination = LegoGameState::e_noArea;
 	m_currentInfomainScript = c_noInfomain;
 	m_currentCutscene = e_noIntro;
 
@@ -116,8 +116,8 @@ MxResult Infocenter::Create(MxDSAction& p_dsAction)
 		}
 	}
 
-	GameState()->SetCurrentArea(2);
-	GameState()->StopArea(0);
+	GameState()->SetCurrentArea(LegoGameState::e_infomain);
+	GameState()->StopArea(LegoGameState::e_previousArea);
 
 	if (m_infocenterState->GetUnknown0x74() == 4) {
 		LegoGameState* state = GameState();
@@ -173,7 +173,7 @@ MxLong Infocenter::Notify(MxParam& p_param)
 			else if (m_transitionDestination != 0) {
 				BackgroundAudioManager()->RaiseVolume();
 				GameState()->SwitchArea(m_transitionDestination);
-				m_transitionDestination = 0;
+				m_transitionDestination = LegoGameState::e_noArea;
 			}
 			break;
 		}
@@ -425,13 +425,13 @@ void Infocenter::ReadyWorld()
 			bgRed->Enable(TRUE);
 
 			if (GameState()->GetCurrentAct() == GameState()->GetLoadedAct()) {
-				GameState()->SetCurrentArea(0x2e);
-				GameState()->StopArea(0x2e);
-				GameState()->SetCurrentArea(0x02);
+				GameState()->SetCurrentArea(LegoGameState::e_act2main);
+				GameState()->StopArea(LegoGameState::e_act2main);
+				GameState()->SetCurrentArea(LegoGameState::e_infomain);
 			}
 
 			m_infocenterState->SetUnknown0x74(5);
-			m_transitionDestination = 0x2e;
+			m_transitionDestination = LegoGameState::e_act2main;
 
 			InfomainScript script =
 				(InfomainScript) m_infocenterState->GetReturnDialogue(GameState()->GetCurrentAct()).Next();
@@ -481,13 +481,13 @@ void Infocenter::ReadyWorld()
 			bgRed->Enable(TRUE);
 
 			if (GameState()->GetCurrentAct() == GameState()->GetLoadedAct()) {
-				GameState()->SetCurrentArea(0x2f);
-				GameState()->StopArea(0x2f);
-				GameState()->SetCurrentArea(0x02);
+				GameState()->SetCurrentArea(LegoGameState::e_act3script);
+				GameState()->StopArea(LegoGameState::e_act3script);
+				GameState()->SetCurrentArea(LegoGameState::e_infomain);
 			}
 
 			m_infocenterState->SetUnknown0x74(5);
-			m_transitionDestination = 0x2f;
+			m_transitionDestination = LegoGameState::e_act3script;
 
 			InfomainScript script =
 				(InfomainScript) m_infocenterState->GetReturnDialogue(GameState()->GetCurrentAct()).Next();
@@ -756,37 +756,37 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 					break;
 				case 10:
 					if (m_selectedCharacter) {
-						m_transitionDestination = 16;
+						m_transitionDestination = LegoGameState::e_unk16;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 11:
 					if (m_selectedCharacter) {
-						m_transitionDestination = 19;
+						m_transitionDestination = LegoGameState::e_unk19;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 12:
 					if (m_selectedCharacter) {
-						m_transitionDestination = 22;
+						m_transitionDestination = LegoGameState::e_unk22;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 13:
 					if (m_selectedCharacter) {
-						m_transitionDestination = 25;
+						m_transitionDestination = LegoGameState::e_unk25;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 14:
 					if (m_selectedCharacter) {
-						m_transitionDestination = 29;
+						m_transitionDestination = LegoGameState::e_unk29;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 15:
 					if (m_selectedCharacter) {
-						m_transitionDestination = 32;
+						m_transitionDestination = LegoGameState::e_unk32;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
@@ -803,7 +803,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				if (m_infocenterState->GetInfocenterBufferElement(0) == NULL) {
 					m_infocenterState->SetUnknown0x74(2);
-					m_transitionDestination = 0;
+					m_transitionDestination = LegoGameState::e_noArea;
 					dialogueToPlay = c_registerToContinueDialogue;
 				}
 				else {
@@ -873,7 +873,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
 				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
-				m_transitionDestination = 5;
+				m_transitionDestination = LegoGameState::e_elevbott;
 			}
 			else {
 				MxU32 objectId = m_infocenterState->GetBricksterDialogue().Next();
@@ -888,7 +888,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
 				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
-				m_transitionDestination = 13;
+				m_transitionDestination = LegoGameState::e_infoscor;
 			}
 			else {
 				MxU32 objectId = m_infocenterState->GetBricksterDialogue().Next();
@@ -936,9 +936,9 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			switch (state->GetCurrentAct()) {
 			case LegoGameState::e_act1:
 				switch (state->GetPreviousArea()) {
-				case 3:
-				case 12:
-				case 13:
+				case LegoGameState::e_infodoor:
+				case LegoGameState::e_regbook:
+				case LegoGameState::e_infoscor:
 					m_infocenterState->SetUnknown0x74(5);
 					m_transitionDestination = state->GetPreviousArea();
 					actionToPlay =
@@ -969,7 +969,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 				break;
 			case LegoGameState::e_act2:
 				m_infocenterState->SetUnknown0x74(5);
-				m_transitionDestination = 0x2e;
+				m_transitionDestination = LegoGameState::e_act2main;
 				actionToPlay =
 					(InfomainScript) m_infocenterState->GetLeaveDialogue(GameState()->GetCurrentAct()).Next();
 				InputManager()->DisableInputProcessing();
@@ -977,7 +977,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 				break;
 			case LegoGameState::e_act3:
 				m_infocenterState->SetUnknown0x74(5);
-				m_transitionDestination = 0x2f;
+				m_transitionDestination = LegoGameState::e_act3script;
 				actionToPlay =
 					(InfomainScript) m_infocenterState->GetLeaveDialogue(GameState()->GetCurrentAct()).Next();
 				InputManager()->DisableInputProcessing();
@@ -986,7 +986,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			}
 			break;
 		case c_bookCtl:
-			m_transitionDestination = 12;
+			m_transitionDestination = LegoGameState::e_regbook;
 			m_infocenterState->SetUnknown0x74(4);
 			actionToPlay = GameState()->GetCurrentAct() != LegoGameState::e_act1 ? c_goToRegBookRed : c_goToRegBook;
 			m_radio.Stop();
@@ -1286,8 +1286,8 @@ void Infocenter::Reset()
 	AnimationManager()->FUN_1005ee80(FALSE);
 	UnkSaveDataWriter()->FUN_100832a0();
 	GameState()->SetCurrentAct(LegoGameState::e_act1);
-	GameState()->SetPreviousArea(0);
-	GameState()->SetUnknown0x42c(0);
+	GameState()->SetPreviousArea(LegoGameState::e_noArea);
+	GameState()->SetUnknown0x42c(LegoGameState::e_noArea);
 
 	InitializeBitmaps();
 	m_selectedCharacter = e_pepper;

--- a/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenter.cpp
@@ -947,7 +947,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 					InputManager()->DisableInputProcessing();
 					InputManager()->SetUnknown336(TRUE);
 					break;
-				case 4:
+				case LegoGameState::e_unk4:
 					if (state->GetUnknownC()) {
 						if (m_infocenterState->GetInfocenterBufferElement(0)) {
 							m_infocenterState->SetUnknown0x74(5);

--- a/LEGO1/lego/legoomni/src/infocenter/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/infocenterdoor.cpp
@@ -16,7 +16,7 @@ DECOMP_SIZE_ASSERT(InfocenterDoor, 0xfc)
 // FUNCTION: LEGO1 0x10037730
 InfocenterDoor::InfocenterDoor()
 {
-	m_unk0xf8 = 0;
+	m_unk0xf8 = LegoGameState::e_noArea;
 
 	NotificationManager()->Register(this);
 }
@@ -43,8 +43,8 @@ MxResult InfocenterDoor::Create(MxDSAction& p_dsAction)
 
 	SetIsWorldActive(FALSE);
 
-	GameState()->SetCurrentArea(3);
-	GameState()->StopArea();
+	GameState()->SetCurrentArea(LegoGameState::e_infodoor);
+	GameState()->StopArea(LegoGameState::e_previousArea);
 
 	return result;
 }
@@ -94,17 +94,17 @@ MxLong InfocenterDoor::HandleClick(LegoControlManagerEvent& p_param)
 
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
-			m_unk0xf8 = 13;
+			m_unk0xf8 = LegoGameState::e_infoscor;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 2:
-			m_unk0xf8 = 5;
+			m_unk0xf8 = LegoGameState::e_elevbott;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 3:
-			m_unk0xf8 = 2;
+			m_unk0xf8 = LegoGameState::e_infomain;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
 			result = 1;
 			break;
@@ -112,7 +112,7 @@ MxLong InfocenterDoor::HandleClick(LegoControlManagerEvent& p_param)
 			if (GameState()->GetUnknownC()) {
 				InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
 				if (state->GetInfocenterBufferElement(0) != NULL) {
-					m_unk0xf8 = 4;
+					m_unk0xf8 = LegoGameState::e_unk4;
 				}
 				else {
 					MxDSAction action;
@@ -163,6 +163,6 @@ void InfocenterDoor::Enable(MxBool p_enable)
 MxBool InfocenterDoor::VTable0x64()
 {
 	DeleteObjects(&m_atom, 500, 510);
-	m_unk0xf8 = 2;
+	m_unk0xf8 = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/infocenter/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/registrationbook.cpp
@@ -48,8 +48,8 @@ MxResult RegistrationBook::Create(MxDSAction& p_dsAction)
 		SetIsWorldActive(FALSE);
 		InputManager()->Register(this);
 
-		GameState()->SetCurrentArea(12);
-		GameState()->StopArea(0);
+		GameState()->SetCurrentArea(LegoGameState::e_regbook);
+		GameState()->StopArea(LegoGameState::e_previousArea);
 
 		m_infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
 	}

--- a/LEGO1/lego/legoomni/src/infocenter/score.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/score.cpp
@@ -19,7 +19,7 @@ DECOMP_SIZE_ASSERT(Score, 0x104)
 // FUNCTION: LEGO1 0x10001000
 Score::Score()
 {
-	m_unk0xf8 = 0;
+	m_unk0xf8 = LegoGameState::e_noArea;
 	NotificationManager()->Register(this);
 }
 
@@ -53,8 +53,8 @@ MxResult Score::Create(MxDSAction& p_dsAction)
 		LegoGameState* gs = GameState();
 		ScoreState* state = (ScoreState*) gs->GetState("ScoreState");
 		m_state = state ? state : (ScoreState*) gs->CreateState("ScoreState");
-		GameState()->SetCurrentArea(0xd);
-		GameState()->StopArea();
+		GameState()->SetCurrentArea(LegoGameState::e_infoscor);
+		GameState()->StopArea(LegoGameState::e_previousArea);
 	}
 
 	return result;
@@ -119,7 +119,7 @@ MxLong Score::FUN_10001510(MxEndActionNotificationParam& p_param)
 		MxU32 id = action->GetObjectId();
 		switch (action->GetObjectId()) {
 		case 10:
-			m_unk0xf8 = 0x38;
+			m_unk0xf8 = LegoGameState::e_histbook;
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
 			break;
 		case 0x1f5:
@@ -163,12 +163,12 @@ MxLong Score::FUN_100016d0(LegoControlManagerEvent& p_param)
 	if (l == 1 || p_param.GetClickedObjectId() == 4) {
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
-			m_unk0xf8 = 2;
+			m_unk0xf8 = LegoGameState::e_infomain;
 			DeleteScript();
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
 			break;
 		case 2:
-			m_unk0xf8 = 3;
+			m_unk0xf8 = LegoGameState::e_infodoor;
 			DeleteScript();
 			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
 			break;
@@ -330,6 +330,6 @@ void Score::FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color)
 MxBool Score::VTable0x64()
 {
 	DeleteScript();
-	m_unk0xf8 = 2;
+	m_unk0xf8 = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/isle/isle.cpp
+++ b/LEGO1/lego/legoomni/src/isle/isle.cpp
@@ -69,7 +69,7 @@ MxResult Isle::Create(MxDSAction& p_dsAction)
 			GameState()->StopArea(LegoGameState::e_act2main);
 			break;
 		case LegoGameState::e_act3:
-			GameState()->StopArea(LegoGameState::e_act3script);
+			GameState()->StopArea(LegoGameState::e_act2main); // Looks like a bug
 			break;
 		case LegoGameState::e_actNotFound:
 			m_unk0x13c = 2;

--- a/LEGO1/lego/legoomni/src/isle/isle.cpp
+++ b/LEGO1/lego/legoomni/src/isle/isle.cpp
@@ -62,21 +62,21 @@ MxResult Isle::Create(MxDSAction& p_dsAction)
 	if (result == SUCCESS) {
 		ControlManager()->Register(this);
 		InputManager()->SetWorld(this);
-		GameState()->StopArea();
+		GameState()->StopArea(LegoGameState::e_previousArea);
 
 		switch (GameState()->GetLoadedAct()) {
 		case LegoGameState::e_act2:
-			GameState()->StopArea(0x2e);
+			GameState()->StopArea(LegoGameState::e_act2main);
 			break;
 		case LegoGameState::e_act3:
-			GameState()->StopArea(0x2e);
+			GameState()->StopArea(LegoGameState::e_act3script);
 			break;
 		case LegoGameState::e_actNotFound:
 			m_unk0x13c = 2;
 		}
 
-		if (GameState()->GetCurrentArea() == 1) {
-			GameState()->SetCurrentArea(0);
+		if (GameState()->GetCurrentArea() == LegoGameState::e_isle) {
+			GameState()->SetCurrentArea(LegoGameState::e_noArea);
 		}
 
 		LegoGameState* gameState = GameState();
@@ -158,7 +158,7 @@ void Isle::ReadyWorld()
 	LegoWorld::ReadyWorld();
 
 	if (m_act1state->GetUnknown21()) {
-		GameState()->SwitchArea(2);
+		GameState()->SwitchArea(LegoGameState::e_infomain);
 		m_act1state->SetUnknown18(0);
 		m_act1state->SetUnknown21(0);
 	}

--- a/LEGO1/lego/legoomni/src/police/police.cpp
+++ b/LEGO1/lego/legoomni/src/police/police.cpp
@@ -13,7 +13,7 @@ DECOMP_SIZE_ASSERT(Police, 0x110)
 Police::Police()
 {
 	m_policeState = NULL;
-	m_transitionDestination = 0;
+	m_transitionDestination = LegoGameState::e_noArea;
 	NotificationManager()->Register(this);
 }
 
@@ -54,8 +54,8 @@ MxResult Police::Create(MxDSAction& p_dsAction)
 	}
 
 	m_policeState = policeState;
-	GameState()->SetCurrentArea(0x22);
-	GameState()->StopArea();
+	GameState()->SetCurrentArea(LegoGameState::e_unk22);
+	GameState()->StopArea(LegoGameState::e_previousArea);
 	return ret;
 }
 
@@ -151,6 +151,6 @@ void Police::Enable(MxBool p_enable)
 MxBool Police::VTable0x64()
 {
 	DeleteObjects(&m_atom, 500, 510);
-	m_transitionDestination = 2;
+	m_transitionDestination = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/police/police.cpp
+++ b/LEGO1/lego/legoomni/src/police/police.cpp
@@ -54,7 +54,7 @@ MxResult Police::Create(MxDSAction& p_dsAction)
 	}
 
 	m_policeState = policeState;
-	GameState()->SetCurrentArea(LegoGameState::e_unk22);
+	GameState()->SetCurrentArea(LegoGameState::e_police);
 	GameState()->StopArea(LegoGameState::e_previousArea);
 	return ret;
 }


### PR DESCRIPTION
This adds an enum containing values for all the areas. The goal here is to replace the large number of magic values in the code base.