### PR TITLE
reccmp: Unique addresses and stub reporting

### DIFF
--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -155,7 +155,7 @@ protected:
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::find
 
 // TEMPLATE: LEGO1 0x10022360
-// _Construct
+// ?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z
 
 // GLOBAL: LEGO1 0x100f11a0
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Nil

--- a/tools/isledecomp/isledecomp/utils.py
+++ b/tools/isledecomp/isledecomp/utils.py
@@ -4,6 +4,9 @@ import colorama
 
 
 def print_diff(udiff, plain):
+    if udiff is None:
+        return False
+
     has_diff = False
     for line in udiff:
         has_diff = True

--- a/tools/isledecomp/tests/test_compare_db.py
+++ b/tools/isledecomp/tests/test_compare_db.py
@@ -1,0 +1,82 @@
+"""Testing compare database behavior, particularly matching"""
+import pytest
+from isledecomp.compare.db import CompareDb
+
+
+@pytest.fixture(name="db")
+def fixture_db():
+    return CompareDb()
+
+
+def test_ignore_recomp_collision(db):
+    """Duplicate recomp addresses are ignored"""
+    db.set_recomp_symbol(0x1234, None, "hello", None, 100)
+    db.set_recomp_symbol(0x1234, None, "alias_for_hello", None, 100)
+    syms = db.get_all()
+    assert len(syms) == 1
+
+
+def test_orig_collision(db):
+    """Don't match if the original address is not unique"""
+    db.set_recomp_symbol(0x1234, None, "hello", None, 100)
+    assert db.match_function(0x5555, "hello") is True
+
+    # Second run on same address fails
+    assert db.match_function(0x5555, "hello") is False
+
+    # Call set_pair directly without wrapper
+    assert db.set_pair(0x5555, 0x1234) is False
+
+
+def test_name_match(db):
+    db.set_recomp_symbol(0x1234, None, "hello", None, 100)
+    assert db.match_function(0x5555, "hello") is True
+
+    match = db.get_by_orig(0x5555)
+    assert match.name == "hello"
+    assert match.recomp_addr == 0x1234
+
+
+def test_match_decorated(db):
+    """Should match using decorated name even though regular name is null"""
+    db.set_recomp_symbol(0x1234, None, None, "?_hello", 100)
+    assert db.match_function(0x5555, "?_hello") is True
+    match = db.get_by_orig(0x5555)
+    assert match is not None
+
+
+def test_duplicate_name(db):
+    """If recomp name is not unique, match only one row"""
+    db.set_recomp_symbol(0x100, None, "_Construct", None, 100)
+    db.set_recomp_symbol(0x200, None, "_Construct", None, 100)
+    db.set_recomp_symbol(0x300, None, "_Construct", None, 100)
+    db.match_function(0x5555, "_Construct")
+    matches = db.get_matches()
+    # We aren't testing _which_ one would be matched, just that only one _was_ matched
+    assert len(matches) == 1
+
+
+def test_static_variable_match(db):
+    """Set up a situation where we can match a static function variable, then match it."""
+
+    # We need a matched function to start with.
+    db.set_recomp_symbol(0x1234, None, "Isle::Tick", "?Tick@IsleApp@@QAEXH@Z", 100)
+    db.match_function(0x5555, "Isle::Tick")
+
+    # Decorated variable name from PDB.
+    db.set_recomp_symbol(
+        0x2000, None, None, "?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA", 4
+    )
+
+    # Provide variable name and orig function address from decomp markers
+    assert db.match_static_variable(0xBEEF, "g_startupDelay", 0x5555) is True
+
+
+def test_match_options_bool(db):
+    """Test handling of boolean match options"""
+
+    # You don't actually need an existing orig addr for this.
+    assert db.get_match_options(0x1234) == {}
+
+    db.mark_stub(0x1234)
+    assert "stub" in db.get_match_options(0x1234)

--- a/tools/isledecomp/tests/test_demangler.py
+++ b/tools/isledecomp/tests/test_demangler.py
@@ -15,6 +15,7 @@ string_demangle_cases = [
         True,
     ),
     ("??_C@_00A@?$AA@", 0, False),
+    ("??_C@_01A@?$AA?$AA@", 1, False),
 ]
 
 

--- a/tools/reccmp/template.html
+++ b/tools/reccmp/template.html
@@ -109,7 +109,14 @@
           var decCel = row.appendChild(document.createElement('td'));
           decCel.colSpan = 3;
           var diff = data[this.dataset.index].diff;
-          if (diff == '') {
+          const stub = "stub" in data[this.dataset.index];
+
+          if (stub) {
+            diff = document.createElement('div');
+            diff.className = 'identical';
+            diff.innerText = 'Stub. No diff.';
+            decCel.appendChild(diff);
+          } else if (diff == '') {
             diff = document.createElement('div');
             diff.className = 'identical';
             diff.innerText = 'Identical function - no diff';
@@ -131,7 +138,7 @@
         }
       }
 
-      const filterOptions = { text: '', hidePerfect: false };
+      const filterOptions = { text: '', hidePerfect: false, hideStub: false };
 
       function filter() {
         closeAllDiffs();
@@ -143,13 +150,15 @@
         for (var ele of collection) {
           var eledata = data[ele.dataset.index];
 
+          const stubOk = (!filterOptions.hideStub || !("stub" in eledata));
+
           const textOk = (ltext == ''
             || eledata.address.toLowerCase().includes(ltext)
             || eledata.name.toLowerCase().includes(ltext));
 
           const perfOk = (!filterOptions.hidePerfect || (eledata.matching < 1));
 
-          if (textOk && perfOk) {
+          if (stubOk && textOk && perfOk) {
             ele.style.display = '';
             searchCount++;
           } else {
@@ -232,9 +241,14 @@
           addrCel.innerText = addrCel.dataset.value = element.address;
           nameCel.innerText = nameCel.dataset.value = element.name;
 
-          var effectiveNote = (element.matching == 1 && element.diff != '') ? '*' : '';
-          matchCel.innerHTML = (element.matching * 100).toFixed(2) + '%' + effectiveNote;
-          matchCel.dataset.value = element.matching;
+          if ("stub" in element) {
+            matchCel.innerHTML = 'stub'
+            matchCel.dataset.value = -1;
+          } else {
+            var effectiveNote = (element.matching == 1 && element.diff != '') ? '*' : '';
+            matchCel.innerHTML = (element.matching * 100).toFixed(2) + '%' + effectiveNote;
+            matchCel.dataset.value = element.matching;
+          }
 
           row.classList.add('funcrow');
           row.addEventListener('click', rowClick);
@@ -254,6 +268,12 @@
           filter();
         })
 
+        const cbHideStub = document.querySelector('#cbHideStub');
+        cbHideStub.addEventListener('change', evt => {
+          filterOptions.hideStub = evt.target.checked;
+          filter();
+        })
+
         sortByColumn(0);
       });
     </script>
@@ -265,6 +285,8 @@
       <div class="filters">
         <label for="cbHidePerfect">Hide 100% match</label>
         <input type="checkbox" id="cbHidePerfect" />
+        <label for="cbHideStub">Hide stubs</label>
+        <input type="checkbox" id="cbHideStub" />
       </div>
       <table id="listing">
         <tr id='listingheader'><th style='width: 20%'>Address</th><th style="width:60%">Name</th><th style='width: 20%'>Matching</th></tr>


### PR DESCRIPTION
The new feature from this PR is that stub functions are now reported in both the text and HTML outputs from `reccmp`. (attn: @tahg)

I added a `--silent` option to reccmp that omits the text output. This is more for my benefit when doing performance testing with the profiler so that there's less stuff printed to the terminal.

The behind-the-scenes work has to do with address uniqueness. Addrs from the original should be unique in our database because they only ever point at one thing. The decomp linter will detect if the address is reused, so we have protection on pull requests. Addrs from the recomp should be unique too, but there are situations where one would be duplicated in the data read from the PDB. For example: the `strlwr` function gets two symbols: `_strlwr` and `__strlwr`. 

Enforcing uniqueness is simple enough. I found that doing this the "correct" way with a unique index in sqlite is a lot slower than just checking whether the address has been used. Maybe the queries aren't using the indices effectively? I can look into that later.

Our addresses were already almost totally unique anyway, except for the two cases that I'll explain now:

One problem is name matching. If the PDB has two symbols with unique address but the same name, we need to match only one of them. We were using an `UPDATE` statement for this, but this will match all rows that have the given name. It _is_ possible for sqlite to update a single row in this situation (with `LIMIT 1`) but not unless the `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` option is enabled. This is not the case for our built-in python sqlite, so the solution is to just select the single recomp address that meets our matching criteria, and then do the update. This funnels all "matching" through the `set_pair` function, but I think this is a good thing because it means we can change our implementation more easily. The database internals should be abstracted away as much as possible.

(A possible enhancement here would be to _not_ match _unless_ only a single row comes back from our query.)

This problem bit us in the `_Construct` function. I have changed the decomp marker from `legoworld.h` to point at the decorated name `?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z` because this is what we were trying to match. Real name: `void __cdecl _Construct(class MxCore * *,class MxCore * const &)`. I added the option for the compare database to match using the decorated name if that's obviously what we have, rather than using the "least obtuse name" as we would normally.

The other odd case has to do with strings and their null terminator. I wrote more about this in the code comments, but basically we need to distinguish between the empty string `"\x00"` and the mostly empty string `"\x00\x00"`. Any string function would handle both as being empty, but they are two different symbols in the PDB for some reason. I'm not sure where the case with two nulls is used; maybe in one of the MSVC libraries.