### PR TITLE
CI: Reusable workflow for downloading original binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  fetch-deps:
+    name: Download original binaries
+    uses: ./.github/workflows/legobin.yml
+
   build-current-toolchain:
     name: 'Current ${{ matrix.toolchain.name }}'
     runs-on: windows-latest
@@ -98,7 +102,7 @@ jobs:
 
   compare:
     name: 'Compare with master'
-    needs: build
+    needs: [build, fetch-deps]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
@@ -111,21 +115,6 @@ jobs:
     - name: Restore cached original binaries
       id: cache-original-binaries
       uses: actions/cache/restore@v3
-      with:
-        enableCrossOsArchive: true
-        path: legobin
-        key: legobin
-
-    - name: Download original island binares
-      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
-      run: |
-        C:\msys64\usr\bin\wget.exe https://legoisland.org/download/CONFIG.EXE --directory-prefix=legobin
-        C:\msys64\usr\bin\wget.exe https://legoisland.org/download/ISLE.EXE --directory-prefix=legobin
-        C:\msys64\usr\bin\wget.exe https://legoisland.org/download/LEGO1.DLL --directory-prefix=legobin
-
-    - name: Cache original binaries
-      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
-      uses: actions/cache/save@v3
       with:
         enableCrossOsArchive: true
         path: legobin

--- a/.github/workflows/legobin.yml
+++ b/.github/workflows/legobin.yml
@@ -1,0 +1,32 @@
+name: Download legobin
+
+on:
+  workflow_call:
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Restore cached original binaries
+      id: cache-original-binaries
+      uses: actions/cache/restore@v3
+      with:
+        enableCrossOsArchive: true
+        path: legobin
+        key: legobin
+
+    - name: Download original island binaries
+      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
+      run: |
+        wget https://legoisland.org/download/CONFIG.EXE --directory-prefix=legobin
+        wget https://legoisland.org/download/ISLE.EXE --directory-prefix=legobin
+        wget https://legoisland.org/download/LEGO1.DLL --directory-prefix=legobin
+
+    - name: Cache original binaries
+      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
+      uses: actions/cache/save@v3
+      with:
+        enableCrossOsArchive: true
+        path: legobin
+        key: legobin

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,9 +3,14 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  fetch-deps:
+    name: Download original binaries
+    uses: ./.github/workflows/legobin.yml
+
   pytest-win:
     name: 'Python Windows'
     runs-on: windows-latest
+    needs: fetch-deps
 
     steps:
     - uses: actions/checkout@v4
@@ -13,20 +18,6 @@ jobs:
     - name: Restore cached original binaries
       id: cache-original-binaries
       uses: actions/cache/restore@v3
-      with:
-        enableCrossOsArchive: true
-        path: legobin
-        key: legobin
-
-    - name: Download original island binares
-      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
-      run: |
-        C:\msys64\usr\bin\wget.exe https://legoisland.org/download/ISLE.EXE --directory-prefix=legobin
-        C:\msys64\usr\bin\wget.exe https://legoisland.org/download/LEGO1.DLL --directory-prefix=legobin
-
-    - name: Cache original binaries
-      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
-      uses: actions/cache/save@v3
       with:
         enableCrossOsArchive: true
         path: legobin
@@ -45,6 +36,7 @@ jobs:
   pytest-ubuntu:
     name: 'Python Linux'
     runs-on: ubuntu-latest
+    needs: fetch-deps
 
     steps:
     - uses: actions/checkout@v4
@@ -52,20 +44,6 @@ jobs:
     - name: Restore cached original binaries
       id: cache-original-binaries
       uses: actions/cache/restore@v3
-      with:
-        enableCrossOsArchive: true
-        path: legobin
-        key: legobin
-
-    - name: Download original island binares
-      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
-      run: |
-        wget https://legoisland.org/download/ISLE.EXE --directory-prefix=legobin
-        wget https://legoisland.org/download/LEGO1.DLL --directory-prefix=legobin
-
-    - name: Cache original binaries
-      if: ${{ !steps.cache-original-binaries.outputs.cache-hit }}
-      uses: actions/cache/save@v3
       with:
         enableCrossOsArchive: true
         path: legobin


### PR DESCRIPTION
Adds a reusable workflow that will download and cache `CONFIG.EXE`, `ISLE.EXE`, and `LEGO1.DLL`.

The "Build" and "Test" actions depend on these files. If the "Test" action ran first (and it usually does) then we were not pulling in `CONFIG.EXE` so the "Build" action would fail.

I went with ubuntu-latest to download the files because this seems to start faster than the Windows runner.