### PR TITLE
LegoCacheSound and related STL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ add_library(lego1 SHARED
   LEGO1/lego/legoomni/src/audio/legocachesound.cpp
   LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
   LEGO1/lego/legoomni/src/audio/legosoundmanager.cpp
+  LEGO1/lego/legoomni/src/audio/legounknown100d5778.cpp
   LEGO1/lego/legoomni/src/audio/legounknown100d6b4c.cpp
   LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
   LEGO1/lego/legoomni/src/build/buildingentity.cpp

--- a/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
+++ b/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
@@ -1,6 +1,8 @@
 #ifndef LEGO3DWAVEPRESENTER_H
 #define LEGO3DWAVEPRESENTER_H
 
+#include "decomp.h"
+#include "legounknown100d5778.h"
 #include "mxwavepresenter.h"
 
 // VTABLE: LEGO1 0x100d52b0
@@ -27,6 +29,10 @@ public:
 
 	// SYNTHETIC: LEGO1 0x1000f4b0
 	// Lego3DWavePresenter::`scalar deleting destructor'
+
+private:
+	undefined m_unk0x6c[4];        // 0x6c
+	LegoUnknown100d5778 m_unk0x70; // 0x70
 };
 
 #endif // LEGO3DWAVEPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legocachesound.h
+++ b/LEGO1/lego/legoomni/include/legocachesound.h
@@ -27,14 +27,14 @@ public:
 	}
 
 	virtual MxResult FUN_10006710();                   // vtable+0x14
-	virtual void FUN_10006920();                       // vtable+0x18
+	virtual void Destroy();                            // vtable+0x18
 	virtual void FUN_10006cd0(undefined4, undefined4); // vtable+0x1c
 
 	inline const MxString& GetString0x48() const { return m_string0x48; }
-	inline const undefined GetUnk0x58() { return m_unk0x58; }
+	inline const undefined GetUnk0x58() const { return m_unk0x58; }
 
 	LegoCacheSound* FUN_10006960();
-	MxResult FUN_10006a30(char* p_str, MxBool p_unused);
+	MxResult FUN_10006a30(char* p_str, MxBool);
 	void FUN_10006b80();
 	void FUN_10006be0();
 
@@ -53,7 +53,7 @@ private:
 	undefined m_unk0x58;            // 0x58
 	PCMWAVEFORMAT m_unk0x59;        // 0x59
 	MxBool m_isLooping;             // 0x69
-	undefined m_unk0x6a;            // 0x6a
+	MxBool m_unk0x6a;               // 0x6a
 	undefined4 m_unk0x6c;           // 0x6c
 	undefined m_unk0x70;            // 0x70
 	MxString m_string0x74;          // 0x74

--- a/LEGO1/lego/legoomni/include/legocachesound.h
+++ b/LEGO1/lego/legoomni/include/legocachesound.h
@@ -2,7 +2,9 @@
 #define LEGOCACHESOUND_H
 
 #include "decomp.h"
+#include "legounknown100d5778.h"
 #include "mxcore.h"
+#include "mxstring.h"
 
 // VTABLE: LEGO1 0x100d4718
 // SIZE 0x88
@@ -24,13 +26,38 @@ public:
 		return !strcmp(p_name, LegoCacheSound::ClassName()) || MxCore::IsA(p_name);
 	}
 
+	virtual MxResult FUN_10006710();                   // vtable+0x14
+	virtual void FUN_10006920();                       // vtable+0x18
+	virtual void FUN_10006cd0(undefined4, undefined4); // vtable+0x1c
+
+	inline const MxString& GetString0x48() const { return m_string0x48; }
+	inline const undefined GetUnk0x58() { return m_unk0x58; }
+
+	LegoCacheSound* FUN_10006960();
+	MxResult FUN_10006a30(char* p_str, MxBool p_unused);
+	void FUN_10006b80();
+	void FUN_10006be0();
+
 	// SYNTHETIC: LEGO1 0x10006610
 	// LegoCacheSound::`scalar deleting destructor'
 
 private:
 	void Init();
 
-	undefined m_padding0x08[0x80]; // 0x08
+	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x08
+	undefined m_unk0xc[4];          // 0x0c
+	LegoUnknown100d5778 m_unk0x10;  // 0x10
+	undefined* m_unk0x40;           // 0x40
+	undefined4 m_unk0x44;           // 0x44
+	MxString m_string0x48;          // 0x48
+	undefined m_unk0x58;            // 0x58
+	PCMWAVEFORMAT m_unk0x59;        // 0x59
+	MxBool m_isLooping;             // 0x69
+	undefined m_unk0x6a;            // 0x6a
+	undefined4 m_unk0x6c;           // 0x6c
+	undefined m_unk0x70;            // 0x70
+	MxString m_string0x74;          // 0x74
+	undefined m_unk0x84;            // 0x84
 };
 
 #endif // LEGOCACHESOUND_H

--- a/LEGO1/lego/legoomni/include/legounknown100d5778.h
+++ b/LEGO1/lego/legoomni/include/legounknown100d5778.h
@@ -1,0 +1,37 @@
+#ifndef LEGOUNKNOWN100D5778_H
+#define LEGOUNKNOWN100D5778_H
+
+#include "decomp.h"
+#include "mxtypes.h"
+#include "roi/legoroi.h"
+
+#include <dsound.h>
+
+// VTABLE: LEGO1 0x100d5778
+// SIZE 0x30
+class LegoUnknown100d5778 {
+public:
+	LegoUnknown100d5778();
+	virtual ~LegoUnknown100d5778();
+	void Init();
+	MxResult FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4 p_two, undefined4 p_three);
+	void FUN_10011880();
+	undefined4 FUN_100118e0(LPDIRECTSOUNDBUFFER p_dsBuffer);
+	void FUN_10011ca0();
+
+	// SYNTHETIC: LEGO1 0x10011650
+	// LegoUnknown100d5778::`scalar deleting destructor'
+
+private:
+	undefined m_unk0x4[4];          // 0x04
+	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x08
+	LegoROI* m_unk0xc;              // 0x0c
+	undefined4 m_unk0x10;           // 0x10
+	MxBool m_unk0x14;               // 0x14
+	MxBool m_unk0x15;               // 0x15
+	undefined4 m_unk0x18;           // 0x18
+	undefined m_unk0x1c[0x10];      // 0x1c
+	undefined4 m_unk0x2c;           // 0x2c
+};
+
+#endif // LEGOUNKNOWN100D5778_H

--- a/LEGO1/lego/legoomni/include/legounknown100d5778.h
+++ b/LEGO1/lego/legoomni/include/legounknown100d5778.h
@@ -13,9 +13,10 @@ class LegoUnknown100d5778 {
 public:
 	LegoUnknown100d5778();
 	virtual ~LegoUnknown100d5778();
+
 	void Init();
-	MxResult FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4 p_two, undefined4 p_three);
-	void FUN_10011880();
+	MxResult FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4, undefined4 p_unk0x2c);
+	void Destroy();
 	undefined4 FUN_100118e0(LPDIRECTSOUNDBUFFER p_dsBuffer);
 	void FUN_10011ca0();
 

--- a/LEGO1/lego/legoomni/include/legounknown100d6b4c.h
+++ b/LEGO1/lego/legoomni/include/legounknown100d6b4c.h
@@ -2,23 +2,117 @@
 #define LEGOUNKNOWN100D6B4C_H
 
 #include "decomp.h"
+#include "legocachesound.h"
+#include "mxstl/stlcompat.h"
 #include "mxtypes.h"
 
-class LegoCacheSound;
+struct Element100d6b4c {
+	Element100d6b4c() : m_sound(NULL), m_name(NULL){};
+	Element100d6b4c(LegoCacheSound* p_sound, const char* p_name) : m_sound(p_sound), m_name(p_name){};
+	Element100d6b4c(LegoCacheSound* p_sound) : m_sound(p_sound), m_name(p_sound->GetString0x48().GetData()){};
+
+	// FUNCTION: LEGO1 0x1003d030
+	~Element100d6b4c()
+	{
+		if (m_sound == NULL) {
+			delete[] const_cast<char*>(m_name);
+		}
+	}
+
+	bool operator==(Element100d6b4c) const { return 0; }
+	bool operator<(Element100d6b4c) const { return 0; }
+
+	inline LegoCacheSound* GetSound() const { return m_sound; }
+	inline const char* GetName() const { return m_name; }
+
+private:
+	LegoCacheSound* m_sound;
+	const char* m_name;
+};
+
+struct Set100d6b4cComparator {
+	bool operator()(const Element100d6b4c& p_a, const Element100d6b4c& p_b) const
+	{
+		return strcmpi(p_a.GetName(), p_b.GetName()) > 0;
+	}
+};
+
+typedef set<Element100d6b4c, Set100d6b4cComparator> Set100d6b4c;
+
+typedef list<Element100d6b4c> List100d6b4c;
 
 // VTABLE: LEGO1 0x100d6b4c
 // SIZE 0x20
 class LegoUnknown100d6b4c {
 public:
-	LegoUnknown100d6b4c();
+	LegoUnknown100d6b4c(){};
 	~LegoUnknown100d6b4c();
 
 	virtual MxResult Tickle(); // vtable+0x00
 
+	LegoCacheSound* FUN_1003d170(const char* p_key);
+	LegoCacheSound* FUN_1003d290(LegoCacheSound* p_sound);
+	void FUN_1003dae0(char* p_one, char* p_two, MxBool p_three);
+	LegoCacheSound* FUN_1003db10(LegoCacheSound* p_one, char* p_two, MxBool p_three);
 	void FUN_1003dc40(LegoCacheSound** p_und);
 
 private:
-	undefined m_pad[0x1c];
+	Set100d6b4c m_set;
+	List100d6b4c m_list;
 };
+
+// TODO: Function names subject to change.
+
+// clang-format off
+
+// TEMPLATE: LEGO1 0x10029c30
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::~_Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >
+
+// TEMPLATE: LEGO1 0x10029d10
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::iterator::_Inc
+
+// TEMPLATE: LEGO1 0x10029d50
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::erase
+
+// TEMPLATE: LEGO1 0x1002a1b0
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Erase
+
+// TEMPLATE: LEGO1 0x1002a210
+// list<Element100d6b4c,allocator<Element100d6b4c> >::~list<Element100d6b4c,allocator<Element100d6b4c> >
+
+// TEMPLATE: LEGO1 0x1002a2a0
+// set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::~set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >
+
+// TEMPLATE: LEGO1 0x1002a2f0
+// Set<Element100d6b4c,Set100d6b4cComparator>::~Set<Element100d6b4c,Set100d6b4cComparator>
+
+// TEMPLATE: LEGO1 0x1002a340
+// List<Element100d6b4c>::~List<Element100d6b4c>
+
+// TEMPLATE: LEGO1 0x1003dab0
+// list<Element100d6b4c,allocator<Element100d6b4c> >::_Buynode
+
+// TEMPLATE: LEGO1 0x1003d450
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::insert
+
+// TEMPLATE: LEGO1 0x1003d6f0
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::iterator::_Dec
+
+// TEMPLATE: LEGO1 0x1003d740
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_BuyNode
+
+// TEMPLATE: LEGO1 0x1003d760
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Insert
+
+// TEMPLATE: LEGO1 0x1003d9f0
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Lrotate
+
+// TEMPLATE: LEGO1 0x1003da50
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Rrotate
+
+// GLOBAL: LEGO1 0x100f31cc
+// _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Nil
+
+// clang-format on
 
 #endif // LEGOUNKNOWN100D6B4C_H

--- a/LEGO1/lego/legoomni/include/legounknown100d6b4c.h
+++ b/LEGO1/lego/legoomni/include/legounknown100d6b4c.h
@@ -6,15 +6,16 @@
 #include "mxstl/stlcompat.h"
 #include "mxtypes.h"
 
+// SIZE 0x08
 struct Element100d6b4c {
-	Element100d6b4c() : m_sound(NULL), m_name(NULL){};
-	Element100d6b4c(LegoCacheSound* p_sound, const char* p_name) : m_sound(p_sound), m_name(p_name){};
-	Element100d6b4c(LegoCacheSound* p_sound) : m_sound(p_sound), m_name(p_sound->GetString0x48().GetData()){};
+	Element100d6b4c() : m_sound(NULL), m_name(NULL) {}
+	Element100d6b4c(LegoCacheSound* p_sound, const char* p_name) : m_sound(p_sound), m_name(p_name) {}
+	Element100d6b4c(LegoCacheSound* p_sound) : m_sound(p_sound), m_name(p_sound->GetString0x48().GetData()) {}
 
 	// FUNCTION: LEGO1 0x1003d030
 	~Element100d6b4c()
 	{
-		if (m_sound == NULL) {
+		if (m_sound == NULL && m_name != NULL) {
 			delete[] const_cast<char*>(m_name);
 		}
 	}
@@ -25,27 +26,28 @@ struct Element100d6b4c {
 	inline LegoCacheSound* GetSound() const { return m_sound; }
 	inline const char* GetName() const { return m_name; }
 
+	friend struct Set100d6b4cComparator;
+
 private:
-	LegoCacheSound* m_sound;
-	const char* m_name;
+	LegoCacheSound* m_sound; // 0x00
+	const char* m_name;      // 0x04
 };
 
 struct Set100d6b4cComparator {
 	bool operator()(const Element100d6b4c& p_a, const Element100d6b4c& p_b) const
 	{
-		return strcmpi(p_a.GetName(), p_b.GetName()) > 0;
+		return strcmpi(p_a.m_name, p_b.m_name) > 0;
 	}
 };
 
 typedef set<Element100d6b4c, Set100d6b4cComparator> Set100d6b4c;
-
 typedef list<Element100d6b4c> List100d6b4c;
 
 // VTABLE: LEGO1 0x100d6b4c
 // SIZE 0x20
 class LegoUnknown100d6b4c {
 public:
-	LegoUnknown100d6b4c(){};
+	LegoUnknown100d6b4c() {}
 	~LegoUnknown100d6b4c();
 
 	virtual MxResult Tickle(); // vtable+0x00
@@ -57,14 +59,13 @@ public:
 	void FUN_1003dc40(LegoCacheSound** p_und);
 
 private:
-	Set100d6b4c m_set;
-	List100d6b4c m_list;
+	Set100d6b4c m_set;   // 0x04
+	List100d6b4c m_list; // 0x14
 };
 
 // TODO: Function names subject to change.
 
 // clang-format off
-
 // TEMPLATE: LEGO1 0x10029c30
 // _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::~_Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >
 
@@ -112,7 +113,6 @@ private:
 
 // GLOBAL: LEGO1 0x100f31cc
 // _Tree<Element100d6b4c,Element100d6b4c,set<Element100d6b4c,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Kfn,Set100d6b4cComparator,allocator<Element100d6b4c> >::_Nil
-
 // clang-format on
 
 #endif // LEGOUNKNOWN100D6B4C_H

--- a/LEGO1/lego/legoomni/include/legounksavedatawriter.h
+++ b/LEGO1/lego/legoomni/include/legounksavedatawriter.h
@@ -42,6 +42,7 @@ public:
 	AutoROI* FUN_10083500(char*, undefined4);
 	void FUN_100832a0();
 	void FUN_10083db0(LegoROI* p_roi);
+	void FUN_10083f10(LegoROI* p_roi);
 
 private:
 	undefined m_unk0x00[0x08]; // 0x00

--- a/LEGO1/lego/legoomni/src/audio/lego3dwavepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/audio/lego3dwavepresenter.cpp
@@ -2,7 +2,7 @@
 
 #include "mxomni.h"
 
-DECOMP_SIZE_ASSERT(Lego3DWavePresenter, 0xa0);
+DECOMP_SIZE_ASSERT(Lego3DWavePresenter, 0xa0)
 
 // FUNCTION: LEGO1 0x1004a7c0
 MxResult Lego3DWavePresenter::AddToManager()

--- a/LEGO1/lego/legoomni/src/audio/lego3dwavepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/audio/lego3dwavepresenter.cpp
@@ -2,6 +2,8 @@
 
 #include "mxomni.h"
 
+DECOMP_SIZE_ASSERT(Lego3DWavePresenter, 0xa0);
+
 // FUNCTION: LEGO1 0x1004a7c0
 MxResult Lego3DWavePresenter::AddToManager()
 {

--- a/LEGO1/lego/legoomni/src/audio/legocachesound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachesound.cpp
@@ -16,17 +16,17 @@ LegoCacheSound::LegoCacheSound()
 LegoCacheSound::~LegoCacheSound()
 {
 	// TODO
-	FUN_10006920();
+	Destroy();
 }
 
 // FUNCTION: LEGO1 0x100066d0
 void LegoCacheSound::Init()
 {
 	m_dsBuffer = NULL;
-	m_unk0x40 = 0;
+	m_unk0x40 = NULL;
 	m_unk0x58 = 0;
 	memset(&m_unk0x59, 0, sizeof(m_unk0x59));
-	m_unk0x6a = 0;
+	m_unk0x6a = FALSE;
 	m_unk0x70 = 0;
 	m_isLooping = TRUE;
 	m_unk0x6c = 79;
@@ -56,7 +56,7 @@ MxResult LegoCacheSound::FUN_10006710()
 }
 
 // FUNCTION: LEGO1 0x10006920
-void LegoCacheSound::FUN_10006920()
+void LegoCacheSound::Destroy()
 {
 	if (m_dsBuffer) {
 		m_dsBuffer->Stop();
@@ -76,7 +76,7 @@ LegoCacheSound* LegoCacheSound::FUN_10006960()
 }
 
 // STUB: LEGO1 0x10006a30
-MxResult LegoCacheSound::FUN_10006a30(char* p_str, MxBool p_unused)
+MxResult LegoCacheSound::FUN_10006a30(char* p_str, MxBool)
 {
 	// TODO
 	// gets param2 from FUN_1003db10
@@ -98,7 +98,7 @@ void LegoCacheSound::FUN_10006b80()
 	}
 
 	m_unk0x58 = 0;
-	m_unk0x6a = 0;
+	m_unk0x6a = FALSE;
 
 	m_unk0x10.FUN_10011ca0();
 	if (m_string0x74.GetLength() != 0) {
@@ -110,13 +110,14 @@ void LegoCacheSound::FUN_10006b80()
 void LegoCacheSound::FUN_10006be0()
 {
 	if (!m_isLooping) {
-
 		DWORD dwStatus;
 		m_dsBuffer->GetStatus(&dwStatus);
+
 		if (m_unk0x70) {
 			if (dwStatus == 0) {
 				return;
 			}
+
 			m_unk0x70 = 0;
 		}
 
@@ -139,11 +140,11 @@ void LegoCacheSound::FUN_10006be0()
 			}
 
 			m_dsBuffer->Stop();
-			m_unk0x6a = 1;
+			m_unk0x6a = TRUE;
 		}
 		else if (m_unk0x6a) {
 			m_dsBuffer->Play(0, 0, m_isLooping);
-			m_unk0x6a = 0;
+			m_unk0x6a = FALSE;
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/audio/legocachesound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachesound.cpp
@@ -1,5 +1,9 @@
 #include "legocachesound.h"
 
+#include "legoomni.h"
+#include "legosoundmanager.h"
+#include "mxomni.h"
+
 DECOMP_SIZE_ASSERT(LegoCacheSound, 0x88)
 
 // FUNCTION: LEGO1 0x100064d0
@@ -12,10 +16,139 @@ LegoCacheSound::LegoCacheSound()
 LegoCacheSound::~LegoCacheSound()
 {
 	// TODO
+	FUN_10006920();
 }
 
-// STUB: LEGO1 0x100066d0
+// FUNCTION: LEGO1 0x100066d0
 void LegoCacheSound::Init()
 {
+	m_dsBuffer = NULL;
+	m_unk0x40 = 0;
+	m_unk0x58 = 0;
+	memset(&m_unk0x59, 0, sizeof(m_unk0x59));
+	m_unk0x6a = 0;
+	m_unk0x70 = 0;
+	m_isLooping = TRUE;
+	m_unk0x6c = 79;
+	m_unk0x84 = 0;
+}
+
+// STUB: LEGO1 0x10006710
+MxResult LegoCacheSound::FUN_10006710()
+{
 	// TODO
+	DSBUFFERDESC desc;
+	memset(&desc, 0, sizeof(desc));
+	desc.dwSize = sizeof(desc);
+
+	if (MxOmni::IsSound3D()) {
+		desc.dwFlags = DSBCAPS_PRIMARYBUFFER | DSBCAPS_CTRL3D;
+	}
+	else {
+		desc.dwFlags = DSBCAPS_PRIMARYBUFFER | DSBCAPS_CTRLVOLUME;
+	}
+
+	if (SoundManager()->GetDirectSound()->CreateSoundBuffer(&desc, &m_dsBuffer, NULL) != DS_OK) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+// FUNCTION: LEGO1 0x10006920
+void LegoCacheSound::FUN_10006920()
+{
+	if (m_dsBuffer) {
+		m_dsBuffer->Stop();
+		m_dsBuffer->Release();
+		m_dsBuffer = NULL;
+	}
+
+	delete m_unk0x40;
+	Init();
+}
+
+// STUB: LEGO1 0x10006960
+LegoCacheSound* LegoCacheSound::FUN_10006960()
+{
+	// TODO
+	return NULL;
+}
+
+// STUB: LEGO1 0x10006a30
+MxResult LegoCacheSound::FUN_10006a30(char* p_str, MxBool p_unused)
+{
+	// TODO
+	// gets param2 from FUN_1003db10
+	if (!m_unk0x40 && !m_unk0x44) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+// FUNCTION: LEGO1 0x10006b80
+void LegoCacheSound::FUN_10006b80()
+{
+	DWORD dwStatus;
+
+	m_dsBuffer->GetStatus(&dwStatus);
+	if (dwStatus) {
+		m_dsBuffer->Stop();
+	}
+
+	m_unk0x58 = 0;
+	m_unk0x6a = 0;
+
+	m_unk0x10.FUN_10011ca0();
+	if (m_string0x74.GetLength() != 0) {
+		m_string0x74 = "";
+	}
+}
+
+// FUNCTION: LEGO1 0x10006be0
+void LegoCacheSound::FUN_10006be0()
+{
+	if (!m_isLooping) {
+
+		DWORD dwStatus;
+		m_dsBuffer->GetStatus(&dwStatus);
+		if (m_unk0x70) {
+			if (dwStatus == 0) {
+				return;
+			}
+			m_unk0x70 = 0;
+		}
+
+		if (dwStatus == 0) {
+			m_dsBuffer->Stop();
+			m_unk0x10.FUN_10011ca0();
+			if (m_string0x74.GetLength() != 0) {
+				m_string0x74 = "";
+			}
+
+			m_unk0x58 = 0;
+			return;
+		}
+	}
+
+	if (m_string0x74.GetLength() != 0 && !m_unk0x84) {
+		if (!m_unk0x10.FUN_100118e0(m_dsBuffer)) {
+			if (m_unk0x6a) {
+				return;
+			}
+
+			m_dsBuffer->Stop();
+			m_unk0x6a = 1;
+		}
+		else if (m_unk0x6a) {
+			m_dsBuffer->Play(0, 0, m_isLooping);
+			m_unk0x6a = 0;
+		}
+	}
+}
+
+// FUNCTION: LEGO1 0x10006cd0
+void LegoCacheSound::FUN_10006cd0(undefined4, undefined4)
+{
 }

--- a/LEGO1/lego/legoomni/src/audio/legounknown100d5778.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legounknown100d5778.cpp
@@ -1,0 +1,81 @@
+#include "legounknown100d5778.h"
+
+#include "legoomni.h"
+#include "legounksavedatawriter.h"
+
+DECOMP_SIZE_ASSERT(LegoUnknown100d5778, 0x30);
+
+// FUNCTION: LEGO1 0x10011630
+LegoUnknown100d5778::LegoUnknown100d5778()
+{
+	Init();
+}
+
+// FUNCTION: LEGO1 0x10011670
+LegoUnknown100d5778::~LegoUnknown100d5778()
+{
+	FUN_10011880();
+}
+
+// FUNCTION: LEGO1 0x10011680
+void LegoUnknown100d5778::Init()
+{
+	m_dsBuffer = NULL;
+	m_unk0xc = NULL;
+	m_unk0x10 = 0;
+	m_unk0x18 = 0;
+	m_unk0x14 = FALSE;
+	m_unk0x15 = FALSE;
+	m_unk0x2c = 79;
+}
+
+// STUB: LEGO1 0x100116a0
+MxResult LegoUnknown100d5778::FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4 p_two, undefined4 p_three)
+{
+	m_unk0x2c = p_three;
+	if (MxOmni::IsSound3D()) {
+		p_dsound->QueryInterface(IID_IDirectSoundBuffer, (LPVOID*) &m_dsBuffer);
+		if (m_dsBuffer == NULL) {
+			return FAILURE;
+		}
+
+		// TODO
+	}
+
+	// TODO
+
+	return SUCCESS;
+}
+
+// FUNCTION: LEGO1 0x10011880
+void LegoUnknown100d5778::FUN_10011880()
+{
+	if (m_dsBuffer) {
+		m_dsBuffer->Release();
+		m_dsBuffer = NULL;
+	}
+
+	if (m_unk0x14 && m_unk0xc && UnkSaveDataWriter()) {
+		if (m_unk0x15) {
+			UnkSaveDataWriter()->FUN_10083db0(m_unk0xc);
+		}
+		else {
+			UnkSaveDataWriter()->FUN_10083f10(m_unk0xc);
+		}
+	}
+
+	Init();
+}
+
+// STUB: LEGO1 0x100118e0
+undefined4 LegoUnknown100d5778::FUN_100118e0(LPDIRECTSOUNDBUFFER p_dsBuffer)
+{
+	// TODO
+	return 0;
+}
+
+// STUB: LEGO1 0x10011ca0
+void LegoUnknown100d5778::FUN_10011ca0()
+{
+	// TODO
+}

--- a/LEGO1/lego/legoomni/src/audio/legounknown100d5778.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legounknown100d5778.cpp
@@ -3,7 +3,7 @@
 #include "legoomni.h"
 #include "legounksavedatawriter.h"
 
-DECOMP_SIZE_ASSERT(LegoUnknown100d5778, 0x30);
+DECOMP_SIZE_ASSERT(LegoUnknown100d5778, 0x30)
 
 // FUNCTION: LEGO1 0x10011630
 LegoUnknown100d5778::LegoUnknown100d5778()
@@ -14,7 +14,7 @@ LegoUnknown100d5778::LegoUnknown100d5778()
 // FUNCTION: LEGO1 0x10011670
 LegoUnknown100d5778::~LegoUnknown100d5778()
 {
-	FUN_10011880();
+	Destroy();
 }
 
 // FUNCTION: LEGO1 0x10011680
@@ -30,9 +30,10 @@ void LegoUnknown100d5778::Init()
 }
 
 // STUB: LEGO1 0x100116a0
-MxResult LegoUnknown100d5778::FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4 p_two, undefined4 p_three)
+MxResult LegoUnknown100d5778::FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4, undefined4 p_unk0x2c)
 {
-	m_unk0x2c = p_three;
+	m_unk0x2c = p_unk0x2c;
+
 	if (MxOmni::IsSound3D()) {
 		p_dsound->QueryInterface(IID_IDirectSoundBuffer, (LPVOID*) &m_dsBuffer);
 		if (m_dsBuffer == NULL) {
@@ -48,7 +49,7 @@ MxResult LegoUnknown100d5778::FUN_100116a0(LPDIRECTSOUND p_dsound, undefined4 p_
 }
 
 // FUNCTION: LEGO1 0x10011880
-void LegoUnknown100d5778::FUN_10011880()
+void LegoUnknown100d5778::Destroy()
 {
 	if (m_dsBuffer) {
 		m_dsBuffer->Release();

--- a/LEGO1/lego/legoomni/src/audio/legounknown100d6b4c.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legounknown100d6b4c.cpp
@@ -1,25 +1,177 @@
 #include "legounknown100d6b4c.h"
 
-// Inline constructor at 0x10029adb
-LegoUnknown100d6b4c::LegoUnknown100d6b4c()
-{
-	// TODO
-}
+#include "legoomni.h"
+#include "legoworld.h"
 
-// STUB: LEGO1 0x1003cf20
+DECOMP_SIZE_ASSERT(LegoUnknown100d6b4c, 0x20);
+
+// FUNCTION: LEGO1 0x1003cf20
 LegoUnknown100d6b4c::~LegoUnknown100d6b4c()
 {
-	// TODO
+	LegoCacheSound* sound;
+
+	while (!m_set.empty()) {
+		sound = (*m_set.begin()).GetSound();
+		m_set.erase(m_set.begin());
+		sound->FUN_10006b80();
+		delete sound;
+	}
+
+	while (!m_list.empty()) {
+		sound = (*m_list.begin()).GetSound();
+		m_list.erase(m_list.begin());
+		sound->FUN_10006b80();
+		// DECOMP: delete should not be inlined here
+		delete sound;
+	}
 }
 
-// STUB: LEGO1 0x1003d050
+// FUNCTION: LEGO1 0x1003d050
 MxResult LegoUnknown100d6b4c::Tickle()
 {
+#ifdef COMPAT_MODE
+	Set100d6b4c::iterator setIter;
+	for (setIter = m_set.begin(); setIter != m_set.end(); setIter++) {
+#else
+	for (Set100d6b4c::iterator setIter = m_set.begin(); setIter != m_set.end(); setIter++) {
+#endif
+		LegoCacheSound* sound = (*setIter).GetSound();
+		if (sound->GetUnk0x58()) {
+			sound->FUN_10006be0();
+		}
+	}
+
+	List100d6b4c::iterator listIter = m_list.begin();
+	while (listIter != m_list.end()) {
+		LegoCacheSound* sound = (*listIter).GetSound();
+		if (sound->GetUnk0x58()) {
+			sound->FUN_10006be0();
+			listIter++;
+			continue;
+		}
+		sound->FUN_10006b80();
+
+		List100d6b4c::iterator temp = listIter;
+		listIter++;
+
+		m_list.erase(temp);
+		delete sound;
+	}
+
 	return SUCCESS;
 }
 
-// STUB: LEGO1 0x1003dc40
-void LegoUnknown100d6b4c::FUN_1003dc40(LegoCacheSound** p_und)
+// STUB: LEGO1 0x1003d170
+LegoCacheSound* LegoUnknown100d6b4c::FUN_1003d170(const char* p_key)
 {
 	// TODO
+	char* x = new char[strlen(p_key) + 1];
+	strcpy(x, p_key);
+
+	Set100d6b4c::iterator setIter;
+	for (setIter = m_set.begin(); setIter != m_set.end(); setIter++) {
+		if (!strcmpi((*setIter).GetName(), x)) {
+			return (*setIter).GetSound();
+		}
+	}
+
+	return NULL;
+}
+
+// FUNCTION: LEGO1 0x1003d290
+LegoCacheSound* LegoUnknown100d6b4c::FUN_1003d290(LegoCacheSound* p_sound)
+{
+	Set100d6b4c::iterator it = m_set.find(Element100d6b4c(p_sound));
+	if (it != m_set.end()) {
+		LegoCacheSound* sound = (*it).GetSound();
+
+		if (sound->GetUnk0x58()) {
+			m_list.push_back(Element100d6b4c(p_sound));
+			return p_sound;
+		}
+
+		delete p_sound;
+		return sound;
+	}
+
+	m_set.insert(Element100d6b4c(p_sound));
+	LegoWorld* world = CurrentWorld();
+	if (world) {
+		world->Add(p_sound);
+	}
+
+	return p_sound;
+}
+
+// FUNCTION: LEGO1 0x1003dae0
+void LegoUnknown100d6b4c::FUN_1003dae0(char* p_one, char* p_two, MxBool p_three)
+{
+	// DECOMP: Second parameter is 0xe4 member of LegoPathActor subclass
+	FUN_1003db10(FUN_1003d170(p_one), p_two, p_three);
+}
+
+// FUNCTION: LEGO1 0x1003db10
+LegoCacheSound* LegoUnknown100d6b4c::FUN_1003db10(LegoCacheSound* p_one, char* p_two, MxBool p_three)
+{
+	if (!p_one) {
+		return NULL;
+	}
+
+	if (p_one->GetUnk0x58()) {
+		LegoCacheSound* result = p_one->FUN_10006960();
+		if (result) {
+			LegoCacheSound* t = FUN_1003d290(result);
+			t->FUN_10006a30(p_two, p_three);
+			return t;
+		}
+	}
+	else {
+		p_one->FUN_10006a30(p_two, p_three);
+		return p_one;
+	}
+
+	return NULL;
+}
+
+// FUNCTION: LEGO1 0x1003dc40
+void LegoUnknown100d6b4c::FUN_1003dc40(LegoCacheSound** p_und)
+{
+	// Called during LegoWorld::Destroy like this:
+	// SoundManager()->GetUnknown0x40()->FUN_1003dc40(&sound);
+	// LegoCacheSound*& p_sound?
+
+#ifdef COMPAT_MODE
+	Set100d6b4c::iterator setIter;
+	for (setIter = m_set.begin(); setIter != m_set.end(); setIter++) {
+#else
+	for (Set100d6b4c::iterator setIter = m_set.begin(); setIter != m_set.end(); setIter++) {
+#endif
+		if ((*setIter).GetSound() == *p_und) {
+			(*p_und)->FUN_10006b80();
+
+			delete *p_und;
+			m_set.erase(setIter);
+			return;
+		}
+	}
+
+#ifdef COMPAT_MODE
+	List100d6b4c::iterator listIter;
+	for (listIter = m_list.begin();; listIter++) {
+#else
+	for (List100d6b4c::iterator listIter = m_list.begin();; listIter++) {
+#endif
+		if (listIter == m_list.end()) {
+			return;
+		}
+
+		LegoCacheSound* sound = (*listIter).GetSound();
+		if (sound == *p_und) {
+			(*p_und)->FUN_10006b80();
+
+			delete sound;
+			m_list.erase(listIter);
+			return;
+		}
+	}
 }

--- a/LEGO1/lego/legoomni/src/audio/legounknown100d6b4c.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legounknown100d6b4c.cpp
@@ -3,7 +3,8 @@
 #include "legoomni.h"
 #include "legoworld.h"
 
-DECOMP_SIZE_ASSERT(LegoUnknown100d6b4c, 0x20);
+DECOMP_SIZE_ASSERT(Element100d6b4c, 0x08)
+DECOMP_SIZE_ASSERT(LegoUnknown100d6b4c, 0x20)
 
 // FUNCTION: LEGO1 0x1003cf20
 LegoUnknown100d6b4c::~LegoUnknown100d6b4c()
@@ -44,18 +45,16 @@ MxResult LegoUnknown100d6b4c::Tickle()
 	List100d6b4c::iterator listIter = m_list.begin();
 	while (listIter != m_list.end()) {
 		LegoCacheSound* sound = (*listIter).GetSound();
+
 		if (sound->GetUnk0x58()) {
 			sound->FUN_10006be0();
 			listIter++;
-			continue;
 		}
-		sound->FUN_10006b80();
-
-		List100d6b4c::iterator temp = listIter;
-		listIter++;
-
-		m_list.erase(temp);
-		delete sound;
+		else {
+			sound->FUN_10006b80();
+			m_list.erase(listIter++);
+			delete sound;
+		}
 	}
 
 	return SUCCESS;
@@ -89,9 +88,10 @@ LegoCacheSound* LegoUnknown100d6b4c::FUN_1003d290(LegoCacheSound* p_sound)
 			m_list.push_back(Element100d6b4c(p_sound));
 			return p_sound;
 		}
-
-		delete p_sound;
-		return sound;
+		else {
+			delete p_sound;
+			return sound;
+		}
 	}
 
 	m_set.insert(Element100d6b4c(p_sound));
@@ -119,6 +119,7 @@ LegoCacheSound* LegoUnknown100d6b4c::FUN_1003db10(LegoCacheSound* p_one, char* p
 
 	if (p_one->GetUnk0x58()) {
 		LegoCacheSound* result = p_one->FUN_10006960();
+
 		if (result) {
 			LegoCacheSound* t = FUN_1003d290(result);
 			t->FUN_10006a30(p_two, p_three);

--- a/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
@@ -83,3 +83,9 @@ void LegoUnkSaveDataWriter::FUN_10083db0(LegoROI* p_roi)
 {
 	// TODO
 }
+
+// STUB: LEGO1 0x10083f10
+void LegoUnkSaveDataWriter::FUN_10083f10(LegoROI* p_roi)
+{
+	// TODO
+}

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -21,6 +21,7 @@ public:
 
 	inline MxS8 Compare(const MxString& p_str) const { return strcmp(m_data, p_str.m_data); }
 	inline const char* GetData() const { return m_data; }
+	inline const MxU16 GetLength() const { return m_length; }
 
 	// SYNTHETIC: LEGO1 0x100ae280
 	// MxString::`scalar deleting destructor'

--- a/LEGO1/omni/src/common/mxatomid.cpp
+++ b/LEGO1/omni/src/common/mxatomid.cpp
@@ -42,8 +42,8 @@ void MxAtomId::Destroy()
 #ifdef COMPAT_MODE
 	MxAtomIdCounterSet::iterator it;
 	{
-		MxAtomIdCounter id_counter(m_internal);
-		it = AtomIdCounterSet()->find(&id_counter);
+		MxAtomIdCounter idCounter(m_internal);
+		it = AtomIdCounterSet()->find(&idCounter);
 	}
 #else
 	MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(&MxAtomIdCounter(m_internal));

--- a/tools/reccmp/template.html
+++ b/tools/reccmp/template.html
@@ -54,6 +54,7 @@
       #listing td, #listing th {
         border: 1px #f0f0f0 solid;
         padding: 0.5em;
+        word-break: break-all !important;
       }
 
       .diffneg {


### PR DESCRIPTION
This started as an exploration into the STL members of `LegoUnknown100d6b4c`, and then expanded out into `LegoCacheSound` and a new related class `LegoUnknown100d5778`.

My goal in pulling in those other classes was to try to understand how `LegoUnknown100d6b4c` works. I don't have the _why_ but I'm more confident about the members being a set and list. It didn't really come together until I reversed the function at `0x1003d290`. The list and set are both using the same "value type" for the nodes, and you can tell that because they both use the same destructor at `0x1003d030`. The unwind section shows this object being instantiated as the arg for the STL functions. (In typical MSVC fashion, I had this function at 100% but it stopped matching when I used getter methods instead of direct member access.)

I'm less confident about the object itself. I have the struct `Element100d6b4c` in there now. This is basically just `std::pair<const char*, LegoCacheSound*>` except for that destructor. Might be missing something obvious here.

Other small items:
* ncc was complaining about the variable name with an underscore in `MxAtomId` so that's fixed. Coincidentally, the `MxAtomIdCounterSet` class is another instance where it seems like we should have a map, but a set fit better for _reasons_. The node size is 0x18, which means two pointers (i.e. key and value) instead of just one, and that would also suggest a map.
* The table in the reccmp HTML output was getting broken due to the very long symbol names without a space character.
