### PR TITLE
GasStation destructor, enable, create

### DIFF
--- a/LEGO1/lego/legoomni/include/gasstation.h
+++ b/LEGO1/lego/legoomni/include/gasstation.h
@@ -2,6 +2,7 @@
 #define GASSTATION_H
 
 #include "decomp.h"
+#include "gasstationstate.h"
 #include "legoworld.h"
 #include "radio.h"
 
@@ -39,18 +40,18 @@ public:
 	// GasStation::`scalar deleting destructor'
 
 private:
-	undefined2 m_unk0xf8;  // 0xf8
-	undefined2 m_unk0xfa;  // 0xfa
-	undefined4 m_unk0xfc;  // 0xfc
-	undefined4 m_unk0x100; // 0x100
-	undefined2 m_unk0x104; // 0x104
-	undefined2 m_unk0x106; // 0x106
-	undefined4 m_unk0x108; // 0x108
-	undefined4 m_unk0x10c; // 0x10c
-	undefined4 m_unk0x110; // 0x110
-	undefined m_unk0x114;  // 0x114
-	undefined m_unk0x115;  // 0x115
-	Radio m_radio;         // 0x118
+	undefined2 m_unk0xf8;               // 0xf8
+	undefined2 m_unk0xfa;               // 0xfa
+	undefined4 m_unk0xfc;               // 0xfc
+	GasStationState* m_gasStationState; // 0x100
+	undefined2 m_unk0x104;              // 0x104
+	undefined2 m_unk0x106;              // 0x106
+	undefined4 m_unk0x108;              // 0x108
+	undefined4 m_unk0x10c;              // 0x10c
+	undefined4 m_unk0x110;              // 0x110
+	undefined m_unk0x114;               // 0x114
+	undefined m_unk0x115;               // 0x115
+	Radio m_radio;                      // 0x118
 };
 
 #endif // GASSTATION_H

--- a/LEGO1/lego/legoomni/include/gasstation.h
+++ b/LEGO1/lego/legoomni/include/gasstation.h
@@ -40,18 +40,18 @@ public:
 	// GasStation::`scalar deleting destructor'
 
 private:
-	undefined2 m_unk0xf8;               // 0xf8
-	undefined2 m_unk0xfa;               // 0xfa
-	undefined4 m_unk0xfc;               // 0xfc
-	GasStationState* m_gasStationState; // 0x100
-	undefined2 m_unk0x104;              // 0x104
-	undefined2 m_unk0x106;              // 0x106
-	undefined4 m_unk0x108;              // 0x108
-	undefined4 m_unk0x10c;              // 0x10c
-	undefined4 m_unk0x110;              // 0x110
-	undefined m_unk0x114;               // 0x114
-	undefined m_unk0x115;               // 0x115
-	Radio m_radio;                      // 0x118
+	undefined2 m_unk0xf8;     // 0xf8
+	undefined2 m_unk0xfa;     // 0xfa
+	undefined4 m_unk0xfc;     // 0xfc
+	GasStationState* m_state; // 0x100
+	undefined2 m_unk0x104;    // 0x104
+	undefined2 m_unk0x106;    // 0x106
+	undefined4 m_unk0x108;    // 0x108
+	undefined4 m_unk0x10c;    // 0x10c
+	undefined4 m_unk0x110;    // 0x110
+	undefined m_unk0x114;     // 0x114
+	undefined m_unk0x115;     // 0x115
+	Radio m_radio;            // 0x118
 };
 
 #endif // GASSTATION_H

--- a/LEGO1/lego/legoomni/include/gasstationstate.h
+++ b/LEGO1/lego/legoomni/include/gasstationstate.h
@@ -27,6 +27,9 @@ public:
 	// SYNTHETIC: LEGO1 0x10006290
 	// GasStationState::`scalar deleting destructor'
 
+	inline undefined4 GetUnknown0x14() { return m_unk0x14; }
+	inline void SetUnknown0x14(undefined4 p_unk0x14) { m_unk0x14 = p_unk0x14; }
+
 private:
 	undefined4 m_unk0x08[3]; // 0x08
 	undefined4 m_unk0x14;    // 0x14

--- a/LEGO1/lego/legoomni/include/gasstationstate.h
+++ b/LEGO1/lego/legoomni/include/gasstationstate.h
@@ -36,7 +36,6 @@ public:
 	// SYNTHETIC: LEGO1 0x10006290
 	// GasStationState::`scalar deleting destructor'
 
-	// inline undefined4 GetUnknown0x14() { return m_unk0x14.m_unk0x00; }
 	inline Unknown0x14& GetUnknown0x14() { return m_unk0x14; }
 
 private:

--- a/LEGO1/lego/legoomni/include/gasstationstate.h
+++ b/LEGO1/lego/legoomni/include/gasstationstate.h
@@ -7,6 +7,15 @@
 // SIZE 0x24
 class GasStationState : public LegoState {
 public:
+	// SIZE 0x04
+	struct Unknown0x14 {
+		inline void SetUnknown0x00(undefined4 p_unk0x00) { m_unk0x00 = p_unk0x00; }
+		inline undefined4 GetUnknown0x00() { return m_unk0x00; }
+
+	private:
+		undefined4 m_unk0x00; // 0x00
+	};
+
 	GasStationState();
 
 	// FUNCTION: LEGO1 0x100061d0
@@ -27,12 +36,12 @@ public:
 	// SYNTHETIC: LEGO1 0x10006290
 	// GasStationState::`scalar deleting destructor'
 
-	inline undefined4 GetUnknown0x14() { return m_unk0x14; }
-	inline void SetUnknown0x14(undefined4 p_unk0x14) { m_unk0x14 = p_unk0x14; }
+	// inline undefined4 GetUnknown0x14() { return m_unk0x14.m_unk0x00; }
+	inline Unknown0x14& GetUnknown0x14() { return m_unk0x14; }
 
 private:
 	undefined4 m_unk0x08[3]; // 0x08
-	undefined4 m_unk0x14;    // 0x14
+	Unknown0x14 m_unk0x14;   // 0x14
 	undefined2 m_unk0x18;    // 0x18
 	undefined2 m_unk0x1a;    // 0x1a
 	undefined2 m_unk0x1c;    // 0x1c

--- a/LEGO1/lego/legoomni/src/gasstation/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/gasstation/gasstation.cpp
@@ -7,13 +7,14 @@
 #include "mxnotificationmanager.h"
 #include "mxticklemanager.h"
 
+// GLOBAL: LEGO1 0x100f0160
 undefined4 g_unk0x100f0160;
 
 // FUNCTION: LEGO1 0x100046a0
 GasStation::GasStation()
 {
 	m_unk0xf8 = 0;
-	m_gasStationState = NULL;
+	m_state = NULL;
 	m_unk0xfc = 0;
 	m_unk0x108 = 0;
 	m_unk0x104 = 0;
@@ -49,22 +50,26 @@ GasStation::~GasStation()
 // FUNCTION: LEGO1 0x10004990
 MxResult GasStation::Create(MxDSAction& p_dsAction)
 {
-	MxResult ret = LegoWorld::Create(p_dsAction);
-	if (ret == SUCCESS) {
+	MxResult result = LegoWorld::Create(p_dsAction);
+	if (result == SUCCESS) {
 		InputManager()->SetWorld(this);
 		ControlManager()->Register(this);
 	}
 
 	InputManager()->SetCamera(NULL);
 
-	m_gasStationState = (GasStationState*) GameState()->GetState("GasStationState");
-	if (!m_gasStationState) {
-		m_gasStationState = (GasStationState*) GameState()->CreateState("GasStationState");
-		m_gasStationState->SetUnknown0x14(1);
+	m_state = (GasStationState*) GameState()->GetState("GasStationState");
+	if (!m_state) {
+		m_state = (GasStationState*) GameState()->CreateState("GasStationState");
+		m_state->GetUnknown0x14().SetUnknown0x00(1);
 	}
 	else {
-		if (m_gasStationState->GetUnknown0x14() != 4) {
-			m_gasStationState->SetUnknown0x14(3);
+		GasStationState::Unknown0x14& unk0x14 = m_state->GetUnknown0x14();
+		if (unk0x14.GetUnknown0x00() == 4) {
+			unk0x14.SetUnknown0x00(4);
+		}
+		else {
+			unk0x14.SetUnknown0x00(3);
 		}
 	}
 
@@ -73,7 +78,7 @@ MxResult GasStation::Create(MxDSAction& p_dsAction)
 
 	InputManager()->Register(this);
 	SetIsWorldActive(FALSE);
-	return ret;
+	return result;
 }
 
 // STUB: LEGO1 0x10004a60

--- a/LEGO1/lego/legoomni/src/gasstation/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/gasstation/gasstation.cpp
@@ -1,12 +1,19 @@
 #include "gasstation.h"
 
+#include "legocontrolmanager.h"
+#include "legogamestate.h"
+#include "legoinputmanager.h"
+#include "legoomni.h"
 #include "mxnotificationmanager.h"
+#include "mxticklemanager.h"
+
+undefined4 g_unk0x100f0160;
 
 // FUNCTION: LEGO1 0x100046a0
 GasStation::GasStation()
 {
 	m_unk0xf8 = 0;
-	m_unk0x100 = 0;
+	m_gasStationState = NULL;
 	m_unk0xfc = 0;
 	m_unk0x108 = 0;
 	m_unk0x104 = 0;
@@ -25,17 +32,48 @@ MxBool GasStation::VTable0x5c()
 	return TRUE;
 }
 
-// STUB: LEGO1 0x100048c0
+// FUNCTION: LEGO1 0x100048c0
 GasStation::~GasStation()
 {
-	// TODO
+	InputManager()->UnRegister(this);
+	if (InputManager()->GetWorld() == this) {
+		InputManager()->ClearWorld();
+	}
+
+	ControlManager()->Unregister(this);
+	TickleManager()->UnregisterClient(this);
+	NotificationManager()->Unregister(this);
+	g_unk0x100f0160 = 3;
 }
 
-// STUB: LEGO1 0x10004990
+// FUNCTION: LEGO1 0x10004990
 MxResult GasStation::Create(MxDSAction& p_dsAction)
 {
-	// TODO
-	return SUCCESS;
+	MxResult ret = LegoWorld::Create(p_dsAction);
+	if (ret == SUCCESS) {
+		InputManager()->SetWorld(this);
+		ControlManager()->Register(this);
+	}
+
+	InputManager()->SetCamera(NULL);
+
+	m_gasStationState = (GasStationState*) GameState()->GetState("GasStationState");
+	if (!m_gasStationState) {
+		m_gasStationState = (GasStationState*) GameState()->CreateState("GasStationState");
+		m_gasStationState->SetUnknown0x14(1);
+	}
+	else {
+		if (m_gasStationState->GetUnknown0x14() != 4) {
+			m_gasStationState->SetUnknown0x14(3);
+		}
+	}
+
+	GameState()->SetCurrentArea(LegoGameState::e_garage);
+	GameState()->StopArea(LegoGameState::e_previousArea);
+
+	InputManager()->Register(this);
+	SetIsWorldActive(FALSE);
+	return ret;
 }
 
 // STUB: LEGO1 0x10004a60
@@ -52,10 +90,21 @@ void GasStation::ReadyWorld()
 	// TODO
 }
 
-// STUB: LEGO1 0x10005c40
+// FUNCTION: LEGO1 0x10005c40
 void GasStation::Enable(MxBool p_enable)
 {
-	// TODO
+	LegoWorld::Enable(p_enable);
+
+	if (p_enable) {
+		InputManager()->SetWorld(this);
+		InputManager()->SetCamera(NULL);
+		return;
+	}
+	else {
+		if (InputManager()->GetWorld() == this) {
+			InputManager()->ClearWorld();
+		}
+	}
 }
 
 // STUB: LEGO1 0x10005c90


### PR DESCRIPTION
I'm still a little confused with some things. There is some global variable, and to be honest I'm new to dealing with globals and statics in decompilation in general, but I'm off a little bit with that global data. The destructor doesn't match because of this.

In the Create function, there is some check about the GasStationState's m_unk0x14 that I just cannot seem to get it match. Ghidra says it sets the value to 4, and then checks if the previous value is not 4, but I already tried doing that and it wasn't matching. Something weird is happening there.