### PR TITLE
Implement/match Tgl::View::Render

### DIFF
--- a/LEGO1/lego/sources/3dmanager/tglsurface.cpp
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.cpp
@@ -181,8 +181,7 @@ double TglSurface::Render()
 		m_renderingRateMeter.StartOperation();
 		renderTimer.Start();
 
-		// TODO: Wrong interface
-		result = m_pView->Render((Tgl::Light*) m_pScene);
+		result = m_pView->Render(m_pScene);
 
 		renderTimer.Stop();
 		assert(Succeeded(result));

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -170,7 +170,7 @@ public:
 	// vtable+0x20
 	Result GetBackgroundColor(float* r, float* g, float* b) override;
 	Result Clear() override;
-	Result Render(const Light*) override;
+	Result Render(const Group*) override;
 	Result ForceUpdate(unsigned long x, unsigned long y, unsigned long width, unsigned long height) override;
 
 	// vtable+0x30
@@ -318,6 +318,8 @@ public:
 
 	// vtable+0x30
 	Result Unknown() override;
+
+	inline IDirect3DRMFrame2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -189,7 +189,7 @@ public:
 	// vtable+0x20
 	virtual Result GetBackgroundColor(float* r, float* g, float* b) = 0;
 	virtual Result Clear() = 0;
-	virtual Result Render(const Light*) = 0;
+	virtual Result Render(const Group*) = 0;
 	virtual Result ForceUpdate(unsigned long x, unsigned long y, unsigned long width, unsigned long height) = 0;
 
 	// vtable+0x30


### PR DESCRIPTION
This fixes/implements and matches the implementation of `Tgl::View::Render` to 100%.

The choice of not following the template pattern of TGL as seen in the 1996 wasn't a good one. It turns out, unsurprisingly, that the inlining patterns actually matter quite a lot to get matching code, as evidenced by this function. We will most likely have to reverse course on the current TGL implementation and re-use what we find in 1996, even if we don't particularly like it from an engineering standpoint.