### PR TITLE
Match more scalar deleting destructors

### DIFF
--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -9,6 +9,9 @@ class AutoROI;
 // SIZE 0x6c (discovered through inline constructor at 0x10009ae6)
 class LegoModelPresenter : public MxVideoPresenter {
 public:
+	// inline in scalar dtor
+	~LegoModelPresenter() override { Destroy(TRUE); }
+
 	static void configureLegoModelPresenter(MxS32 p_modelPresenterConfig);
 
 	// FUNCTION: LEGO1 0x1000ccb0

--- a/LEGO1/lego/legoomni/include/legoobjectfactory.h
+++ b/LEGO1/lego/legoomni/include/legoobjectfactory.h
@@ -111,6 +111,9 @@ public:
 	// SYNTHETIC: LEGO1 0x10009000
 	// LegoObjectFactory::`scalar deleting destructor'
 
+	// SYNTHETIC: LEGO1 0x10009170
+	// LegoObjectFactory::~LegoObjectFactory
+
 private:
 #define X(V) MxAtomId m_id##V;
 	FOR_LEGOOBJECTFACTORY_OBJECTS(X)

--- a/LEGO1/lego/legoomni/include/legopartpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopartpresenter.h
@@ -7,6 +7,8 @@
 // SIZE 0x54 (from inlined construction at 0x10009fac)
 class LegoPartPresenter : public MxMediaPresenter {
 public:
+	~LegoPartPresenter() override { Destroy(TRUE); }
+
 	// FUNCTION: LEGO1 0x1000cf70
 	inline const char* ClassName() const override // vtable+0x0c
 	{
@@ -28,6 +30,9 @@ public:
 
 	// SYNTHETIC: LEGO1 0x1000d060
 	// LegoPartPresenter::`scalar deleting destructor'
+
+private:
+	void Destroy(MxBool p_fromDestructor);
 };
 
 #endif // LEGOPARTPRESENTER_H

--- a/LEGO1/lego/legoomni/include/racestate.h
+++ b/LEGO1/lego/legoomni/include/racestate.h
@@ -34,6 +34,9 @@ public:
 
 	inline MxU16 GetColor(MxU8 p_id) { return GetState(p_id)->m_color; }
 
+	// SYNTHETIC: LEGO1 0x1000f6f0
+	// RaceState::~RaceState
+
 	// SYNTHETIC: LEGO1 0x100160d0
 	// RaceState::`scalar deleting destructor'
 

--- a/LEGO1/lego/legoomni/src/video/legopartpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legopartpresenter.cpp
@@ -9,10 +9,10 @@ int g_partPresenterConfig1 = 1;
 // GLOBAL: LEGO1 0x100f7aa4
 int g_partPresenterConfig2 = 100;
 
-// STUB: LEGO1 0x1000cf60
+// FUNCTION: LEGO1 0x1000cf60
 void LegoPartPresenter::Destroy()
 {
-	// TODO
+	Destroy(FALSE);
 }
 
 // FUNCTION: LEGO1 0x1007c990
@@ -27,6 +27,12 @@ MxResult LegoPartPresenter::AddToManager()
 {
 	VideoManager()->RegisterPresenter(*this);
 	return SUCCESS;
+}
+
+// STUB: LEGO1 0x1007c9d0
+void LegoPartPresenter::Destroy(MxBool p_fromDestructor)
+{
+	// TODO
 }
 
 // STUB: LEGO1 0x1007deb0

--- a/LEGO1/omni/include/mxthread.h
+++ b/LEGO1/omni/include/mxthread.h
@@ -47,7 +47,6 @@ protected:
 class MxTickleThread : public MxThread {
 public:
 	MxTickleThread(MxCore* p_target, MxS32 p_frequencyMS);
-	~MxTickleThread() override {}
 
 	MxResult Run() override;
 

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -101,6 +101,7 @@ class Unk;
 // VTABLE: LEGO1 0x100db980
 class Object {
 public:
+	// FUNCTION: LEGO1 0x100a2240
 	virtual ~Object() {}
 
 	virtual void* ImplementationDataPtr() = 0;
@@ -146,6 +147,9 @@ public:
 	// vtable+0x30
 	virtual Result SetTextureDefaultColorCount(unsigned long) = 0;
 
+	// SYNTHETIC: LEGO1 0x100a1770
+	// Tgl::Renderer::~Renderer
+
 	// SYNTHETIC: LEGO1 0x100a17c0
 	// Tgl::Renderer::`scalar deleting destructor'
 };
@@ -169,6 +173,9 @@ public:
 	virtual Result Update() = 0;
 	virtual void InitFromD3DDevice(Device*) = 0;
 	virtual void InitFromWindowsDevice(Device*) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2350
+	// Tgl::Device::~Device
 
 	// SYNTHETIC: LEGO1 0x100a28e0
 	// Tgl::Device::`scalar deleting destructor'
@@ -227,6 +234,9 @@ public:
 		int& rPickedGroupCount
 	) = 0;
 
+	// SYNTHETIC: LEGO1 0x100a2430
+	// Tgl::View::~View
+
 	// SYNTHETIC: LEGO1 0x100a2950
 	// Tgl::View::`scalar deleting destructor'
 };
@@ -235,6 +245,9 @@ public:
 class Camera : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a25f0
+	// Tgl::Camera::~Camera
 
 	// SYNTHETIC: LEGO1 0x100a2a30
 	// Tgl::Camera::`scalar deleting destructor'
@@ -245,6 +258,9 @@ class Light : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
 	virtual Result SetColor(float r, float g, float b) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a26d0
+	// Tgl::Light::~Light
 
 	// SYNTHETIC: LEGO1 0x100a2aa0
 	// Tgl::Light::`scalar deleting destructor'
@@ -288,6 +304,9 @@ public:
 	// to have been replaced by something else in the shipped code.
 	virtual Result Unknown() = 0;
 
+	// SYNTHETIC: LEGO1 0x100a2510
+	// Tgl::Group::~Group
+
 	// SYNTHETIC: LEGO1 0x100a29c0
 	// Tgl::Group::`scalar deleting destructor'
 };
@@ -309,6 +328,9 @@ public:
 	) = 0;
 	virtual Result GetBoundingBox(float min[3], float max[3]) = 0;
 	virtual Unk* Clone() = 0;
+
+	// SYNTHETIC: LEGO1 0x100a27b0
+	// Tgl::Unk::~Unk
 
 	// SYNTHETIC: LEGO1 0x100a2b10
 	// Tgl::Unk::`scalar deleting destructor'
@@ -332,6 +354,9 @@ public:
 		PaletteEntry** ppPalette
 	) = 0;
 	virtual Result SetPalette(int entryCount, PaletteEntry* pEntries) = 0;
+
+	// SYNTHETIC: LEGO1 0x100a2890
+	// Tgl::Texture::~Texture
 
 	// SYNTHETIC: LEGO1 0x100a2b80
 	// Tgl::Texture::`scalar deleting destructor'


### PR DESCRIPTION
A few minor changes to match various `scalar deleting destructor` functions.

The ones from the `Tgl` namespace just needed annotations for the regular (synthetic) destructors.

In other cases, a destructor needed to be added or removed from the header. The deciding factor is whether the scalar dtor sets the class vtable during the destruction.

Of the remaining destructors that are close to matching: I left LegoPathController alone because it is missing two STL members. They both look like a `<set>` with different value types at +0x20 and +0x30. LegoROI calls ~ViewROI, but this function is non-trivial. ViewROI has a destructor defined as inline, but it is not this one.
