### PR TITLE
Implement/match RegisterExtraPaths

### DIFF
--- a/LEGO1/lego/legoomni/include/legoomni.h
+++ b/LEGO1/lego/legoomni/include/legoomni.h
@@ -104,6 +104,65 @@ public:
 		MxAtomId* m_script; // 0x18
 	};
 
+	// SIZE 0x38
+	struct PathContainer {
+		PathContainer() {}
+
+		// FUNCTION: LEGO1 0x1001b1b0
+		PathContainer(
+			undefined4 p_unk0x00,
+			MxAtomId* p_script,
+			undefined4 p_unk0x04,
+			const char* p_key,
+			undefined2 p_unk0x20,
+			float p_unk0x24,
+			undefined2 p_unk0x28,
+			float p_unk0x2c,
+			undefined4 p_unk0x30,
+			MxS32 p_unk0x34
+		)
+		{
+			m_unk0x00 = p_unk0x00;
+			m_script = p_script;
+			m_unk0x04 = p_unk0x04;
+			strcpy(m_key, p_key);
+			m_unk0x20 = p_unk0x20;
+			m_unk0x24 = p_unk0x24;
+			m_unk0x28 = p_unk0x28;
+			m_unk0x2c = p_unk0x2c;
+			m_unk0x30 = p_unk0x30;
+			m_unk0x34 = p_unk0x34;
+		}
+
+		// FUNCTION: LEGO1 0x1001b230
+		PathContainer& operator=(const PathContainer& p_container)
+		{
+			m_unk0x00 = p_container.m_unk0x00;
+			m_script = p_container.m_script;
+			m_unk0x04 = p_container.m_unk0x04;
+			strcpy(m_key, p_container.m_key);
+			m_unk0x20 = p_container.m_unk0x20;
+			m_unk0x24 = p_container.m_unk0x24;
+			m_unk0x28 = p_container.m_unk0x28;
+			m_unk0x2c = p_container.m_unk0x2c;
+			m_unk0x30 = p_container.m_unk0x30;
+			m_unk0x34 = p_container.m_unk0x34;
+			return *this;
+		}
+
+	private:
+		undefined4 m_unk0x00; // 0x00
+		MxAtomId* m_script;   // 0x04
+		undefined4 m_unk0x04; // 0x08
+		char m_key[20];       // 0x0c
+		undefined2 m_unk0x20; // 0x20
+		float m_unk0x24;      // 0x24
+		undefined2 m_unk0x28; // 0x28
+		float m_unk0x2c;      // 0x2c
+		undefined4 m_unk0x30; // 0x30
+		MxS32 m_unk0x34;      // 0x34
+	};
+
 	LegoOmni();
 	~LegoOmni() override; // vtable+00
 

--- a/LEGO1/lego/legoomni/src/main/legoomni.cpp
+++ b/LEGO1/lego/legoomni/src/main/legoomni.cpp
@@ -26,6 +26,7 @@
 #include "viewmanager/viewmanager.h"
 
 DECOMP_SIZE_ASSERT(LegoOmni::ScriptContainer, 0x1c)
+DECOMP_SIZE_ASSERT(LegoOmni::PathContainer, 0x38)
 DECOMP_SIZE_ASSERT(LegoWorldList, 0x18)
 DECOMP_SIZE_ASSERT(LegoWorldListCursor, 0x10)
 
@@ -119,6 +120,9 @@ const char* g_current = "current";
 
 // GLOBAL: LEGO1 0x100f4c58
 MxBool g_isWorldActive = TRUE;
+
+// GLOBAL: LEGO1 0x10102b28
+LegoOmni::PathContainer g_extraPaths[29];
 
 // FUNCTION: LEGO1 0x10015700
 LegoOmni* Lego()
@@ -286,12 +290,38 @@ void DeleteObjects(MxAtomId* p_id, MxS32 p_first, MxS32 p_last)
 	}
 }
 
-// STUB: LEGO1 0x1001a700
-void FUN_1001a700()
+// FUNCTION: LEGO1 0x1001a700
+void RegisterExtraPaths()
 {
-	// TODO
-
-	// This function seems to populate an unknown structure, and then calls 0x1001b230
+	g_extraPaths[0] = LegoOmni::PathContainer(0x16, g_isleScript, 0, "int35", 2, 0.6, 4, 0.4, 0x2a, 0x12);
+	g_extraPaths[1] = LegoOmni::PathContainer(0x17, g_isleScript, 0, "edg00_49", 1, 0.43, 2, 0.6, 0x27, 0x12);
+	g_extraPaths[2] = LegoOmni::PathContainer(0x18, g_isleScript, 0, "edg00_191", 2, 0.5, 0, 0.55, 0x26, 0x12);
+	g_extraPaths[3] = LegoOmni::PathContainer(0x04, g_isleScript, 0, "int46", 0, 0.5, 2, 0.5, 0x10, 0x0b);
+	g_extraPaths[4] = LegoOmni::PathContainer(0x10, g_isleScript, 0, "EDG00_46", 0, 0.95, 2, 0.19, 0x17, 0x11);
+	g_extraPaths[5] = LegoOmni::PathContainer(0x11, g_isleScript, 0, "EDG00_46", 3, 0.625, 2, 0.03, 0x18, 0x11);
+	g_extraPaths[6] = LegoOmni::PathContainer(0x0f, g_isleScript, 0, "EDG10_63", 0, 0.26, 1, 0.01, 0, -1);
+	g_extraPaths[7] = LegoOmni::PathContainer(0x13, g_isleScript, 0, "INT15", 5, 0.65, 1, 0.68, 0x33, 0x0e);
+	g_extraPaths[8] = LegoOmni::PathContainer(0x14, g_isleScript, 0, "INT16", 4, 0.1, 2, 0, 0x34, 0x0e);
+	g_extraPaths[9] = LegoOmni::PathContainer(0x15, g_isleScript, 0, "INT62", 2, 0.1, 3, 0.7, 0x36, 0x0e);
+	g_extraPaths[10] = LegoOmni::PathContainer(0x19, g_isleScript, 0, "INT24", 0, 0.55, 2, 0.71, 0x08, 0x0f);
+	g_extraPaths[11] = LegoOmni::PathContainer(0x1c, g_isleScript, 0, "INT24", 2, 0.73, 4, 0.71, 0x0a, 0x0f);
+	g_extraPaths[12] = LegoOmni::PathContainer(0x1d, g_isleScript, 0, "INT19", 0, 0.85, 1, 0.28, 0, 0x0a);
+	g_extraPaths[13] = LegoOmni::PathContainer(0x1f, g_isleScript, 0, "EDG02_28", 3, 0.37, 1, 0.52, 0x0c, 0x0a);
+	g_extraPaths[14] = LegoOmni::PathContainer(0x20, g_isleScript, 0, "INT33", 0, 0.88, 2, 0.74, 0x22, 0x0c);
+	g_extraPaths[15] = LegoOmni::PathContainer(0x21, g_isleScript, 0, "EDG02_64", 2, 0.24, 0, 0.84, 0x23, 0x0c);
+	g_extraPaths[16] = LegoOmni::PathContainer(0x28, g_isleScript, 0, "edg02_51", 2, 0.63, 3, 0.01, 0, -1);
+	g_extraPaths[17] = LegoOmni::PathContainer(0x29, g_isleScript, 0, "edg02_51", 2, 0.63, 0, 0.4, 0, -1);
+	g_extraPaths[18] = LegoOmni::PathContainer(0x2b, g_isleScript, 0, "edg02_35", 2, 0.8, 0, 0.2, 0, -1);
+	g_extraPaths[19] = LegoOmni::PathContainer(0x2c, g_isleScript, 0, "EDG03_01", 2, 0.25, 0, 0.75, 0, -1);
+	g_extraPaths[20] = LegoOmni::PathContainer(0x2d, g_isleScript, 0, "edg10_70", 3, 0.25, 0, 0.7, 0x44, -1);
+	g_extraPaths[21] = LegoOmni::PathContainer(0x2a, g_isleScript, 0, "inv_05", 2, 0.75, 0, 0.19, 0, -1);
+	g_extraPaths[22] = LegoOmni::PathContainer(0x30, g_act3Script, 0, "edg02_51", 2, 0.63, 0, 0.4, 0, -1);
+	g_extraPaths[23] = LegoOmni::PathContainer(0x31, g_act3Script, 0, "inv_05", 2, 0.75, 0, 0.19, 0, -1);
+	g_extraPaths[24] = LegoOmni::PathContainer(0x32, g_act2mainScript, 0, "EDG02_51", 0, 0.64, 1, 0.37, 0, -1);
+	g_extraPaths[25] = LegoOmni::PathContainer(0x33, g_isleScript, 0, "edg02_32", 0, 0.5, 2, 0.5, 0, -1);
+	g_extraPaths[26] = LegoOmni::PathContainer(0x34, g_isleScript, 0, "edg02_19", 2, 0.5, 0, 0.5, 0, -1);
+	g_extraPaths[27] = LegoOmni::PathContainer(0x36, g_isleScript, 0, "int36", 0, 0.2, 4, 0.4, 0, -1);
+	g_extraPaths[28] = LegoOmni::PathContainer(0x37, g_isleScript, 0, "edg02_50", 2, 0.8, 1, 0.3, 0, -1);
 }
 
 // FUNCTION: LEGO1 0x1003dd70
@@ -604,7 +634,7 @@ MxResult LegoOmni::Create(MxOmniCreateParam& p_param)
 	m_variableTable->SetVariable(variable);
 
 	CreateScripts();
-	FUN_1001a700();
+	RegisterExtraPaths();
 	result = RegisterScripts();
 
 	if (result != SUCCESS) {


### PR DESCRIPTION
This is another function called in `LegoOmni::Create` that registers what appears to be path data, which can also be found in the "extra" data of some actors in the `.si` files:

```
Act3Brickster,
Speed:0.0,
Path:edg02_67;2;0.5;0;0.5,
COLLIDE_BOX,
Animation:Brickstr_Shoot;-1.0;Brickstr_Walk;1.0
```

There appears to be no overlap between the data found in the `.si` files and the data registered in this function.

100% match