### PR TITLE
Fix LegoROI / add TimeROI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,7 +489,10 @@ if (MSVC)
 endif()
 
 if (MSVC_FOR_DECOMP)
-    target_compile_definitions(lego1 PRIVATE "ENABLE_DECOMP_ASSERTS")
+    foreach(tgt IN LISTS lego1_targets)
+      target_compile_definitions(${tgt} PRIVATE "ENABLE_DECOMP_ASSERTS")
+    endforeach()
+
     if (TARGET isle)
       target_compile_definitions(isle PRIVATE "ENABLE_DECOMP_ASSERTS")
     endif()
@@ -533,7 +536,7 @@ if (MSVC_FOR_DECOMP)
   # Older MSVC versions don't support building in parallel.
   # Force non-parallel builds of isle and lego1 by putting them in a pool with 1 available job.
   if (CMAKE_CXX_COMPILER_ID VERSION_LESS 12)
-    foreach(tgt IN LISTS lego1_taregets)
+    foreach(tgt IN LISTS lego1_targets)
       set_property(GLOBAL APPEND PROPERTY JOB_POOLS "msvc_${tgt}=1;msvc_lego1=1")
       set_property(TARGET ${tgt} PROPERTY JOB_POOL_COMPILE msvc_${tgt})
       set_property(TARGET ${tgt} PROPERTY JOB_POOL_LINK msvc_${tgt})

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -3,7 +3,7 @@
 
 #include "mxvideopresenter.h"
 
-class AutoROI;
+class LegoROI;
 
 // VTABLE: LEGO1 0x100d4e50
 // SIZE 0x6c (discovered through inline constructor at 0x10009ae6)
@@ -38,7 +38,7 @@ protected:
 	void Destroy(MxBool p_fromDestructor);
 
 private:
-	AutoROI* m_roi;       // 0x64
+	LegoROI* m_roi;       // 0x64
 	MxBool m_addedToView; // 0x68
 
 	MxResult CreateROI(MxStreamChunk* p_chunk);

--- a/LEGO1/lego/legoomni/include/legounksavedatawriter.h
+++ b/LEGO1/lego/legoomni/include/legounksavedatawriter.h
@@ -6,7 +6,6 @@
 #include "mxtypes.h"
 
 class LegoROI;
-class LegoROI;
 
 struct LegoSaveDataEntry3 {
 	char* m_name;

--- a/LEGO1/lego/legoomni/include/legounksavedatawriter.h
+++ b/LEGO1/lego/legoomni/include/legounksavedatawriter.h
@@ -5,7 +5,7 @@
 #include "lego/sources/misc/legostorage.h"
 #include "mxtypes.h"
 
-class AutoROI;
+class LegoROI;
 class LegoROI;
 
 struct LegoSaveDataEntry3 {
@@ -39,7 +39,7 @@ public:
 	LegoUnkSaveDataWriter();
 
 	MxResult WriteSaveData3(LegoStorage* p_stream);
-	AutoROI* FUN_10083500(char*, undefined4);
+	LegoROI* FUN_10083500(char*, undefined4);
 	void FUN_100832a0();
 	void FUN_10083db0(LegoROI* p_roi);
 	void FUN_10083f10(LegoROI* p_roi);

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -67,7 +67,7 @@ public:
 	inline LegoCameraController* GetCamera() { return m_cameraController; }
 	inline MxS32 GetScriptIndex() { return m_scriptIndex; }
 	inline MxCoreSet& GetUnknown0xd0() { return m_set0xd0; }
-	inline list<AutoROI*>& GetUnknownList0xe0() { return m_list0xe0; }
+	inline list<LegoROI*>& GetUnknownList0xe0() { return m_list0xe0; }
 
 	inline void SetScriptIndex(MxS32 p_scriptIndex) { m_scriptIndex = p_scriptIndex; }
 
@@ -91,7 +91,7 @@ protected:
 	MxCoreSet m_set0xa8;                        // 0xa8
 	MxPresenterList m_controlPresenters;        // 0xb8
 	MxCoreSet m_set0xd0;                        // 0xd0
-	list<AutoROI*> m_list0xe0;                  // 0xe0
+	list<LegoROI*> m_list0xe0;                  // 0xe0
 	MxS32 m_scriptIndex;                        // 0xec
 	LegoHideAnimPresenter* m_hideAnimPresenter; // 0xf0
 	MxS16 m_startupTicks;                       // 0xf4
@@ -116,13 +116,13 @@ protected:
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Init
 
 // TEMPLATE: LEGO1 0x1001ddf0
-// list<AutoROI *,allocator<AutoROI *> >::~list<AutoROI *,allocator<AutoROI *> >
+// list<LegoROI *,allocator<LegoROI *> >::~list<LegoROI *,allocator<LegoROI *> >
 
 // TEMPLATE: LEGO1 0x1001df50
-// List<AutoROI *>::~List<AutoROI *>
+// List<LegoROI *>::~List<LegoROI *>
 
 // TEMPLATE: LEGO1 0x1001de60
-// list<AutoROI *,allocator<AutoROI *> >::_Buynode
+// list<LegoROI *,allocator<LegoROI *> >::_Buynode
 
 // TEMPLATE: LEGO1 0x1001de90
 // set<MxCore *,CoreSetCompare,allocator<MxCore *> >::~set<MxCore *,CoreSetCompare,allocator<MxCore *> >
@@ -131,7 +131,7 @@ protected:
 // Set<MxCore *,CoreSetCompare>::~Set<MxCore *,CoreSetCompare>
 
 // TEMPLATE: LEGO1 0x1001f590
-// list<AutoROI *,allocator<AutoROI *> >::erase
+// list<LegoROI *,allocator<LegoROI *> >::erase
 
 // TEMPLATE: LEGO1 0x100208b0
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::insert

--- a/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
@@ -71,7 +71,7 @@ MxResult LegoUnkSaveDataWriter::WriteSaveData3(LegoStorage* p_stream)
 }
 
 // STUB: LEGO1 0x10083500
-AutoROI* LegoUnkSaveDataWriter::FUN_10083500(char*, undefined4)
+LegoROI* LegoUnkSaveDataWriter::FUN_10083500(char*, undefined4)
 {
 	// TODO
 	// involves an STL map with a _Nil node at 0x100fc508

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -204,7 +204,7 @@ void LegoWorld::Destroy(MxBool p_fromDestructor)
 	}
 
 	while (!m_list0xe0.empty()) {
-		AutoROI* roi = m_list0xe0.front();
+		LegoROI* roi = m_list0xe0.front();
 		m_list0xe0.pop_front();
 		delete roi;
 	}

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -132,9 +132,9 @@ void LegoModelPresenter::ParseExtra()
 		}
 		else if (KeyValueStringParse(output, g_dbCreate, buffer) != 0 && m_roi == NULL) {
 			LegoWorld* currentWorld = CurrentWorld();
-			list<AutoROI*>& roiList = currentWorld->GetUnknownList0xe0();
+			list<LegoROI*>& roiList = currentWorld->GetUnknownList0xe0();
 
-			for (list<AutoROI*>::iterator it = roiList.begin(); it != roiList.end(); it++) {
+			for (list<LegoROI*>::iterator it = roiList.begin(); it != roiList.end(); it++) {
 				if (!strcmpi(((LegoROI*) (*it))->GetName(), output)) {
 					m_roi = *it;
 					roiList.erase(it);

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -183,7 +183,7 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	}
 
 	pLODList = m_3dManager->GetViewLODListManager()->Create("CameraROI", 1);
-	m_viewROI = new LegoROI(m_renderer, pLODList, Timer()->GetTime());
+	m_viewROI = new TimeROI(m_renderer, pLODList, Timer()->GetTime());
 	pLODList->Release();
 
 	CalcLocalTransform(posVec, dirVec, upVec, outMatrix);

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -38,6 +38,28 @@ int g_roiConfig = 100;
 // GLOBAL: LEGO1 0x101013ac
 ROIHandler g_someHandlerFunction = NULL;
 
+// FUNCTION: LEGO1 0x100a46a0
+void LegoROI::WrappedSetLocalTransform(Matrix4& p_transform)
+{
+	SetLocalTransform(p_transform);
+}
+
+// STUB: LEGO1 0x100a46b0
+void LegoROI::FUN_100a46b0(Matrix4& p_transform)
+{
+}
+
+// STUB: LEGO1 0x100a58f0
+void LegoROI::FUN_100a58f0(Matrix4& p_transform)
+{
+}
+
+// FUNCTION: LEGO1 0x100a81c0
+void LegoROI::configureLegoROI(int p_roiConfig)
+{
+	g_roiConfig = p_roiConfig;
+}
+
 // FUNCTION: LEGO1 0x100a81d0
 LegoROI::LegoROI(Tgl::Renderer* p_renderer) : ViewROI(p_renderer, NULL), m_unk0xe0(-1)
 {
@@ -72,28 +94,6 @@ LegoROI::~LegoROI()
 	if (m_name) {
 		delete[] m_name;
 	}
-}
-
-// FUNCTION: LEGO1 0x100a46a0
-void LegoROI::WrappedSetLocalTransform(Matrix4& p_transform)
-{
-	SetLocalTransform(p_transform);
-}
-
-// STUB: LEGO1 0x100a46b0
-void LegoROI::FUN_100a46b0(Matrix4& p_transform)
-{
-}
-
-// STUB: LEGO1 0x100a58f0
-void LegoROI::FUN_100a58f0(Matrix4& p_transform)
-{
-}
-
-// FUNCTION: LEGO1 0x100a81c0
-void LegoROI::configureLegoROI(int p_roiConfig)
-{
-	g_roiConfig = p_roiConfig;
 }
 
 // FUNCTION: LEGO1 0x100a9a50

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -2,7 +2,8 @@
 
 #include <string.h>
 
-DECOMP_SIZE_ASSERT(LegoROI, 0x10c);
+DECOMP_SIZE_ASSERT(LegoROI, 0x108)
+DECOMP_SIZE_ASSERT(TimeROI, 0x10c)
 
 // SIZE 0x14
 typedef struct {
@@ -37,6 +38,42 @@ int g_roiConfig = 100;
 // GLOBAL: LEGO1 0x101013ac
 ROIHandler g_someHandlerFunction = NULL;
 
+// FUNCTION: LEGO1 0x100a81d0
+LegoROI::LegoROI(Tgl::Renderer* p_renderer) : ViewROI(p_renderer, NULL), m_unk0xe0(-1)
+{
+	m_unk0xd4 = NULL;
+	m_name = NULL;
+	m_unk0x104 = NULL;
+}
+
+// FUNCTION: LEGO1 0x100a82d0
+LegoROI::LegoROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList) : ViewROI(p_renderer, p_lodList), m_unk0xe0(-1)
+{
+	m_unk0xd4 = NULL;
+	m_name = NULL;
+	m_unk0x104 = NULL;
+}
+
+// FUNCTION: LEGO1 0x100a83c0
+LegoROI::~LegoROI()
+{
+	if (comp) {
+		CompoundObject::iterator iterator;
+
+		for (iterator = comp->begin(); !(iterator == comp->end()); ++iterator) {
+			ROI* child = *iterator;
+
+			delete child;
+		}
+
+		delete comp;
+		comp = 0;
+	}
+	if (m_name) {
+		delete[] m_name;
+	}
+}
+
 // FUNCTION: LEGO1 0x100a46a0
 void LegoROI::WrappedSetLocalTransform(Matrix4& p_transform)
 {
@@ -59,8 +96,8 @@ void LegoROI::configureLegoROI(int p_roiConfig)
 	g_roiConfig = p_roiConfig;
 }
 
-// STUB: LEGO1 0x100a9a50
-LegoROI::LegoROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList, int p_time) : ViewROI(p_renderer, p_lodList)
+// FUNCTION: LEGO1 0x100a9a50
+TimeROI::TimeROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList, int p_time) : LegoROI(p_renderer, p_lodList)
 {
 	m_time = p_time;
 }
@@ -127,7 +164,6 @@ float LegoROI::IntrinsicImportance() const
 	return .5;
 }
 
-// Note: Actually part of parent class (doesn't exist yet)
 // STUB: LEGO1 0x100aa350
 void LegoROI::UpdateWorldBoundingVolumes()
 {

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -7,20 +7,15 @@ typedef unsigned char (*ROIHandler)(char*, char*, unsigned int);
 
 class LegoEntity;
 
-// Note: There is an extra class between LegoROI and ViewROI,
-// maybe called "AutoROI". VTABLE 0x100dbe38
-
-// TODO: Set as superclass of LegoROI
-class AutoROI : public ViewROI {};
-
-// VTABLE: LEGO1 0x100dbea8
-// SIZE 0x10c
+// VTABLE: LEGO1 0x100dbe38
+// SIZE 0x108
 class LegoROI : public ViewROI {
 public:
-	LegoROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList, int p_time);
+	LegoROI(Tgl::Renderer* p_renderer);
+	LegoROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList);
+	~LegoROI() override;
 
 	float IntrinsicImportance() const override; // vtable+0x04
-	// Note: Actually part of parent class (doesn't exist yet)
 	void UpdateWorldBoundingVolumes() override; // vtable+0x18
 
 	void SetDisplayBB(int p_displayBB);
@@ -40,20 +35,33 @@ public:
 	void FUN_100a46b0(Matrix4& p_transform);
 	void FUN_100a58f0(Matrix4& p_transform);
 
-	inline const char* GetName() { return m_name; }
+	inline const char* GetName() const { return m_name; }
 	inline LegoEntity* GetUnknown0x104() { return m_unk0x104; }
 
 	inline void SetUnknown0x104(LegoEntity* p_unk0x104) { m_unk0x104 = p_unk0x104; }
 
-	// SYNTHETIC: LEGO1 0x100a9ad0
+	// SYNTHETIC: LEGO1 0x100a82b0
 	// LegoROI::`scalar deleting destructor'
 
 private:
-	undefined4 m_unk0xe0;      // 0xe0
-	const char* m_name;        // 0xe4
-	undefined m_unk0xe8[0x1c]; // 0xe8
-	LegoEntity* m_unk0x104;    // 0x104
-	int m_time;                // 0x108
+	int m_unk0xe0;           // 0xe0
+	char* m_name;            // 0xe4
+	BoundingSphere m_sphere; // 0xe8
+	undefined4 m_unk0x100;   // 0x100
+	LegoEntity* m_unk0x104;  // 0x104
+};
+
+// VTABLE: LEGO1 0x100dbea8
+// SIZE 0x10c
+class TimeROI : public LegoROI {
+public:
+	TimeROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList, int p_time);
+
+	// SYNTHETIC: LEGO1 0x100a9ad0
+	// TimeROI::`scalar deleting destructor'
+
+private:
+	int m_time; // 0x108
 };
 
 #endif // LEGOROI_H

--- a/LEGO1/realtime/orientableroi.cpp
+++ b/LEGO1/realtime/orientableroi.cpp
@@ -53,8 +53,8 @@ void OrientableROI::UpdateWorldData(const MxMatrix& p_transform)
 	UpdateWorldVelocity();
 
 	// iterate over comps
-	if (m_comp) {
-		for (CompoundObject::iterator iter = m_comp->begin(); !(iter == m_comp->end()); iter++) {
+	if (comp) {
+		for (CompoundObject::iterator iter = comp->begin(); !(iter == comp->end()); iter++) {
 			ROI* child = *iter;
 			static_cast<OrientableROI*>(child)->UpdateWorldData(p_transform);
 		}

--- a/LEGO1/realtime/roi.h
+++ b/LEGO1/realtime/roi.h
@@ -21,8 +21,8 @@ public:
 	Mx3DPointFloat& Max() { return max; }
 
 private:
-	Mx3DPointFloat min;
-	Mx3DPointFloat max;
+	Mx3DPointFloat min; // 0x00
+	Mx3DPointFloat max; // 0x14
 };
 
 /*
@@ -37,8 +37,8 @@ public:
 	float& Radius() { return radius; }
 
 private:
-	Mx3DPointFloat center;
-	float radius;
+	Mx3DPointFloat center; // 0x00
+	float radius;          // 0x14
 };
 
 /*
@@ -79,42 +79,44 @@ class ROI {
 public:
 	ROI()
 	{
-		m_comp = 0;
-		m_lods = 0;
+		comp = 0;
+		lods = 0;
 		m_unk0x0c = 1;
 	}
 	virtual ~ROI()
 	{
 		// if derived class set the comp and lods, it should delete them
-		assert(!m_comp);
-		assert(!m_lods);
+		assert(!comp);
+		assert(!lods);
 	}
 	virtual float IntrinsicImportance() const = 0;                    // vtable+0x04
 	virtual const float* GetWorldVelocity() const = 0;                // vtable+0x08
 	virtual const BoundingBox& GetWorldBoundingBox() const = 0;       // vtable+0x0c
 	virtual const BoundingSphere& GetWorldBoundingSphere() const = 0; // vtable+0x10
 
-	const LODListBase* GetLODs() const { return m_lods; }
+	const LODListBase* GetLODs() const { return lods; }
 	const LODObject* GetLOD(int i) const
 	{
-		assert(m_lods);
-		return (*m_lods)[i];
+		assert(lods);
+		return (*lods)[i];
 	}
-	int GetLODCount() const { return m_lods ? m_lods->Size() : 0; }
-	const CompoundObject* GetComp() const { return m_comp; }
+	int GetLODCount() const { return lods ? lods->Size() : 0; }
+	const CompoundObject* GetComp() const { return comp; }
 
 	inline undefined GetUnknown0x0c() { return m_unk0x0c; }
-
 	inline void SetUnknown0x0c(undefined p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
 
 	// SYNTHETIC: LEGO1 0x100a5d60
 	// ROI::`scalar deleting destructor'
 
 protected:
-	CompoundObject* m_comp; // 0x04
-	LODListBase* m_lods;    // 0x08
-	undefined m_unk0x0c;    // 0x0c
+	CompoundObject* comp; // 0x04
+	LODListBase* lods;    // 0x08
+	undefined m_unk0x0c;  // 0x0c
 };
+
+// TEMPLATE: LEGO1 0x10084930
+// list<ROI *,allocator<ROI *> >::~list<ROI *,allocator<ROI *> >
 
 // SYNTHETIC: LEGO1 0x100a5d50
 // ROI::~ROI

--- a/LEGO1/viewmanager/viewmanager.h
+++ b/LEGO1/viewmanager/viewmanager.h
@@ -27,7 +27,7 @@ public:
 private:
 	undefined4 m_unk0x04;     // 0x04
 	CompoundObject m_unk0x08; // 0x08
-	undefined m_pad[0x1c8];   // 0x14
+	undefined m_pad[0x1a8];   // 0x14
 };
 
 // TEMPLATE: LEGO1 0x10022030

--- a/LEGO1/viewmanager/viewroi.h
+++ b/LEGO1/viewmanager/viewroi.h
@@ -21,12 +21,15 @@ public:
 		SetLODList(lodList);
 		geometry = pRenderer->CreateGroup();
 	}
+
+	// FUNCTION: LEGO1 0x100a9e20
 	inline ~ViewROI() override
 	{
 		// SetLODList() will decrease refCount of LODList
 		SetLODList(0);
 		delete geometry;
 	}
+
 	inline void SetLODList(ViewLODList* lodList)
 	{
 		// ??? inherently type unsafe - kind of... because, now, ROI
@@ -34,16 +37,17 @@ public:
 		// solution: create pure virtual LODListBase* ROI::GetLODList()
 		// and let derived ROI classes hold the LODList
 
-		if (m_lods) {
-			reinterpret_cast<ViewLODList*>(m_lods)->Release();
+		if (lods) {
+			reinterpret_cast<ViewLODList*>(lods)->Release();
 		}
 
-		m_lods = lodList;
+		lods = lodList;
 
-		if (m_lods) {
-			reinterpret_cast<ViewLODList*>(m_lods)->AddRef();
+		if (lods) {
+			reinterpret_cast<ViewLODList*>(lods)->AddRef();
 		}
 	}
+
 	float IntrinsicImportance() const override;                  // vtable+0x04
 	void VTable0x1c() override;                                  // vtable+0x1c
 	void SetLocalTransform(const Matrix4& p_transform) override; // vtable+0x20
@@ -54,8 +58,9 @@ public:
 	static undefined SetUnk101013d8(undefined p_flag);
 
 protected:
-	Tgl::Group* geometry;
 	void UpdateWorldData(const MxMatrix& parent2world) override;
+
+	Tgl::Group* geometry; // 0xdc
 };
 
 // SYNTHETIC: LEGO1 0x100aa250


### PR DESCRIPTION
This PR fixes the `*ROI` class hierarchy. Turns out what I assumed is a distinct class `AutoROI` is actually `LegoROI` - plus a thin class on top of it which I've called `TimeROI`, which is only used in `LegoVideoManager::Create`.

Constructors/destructors of `LegoROI` and `ViewROI` and related functions generally match now.