### PR TITLE
parser: Detect function declaration

### DIFF
--- a/tools/isledecomp/isledecomp/parser/error.py
+++ b/tools/isledecomp/isledecomp/parser/error.py
@@ -78,6 +78,11 @@ class ParserError(Enum):
     # they annotate are different.
     WRONG_STRING = 205
 
+    # ERROR: This lineref FUNCTION marker is next to a function declaration or
+    # forward reference. The correct place for the marker is where the function
+    # is implemented so we can match with the PDB.
+    NO_IMPLEMENTATION = 206
+
 
 @dataclass
 class ParserAlert:

--- a/tools/isledecomp/isledecomp/parser/parser.py
+++ b/tools/isledecomp/isledecomp/parser/parser.py
@@ -487,6 +487,9 @@ class DecompParser:
                 ):
                     self._function_starts_here()
                     self._function_done()
+                elif self.function_sig.endswith(");"):
+                    # Detect forward reference or declaration
+                    self._syntax_error(ParserError.NO_IMPLEMENTATION)
                 else:
                     self.state = ReaderState.WANT_CURLY
 

--- a/tools/isledecomp/tests/test_parser.py
+++ b/tools/isledecomp/tests/test_parser.py
@@ -695,3 +695,19 @@ def test_static_variable_incomplete_coverage(parser):
     # Failed for TEST module
     assert len(parser.alerts) == 1
     assert parser.alerts[0].code == ParserError.ORPHANED_STATIC_VARIABLE
+
+
+def test_header_function_declaration(parser):
+    """This is either a forward reference or a declaration in a header file.
+    Meaning: The implementation is not here. This is not the correct place
+    for the FUNCTION marker and it will probably not match anything."""
+
+    parser.read_lines(
+        [
+            "// FUNCTION: HELLO 0x1234",
+            "void sample_function(int);",
+        ]
+    )
+
+    assert len(parser.alerts) == 1
+    assert parser.alerts[0].code == ParserError.NO_IMPLEMENTATION


### PR DESCRIPTION
For "lineref" function annotations, we are trying to find the line with the opening curly brace `{` because this is where the PDB says the function starts.

We can do this even if the function is only on one line. e.g.
```// FUNCTION: TEST 0x1234
virtual void Destroy() { something_here(); }
```

If that line has no curly brace, we assume it is a regular function. We will try to find the curly brace on the following lines and can get stuck in this state until the end of the file. This can happen if the annotation is above a function declaration, forward reference, or worse, a function call. e.g.

```
// FUNCTION: TEXT 0x555
void SomeFunction();
```

In cases like this, we now throw a `NO_IMPLEMENTATION` error. The annotation should go wherever the actual code goes.