### PR TITLE
reccmp: diff bugfixes

### DIFF
--- a/tools/isledecomp/isledecomp/compare/diff.py
+++ b/tools/isledecomp/isledecomp/compare/diff.py
@@ -34,6 +34,10 @@ def combined_diff(
         orig_addrs = set()
         recomp_addrs = set()
 
+        first, last = group[0], group[-1]
+        orig_range = len(orig_combined[first[1] : last[2]])
+        recomp_range = len(recomp_combined[first[3] : last[4]])
+
         for code, i1, i2, j1, j2 in group:
             if code == "equal":
                 # The sections are equal, so the list slices are guaranteed
@@ -74,7 +78,20 @@ def combined_diff(
         orig_sorted = sorted(orig_addrs)
         recomp_sorted = sorted(recomp_addrs)
 
-        diff_slug = f"@@ -{orig_sorted[0]},{orig_sorted[-1]} +{recomp_sorted[0]},{recomp_sorted[-1]} @@"
+        # We could get a diff group that has no original addresses.
+        # This might happen for a stub function where we are not able to
+        # produce even a single instruction from the original.
+        # In that case, show the best slug line that we can.
+        def peek_front(list_, default=""):
+            try:
+                return list_[0]
+            except IndexError:
+                return default
+
+        orig_first = peek_front(orig_sorted)
+        recomp_first = peek_front(recomp_sorted)
+
+        diff_slug = f"@@ -{orig_first},{orig_range} +{recomp_first},{recomp_range} @@"
 
         unified_diff.append((diff_slug, subgroups))
 

--- a/tools/isledecomp/isledecomp/utils.py
+++ b/tools/isledecomp/isledecomp/utils.py
@@ -53,7 +53,7 @@ def print_combined_diff(udiff, plain: bool = False, show_both: bool = False):
                     addr_prefix = (
                         f"{'':{padding_size}} / {recomp_addr}"
                         if show_both
-                        else recomp_addr
+                        else " " * padding_size
                     )
 
                     if plain:

--- a/tools/reccmp/reccmp.js
+++ b/tools/reccmp/reccmp.js
@@ -418,26 +418,26 @@ class DiffDisplay extends window.HTMLElement {
     const div = document.createElement('div');
     const obj = getDataByAddr(this.address);
 
-    const createSingleCellRow = (text, className) => {
-      const tr = document.createElement('tr');
-      const td = document.createElement('td');
-      td.setAttribute('colspan', 3);
-      td.textContent = text;
-      td.className = className;
-      tr.appendChild(td);
-      return tr;
+    const createHeaderLine = (text, className) => {
+      const div = document.createElement('div');
+      div.textContent = text;
+      div.className = className;
+      return div;
     };
 
     const groups = obj.diff;
     groups.forEach(([slug, subgroups]) => {
       const secondTable = document.createElement('table');
-      secondTable.classList.add('diffTable', 'showOrig');
+      secondTable.classList.add('diffTable');
+
+      const hdr = document.createElement('div');
+      hdr.appendChild(createHeaderLine('---', 'diffneg'));
+      hdr.appendChild(createHeaderLine('+++', 'diffpos'));
+      hdr.appendChild(createHeaderLine(slug, 'diffslug'));
+      div.appendChild(hdr);
 
       const tbody = document.createElement('tbody');
       secondTable.appendChild(tbody);
-      tbody.appendChild(createSingleCellRow('---', 'diffneg'));
-      tbody.appendChild(createSingleCellRow('+++', 'diffpos'));
-      tbody.appendChild(createSingleCellRow(slug, 'diffslug'));
 
       const diffs = formatAsm(subgroups, this.option);
       for (const el of diffs) {


### PR DESCRIPTION
A few small fixes for the "diff-with-addresses" feature (#581).

- `reccmp` verbose mode could sometimes crash if the function being displayed had no original addresses for whatever reason, usually if the function is a stub.

- Another one from verbose mode: recomp addresses would sometimes appear even if `--print-rec-addr` was not enabled.

- According to our friends at [wikipedia](https://en.wikipedia.org/wiki/Diff#Unified_format), the `@@` thing in the unified diff is the "range information". In regular diff it should specify the starting line and the number of lines for this diff hunk. My version of this had the start and end virtual address, so this is not totally faithful. We can't get the number of bytes occupied by each hunk, but we can show the starting address and number of lines (or instructions). I figure the goal here is to show whether there is "more stuff" contributed from one file versus the other, so I think this display makes sense.

- Minor visual bug in the HTML display. If the `@@` diff range indicator was longer than any of the rows under it (i.e if the diff hunk had very short instructions), the HTML table would be askew and not aligned to the left. Solved by detaching the indicator from the table so it will always display as concisely as possible.
