### PR TITLE
CustomizeAnimFile MxVariable

### DIFF
--- a/LEGO1/lego/legoomni/include/legobuildingmanager.h
+++ b/LEGO1/lego/legoomni/include/legobuildingmanager.h
@@ -21,6 +21,7 @@ public:
 	}
 
 	static void configureLegoBuildingManager(MxS32);
+	static void SetCustomizeAnimFile(const char* p_value);
 
 	void FUN_1002fa00();
 	void FUN_1002fb30();
@@ -30,6 +31,8 @@ public:
 	// LegoBuildingManager::`scalar deleting destructor'
 
 private:
+	static char* g_customizeAnimFile;
+
 	void Init();
 
 	undefined m_unk0x08[0x28]; // 0x08

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -24,10 +24,14 @@ public:
 	void FUN_100263a0(undefined4 p_und);
 	void FUN_10027120();
 
+	static void SetCustomizeAnimFile(const char* p_value);
+
 	// SYNTHETIC: LEGO1 0x100262a0
 	// LegoPlantManager::`scalar deleting destructor'
 
 private:
+	static char* g_customizeAnimFile;
+
 	void Init();
 
 	undefined m_unk0x08[0x24]; // 0x08

--- a/LEGO1/lego/legoomni/include/legounksavedatawriter.h
+++ b/LEGO1/lego/legoomni/include/legounksavedatawriter.h
@@ -3,9 +3,24 @@
 
 #include "decomp.h"
 #include "lego/sources/misc/legostorage.h"
+#include "mxstl/stlcompat.h"
 #include "mxtypes.h"
 
 class LegoROI;
+
+// TODO: generic string comparator?
+struct LegoUnkSaveDataMapComparator {
+	bool operator()(const char* const& p_a, const char* const& p_b) const { return strcmpi(p_a, p_b) > 0; }
+};
+
+// TODO: pair instead?
+// SIZE 0x8
+struct LegoUnkSaveDataMapValue {
+	LegoROI* m_roi;  // 0x00
+	MxU32 m_counter; // 0x04
+};
+
+typedef map<char*, LegoUnkSaveDataMapValue*, LegoUnkSaveDataMapComparator> LegoUnkSaveDataMap;
 
 struct LegoSaveDataEntry3 {
 	char* m_name;
@@ -38,13 +53,41 @@ public:
 	LegoUnkSaveDataWriter();
 
 	MxResult WriteSaveData3(LegoStorage* p_stream);
-	LegoROI* FUN_10083500(char*, undefined4);
+	LegoROI* FUN_10083500(char*, MxBool);
+	void InitSaveData();
 	void FUN_100832a0();
 	void FUN_10083db0(LegoROI* p_roi);
 	void FUN_10083f10(LegoROI* p_roi);
 
+	static void SetCustomizeAnimFile(const char* p_value);
+
 private:
-	undefined m_unk0x00[0x08]; // 0x00
+	static char* g_customizeAnimFile;
+
+	LegoUnkSaveDataMap* m_map; // 0x00
+	undefined m_unk0x04[0x04]; // 0x04
 };
+
+// clang-format off
+
+// FUNCTION: LEGO1 0x10082b90
+// _Tree<char *,pair<char * const,LegoUnkSaveDataMapValue *>,map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Kfn,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::~_Tree<char *,pair<char * const,LegoUnkSaveDataMapValue *>,map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Kfn,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >
+
+// FUNCTION: LEGO1 0x10082c60
+// _Tree<char *,pair<char * const,LegoUnkSaveDataMapValue *>,map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Kfn,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::iterator::_Inc
+
+// FUNCTION: LEGO1 0x10082ca0
+// _Tree<char *,pair<char * const,LegoUnkSaveDataMapValue *>,map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Kfn,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::erase
+
+// FUNCTION: LEGO1 0x100830f0
+// _Tree<char *,pair<char * const,LegoUnkSaveDataMapValue *>,map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Kfn,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Erase
+
+// FUNCTION: LEGO1 0x10083130
+// map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::~map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >
+
+// GLOBAL: LEGO1 0x100fc508
+// _Tree<char *,pair<char * const,LegoUnkSaveDataMapValue *>,map<char *,LegoUnkSaveDataMapValue *,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Kfn,LegoUnkSaveDataMapComparator,allocator<LegoUnkSaveDataMapValue *> >::_Nil
+
+// clang-format on
 
 #endif // LEGOUNKSAVEDATAWRITER_H

--- a/LEGO1/lego/legoomni/include/legounksavedatawriter.h
+++ b/LEGO1/lego/legoomni/include/legounksavedatawriter.h
@@ -3,10 +3,13 @@
 
 #include "decomp.h"
 #include "lego/sources/misc/legostorage.h"
+#include "legovariables.h"
 #include "mxstl/stlcompat.h"
 #include "mxtypes.h"
 
 class LegoROI;
+
+#pragma warning(disable : 4237)
 
 // TODO: generic string comparator?
 struct LegoUnkSaveDataMapComparator {
@@ -14,7 +17,7 @@ struct LegoUnkSaveDataMapComparator {
 };
 
 // TODO: pair instead?
-// SIZE 0x8
+// SIZE 0x08
 struct LegoUnkSaveDataMapValue {
 	LegoROI* m_roi;  // 0x00
 	MxU32 m_counter; // 0x04
@@ -54,18 +57,19 @@ public:
 
 	MxResult WriteSaveData3(LegoStorage* p_stream);
 	LegoROI* FUN_10083500(char*, MxBool);
-	void InitSaveData();
+
+	static void InitSaveData();
+	static void SetCustomizeAnimFile(const char* p_value);
+
 	void FUN_100832a0();
 	void FUN_10083db0(LegoROI* p_roi);
 	void FUN_10083f10(LegoROI* p_roi);
 
-	static void SetCustomizeAnimFile(const char* p_value);
-
 private:
 	static char* g_customizeAnimFile;
 
-	LegoUnkSaveDataMap* m_map; // 0x00
-	undefined m_unk0x04[0x04]; // 0x04
+	LegoUnkSaveDataMap* m_map;                      // 0x00
+	CustomizeAnimFileVariable* m_customizeAnimFile; // 0x04
 };
 
 // clang-format off

--- a/LEGO1/lego/legoomni/include/legovariables.h
+++ b/LEGO1/lego/legoomni/include/legovariables.h
@@ -44,4 +44,14 @@ public:
 	void SetValue(const char* p_value) override; // vtable+0x04
 };
 
+// VTABLE: LEGO1 0x100da878
+// SIZE 0x24
+class CustomizeAnimFileVariable : public MxVariable {
+public:
+	// FUNCTION: LEGO1 0x10085aa0
+	CustomizeAnimFileVariable() : MxVariable("CUSTOMIZE_ANIM_FILE") {}
+
+	void SetValue(const char* p_value) override; // vtable+0x04
+};
+
 #endif // LEGOVARIABLES_H

--- a/LEGO1/lego/legoomni/include/legovariables.h
+++ b/LEGO1/lego/legoomni/include/legovariables.h
@@ -48,8 +48,7 @@ public:
 // SIZE 0x24
 class CustomizeAnimFileVariable : public MxVariable {
 public:
-	// FUNCTION: LEGO1 0x10085aa0
-	CustomizeAnimFileVariable() : MxVariable("CUSTOMIZE_ANIM_FILE") {}
+	CustomizeAnimFileVariable(const char* p_key);
 
 	void SetValue(const char* p_value) override; // vtable+0x04
 };

--- a/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
@@ -2,6 +2,9 @@
 
 DECOMP_SIZE_ASSERT(LegoBuildingManager, 0x30)
 
+// GLOBAL: LEGO1 0x100f37c8
+char* LegoBuildingManager::g_customizeAnimFile = NULL;
+
 // GLOBAL: LEGO1 0x100f37cc
 int g_buildingManagerConfig = 1;
 
@@ -39,6 +42,26 @@ void LegoBuildingManager::FUN_1002fa00()
 void LegoBuildingManager::FUN_1002fb30()
 {
 	// TODO
+}
+
+// FUNCTION: LEGO1 0x1002ff90
+void LegoBuildingManager::SetCustomizeAnimFile(const char* p_value)
+{
+	if (g_customizeAnimFile != NULL) {
+		delete[] g_customizeAnimFile;
+	}
+
+	if (p_value != NULL) {
+		g_customizeAnimFile = new char[strlen(p_value) + 1];
+		if (g_customizeAnimFile == NULL) {
+			return;
+		}
+
+		strcpy(g_customizeAnimFile, p_value);
+		return;
+	}
+
+	g_customizeAnimFile = NULL;
 }
 
 // STUB: LEGO1 0x10030220

--- a/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
@@ -58,10 +58,10 @@ void LegoBuildingManager::SetCustomizeAnimFile(const char* p_value)
 		}
 
 		strcpy(g_customizeAnimFile, p_value);
-		return;
 	}
-
-	g_customizeAnimFile = NULL;
+	else {
+		g_customizeAnimFile = NULL;
+	}
 }
 
 // STUB: LEGO1 0x10030220

--- a/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
@@ -53,11 +53,10 @@ void LegoBuildingManager::SetCustomizeAnimFile(const char* p_value)
 
 	if (p_value != NULL) {
 		g_customizeAnimFile = new char[strlen(p_value) + 1];
-		if (g_customizeAnimFile == NULL) {
-			return;
-		}
 
-		strcpy(g_customizeAnimFile, p_value);
+		if (g_customizeAnimFile != NULL) {
+			strcpy(g_customizeAnimFile, p_value);
+		}
 	}
 	else {
 		g_customizeAnimFile = NULL;

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -44,11 +44,10 @@ void LegoPlantManager::SetCustomizeAnimFile(const char* p_value)
 
 	if (p_value != NULL) {
 		g_customizeAnimFile = new char[strlen(p_value) + 1];
-		if (g_customizeAnimFile == NULL) {
-			return;
-		}
 
-		strcpy(g_customizeAnimFile, p_value);
+		if (g_customizeAnimFile != NULL) {
+			strcpy(g_customizeAnimFile, p_value);
+		}
 	}
 	else {
 		g_customizeAnimFile = NULL;

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -49,10 +49,10 @@ void LegoPlantManager::SetCustomizeAnimFile(const char* p_value)
 		}
 
 		strcpy(g_customizeAnimFile, p_value);
-		return;
 	}
-
-	g_customizeAnimFile = NULL;
+	else {
+		g_customizeAnimFile = NULL;
+	}
 }
 
 // STUB: LEGO1 0x10026e00

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -2,6 +2,9 @@
 
 DECOMP_SIZE_ASSERT(LegoPlantManager, 0x2c)
 
+// GLOBAL: LEGO1 0x100f3188
+char* LegoPlantManager::g_customizeAnimFile = NULL;
+
 // FUNCTION: LEGO1 0x10026220
 LegoPlantManager::LegoPlantManager()
 {
@@ -30,6 +33,26 @@ void LegoPlantManager::FUN_10026360(MxS32 p_scriptIndex)
 void LegoPlantManager::FUN_100263a0(undefined4 p_und)
 {
 	// TODO
+}
+
+// FUNCTION: LEGO1 0x10026be0
+void LegoPlantManager::SetCustomizeAnimFile(const char* p_value)
+{
+	if (g_customizeAnimFile != NULL) {
+		delete[] g_customizeAnimFile;
+	}
+
+	if (p_value != NULL) {
+		g_customizeAnimFile = new char[strlen(p_value) + 1];
+		if (g_customizeAnimFile == NULL) {
+			return;
+		}
+
+		strcpy(g_customizeAnimFile, p_value);
+		return;
+	}
+
+	g_customizeAnimFile = NULL;
 }
 
 // STUB: LEGO1 0x10026e00

--- a/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
@@ -1,18 +1,39 @@
 #include "legounksavedatawriter.h"
 
 #include "legogamestate.h"
+#include "legoomni.h"
+#include "legovariables.h"
 #include "roi/legoroi.h"
 
 DECOMP_SIZE_ASSERT(LegoUnkSaveDataWriter, 0x08)
 DECOMP_SIZE_ASSERT(LegoSaveDataEntry3, 0x108)
 
+// GLOBAL: LEGO1 0x100f80c0
+LegoSaveDataEntry3 g_saveDataInit[66]; // TODO: add data
+
+// GLOBAL: LEGO1 0x100fc4e4
+char* LegoUnkSaveDataWriter::g_customizeAnimFile = NULL;
+
 // GLOBAL: LEGO1 0x10104f20
 LegoSaveDataEntry3 g_saveData3[66];
 
-// STUB: LEGO1 0x10082a20
+// FUNCTION: LEGO1 0x10082a20
 LegoUnkSaveDataWriter::LegoUnkSaveDataWriter()
 {
-	// TODO
+	m_map = new LegoUnkSaveDataMap();
+	InitSaveData();
+
+	// DECOMP: this constructor is partially inlined
+	CustomizeAnimFileVariable* v = new CustomizeAnimFileVariable();
+	VariableTable()->SetVariable(v);
+}
+
+// FUNCTION: LEGO1 0x10083270
+void LegoUnkSaveDataWriter::InitSaveData()
+{
+	for (MxS32 i = 0; i < 66; i++) {
+		g_saveData3[i] = g_saveDataInit[i];
+	}
 }
 
 // STUB: LEGO1 0x100832a0
@@ -71,7 +92,7 @@ MxResult LegoUnkSaveDataWriter::WriteSaveData3(LegoStorage* p_stream)
 }
 
 // STUB: LEGO1 0x10083500
-LegoROI* LegoUnkSaveDataWriter::FUN_10083500(char*, undefined4)
+LegoROI* LegoUnkSaveDataWriter::FUN_10083500(char* p_key, MxBool p_option)
 {
 	// TODO
 	// involves an STL map with a _Nil node at 0x100fc508
@@ -88,4 +109,24 @@ void LegoUnkSaveDataWriter::FUN_10083db0(LegoROI* p_roi)
 void LegoUnkSaveDataWriter::FUN_10083f10(LegoROI* p_roi)
 {
 	// TODO
+}
+
+// FUNCTION: LEGO1 0x100851a0
+void LegoUnkSaveDataWriter::SetCustomizeAnimFile(const char* p_value)
+{
+	if (g_customizeAnimFile != NULL) {
+		delete[] g_customizeAnimFile;
+	}
+
+	if (p_value != NULL) {
+		g_customizeAnimFile = new char[strlen(p_value) + 1];
+		if (g_customizeAnimFile == NULL) {
+			return;
+		}
+
+		strcpy(g_customizeAnimFile, p_value);
+		return;
+	}
+
+	g_customizeAnimFile = NULL;
 }

--- a/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
@@ -118,11 +118,10 @@ void LegoUnkSaveDataWriter::SetCustomizeAnimFile(const char* p_value)
 
 	if (p_value != NULL) {
 		g_customizeAnimFile = new char[strlen(p_value) + 1];
-		if (g_customizeAnimFile == NULL) {
-			return;
-		}
 
-		strcpy(g_customizeAnimFile, p_value);
+		if (g_customizeAnimFile != NULL) {
+			strcpy(g_customizeAnimFile, p_value);
+		}
 	}
 	else {
 		g_customizeAnimFile = NULL;

--- a/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legounksavedatawriter.cpp
@@ -2,7 +2,6 @@
 
 #include "legogamestate.h"
 #include "legoomni.h"
-#include "legovariables.h"
 #include "roi/legoroi.h"
 
 DECOMP_SIZE_ASSERT(LegoUnkSaveDataWriter, 0x08)
@@ -23,9 +22,8 @@ LegoUnkSaveDataWriter::LegoUnkSaveDataWriter()
 	m_map = new LegoUnkSaveDataMap();
 	InitSaveData();
 
-	// DECOMP: this constructor is partially inlined
-	CustomizeAnimFileVariable* v = new CustomizeAnimFileVariable();
-	VariableTable()->SetVariable(v);
+	m_customizeAnimFile = new CustomizeAnimFileVariable("CUSTOMIZE_ANIM_FILE");
+	VariableTable()->SetVariable(m_customizeAnimFile);
 }
 
 // FUNCTION: LEGO1 0x10083270
@@ -125,8 +123,8 @@ void LegoUnkSaveDataWriter::SetCustomizeAnimFile(const char* p_value)
 		}
 
 		strcpy(g_customizeAnimFile, p_value);
-		return;
 	}
-
-	g_customizeAnimFile = NULL;
+	else {
+		g_customizeAnimFile = NULL;
+	}
 }

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -5,6 +5,12 @@
 #include "legoplantmanager.h"
 #include "legounksavedatawriter.h"
 
+DECOMP_SIZE_ASSERT(VisibilityVariable, 0x24)
+DECOMP_SIZE_ASSERT(CameraLocationVariable, 0x24)
+DECOMP_SIZE_ASSERT(CursorVariable, 0x24)
+DECOMP_SIZE_ASSERT(WhoAmIVariable, 0x24)
+DECOMP_SIZE_ASSERT(CustomizeAnimFileVariable, 0x24)
+
 // GLOBAL: LEGO1 0x100f3a40
 // STRING: LEGO1 0x100f3808
 const char* g_varVISIBILITY = "VISIBILITY";

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -44,15 +44,20 @@ void WhoAmIVariable::SetValue(const char* p_value)
 	// TODO
 }
 
+// FUNCTION: LEGO1 0x10085aa0
+CustomizeAnimFileVariable::CustomizeAnimFileVariable(const char* p_key)
+{
+	m_key = p_key;
+	m_key.ToUpperCase();
+}
+
 // FUNCTION: LEGO1 0x10085b50
 void CustomizeAnimFileVariable::SetValue(const char* p_value)
 {
 	// STRING: LEGO1 0x100fc4f4
-	if (strcmp(m_key.GetData(), "CUSTOMIZE_ANIM_FILE") != 0) {
-		return;
+	if (strcmp(m_key.GetData(), "CUSTOMIZE_ANIM_FILE") == 0) {
+		UnkSaveDataWriter()->SetCustomizeAnimFile(p_value);
+		PlantManager()->SetCustomizeAnimFile(p_value);
+		BuildingManager()->SetCustomizeAnimFile(p_value);
 	}
-
-	UnkSaveDataWriter()->SetCustomizeAnimFile(p_value);
-	PlantManager()->SetCustomizeAnimFile(p_value);
-	BuildingManager()->SetCustomizeAnimFile(p_value);
 }

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -1,5 +1,10 @@
 #include "legovariables.h"
 
+#include "legobuildingmanager.h"
+#include "legoomni.h"
+#include "legoplantmanager.h"
+#include "legounksavedatawriter.h"
+
 // GLOBAL: LEGO1 0x100f3a40
 // STRING: LEGO1 0x100f3808
 const char* g_varVISIBILITY = "VISIBILITY";
@@ -37,4 +42,17 @@ void CursorVariable::SetValue(const char* p_value)
 void WhoAmIVariable::SetValue(const char* p_value)
 {
 	// TODO
+}
+
+// FUNCTION: LEGO1 0x10085b50
+void CustomizeAnimFileVariable::SetValue(const char* p_value)
+{
+	// STRING: LEGO1 0x100fc4f4
+	if (strcmp(m_key.GetData(), "CUSTOMIZE_ANIM_FILE") != 0) {
+		return;
+	}
+
+	UnkSaveDataWriter()->SetCustomizeAnimFile(p_value);
+	PlantManager()->SetCustomizeAnimFile(p_value);
+	BuildingManager()->SetCustomizeAnimFile(p_value);
 }

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -126,7 +126,7 @@ void LegoModelPresenter::ParseExtra()
 		if (KeyValueStringParse(output, g_autoCreate, buffer) != 0) {
 			char* token = strtok(output, g_parseExtraTokens);
 			if (m_roi == NULL) {
-				m_roi = UnkSaveDataWriter()->FUN_10083500(token, 0);
+				m_roi = UnkSaveDataWriter()->FUN_10083500(token, FALSE);
 				m_addedToView = FALSE;
 			}
 		}


### PR DESCRIPTION
Another child of `MxVariable`, with the key string "CUSTOMIZE_ANIM_FILE". The value is sent to static functions from `LegoUnkSaveDataWriter`, `LegoPlantManager` and `LegoBuildingManager`. They all have the same code to set a static member for the respective class.

The constructor for `LegoUnkSaveDataWriter` should inline almost all of the constructor for the new variable, but it's not happening. If not for that then it should match. The function at `0x10085aa0` is a wrapper for the `MxVariable` constructor except that it sets a second vtable.

The STL map from `LegoUnkSaveDataWriter` is also referenced in the constructor so I looked into that too. I feel pretty confident about the value type being the pair of  `LegoROI*` and `MxU32/MxS32`; I left it as its own struct for the moment. `FUN_10083500` wraps around the `_Insert` function of the map. If the value struct didn't already exist, it gets set up around `0x100835f4`. If it did exist, the counter is incremented at `0x100835aa`. `FUN_10084030` does something to the `LegoROI*` parameter before setting it in the struct.