### PR TITLE
Implement LegoTextureContainer::Insert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ add_library(misc STATIC
 )
 register_lego1_target(misc)
 set_property(TARGET misc PROPERTY ARCHIVE_OUTPUT_NAME "misc$<$<CONFIG:Debug>:d>")
-target_include_directories(misc PRIVATE "${CMAKE_SOURCE_DIR}/LEGO1/omni/include" "${CMAKE_SOURCE_DIR}/LEGO1" "${CMAKE_SOURCE_DIR}/util")
+target_include_directories(misc PRIVATE "${CMAKE_SOURCE_DIR}/LEGO1/omni/include" "${CMAKE_SOURCE_DIR}/LEGO1" "${CMAKE_SOURCE_DIR}/LEGO1/lego/sources" "${CMAKE_SOURCE_DIR}/util")
 target_link_libraries(misc PRIVATE)
 
 add_library(3dmanager STATIC

--- a/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp
+++ b/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp
@@ -44,15 +44,15 @@ LegoTextureInfo::~LegoTextureInfo()
 // FUNCTION: LEGO1 0x10065c60
 LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_texture)
 {
-	LegoTextureInfo* texture = new LegoTextureInfo();
+	LegoTextureInfo* textureInfo = new LegoTextureInfo();
 
 	if (p_name == NULL || p_texture == NULL) {
 		return NULL;
 	}
 
 	if (p_name) {
-		texture->m_name = new char[strlen(p_name) + 1];
-		strcpy(texture->m_name, p_name);
+		textureInfo->m_name = new char[strlen(p_name) + 1];
+		strcpy(textureInfo->m_name, p_name);
 	}
 
 	LPDIRECTDRAW pDirectDraw = VideoManager()->GetDirect3D()->DirectDraw();
@@ -73,7 +73,7 @@ LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_text
 	LegoU8* bits;
 	MxU8* surface;
 
-	if (pDirectDraw->CreateSurface(&desc, &texture->m_surface, NULL) != DD_OK) {
+	if (pDirectDraw->CreateSurface(&desc, &textureInfo->m_surface, NULL) != DD_OK) {
 		goto done;
 	}
 
@@ -82,7 +82,7 @@ LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_text
 	memset(&desc, 0, sizeof(desc));
 	desc.dwSize = sizeof(desc);
 
-	if (texture->m_surface->Lock(NULL, &desc, DDLOCK_SURFACEMEMORYPTR, NULL) != DD_OK) {
+	if (textureInfo->m_surface->Lock(NULL, &desc, DDLOCK_SURFACEMEMORYPTR, NULL) != DD_OK) {
 		goto done;
 	}
 
@@ -98,7 +98,7 @@ LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_text
 		}
 	}
 
-	texture->m_surface->Unlock(desc.lpSurface);
+	textureInfo->m_surface->Unlock(desc.lpSurface);
 
 	PALETTEENTRY entries[256];
 	memset(entries, 0, sizeof(entries));
@@ -115,38 +115,38 @@ LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_text
 		}
 	}
 
-	if (pDirectDraw->CreatePalette(DDPCAPS_ALLOW256 | DDPCAPS_8BIT, entries, &texture->m_palette, NULL) != DD_OK) {
+	if (pDirectDraw->CreatePalette(DDPCAPS_ALLOW256 | DDPCAPS_8BIT, entries, &textureInfo->m_palette, NULL) != DD_OK) {
 		goto done;
 	}
 
-	texture->m_surface->SetPalette(texture->m_palette);
+	textureInfo->m_surface->SetPalette(textureInfo->m_palette);
 
 	if (((TglImpl::RendererImpl*) VideoManager()->GetRenderer())
-			->CreateTextureFromSurface(texture->m_surface, &texture->m_texture) != D3DRM_OK) {
+			->CreateTextureFromSurface(textureInfo->m_surface, &textureInfo->m_texture) != D3DRM_OK) {
 		goto done;
 	}
 
-	texture->m_texture->SetAppData((DWORD) texture);
-	return texture;
+	textureInfo->m_texture->SetAppData((DWORD) textureInfo);
+	return textureInfo;
 
 done:
-	if (texture->m_name != NULL) {
-		delete[] texture->m_name;
-		texture->m_name = NULL;
+	if (textureInfo->m_name != NULL) {
+		delete[] textureInfo->m_name;
+		textureInfo->m_name = NULL;
 	}
 
-	if (texture->m_palette != NULL) {
-		texture->m_palette->Release();
-		texture->m_palette = NULL;
+	if (textureInfo->m_palette != NULL) {
+		textureInfo->m_palette->Release();
+		textureInfo->m_palette = NULL;
 	}
 
-	if (texture->m_surface != NULL) {
-		texture->m_surface->Release();
-		texture->m_surface = NULL;
+	if (textureInfo->m_surface != NULL) {
+		textureInfo->m_surface->Release();
+		textureInfo->m_surface = NULL;
 	}
 
-	if (texture != NULL) {
-		delete texture;
+	if (textureInfo != NULL) {
+		delete textureInfo;
 	}
 
 	return NULL;

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -88,7 +88,7 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 			textureInfo->m_surface->Release();
 			textureInfo->m_palette->Release();
 			delete textureInfo;
-			textureInfo = NULL;
+			return NULL;
 		}
 		else {
 			if (((TglImpl::RendererImpl*) VideoManager()->GetRenderer())
@@ -96,11 +96,13 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 				textureInfo->m_surface->Release();
 				textureInfo->m_palette->Release();
 				delete textureInfo;
-				textureInfo = NULL;
+				return NULL;
 			}
 			else {
 				textureInfo->m_texture->SetAppData((DWORD) textureInfo);
 				m_list.push_back(LegoTextureListElement(textureInfo, TRUE));
+
+				textureInfo->m_texture->AddRef();
 
 				if (textureInfo->m_name != NULL) {
 					delete[] textureInfo->m_name;

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -1,5 +1,9 @@
 #include "legocontainer.h"
 
+#include "lego/legoomni/include/legoomni.h"
+#include "lego/legoomni/include/legovideomanager.h"
+#include "tgl/d3drm/impl.h"
+
 DECOMP_SIZE_ASSERT(LegoContainerInfo<LegoTexture>, 0x10);
 // DECOMP_SIZE_ASSERT(LegoContainer<LegoTexture>, 0x18);
 DECOMP_SIZE_ASSERT(LegoTextureContainer, 0x24);
@@ -9,16 +13,116 @@ LegoTextureContainer::~LegoTextureContainer()
 {
 }
 
-// STUB: LEGO1 0x100998e0
-LegoTextureInfo* LegoTextureContainer::Create(undefined* p_und)
+// FUNCTION: LEGO1 0x100998e0
+LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 {
+	DDSURFACEDESC desc;
+	DWORD width, height;
+	memset(&desc, 0, sizeof(desc));
+	desc.dwSize = sizeof(desc);
+
+	if (p_textureInfo->m_surface->Lock(NULL, &desc, DDLOCK_SURFACEMEMORYPTR, NULL) == DD_OK) {
+		width = desc.dwWidth;
+		height = desc.dwHeight;
+		p_textureInfo->m_surface->Unlock(desc.lpSurface);
+	}
+
+#ifdef COMPAT_MODE
+	LegoTextureList::iterator it;
+	for (it = m_list.begin(); it != m_list.end(); it++) {
+#else
+	for (LegoTextureList::iterator it = m_list.begin(); it != m_list.end(); it++) {
+#endif
+		if ((*it).second == FALSE) {
+			LegoTextureInfo* textureInfo = (*it).first;
+
+			if (textureInfo->m_texture->AddRef() != 0 && textureInfo->m_texture->Release() == 1) {
+				if (!strcmp(textureInfo->m_name, p_textureInfo->m_name)) {
+					DDSURFACEDESC desc;
+					memset(&desc, 0, sizeof(desc));
+					desc.dwSize = sizeof(desc);
+
+					if (textureInfo->m_surface->Lock(NULL, &desc, DDLOCK_SURFACEMEMORYPTR, NULL) == DD_OK) {
+						BOOL und = FALSE;
+						if (desc.dwWidth == width && desc.dwHeight == height) {
+							und = TRUE;
+						}
+
+						textureInfo->m_surface->Unlock(desc.lpSurface);
+
+						if (und) {
+							(*it).second = TRUE;
+							textureInfo->m_texture->AddRef();
+							return textureInfo;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	LegoTextureInfo* textureInfo = new LegoTextureInfo();
+
+	textureInfo->m_palette = p_textureInfo->m_palette;
+	p_textureInfo->m_palette->Release();
+
+	DDSURFACEDESC newDesc;
+	memset(&newDesc, 0, sizeof(newDesc));
+	newDesc.dwWidth = desc.dwWidth;
+	newDesc.dwHeight = desc.dwHeight;
+	newDesc.dwSize = sizeof(newDesc);
+	newDesc.dwFlags = DDSD_PIXELFORMAT | DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
+	newDesc.ddsCaps.dwCaps = DDCAPS_OVERLAYCANTCLIP | DDCAPS_OVERLAY;
+	newDesc.ddpfPixelFormat.dwSize = sizeof(desc.ddpfPixelFormat);
+	newDesc.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_PALETTEINDEXED8;
+	newDesc.ddpfPixelFormat.dwRGBBitCount = 8;
+
+	if (VideoManager()->GetDirect3D()->DirectDraw()->CreateSurface(&newDesc, &textureInfo->m_surface, NULL) == DD_OK) {
+		RECT rect;
+		rect.left = 0;
+		rect.top = newDesc.dwWidth - 1;
+		rect.right = 0;
+		rect.bottom = newDesc.dwHeight - 1;
+
+		textureInfo->m_surface->SetPalette(textureInfo->m_palette);
+
+		if (textureInfo->m_surface->BltFast(0, 0, p_textureInfo->m_surface, &rect, DDBLTFAST_WAIT) != DD_OK) {
+			textureInfo->m_surface->Release();
+			textureInfo->m_palette->Release();
+			delete textureInfo;
+			textureInfo = NULL;
+		}
+		else {
+			if (((TglImpl::RendererImpl*) VideoManager()->GetRenderer())
+					->CreateTextureFromSurface(textureInfo->m_surface, &textureInfo->m_texture) != D3DRM_OK) {
+				textureInfo->m_surface->Release();
+				textureInfo->m_palette->Release();
+				delete textureInfo;
+				textureInfo = NULL;
+			}
+			else {
+				textureInfo->m_texture->SetAppData((DWORD) textureInfo);
+				m_list.push_back(LegoTextureListElement(textureInfo, TRUE));
+
+				if (textureInfo->m_name != NULL) {
+					delete[] textureInfo->m_name;
+				}
+
+				textureInfo->m_name = new char[strlen(p_textureInfo->m_name) + 1];
+				strcpy(textureInfo->m_name, p_textureInfo->m_name);
+
+				return textureInfo;
+			}
+		}
+	}
+
 	return NULL;
 }
 
 // FUNCTION: LEGO1 0x10099cc0
-void LegoTextureContainer::Destroy(LegoTextureInfo* p_data)
+void LegoTextureContainer::Erase(LegoTextureInfo* p_textureInfo)
 {
-	if (p_data == NULL) {
+	if (p_textureInfo == NULL) {
 		return;
 	}
 
@@ -28,12 +132,11 @@ void LegoTextureContainer::Destroy(LegoTextureInfo* p_data)
 #else
 	for (LegoTextureList::iterator it = m_list.begin(); it != m_list.end(); it++) {
 #endif
-		if (((*it).first) == p_data) {
-			// TODO: Element type
-			(*it).second = 0;
+		if ((*it).first == p_textureInfo) {
+			(*it).second = FALSE;
 
-			if (p_data->m_texture->Release() == TRUE) {
-				delete p_data;
+			if (p_textureInfo->m_texture->Release() == TRUE) {
+				delete p_textureInfo;
 				m_list.erase(it);
 			}
 

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -16,7 +16,7 @@ LegoTextureContainer::~LegoTextureContainer()
 // FUNCTION: LEGO1 0x100998e0
 LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 {
-	DDSURFACEDESC desc;
+	DDSURFACEDESC desc, newDesc;
 	DWORD width, height;
 	memset(&desc, 0, sizeof(desc));
 	desc.dwSize = sizeof(desc);
@@ -38,17 +38,16 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 
 			if (textureInfo->m_texture->AddRef() != 0 && textureInfo->m_texture->Release() == 1) {
 				if (!strcmp(textureInfo->m_name, p_textureInfo->m_name)) {
-					DDSURFACEDESC desc;
-					memset(&desc, 0, sizeof(desc));
-					desc.dwSize = sizeof(desc);
+					memset(&newDesc, 0, sizeof(newDesc));
+					newDesc.dwSize = sizeof(newDesc);
 
-					if (textureInfo->m_surface->Lock(NULL, &desc, DDLOCK_SURFACEMEMORYPTR, NULL) == DD_OK) {
+					if (textureInfo->m_surface->Lock(NULL, &newDesc, DDLOCK_SURFACEMEMORYPTR, NULL) == DD_OK) {
 						BOOL und = FALSE;
-						if (desc.dwWidth == width && desc.dwHeight == height) {
+						if (newDesc.dwWidth == width && newDesc.dwHeight == height) {
 							und = TRUE;
 						}
 
-						textureInfo->m_surface->Unlock(desc.lpSurface);
+						textureInfo->m_surface->Unlock(newDesc.lpSurface);
 
 						if (und) {
 							(*it).second = TRUE;
@@ -66,7 +65,6 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 	textureInfo->m_palette = p_textureInfo->m_palette;
 	p_textureInfo->m_palette->Release();
 
-	DDSURFACEDESC newDesc;
 	memset(&newDesc, 0, sizeof(newDesc));
 	newDesc.dwWidth = desc.dwWidth;
 	newDesc.dwHeight = desc.dwHeight;

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -18,6 +18,7 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 {
 	DDSURFACEDESC desc, newDesc;
 	DWORD width, height;
+	LegoTextureInfo* textureInfo;
 	memset(&desc, 0, sizeof(desc));
 	desc.dwSize = sizeof(desc);
 
@@ -27,14 +28,10 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 		p_textureInfo->m_surface->Unlock(desc.lpSurface);
 	}
 
-#ifdef COMPAT_MODE
 	LegoTextureList::iterator it;
 	for (it = m_list.begin(); it != m_list.end(); it++) {
-#else
-	for (LegoTextureList::iterator it = m_list.begin(); it != m_list.end(); it++) {
-#endif
 		if ((*it).second == FALSE) {
-			LegoTextureInfo* textureInfo = (*it).first;
+			textureInfo = (*it).first;
 
 			if (textureInfo->m_texture->AddRef() != 0 && textureInfo->m_texture->Release() == 1) {
 				if (!strcmp(textureInfo->m_name, p_textureInfo->m_name)) {
@@ -60,7 +57,7 @@ LegoTextureInfo* LegoTextureContainer::Insert(LegoTextureInfo* p_textureInfo)
 		}
 	}
 
-	LegoTextureInfo* textureInfo = new LegoTextureInfo();
+	textureInfo = new LegoTextureInfo();
 
 	textureInfo->m_palette = p_textureInfo->m_palette;
 	p_textureInfo->m_palette->Release();

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -119,7 +119,7 @@ protected:
 // _Tree<char const *,pair<char const * const,LegoTextureInfo *>,map<char const *,LegoTextureInfo *,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >::_Kfn,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >::_Erase
 
 // TEMPLATE: LEGO1 0x1005a250
-// list<pair<LegoTextureInfo *,int>,allocator<pair<LegoTextureInfo *,int> > >::~list<pair<LegoTextureInfo *,unsigned int>,allocator<pair<LegoTextureInfo *,unsigned int> > >
+// list<pair<LegoTextureInfo *,int>,allocator<pair<LegoTextureInfo *,int> > >::~list<pair<LegoTextureInfo *,int>,allocator<pair<LegoTextureInfo *,int> > >
 
 // TEMPLATE: LEGO1 0x1005a2c0
 // map<char const *,LegoTextureInfo *,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >::~map<char const *,LegoTextureInfo *,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -67,7 +67,7 @@ protected:
 // class LegoContainer<LegoTextureInfo>
 
 // TODO: Element type
-typedef pair<LegoTextureInfo*, undefined4> LegoTextureListElement;
+typedef pair<LegoTextureInfo*, BOOL> LegoTextureListElement;
 typedef list<LegoTextureListElement> LegoTextureList;
 
 // VTABLE: LEGO1 0x100d86fc
@@ -77,8 +77,8 @@ public:
 	LegoTextureContainer() { m_ownership = TRUE; }
 	~LegoTextureContainer() override;
 
-	LegoTextureInfo* Create(undefined* p_und);
-	void Destroy(LegoTextureInfo* p_data);
+	LegoTextureInfo* Insert(LegoTextureInfo* p_textureInfo);
+	void Erase(LegoTextureInfo* p_textureInfo);
 
 protected:
 	LegoTextureList m_list; // 0x18
@@ -119,7 +119,7 @@ protected:
 // _Tree<char const *,pair<char const * const,LegoTextureInfo *>,map<char const *,LegoTextureInfo *,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >::_Kfn,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >::_Erase
 
 // TEMPLATE: LEGO1 0x1005a250
-// list<pair<LegoTextureInfo *,unsigned int>,allocator<pair<LegoTextureInfo *,unsigned int> > >::~list<pair<LegoTextureInfo *,unsigned int>,allocator<pair<LegoTextureInfo *,unsigned int> > >
+// list<pair<LegoTextureInfo *,int>,allocator<pair<LegoTextureInfo *,int> > >::~list<pair<LegoTextureInfo *,unsigned int>,allocator<pair<LegoTextureInfo *,unsigned int> > >
 
 // TEMPLATE: LEGO1 0x1005a2c0
 // map<char const *,LegoTextureInfo *,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >::~map<char const *,LegoTextureInfo *,LegoContainerInfoComparator,allocator<LegoTextureInfo *> >
@@ -137,7 +137,7 @@ protected:
 // LegoTextureContainer::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x1005a5a0
-// List<pair<LegoTextureInfo *,unsigned int> >::~List<pair<LegoTextureInfo *,unsigned int> >
+// List<pair<LegoTextureInfo *,int> >::~List<pair<LegoTextureInfo *,int> >
 
 // TEMPLATE: LEGO1 0x1005b660
 // LegoContainer<LegoTextureInfo>::~LegoContainer<LegoTextureInfo>


### PR DESCRIPTION
This PR implements `LegoTextureContainer::Insert` and fixes the element type of `LegoTextureList`. 

The match isn't great at ~55% due to a different stack allocation; functionally it should be correct. Since it's a very large function it's difficult to find the correct setup of variables, as usual.