### PR TITLE
Minor style/naming fixes

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -38,7 +38,7 @@ public:
 	MxResult StartAction(MxStreamController* p_controller, MxDSAction* p_action) override; // vtable+0x3c
 	void EndAction() override;                                                             // vtable+0x40
 	void PutFrame() override;                                                              // vtable+0x6c
-	virtual MxResult VTable0x88(MxStreamChunk* p_chunk);                                   // vtable+0x88
+	virtual MxResult CreateAnim(MxStreamChunk* p_chunk);                                   // vtable+0x88
 
 	inline LegoAnim* GetAnimation() { return m_anim; }
 

--- a/LEGO1/lego/legoomni/include/legocachesoundlist.h
+++ b/LEGO1/lego/legoomni/include/legocachesoundlist.h
@@ -38,7 +38,7 @@ public:
 // SIZE 0x10
 class LegoCacheSoundListCursor : public MxPtrListCursor<LegoCacheSound> {
 public:
-	LegoCacheSoundListCursor(LegoCacheSoundList* p_list) : MxPtrListCursor<LegoCacheSound>(p_list){};
+	LegoCacheSoundListCursor(LegoCacheSoundList* p_list) : MxPtrListCursor<LegoCacheSound>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x1001e670

--- a/LEGO1/lego/legoomni/include/legoentitylist.h
+++ b/LEGO1/lego/legoomni/include/legoentitylist.h
@@ -38,7 +38,7 @@ public:
 // SIZE 0x10
 class LegoEntityListCursor : public MxPtrListCursor<LegoEntity> {
 public:
-	LegoEntityListCursor(LegoEntityList* p_list) : MxPtrListCursor<LegoEntity>(p_list){};
+	LegoEntityListCursor(LegoEntityList* p_list) : MxPtrListCursor<LegoEntity>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x1001e2f0

--- a/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
@@ -30,7 +30,7 @@ public:
 	void Destroy() override;                              // vtable+0x38
 	void EndAction() override;                            // vtable+0x40
 	void PutFrame() override;                             // vtable+0x6c
-	MxResult VTable0x88(MxStreamChunk* p_chunk) override; // vtable+0x88
+	MxResult CreateAnim(MxStreamChunk* p_chunk) override; // vtable+0x88
 
 	// SYNTHETIC: LEGO1 0x1006cfe0
 	// LegoLocomotionAnimPresenter::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
+++ b/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
@@ -37,7 +37,7 @@ public:
 // SIZE 0x10
 class LegoPathControllerListCursor : public MxPtrListCursor<LegoPathController> {
 public:
-	LegoPathControllerListCursor(LegoPathControllerList* p_list) : MxPtrListCursor<LegoPathController>(p_list){};
+	LegoPathControllerListCursor(LegoPathControllerList* p_list) : MxPtrListCursor<LegoPathController>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x1001d230

--- a/LEGO1/lego/legoomni/include/legoworldlist.h
+++ b/LEGO1/lego/legoomni/include/legoworldlist.h
@@ -38,7 +38,7 @@ public:
 // SIZE 0x10
 class LegoWorldListCursor : public MxPtrListCursor<LegoWorld> {
 public:
-	LegoWorldListCursor(LegoWorldList* p_list) : MxPtrListCursor<LegoWorld>(p_list){};
+	LegoWorldListCursor(LegoWorldList* p_list) : MxPtrListCursor<LegoWorld>(p_list) {}
 };
 
 // SYNTHETIC: LEGO1 0x1003e870

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -54,7 +54,7 @@ void LegoAnimPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x10068fb0
-MxResult LegoAnimPresenter::VTable0x88(MxStreamChunk* p_chunk)
+MxResult LegoAnimPresenter::CreateAnim(MxStreamChunk* p_chunk)
 {
 	MxResult result = FAILURE;
 	LegoMemory storage(p_chunk->GetData());
@@ -120,7 +120,7 @@ void LegoAnimPresenter::ReadyTickle()
 
 		if (chunk && chunk->GetTime() + m_action->GetStartTime() <= m_action->GetElapsedTime()) {
 			chunk = m_subscriber->PopData();
-			MxResult result = VTable0x88(chunk);
+			MxResult result = CreateAnim(chunk);
 			m_subscriber->FreeDataChunk(chunk);
 
 			if (result == SUCCESS) {

--- a/LEGO1/lego/legoomni/src/video/legolocomotionanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legolocomotionanimpresenter.cpp
@@ -52,9 +52,9 @@ void LegoLocomotionAnimPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x1006d140
-MxResult LegoLocomotionAnimPresenter::VTable0x88(MxStreamChunk* p_chunk)
+MxResult LegoLocomotionAnimPresenter::CreateAnim(MxStreamChunk* p_chunk)
 {
-	MxResult result = LegoAnimPresenter::VTable0x88(p_chunk);
+	MxResult result = LegoAnimPresenter::CreateAnim(p_chunk);
 	return result == SUCCESS ? SUCCESS : result;
 }
 

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -214,7 +214,7 @@ void LegoModelPresenter::ReadyTickle()
 
 	if (m_roi != NULL) {
 		if (m_compositePresenter && m_compositePresenter->IsA("LegoEntityPresenter")) {
-			((LegoEntityPresenter*) m_compositePresenter)->GetEntity()->SetROI((LegoROI*) m_roi, m_addedToView, TRUE);
+			((LegoEntityPresenter*) m_compositePresenter)->GetEntity()->SetROI(m_roi, m_addedToView, TRUE);
 			((LegoEntityPresenter*) m_compositePresenter)
 				->GetEntity()
 				->SetFlags(
@@ -240,7 +240,7 @@ void LegoModelPresenter::ReadyTickle()
 				VideoManager()->Get3DManager()->GetLego3DView()->Moved(*m_roi);
 
 				if (m_compositePresenter != NULL && m_compositePresenter->IsA("LegoEntityPresenter")) {
-					((LegoEntityPresenter*) m_compositePresenter)->GetEntity()->SetROI((LegoROI*) m_roi, TRUE, TRUE);
+					((LegoEntityPresenter*) m_compositePresenter)->GetEntity()->SetROI(m_roi, TRUE, TRUE);
 					((LegoEntityPresenter*) m_compositePresenter)
 						->GetEntity()
 						->SetFlags(

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -13,7 +13,10 @@
 #pragma warning(disable : 4237)
 
 struct LegoContainerInfoComparator {
-	LegoU8 operator()(const char* const& p_key0, const char* const& p_key1) const { return strcmp(p_key0, p_key1) > 0; }
+	LegoBool operator()(const char* const& p_key0, const char* const& p_key1) const
+	{
+		return strcmp(p_key0, p_key1) > 0;
+	}
 };
 
 // SIZE 0x10

--- a/LEGO1/lego/sources/misc/legostorage.h
+++ b/LEGO1/lego/sources/misc/legostorage.h
@@ -20,7 +20,7 @@ public:
 	LegoStorage() : m_mode(0) {}
 
 	// FUNCTION: LEGO1 0x10045ad0
-	virtual ~LegoStorage(){};
+	virtual ~LegoStorage() {}
 
 	virtual LegoResult Read(void* p_buffer, LegoU32 p_size) = 0;
 	virtual LegoResult Write(const void* p_buffer, LegoU32 p_size) = 0;

--- a/LEGO1/omni/include/mxcollection.h
+++ b/LEGO1/omni/include/mxcollection.h
@@ -12,7 +12,7 @@ public:
 		SetDestroy(Destroy);
 	}
 
-	static void Destroy(T){};
+	static void Destroy(T) {}
 
 	void SetDestroy(void (*p_customDestructor)(T)) { this->m_customDestructor = p_customDestructor; }
 

--- a/LEGO1/omni/include/mxdsactionlist.h
+++ b/LEGO1/omni/include/mxdsactionlist.h
@@ -41,7 +41,7 @@ private:
 // SIZE 0x10
 class MxDSActionListCursor : public MxListCursor<MxDSAction*> {
 public:
-	MxDSActionListCursor(MxDSActionList* p_list) : MxListCursor<MxDSAction*>(p_list){};
+	MxDSActionListCursor(MxDSActionList* p_list) : MxListCursor<MxDSAction*>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x100c9cc0

--- a/LEGO1/omni/include/mxlist.h
+++ b/LEGO1/omni/include/mxlist.h
@@ -135,7 +135,7 @@ private:
 template <class T>
 class MxPtrListCursor : public MxListCursor<T*> {
 public:
-	MxPtrListCursor(MxPtrList<T>* p_list) : MxListCursor<T*>(p_list){};
+	MxPtrListCursor(MxPtrList<T>* p_list) : MxListCursor<T*>(p_list) {}
 };
 
 template <class T>

--- a/LEGO1/omni/include/mxpresenterlist.h
+++ b/LEGO1/omni/include/mxpresenterlist.h
@@ -32,7 +32,7 @@ public:
 // VTABLE: LEGO1 0x100d6470
 class MxPresenterListCursor : public MxPtrListCursor<MxPresenter> {
 public:
-	MxPresenterListCursor(MxPresenterList* p_list) : MxPtrListCursor<MxPresenter>(p_list){};
+	MxPresenterListCursor(MxPresenterList* p_list) : MxPtrListCursor<MxPresenter>(p_list) {}
 };
 
 // VTABLE: LEGO1 0x100d6350

--- a/LEGO1/omni/include/mxrectlist.h
+++ b/LEGO1/omni/include/mxrectlist.h
@@ -20,7 +20,7 @@ public:
 // VTABLE: LEGO1 0x100dc420
 class MxRectListCursor : public MxPtrListCursor<MxRect32> {
 public:
-	MxRectListCursor(MxRectList* p_list) : MxPtrListCursor<MxRect32>(p_list){};
+	MxRectListCursor(MxRectList* p_list) : MxPtrListCursor<MxRect32>(p_list) {}
 };
 
 // VTABLE: LEGO1 0x100dc3d8

--- a/LEGO1/omni/include/mxregionlist.h
+++ b/LEGO1/omni/include/mxregionlist.h
@@ -54,7 +54,7 @@ public:
 // VTABLE: LEGO1 0x100dcc10
 class MxRegionLeftRightListCursor : public MxPtrListCursor<MxRegionLeftRight> {
 public:
-	MxRegionLeftRightListCursor(MxRegionLeftRightList* p_list) : MxPtrListCursor<MxRegionLeftRight>(p_list){};
+	MxRegionLeftRightListCursor(MxRegionLeftRightList* p_list) : MxPtrListCursor<MxRegionLeftRight>(p_list) {}
 };
 
 // SIZE 0x0c
@@ -116,7 +116,7 @@ public:
 // VTABLE: LEGO1 0x100dcb88
 class MxRegionTopBottomListCursor : public MxPtrListCursor<MxRegionTopBottom> {
 public:
-	MxRegionTopBottomListCursor(MxPtrList<MxRegionTopBottom>* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list){};
+	MxRegionTopBottomListCursor(MxPtrList<MxRegionTopBottom>* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x100c32e0

--- a/LEGO1/omni/include/mxstreamchunklist.h
+++ b/LEGO1/omni/include/mxstreamchunklist.h
@@ -35,7 +35,7 @@ public:
 // SIZE 0x10
 class MxStreamChunkListCursor : public MxListCursor<MxStreamChunk*> {
 public:
-	MxStreamChunkListCursor(MxStreamChunkList* p_list) : MxListCursor<MxStreamChunk*>(p_list){};
+	MxStreamChunkListCursor(MxStreamChunkList* p_list) : MxListCursor<MxStreamChunk*>(p_list) {}
 };
 
 // VTABLE: LEGO1 0x100dc528

--- a/LEGO1/omni/include/mxstringlist.h
+++ b/LEGO1/omni/include/mxstringlist.h
@@ -12,7 +12,7 @@ class MxStringList : public MxList<MxString> {};
 // SIZE 0x10
 class MxStringListCursor : public MxListCursor<MxString> {
 public:
-	MxStringListCursor(MxStringList* p_list) : MxListCursor<MxString>(p_list){};
+	MxStringListCursor(MxStringList* p_list) : MxListCursor<MxString>(p_list) {}
 
 	// SYNTHETIC: LEGO1 0x100cb860
 	// MxStringList::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -43,20 +43,20 @@ public:
 	MxBool IsHit(MxS32 p_x, MxS32 p_y) override; // vtable+0x50
 
 	// FUNCTION: LEGO1 0x1000c700
-	virtual void LoadHeader(MxStreamChunk* p_chunk){}; // vtable+0x5c
+	virtual void LoadHeader(MxStreamChunk* p_chunk) {} // vtable+0x5c
 
 	// FUNCTION: LEGO1 0x1000c710
-	virtual void CreateBitmap(){}; // vtable+0x60
+	virtual void CreateBitmap() {} // vtable+0x60
 
 	virtual void NextFrame(); // vtable+0x64
 
 	// FUNCTION: LEGO1 0x1000c720
-	virtual void LoadFrame(MxStreamChunk* p_chunk){}; // vtable+0x68
+	virtual void LoadFrame(MxStreamChunk* p_chunk) {} // vtable+0x68
 
 	virtual void PutFrame(); // vtable+0x6c
 
 	// FUNCTION: LEGO1 0x1000c730
-	virtual void RealizePalette(){}; // vtable+0x70
+	virtual void RealizePalette() {} // vtable+0x70
 
 	virtual undefined VTable0x74(); // vtable+0x74
 


### PR DESCRIPTION
Fixes a few minor style/naming issues, among other things an issue with clang-format's `RemoveSemicolon` (which happened to be fixed recently though, so we can upgrade to a newer version at some point: https://github.com/llvm/llvm-project/pull/82278)