### PR TITLE
fix bug in MxPresenter::CreateEntity

### DIFF
--- a/LEGO1/omni/include/mxpresenter.h
+++ b/LEGO1/omni/include/mxpresenter.h
@@ -107,7 +107,7 @@ public:
 
 	virtual void Enable(MxBool p_enable); // vtable+0x54
 
-	MxEntity* CreateEntity(const char* p_name);
+	MxEntity* CreateEntity(const char* p_defaultName);
 	void SendToCompositePresenter(MxOmni*);
 	MxBool IsEnabled();
 

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -239,24 +239,26 @@ const char* PresenterNameDispatch(const MxDSAction& p_action)
 }
 
 // FUNCTION: LEGO1 0x100b5410
-MxEntity* MxPresenter::CreateEntity(const char* p_name)
+MxEntity* MxPresenter::CreateEntity(const char* p_defaultName)
 {
+	char objectName[512];
 	char buffer[512];
-	char buffer2[512];
-	strcpy(buffer, p_name);
 
+	// create an object from LegoObjectFactory based on OBJECT: value in extra data. If that is missing, p_defaultName
+	// is used
+
+	strcpy(objectName, p_defaultName);
 	MxU16 extraLen = m_action->GetExtraLength();
 
 	buffer[0] = extraLen;
 	buffer[1] = extraLen >> 8;
-	if (extraLen) {
-		extraLen &= MAXWORD;
-		memcpy(buffer2 + 2, m_action->GetExtraData(), extraLen);
-		buffer2[extraLen + 2] = 0;
-		KeyValueStringParse(buffer, g_strOBJECT, buffer2 + 2);
+	if (extraLen & MAXWORD) {
+		memcpy(buffer + 2, m_action->GetExtraData(), extraLen & MAXWORD);
+		buffer[extraLen + 2] = 0;
+		KeyValueStringParse(objectName, g_strOBJECT, buffer + 2);
 	}
 
-	return (MxEntity*) ObjectFactory()->Create(buffer);
+	return (MxEntity*) ObjectFactory()->Create(objectName);
 }
 
 // FUNCTION: LEGO1 0x100b54c0

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -241,21 +241,21 @@ const char* PresenterNameDispatch(const MxDSAction& p_action)
 // FUNCTION: LEGO1 0x100b5410
 MxEntity* MxPresenter::CreateEntity(const char* p_defaultName)
 {
+	// create an object from LegoObjectFactory based on OBJECT: value in extra data.
+	// If that is missing, p_defaultName is used
+
 	char objectName[512];
-	char buffer[512];
-
-	// create an object from LegoObjectFactory based on OBJECT: value in extra data. If that is missing, p_defaultName
-	// is used
-
 	strcpy(objectName, p_defaultName);
-	MxU16 extraLen = m_action->GetExtraLength();
 
-	buffer[0] = extraLen;
-	buffer[1] = extraLen >> 8;
-	if (extraLen & MAXWORD) {
-		memcpy(buffer + 2, m_action->GetExtraData(), extraLen & MAXWORD);
-		buffer[extraLen + 2] = 0;
-		KeyValueStringParse(objectName, g_strOBJECT, buffer + 2);
+	MxU16 extraLength;
+	char* extraData;
+	m_action->GetExtra(extraLength, extraData);
+
+	if (extraLength & MAXWORD) {
+		char extraCopy[512];
+		memcpy(extraCopy, extraData, extraLength & MAXWORD);
+		extraCopy[extraLength & MAXWORD] = '\0';
+		KeyValueStringParse(objectName, g_strOBJECT, extraCopy);
 	}
 
 	return (MxEntity*) ObjectFactory()->Create(objectName);


### PR DESCRIPTION
The game crashed as MxPresenter::CreateEntity returned null, and LegoWorldPresenter expects it not to be null. Fixed an issue where the default name would be overwritten with the extra data size. After this fix, the game now crashes in LegoModelPresenter as the names of LegoROI aren't being read yet.