### PR TITLE
reccmp: Sanitize performance (and more)

### DIFF
--- a/tools/isledecomp/isledecomp/compare/asm/const.py
+++ b/tools/isledecomp/isledecomp/compare/asm/const.py
@@ -1,0 +1,27 @@
+# Duplicates removed, according to the mnemonics capstone uses.
+# e.g. je and jz are the same instruction. capstone uses je.
+# See: /arch/X86/X86GenAsmWriter.inc in the capstone repo.
+JUMP_MNEMONICS = {
+    "ja",
+    "jae",
+    "jb",
+    "jbe",
+    "jcxz",  # unused?
+    "je",
+    "jecxz",
+    "jg",
+    "jge",
+    "jl",
+    "jle",
+    "jmp",
+    "jne",
+    "jno",
+    "jnp",
+    "jns",
+    "jo",
+    "jp",
+    "js",
+}
+
+# Guaranteed to be a single operand.
+SINGLE_OPERAND_INSTS = {"push", "call", *JUMP_MNEMONICS}

--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -158,9 +158,9 @@ class Compare:
                 addr, sym.node_type, sym.name(), sym.decorated_name, sym.size()
             )
 
-        for lineref in cv.lines:
-            addr = self.recomp_bin.get_abs_addr(lineref.section, lineref.offset)
-            self._lines_db.add_line(lineref.filename, lineref.line_no, addr)
+        for (section, offset), (filename, line_no) in res.verified_lines.items():
+            addr = self.recomp_bin.get_abs_addr(section, offset)
+            self._lines_db.add_line(filename, line_no, addr)
 
         # The _entry symbol is referenced in the PE header so we get this match for free.
         self._db.set_function_pair(self.orig_bin.entry, self.recomp_bin.entry)


### PR DESCRIPTION
The sanitize function prepares each assembly instruction line for the text diff. On latest, we call it about 275,000 times in both original and recomp version of `LEGO1.DLL`. Of those calls, only about 62,000 result in any change to the operands.

The biggest optimization by far is to just not call the sanitize function if the string "0x" doesn't appear in `inst.op_str`. If there's no hex value to sanitize, skip the function altogether. I first approached this problem by isolating the mnemonics we would consider replacing and checking `inst.op_str` against the list of registers, but this way (elegant or not) seems to be the best.

Another thing we can check is whether the instruction is "big enough" to have a pointer or immediate value that is an address. If the instruction is not a jump and is fewer than 5 bytes, skip it.

Those changes brought us down to 78,000 calls to sanitize and only 16,000 that are "wasted" with no effect on the final string.

I also refactored the sanitize function itself. To get more code clarity, I used regular expressions almost exclusively for the hex replacement.

Other small things:

- Use `io.TextIOWrapper` to wrap the `subprocess` call to `cvdump`. This is faster than reading the entire thing into memory and using string split.

- Tuned some regular expressions in a few places.

- For cvdump `TYPES` parsing, use better control flow and skip `LF_` types that will not be used when comparing variables.

- The `LINES` section in cvdump is the main thing we use for matching functions. The line that has the opening curly brace is considered the function start, and we match this against an address in the recomp from this section. Each subsection from `LINES` looks like this:

```
  C:\isle\LEGO1\modeldb\modeldb.cpp (None), 0001:0003B5A0-0003B65C, line/addr pairs = 10

     53 0003B5A0     57 0003B5B1     58 0003B5C8     62 0003B5D8
     63 0003B5F2     66 0003B602     68 0003B60E     69 0003B624
     72 0003B634     73 0003B652
```

These might be the lines from one function or multiple functions, so we have to read them all. However, we need very few of these line/address pairs to actually match something, so I reduce the list of possible values down based on which recomp addresses can be found elsewhere in the PDB.

