### PR TITLE
rename MxTransitionManager transitions

### DIFF
--- a/LEGO1/lego/legoomni/include/mxtransitionmanager.h
+++ b/LEGO1/lego/legoomni/include/mxtransitionmanager.h
@@ -37,8 +37,8 @@ public:
 		e_notTransitioning = 0,
 		e_noAnimation,
 		e_dissolve,
-		e_pixelation,
-		e_screenWipe,
+		e_mosaic,
+		e_wipeDown,
 		e_windows,
 		e_broken // Unknown what this is supposed to be, it locks the game up
 	};
@@ -53,11 +53,11 @@ public:
 private:
 	void EndTransition(MxBool p_notifyWorld);
 	void TransitionNone();
-	void TransitionDissolve();
-	void TransitionPixelation();
-	void TransitionWipe();
-	void TransitionWindows();
-	void TransitionBroken();
+	void DissolveTransition();
+	void MosaicTransition();
+	void WipeDownTransition();
+	void WindowsTransition();
+	void BrokenTransition();
 
 	void SubmitCopyRect(LPDDSURFACEDESC p_ddsc);
 	void SetupCopyRect(LPDDSURFACEDESC p_ddsc);

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -116,7 +116,7 @@ MxU32 Helicopter::VTable0xcc()
 		VTable0xe8(0x29, TRUE, 7);
 		((Isle*) CurrentWorld())->SetUnknown13c(0x3c);
 		FUN_10015820(TRUE, 0);
-		TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, TRUE);
+		TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, TRUE);
 		SetUnknownDC(4);
 		PlayMusic(JukeboxScript::c_Jail_Music);
 		break;
@@ -158,7 +158,7 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 		case 0x17:
 			if (*g_act3Script == script) {
 				((Act3*) CurrentWorld())->SetUnkown4270(2);
-				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			}
 			else if (m_state->GetUnkown8() != 0) {
 				break;
@@ -230,7 +230,7 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 		case 0x1c:
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				((Isle*) CurrentWorld())->SetUnknown13c(2);
-				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 				VTable0xe4();
 			}
 			ret = 1;

--- a/LEGO1/lego/legoomni/src/actors/jukeboxentity.cpp
+++ b/LEGO1/lego/legoomni/src/actors/jukeboxentity.cpp
@@ -37,7 +37,7 @@ MxLong JukeBoxEntity::Notify(MxParam& p_param)
 		}
 
 		((Isle*) FindWorld(*g_isleScript, 0))->SetUnknown13c(0x35);
-		TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+		TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 		return 1;
 	}
 

--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -64,19 +64,19 @@ MxResult MxTransitionManager::Tickle()
 		TransitionNone();
 		break;
 	case e_dissolve:
-		TransitionDissolve();
+		DissolveTransition();
 		break;
-	case e_pixelation:
-		TransitionPixelation();
+	case e_mosaic:
+		MosaicTransition();
 		break;
-	case e_screenWipe:
-		TransitionWipe();
+	case e_wipeDown:
+		WipeDownTransition();
 		break;
 	case e_windows:
-		TransitionWindows();
+		WindowsTransition();
 		break;
 	case e_broken:
-		TransitionBroken();
+		BrokenTransition();
 		break;
 	}
 	return SUCCESS;
@@ -165,7 +165,7 @@ void MxTransitionManager::TransitionNone()
 }
 
 // FUNCTION: LEGO1 0x1004bd10
-void MxTransitionManager::TransitionDissolve()
+void MxTransitionManager::DissolveTransition()
 {
 	// If the animation is finished
 	if (m_animationTimer == 40) {
@@ -251,7 +251,7 @@ void MxTransitionManager::TransitionDissolve()
 }
 
 // FUNCTION: LEGO1 0x1004bed0
-void MxTransitionManager::TransitionPixelation()
+void MxTransitionManager::MosaicTransition()
 {
 	if (m_animationTimer == 16) {
 		m_animationTimer = 0;
@@ -355,7 +355,7 @@ void MxTransitionManager::TransitionPixelation()
 }
 
 // FUNCTION: LEGO1 0x1004c170
-void MxTransitionManager::TransitionWipe()
+void MxTransitionManager::WipeDownTransition()
 {
 	// If the animation is finished
 	if (m_animationTimer == 240) {
@@ -394,7 +394,7 @@ void MxTransitionManager::TransitionWipe()
 }
 
 // FUNCTION: LEGO1 0x1004c270
-void MxTransitionManager::TransitionWindows()
+void MxTransitionManager::WindowsTransition()
 {
 	if (m_animationTimer == 240) {
 		m_animationTimer = 0;
@@ -440,7 +440,7 @@ void MxTransitionManager::TransitionWindows()
 }
 
 // FUNCTION: LEGO1 0x1004c3e0
-void MxTransitionManager::TransitionBroken()
+void MxTransitionManager::BrokenTransition()
 {
 	// This function has no actual animation logic.
 	// It also never calls EndTransition to

--- a/LEGO1/lego/legoomni/src/worlds/elevatorbottom.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/elevatorbottom.cpp
@@ -85,12 +85,12 @@ MxLong ElevatorBottom::HandleClick(LegoControlManagerEvent& p_param)
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
 			m_unk0xf8 = LegoGameState::e_infodoor;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 2:
 			m_unk0xf8 = LegoGameState::e_infomain;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 3:
@@ -103,7 +103,7 @@ MxLong ElevatorBottom::HandleClick(LegoControlManagerEvent& p_param)
 
 			state->SetUnknown1c(1);
 			m_unk0xf8 = LegoGameState::e_elevride;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			VariableTable()->SetVariable(g_varCAMERALOCATION, "LCAMZI1,90");
 			result = 1;
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -51,7 +51,7 @@ MxLong HistoryBook::Notify(MxParam& p_param)
 		switch (((MxNotificationParam&) p_param).GetNotification()) {
 		case c_notificationButtonUp:
 			m_transitionDestination = LegoGameState::Area::e_infoscor;
-			TransitionManager()->StartTransition(MxTransitionManager::TransitionType::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::TransitionType::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case c_notificationTransitioned:
 			GameState()->SwitchArea(m_transitionDestination);

--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -301,7 +301,7 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 	case 4:
 		if (action->GetObjectId() == InfomainScript::c_GoTo_RegBook ||
 			action->GetObjectId() == InfomainScript::c_GoTo_RegBook_Red) {
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			m_infocenterState->SetUnknown0x74(14);
 			return 1;
 		}
@@ -311,7 +311,7 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 			if (GameState()->GetCurrentAct() != LegoGameState::e_act3 && m_selectedCharacter != e_noCharacter) {
 				GameState()->SetActor(m_selectedCharacter);
 			}
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			m_infocenterState->SetUnknown0x74(14);
 			return 1;
 		}
@@ -331,7 +331,7 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 		return 1;
 	case 12:
 		if (action->GetObjectId() == m_currentInfomainScript) {
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 		}
 	}
 
@@ -881,7 +881,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
-				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 				m_transitionDestination = LegoGameState::e_elevbott;
 			}
 			else {
@@ -896,7 +896,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
-				TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 				m_transitionDestination = LegoGameState::e_infoscor;
 			}
 			else {

--- a/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
@@ -97,17 +97,17 @@ MxLong InfocenterDoor::HandleClick(LegoControlManagerEvent& p_param)
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
 			m_unk0xf8 = LegoGameState::e_infoscor;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 2:
 			m_unk0xf8 = LegoGameState::e_elevbott;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 3:
 			m_unk0xf8 = LegoGameState::e_infomain;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 4:
@@ -134,7 +134,7 @@ MxLong InfocenterDoor::HandleClick(LegoControlManagerEvent& p_param)
 				goto done;
 			}
 
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 
 		done:
 			result = 1;

--- a/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
@@ -212,7 +212,7 @@ MxBool JukeBox::HandleClick(LegoControlManagerEvent& p_param)
 			Act1State* act1State = (Act1State*) gameState->GetState("Act1State");
 			act1State->SetUnknown18(11);
 			m_transitionDestination = LegoGameState::Area::e_unk54;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, 0, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, 0, FALSE);
 			break;
 		}
 	}

--- a/LEGO1/lego/legoomni/src/worlds/police.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/police.cpp
@@ -111,7 +111,7 @@ MxLong Police::HandleClick(LegoControlManagerEvent& p_param)
 
 			BackgroundAudioManager()->Stop();
 			m_transitionDestination = LegoGameState::Area::e_polidoor;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Info_Ctl:
 			if (m_policeState->GetUnknown0x0c() == 1) {
@@ -120,7 +120,7 @@ MxLong Police::HandleClick(LegoControlManagerEvent& p_param)
 
 			BackgroundAudioManager()->Stop();
 			m_transitionDestination = LegoGameState::Area::e_infomain;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Door_Ctl:
 			if (m_policeState->GetUnknown0x0c() == 1) {
@@ -129,7 +129,7 @@ MxLong Police::HandleClick(LegoControlManagerEvent& p_param)
 
 			BackgroundAudioManager()->Stop();
 			m_transitionDestination = LegoGameState::Area::e_copter;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 50, FALSE, FALSE);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Donut_Ctl:
 			m_policeState->FUN_1005ea40();

--- a/LEGO1/lego/legoomni/src/worlds/score.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/score.cpp
@@ -122,7 +122,7 @@ MxLong Score::FUN_10001510(MxEndActionNotificationParam& p_param)
 		switch (action->GetObjectId()) {
 		case 10:
 			m_unk0xf8 = LegoGameState::e_histbook;
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 0x32, 0, 0);
 			break;
 		case 0x1f5:
 			PlayMusic(JukeboxScript::c_InformationCenter_Music);
@@ -167,12 +167,12 @@ MxLong Score::FUN_100016d0(LegoControlManagerEvent& p_param)
 		case 1:
 			m_unk0xf8 = LegoGameState::e_infomain;
 			DeleteScript();
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 0x32, 0, 0);
 			break;
 		case 2:
 			m_unk0xf8 = LegoGameState::e_infodoor;
 			DeleteScript();
-			TransitionManager()->StartTransition(MxTransitionManager::e_pixelation, 0x32, 0, 0);
+			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 0x32, 0, 0);
 			break;
 		case 3: {
 			LegoInputManager* im = InputManager();


### PR DESCRIPTION
This PR renames the MxTransitionManager transitions. Some assertions in Beta 1.0's debug build reveal their actual names:

![image](https://github.com/isledecomp/isle/assets/64166386/f4c1d9c3-5394-4362-adcf-d01e5c3c6908)

To my surprise, I was fairly spot on with the name guesses I made a couple years back. Wipe is actually called WipeDown, and Pixelation is actually called Mosaic. There are no assertions for the Windows transition or the completely broken one. 

These assertions also reveal that "Transition" comes at the end in their function names, rather than being prepended like we had before. Aside from this, we were actually extremely close to the original function names.

I've also renamed the relevant MxTransitionManager enum labels to reflect the changes.