### PR TITLE
KeyValueStringParse closer to beta version

### DIFF
--- a/LEGO1/omni/src/common/mxutilities.cpp
+++ b/LEGO1/omni/src/common/mxutilities.cpp
@@ -83,12 +83,12 @@ void MakeSourceName(char* p_output, const char* p_input)
 MxBool KeyValueStringParse(char* p_output, const char* p_command, const char* p_string)
 {
 	MxBool didMatch = FALSE;
-	assert(p_string);  // 90
-	assert(p_command); // 91
+	assert(p_string);
+	assert(p_command);
 
 	MxS16 len = strlen(p_string);
 	char* string = new char[len + 1];
-	assert(string); // 95
+	assert(string);
 	strcpy(string, p_string);
 
 	for (char* token = strtok(string, ", \t\r\n:"); token; token = strtok(NULL, ", \t\r\n:")) {

--- a/LEGO1/omni/src/common/mxutilities.cpp
+++ b/LEGO1/omni/src/common/mxutilities.cpp
@@ -9,6 +9,8 @@
 #include "mxpresenterlist.h"
 #include "mxrect32.h"
 
+#include <assert.h>
+
 // GLOBAL: LEGO1 0x101020e8
 void (*g_omniUserMessage)(const char*, int) = NULL;
 
@@ -78,39 +80,37 @@ void MakeSourceName(char* p_output, const char* p_input)
 }
 
 // FUNCTION: LEGO1 0x100b7050
-MxBool KeyValueStringParse(char* p_outputValue, const char* p_key, const char* p_source)
+MxBool KeyValueStringParse(char* p_output, const char* p_command, const char* p_string)
 {
 	MxBool didMatch = FALSE;
+	assert(p_string);  // 90
+	assert(p_command); // 91
 
-	MxS16 len = strlen(p_source);
-	char* temp = new char[len + 1];
-	strcpy(temp, p_source);
+	MxS16 len = strlen(p_string);
+	char* string = new char[len + 1];
+	assert(string); // 95
+	strcpy(string, p_string);
 
-	char* token = strtok(temp, ", \t\r\n:");
-	while (token) {
+	for (char* token = strtok(string, ", \t\r\n:"); token; token = strtok(NULL, ", \t\r\n:")) {
 		len -= (strlen(token) + 1);
 
-		if (strcmpi(token, p_key) == 0) {
-			if (p_outputValue && len > 0) {
-				char* cur = &token[strlen(p_key)];
+		if (strcmpi(token, p_command) == 0) {
+			if (p_output && len > 0) {
+				char* output = p_output;
+				char* cur = &token[strlen(p_command)];
 				cur++;
-				while (*cur != ',') {
-					if (*cur == ' ' || *cur == '\0' || *cur == '\t' || *cur == '\n' || *cur == '\r') {
-						break;
-					}
-					*p_outputValue++ = *cur++;
+				while (*cur != ',' && *cur != ' ' && *cur != '\0' && *cur != '\t' && *cur != '\n' && *cur != '\r') {
+					*output++ = *cur++;
 				}
-				*p_outputValue = '\0';
+				*output = '\0';
 			}
 
 			didMatch = TRUE;
 			break;
 		}
-
-		token = strtok(NULL, ", \t\r\n:");
 	}
 
-	delete[] temp;
+	delete[] string;
 	return didMatch;
 }
 


### PR DESCRIPTION
Changed some code in the public KeyValueStringParse function from `MxUtilities` to more closely match Beta 1.0. Two parameter names and a variable name were revealed in the asserts and I changed `p_output` to be shorter to match.

No effect on match percentage for the release `LEGO1` except marginal compiler entropy in three places.

My main goal with this is to get some discussion going about what things from the beta we should add to our codebase.

- Do we want the asserts even though they are no-ops in non-debug builds? (Maybe that _is_ the reason to add them)
- Any consideration for line numbers of the asserts? I commented the line numbers for the three here, but ours will probably never match exactly with the addition of the decomp assertions and ifdefs for building on newer compilers.
- Do we want decomp assertions for the beta build to compare against? What should the module name be? `BETA10`?
- I was looking at `MxPresenter::ParseExtra` and that led me to this function. The `MxAutoLocker` call is a bit different. The 96 source shows that they used the macro `AUTOLOCK` in place of `MxAutoLocker lock(&m_criticalSection)`. I think the reason is that in the debug version they add two parameters: `__FILE__` and `__LINE__`, similar to an assert. Do we want to do the same for our debug builds?

*Maybe we can find a better name for this function too*