### PR TITLE
MxTransitionManager::TransitionNone() -> NoTransition()

### DIFF
--- a/LEGO1/lego/legoomni/include/mxtransitionmanager.h
+++ b/LEGO1/lego/legoomni/include/mxtransitionmanager.h
@@ -52,7 +52,7 @@ public:
 
 private:
 	void EndTransition(MxBool p_notifyWorld);
-	void TransitionNone();
+	void NoTransition();
 	void DissolveTransition();
 	void MosaicTransition();
 	void WipeDownTransition();

--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -61,7 +61,7 @@ MxResult MxTransitionManager::Tickle()
 
 	switch (this->m_transitionType) {
 	case e_noAnimation:
-		TransitionNone();
+		NoTransition();
 		break;
 	case e_dissolve:
 		DissolveTransition();
@@ -157,7 +157,7 @@ void MxTransitionManager::EndTransition(MxBool p_notifyWorld)
 }
 
 // FUNCTION: LEGO1 0x1004bcf0
-void MxTransitionManager::TransitionNone()
+void MxTransitionManager::NoTransition()
 {
 	LegoVideoManager* videoManager = VideoManager();
 	videoManager->GetDisplaySurface()->ClearScreen();


### PR DESCRIPTION
Small styling difference inferred from the naming style of these Transition functions revealed in the Beta 1.0 debug build that escaped #655.