### PR TITLE
slight style tweaks to LegoGameState and related members

### DIFF
--- a/LEGO1/lego/legoomni/include/elevatorbottom.h
+++ b/LEGO1/lego/legoomni/include/elevatorbottom.h
@@ -42,7 +42,7 @@ public:
 	// ElevatorBottom::`scalar deleting destructor'
 
 private:
-	LegoGameState::Area m_unk0xf8; // 0xf8
+	LegoGameState::Area m_destLocation; // 0xf8
 
 	MxLong HandleClick(LegoControlManagerEvent& p_param);
 };

--- a/LEGO1/lego/legoomni/include/gasstation.h
+++ b/LEGO1/lego/legoomni/include/gasstation.h
@@ -45,18 +45,18 @@ private:
 	MxLong HandleKeyPress(MxS8 p_key);
 	MxLong HandleButtonDown(LegoControlManagerEvent& p_param);
 
-	undefined2 m_unk0xf8;                        // 0xf8
-	undefined2 m_unk0xfa;                        // 0xfa
-	LegoGameState::Area m_transitionDestination; // 0xfc
-	GasStationState* m_state;                    // 0x100
-	undefined2 m_unk0x104;                       // 0x104
-	undefined2 m_unk0x106;                       // 0x106
-	undefined4 m_unk0x108;                       // 0x108
-	undefined4 m_unk0x10c;                       // 0x10c
-	undefined4 m_unk0x110;                       // 0x110
-	undefined m_unk0x114;                        // 0x114
-	undefined m_unk0x115;                        // 0x115
-	Radio m_radio;                               // 0x118
+	undefined2 m_unk0xf8;               // 0xf8
+	undefined2 m_unk0xfa;               // 0xfa
+	LegoGameState::Area m_destLocation; // 0xfc
+	GasStationState* m_state;           // 0x100
+	undefined2 m_unk0x104;              // 0x104
+	undefined2 m_unk0x106;              // 0x106
+	undefined4 m_unk0x108;              // 0x108
+	undefined4 m_unk0x10c;              // 0x10c
+	undefined4 m_unk0x110;              // 0x110
+	undefined m_unk0x114;               // 0x114
+	undefined m_unk0x115;               // 0x115
+	Radio m_radio;                      // 0x118
 };
 
 #endif // GASSTATION_H

--- a/LEGO1/lego/legoomni/include/historybook.h
+++ b/LEGO1/lego/legoomni/include/historybook.h
@@ -36,10 +36,10 @@ public:
 	// HistoryBook::`scalar deleting destructor'
 
 private:
-	LegoGameState::Area m_transitionDestination; // 0xf8
-	MxStillPresenter* m_alphabet[26];            // 0xfc
-	MxStillPresenter* m_names[20][7];            // 0x164
-	MxStillPresenter* m_scores[20];              // 0x394
+	LegoGameState::Area m_destLocation; // 0xf8
+	MxStillPresenter* m_alphabet[26];   // 0xfc
+	MxStillPresenter* m_names[20][7];   // 0x164
+	MxStillPresenter* m_scores[20];     // 0x394
 };
 
 #endif // HISTORYBOOK_H

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -3,6 +3,7 @@
 
 #include "decomp.h"
 #include "hospitalstate.h"
+#include "legogamestate.h"
 #include "legoworld.h"
 
 // VTABLE: LEGO1 0x100d9730
@@ -38,19 +39,19 @@ public:
 	// Hospital::`scalar deleting destructor'
 
 private:
-	undefined2 m_unk0xf8;           // 0xf8
-	undefined4 m_unk0xfc;           // 0xfc
-	undefined2 m_unk0x100;          // 0x100
-	HospitalState* m_hospitalState; // 0x104
-	undefined2 m_unk0x108;          // 0x108
-	undefined4 m_unk0x10c;          // 0x10c
-	undefined4 m_unk0x110;          // 0x110
-	undefined4 m_unk0x114;          // 0x114
-	undefined m_unk0x118;           // 0x118
-	undefined4 m_unk0x11c;          // 0x11c
-	undefined4 m_unk0x120;          // 0x120
-	undefined m_unk0x124[4];        // 0x124
-	undefined m_unk0x128;           // 0x128
+	undefined2 m_unk0xf8;               // 0xf8
+	LegoGameState::Area m_destLocation; // 0xfc
+	undefined2 m_unk0x100;              // 0x100
+	HospitalState* m_hospitalState;     // 0x104
+	undefined2 m_unk0x108;              // 0x108
+	undefined4 m_unk0x10c;              // 0x10c
+	undefined4 m_unk0x110;              // 0x110
+	undefined4 m_unk0x114;              // 0x114
+	undefined m_unk0x118;               // 0x118
+	undefined4 m_unk0x11c;              // 0x11c
+	undefined4 m_unk0x120;              // 0x120
+	undefined m_unk0x124[4];            // 0x124
+	undefined m_unk0x128;               // 0x128
 };
 
 #endif // HOSPITAL_H

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -102,7 +102,7 @@ private:
 	InfomainScript::Script m_currentInfomainScript; // 0xf8
 	MxS16 m_selectedCharacter;                      // 0xfc
 	InfocenterState* m_infocenterState;             // 0x100
-	LegoGameState::Area m_transitionDestination;    // 0x104
+	LegoGameState::Area m_destLocation;             // 0x104
 	Cutscene m_currentCutscene;                     // 0x108
 	Radio m_radio;                                  // 0x10c
 	MxStillPresenter* m_unk0x11c;                   // 0x11c

--- a/LEGO1/lego/legoomni/include/infocenterdoor.h
+++ b/LEGO1/lego/legoomni/include/infocenterdoor.h
@@ -41,7 +41,7 @@ public:
 	// InfocenterDoor::`scalar deleting destructor'
 
 private:
-	LegoGameState::Area m_unk0xf8; // 0xf8
+	LegoGameState::Area m_destLocation; // 0xf8
 
 	MxLong HandleClick(LegoControlManagerEvent& p_param);
 };

--- a/LEGO1/lego/legoomni/include/jukebox.h
+++ b/LEGO1/lego/legoomni/include/jukebox.h
@@ -44,9 +44,9 @@ public:
 private:
 	MxBool HandleClick(LegoControlManagerEvent& p_param);
 
-	LegoGameState::Area m_transitionDestination; // 0xf8
-	JukeBoxState* m_state;                       // 0xfc
-	undefined2 m_unk0x100;                       // 0x100
+	LegoGameState::Area m_destLocation; // 0xf8
+	JukeBoxState* m_state;              // 0xfc
+	undefined2 m_unk0x100;              // 0x100
 };
 
 #endif // JUKEBOX_H

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -28,7 +28,7 @@ public:
 	};
 
 	enum Area {
-		e_noArea = 0,
+		e_undefined = 0,
 		e_previousArea = 0,
 		e_isle,
 		e_infomain,

--- a/LEGO1/lego/legoomni/include/police.h
+++ b/LEGO1/lego/legoomni/include/police.h
@@ -48,9 +48,9 @@ private:
 	MxLong HandleEndAction(MxEndActionNotificationParam& p_param);
 	MxLong HandleKeyPress(LegoEventNotificationParam& p_param);
 
-	Radio m_radio;                               // 0xf8
-	PoliceState* m_policeState;                  // 0x108
-	LegoGameState::Area m_transitionDestination; // 0x10c
+	Radio m_radio;                      // 0xf8
+	PoliceState* m_policeState;         // 0x108
+	LegoGameState::Area m_destLocation; // 0x10c
 };
 
 #endif // POLICE_H

--- a/LEGO1/lego/legoomni/include/score.h
+++ b/LEGO1/lego/legoomni/include/score.h
@@ -44,7 +44,7 @@ public:
 	void FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color);
 
 protected:
-	LegoGameState::Area m_unk0xf8;
+	LegoGameState::Area m_destLocation;
 	ScoreState* m_state;
 	MxU8* m_surface;
 

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -94,9 +94,9 @@ LegoGameState::LegoGameState()
 	m_savePath = NULL;
 	m_stateArray = NULL;
 	m_unk0x41c = -1;
-	m_currentArea = e_noArea;
-	m_previousArea = e_noArea;
-	m_unk0x42c = e_noArea;
+	m_currentArea = e_undefined;
+	m_previousArea = e_undefined;
+	m_unk0x42c = e_undefined;
 	m_playerCount = 0;
 	m_isDirty = FALSE;
 	m_loadedAct = e_actNotFound;
@@ -372,7 +372,7 @@ MxResult LegoGameState::Load(MxULong p_slot)
 	Read(&fileStorage, &area);
 
 	if (m_currentAct == 0) {
-		m_unk0x42c = e_noArea;
+		m_unk0x42c = e_undefined;
 	}
 	else {
 		m_unk0x42c = (Area) area;
@@ -1091,7 +1091,7 @@ void LegoGameState::Init()
 		}
 	}
 
-	m_unk0x42c = e_noArea;
+	m_unk0x42c = e_undefined;
 }
 
 // FUNCTION: LEGO1 0x1003c670

--- a/LEGO1/lego/legoomni/src/worlds/elevatorbottom.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/elevatorbottom.cpp
@@ -18,7 +18,7 @@ DECOMP_SIZE_ASSERT(ElevatorBottom, 0xfc)
 ElevatorBottom::ElevatorBottom()
 {
 	NotificationManager()->Register(this);
-	this->m_unk0xf8 = LegoGameState::e_noArea;
+	m_destLocation = LegoGameState::e_undefined;
 }
 
 // FUNCTION: LEGO1 0x10018060
@@ -60,7 +60,7 @@ MxLong ElevatorBottom::Notify(MxParam& p_param)
 			ret = HandleClick((LegoControlManagerEvent&) p_param);
 			break;
 		case c_notificationTransitioned:
-			GameState()->SwitchArea(m_unk0xf8);
+			GameState()->SwitchArea(m_destLocation);
 			break;
 		}
 	}
@@ -84,12 +84,12 @@ MxLong ElevatorBottom::HandleClick(LegoControlManagerEvent& p_param)
 	if (p_param.GetUnknown0x28() == 1) {
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
-			m_unk0xf8 = LegoGameState::e_infodoor;
+			m_destLocation = LegoGameState::e_infodoor;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 2:
-			m_unk0xf8 = LegoGameState::e_infomain;
+			m_destLocation = LegoGameState::e_infomain;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
@@ -102,7 +102,7 @@ MxLong ElevatorBottom::HandleClick(LegoControlManagerEvent& p_param)
 			}
 
 			state->SetUnknown1c(1);
-			m_unk0xf8 = LegoGameState::e_elevride;
+			m_destLocation = LegoGameState::e_elevride;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			VariableTable()->SetVariable(g_varCAMERALOCATION, "LCAMZI1,90");
 			result = 1;
@@ -133,6 +133,6 @@ void ElevatorBottom::Enable(MxBool p_enable)
 MxBool ElevatorBottom::VTable0x64()
 {
 	DeleteObjects(&m_atom, 500, 999);
-	m_unk0xf8 = LegoGameState::e_infomain;
+	m_destLocation = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
@@ -16,7 +16,7 @@ GasStation::GasStation()
 {
 	m_unk0xf8 = 0;
 	m_state = NULL;
-	m_transitionDestination = LegoGameState::e_noArea;
+	m_destLocation = LegoGameState::e_undefined;
 	m_unk0x108 = 0;
 	m_unk0x104 = 0;
 	m_unk0x114 = 0;
@@ -100,7 +100,7 @@ MxLong GasStation::Notify(MxParam& p_param)
 			result = HandleClick((LegoControlManagerEvent&) p_param);
 			break;
 		case c_notificationTransitioned:
-			GameState()->SwitchArea(m_transitionDestination);
+			GameState()->SwitchArea(m_destLocation);
 			break;
 		}
 	}

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -50,11 +50,11 @@ MxLong HistoryBook::Notify(MxParam& p_param)
 	if (m_worldStarted) {
 		switch (((MxNotificationParam&) p_param).GetNotification()) {
 		case c_notificationButtonUp:
-			m_transitionDestination = LegoGameState::Area::e_infoscor;
+			m_destLocation = LegoGameState::Area::e_infoscor;
 			TransitionManager()->StartTransition(MxTransitionManager::TransitionType::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case c_notificationTransitioned:
-			GameState()->SwitchArea(m_transitionDestination);
+			GameState()->SwitchArea(m_destLocation);
 			break;
 		}
 	}
@@ -149,6 +149,6 @@ void HistoryBook::ReadyWorld()
 // FUNCTION: LEGO1 0x10082a10
 MxBool HistoryBook::VTable0x64()
 {
-	m_transitionDestination = LegoGameState::Area::e_infomain;
+	m_destLocation = LegoGameState::Area::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -1,7 +1,6 @@
 #include "hospital.h"
 
 #include "legocontrolmanager.h"
-#include "legogamestate.h"
 #include "legoinputmanager.h"
 #include "legoutils.h"
 #include "misc.h"
@@ -17,7 +16,7 @@ Hospital::Hospital()
 	m_unk0x100 = 0;
 	m_hospitalState = NULL;
 	m_unk0x108 = 0;
-	m_unk0xfc = 0;
+	m_destLocation = LegoGameState::e_undefined;
 	m_unk0x10c = 0;
 	m_unk0x110 = 0;
 	m_unk0x114 = 0;

--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -43,7 +43,7 @@ Infocenter::Infocenter()
 	m_unk0x11c = NULL;
 	m_infocenterState = NULL;
 	m_frameHotBitmap = NULL;
-	m_transitionDestination = LegoGameState::e_noArea;
+	m_destLocation = LegoGameState::e_undefined;
 	m_currentInfomainScript = InfomainScript::c_noneInfomain;
 	m_currentCutscene = e_noIntro;
 
@@ -174,10 +174,10 @@ MxLong Infocenter::Notify(MxParam& p_param)
 				StartCredits();
 				m_infocenterState->SetUnknown0x74(0xd);
 			}
-			else if (m_transitionDestination != 0) {
+			else if (m_destLocation != 0) {
 				BackgroundAudioManager()->RaiseVolume();
-				GameState()->SwitchArea(m_transitionDestination);
-				m_transitionDestination = LegoGameState::e_noArea;
+				GameState()->SwitchArea(m_destLocation);
+				m_destLocation = LegoGameState::e_undefined;
 			}
 			break;
 		}
@@ -439,7 +439,7 @@ void Infocenter::ReadyWorld()
 			}
 
 			m_infocenterState->SetUnknown0x74(5);
-			m_transitionDestination = LegoGameState::e_act2main;
+			m_destLocation = LegoGameState::e_act2main;
 
 			InfomainScript::Script script =
 				(InfomainScript::Script) m_infocenterState->GetReturnDialogue(GameState()->GetCurrentAct()).Next();
@@ -495,7 +495,7 @@ void Infocenter::ReadyWorld()
 			}
 
 			m_infocenterState->SetUnknown0x74(5);
-			m_transitionDestination = LegoGameState::e_act3script;
+			m_destLocation = LegoGameState::e_act3script;
 
 			InfomainScript::Script script =
 				(InfomainScript::Script) m_infocenterState->GetReturnDialogue(GameState()->GetCurrentAct()).Next();
@@ -764,37 +764,37 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 					break;
 				case 10:
 					if (m_selectedCharacter) {
-						m_transitionDestination = LegoGameState::e_jetraceExterior;
+						m_destLocation = LegoGameState::e_jetraceExterior;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 11:
 					if (m_selectedCharacter) {
-						m_transitionDestination = LegoGameState::e_carraceExterior;
+						m_destLocation = LegoGameState::e_carraceExterior;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 12:
 					if (m_selectedCharacter) {
-						m_transitionDestination = LegoGameState::e_pizzeriaExterior;
+						m_destLocation = LegoGameState::e_pizzeriaExterior;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 13:
 					if (m_selectedCharacter) {
-						m_transitionDestination = LegoGameState::e_garageExterior;
+						m_destLocation = LegoGameState::e_garageExterior;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 14:
 					if (m_selectedCharacter) {
-						m_transitionDestination = LegoGameState::e_hospitalExterior;
+						m_destLocation = LegoGameState::e_hospitalExterior;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
 				case 15:
 					if (m_selectedCharacter) {
-						m_transitionDestination = LegoGameState::e_policeExterior;
+						m_destLocation = LegoGameState::e_policeExterior;
 						m_infocenterState->SetUnknown0x74(5);
 					}
 					break;
@@ -811,7 +811,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				if (!m_infocenterState->HasRegistered()) {
 					m_infocenterState->SetUnknown0x74(2);
-					m_transitionDestination = LegoGameState::e_noArea;
+					m_destLocation = LegoGameState::e_undefined;
 					dialogueToPlay = InfomainScript::c_iic007in_PlayWav;
 				}
 				else {
@@ -882,7 +882,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
 				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
-				m_transitionDestination = LegoGameState::e_elevbott;
+				m_destLocation = LegoGameState::e_elevbott;
 			}
 			else {
 				MxU32 objectId = m_infocenterState->GetBricksterDialogue().Next();
@@ -897,7 +897,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
 				m_radio.Stop();
 				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
-				m_transitionDestination = LegoGameState::e_infoscor;
+				m_destLocation = LegoGameState::e_infoscor;
 			}
 			else {
 				MxU32 objectId = m_infocenterState->GetBricksterDialogue().Next();
@@ -949,7 +949,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 				case LegoGameState::e_regbook:
 				case LegoGameState::e_infoscor:
 					m_infocenterState->SetUnknown0x74(5);
-					m_transitionDestination = state->GetPreviousArea();
+					m_destLocation = state->GetPreviousArea();
 					actionToPlay =
 						(InfomainScript::Script) m_infocenterState->GetLeaveDialogue(GameState()->GetCurrentAct())
 							.Next();
@@ -961,7 +961,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 					if (state->GetActorId()) {
 						if (m_infocenterState->HasRegistered()) {
 							m_infocenterState->SetUnknown0x74(5);
-							m_transitionDestination = state->GetPreviousArea();
+							m_destLocation = state->GetPreviousArea();
 							actionToPlay = (InfomainScript::Script) m_infocenterState
 											   ->GetLeaveDialogue(GameState()->GetCurrentAct())
 											   .Next();
@@ -979,7 +979,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 				break;
 			case LegoGameState::e_act2:
 				m_infocenterState->SetUnknown0x74(5);
-				m_transitionDestination = LegoGameState::e_act2main;
+				m_destLocation = LegoGameState::e_act2main;
 				actionToPlay =
 					(InfomainScript::Script) m_infocenterState->GetLeaveDialogue(GameState()->GetCurrentAct()).Next();
 				InputManager()->DisableInputProcessing();
@@ -987,7 +987,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 				break;
 			case LegoGameState::e_act3:
 				m_infocenterState->SetUnknown0x74(5);
-				m_transitionDestination = LegoGameState::e_act3script;
+				m_destLocation = LegoGameState::e_act3script;
 				actionToPlay =
 					(InfomainScript::Script) m_infocenterState->GetLeaveDialogue(GameState()->GetCurrentAct()).Next();
 				InputManager()->DisableInputProcessing();
@@ -996,7 +996,7 @@ MxU8 Infocenter::HandleClick(LegoControlManagerEvent& p_param)
 			}
 			break;
 		case InfomainScript::c_Book_Ctl:
-			m_transitionDestination = LegoGameState::e_regbook;
+			m_destLocation = LegoGameState::e_regbook;
 			m_infocenterState->SetUnknown0x74(4);
 			actionToPlay = GameState()->GetCurrentAct() != LegoGameState::e_act1 ? InfomainScript::c_GoTo_RegBook_Red
 																				 : InfomainScript::c_GoTo_RegBook;
@@ -1303,8 +1303,8 @@ void Infocenter::Reset()
 	AnimationManager()->FUN_1005ee80(FALSE);
 	CharacterManager()->FUN_100832a0();
 	GameState()->SetCurrentAct(LegoGameState::e_act1);
-	GameState()->SetPreviousArea(LegoGameState::e_noArea);
-	GameState()->SetUnknown0x42c(LegoGameState::e_noArea);
+	GameState()->SetPreviousArea(LegoGameState::e_undefined);
+	GameState()->SetUnknown0x42c(LegoGameState::e_undefined);
 
 	InitializeBitmaps();
 	m_selectedCharacter = e_pepper;

--- a/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
@@ -18,7 +18,7 @@ DECOMP_SIZE_ASSERT(InfocenterDoor, 0xfc)
 // FUNCTION: LEGO1 0x10037730
 InfocenterDoor::InfocenterDoor()
 {
-	m_unk0xf8 = LegoGameState::e_noArea;
+	m_destLocation = LegoGameState::e_undefined;
 
 	NotificationManager()->Register(this);
 }
@@ -69,7 +69,7 @@ MxLong InfocenterDoor::Notify(MxParam& p_param)
 			result = HandleClick((LegoControlManagerEvent&) p_param);
 			break;
 		case c_notificationTransitioned:
-			GameState()->SwitchArea(m_unk0xf8);
+			GameState()->SwitchArea(m_destLocation);
 			result = 1;
 			break;
 		}
@@ -96,17 +96,17 @@ MxLong InfocenterDoor::HandleClick(LegoControlManagerEvent& p_param)
 
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
-			m_unk0xf8 = LegoGameState::e_infoscor;
+			m_destLocation = LegoGameState::e_infoscor;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 2:
-			m_unk0xf8 = LegoGameState::e_elevbott;
+			m_destLocation = LegoGameState::e_elevbott;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
 		case 3:
-			m_unk0xf8 = LegoGameState::e_infomain;
+			m_destLocation = LegoGameState::e_infomain;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			result = 1;
 			break;
@@ -114,7 +114,7 @@ MxLong InfocenterDoor::HandleClick(LegoControlManagerEvent& p_param)
 			if (GameState()->GetActorId()) {
 				InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
 				if (state->HasRegistered()) {
-					m_unk0xf8 = LegoGameState::e_unk4;
+					m_destLocation = LegoGameState::e_unk4;
 				}
 				else {
 					MxDSAction action;
@@ -165,6 +165,6 @@ void InfocenterDoor::Enable(MxBool p_enable)
 MxBool InfocenterDoor::VTable0x64()
 {
 	DeleteObjects(&m_atom, 500, 510);
-	m_unk0xf8 = LegoGameState::e_infomain;
+	m_destLocation = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -78,7 +78,7 @@ MxResult Isle::Create(MxDSAction& p_dsAction)
 		}
 
 		if (GameState()->GetCurrentArea() == LegoGameState::e_isle) {
-			GameState()->SetCurrentArea(LegoGameState::e_noArea);
+			GameState()->SetCurrentArea(LegoGameState::e_undefined);
 		}
 
 		LegoGameState* gameState = GameState();

--- a/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
@@ -77,7 +77,7 @@ MxLong JukeBox::Notify(MxParam& p_param)
 			result = HandleClick((LegoControlManagerEvent&) p_param);
 			break;
 		case c_notificationTransitioned:
-			GameState()->SwitchArea(m_transitionDestination);
+			GameState()->SwitchArea(m_destLocation);
 			result = 1;
 			break;
 		}
@@ -211,7 +211,7 @@ MxBool JukeBox::HandleClick(LegoControlManagerEvent& p_param)
 			LegoGameState* gameState = GameState();
 			Act1State* act1State = (Act1State*) gameState->GetState("Act1State");
 			act1State->SetUnknown18(11);
-			m_transitionDestination = LegoGameState::Area::e_unk54;
+			m_destLocation = LegoGameState::Area::e_unk54;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, 0, FALSE);
 			break;
 		}
@@ -255,6 +255,6 @@ MxResult JukeBox::Tickle()
 // FUNCTION: LEGO1 0x1005de70
 MxBool JukeBox::VTable0x64()
 {
-	m_transitionDestination = LegoGameState::e_infomain;
+	m_destLocation = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/worlds/police.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/police.cpp
@@ -18,7 +18,7 @@ DECOMP_SIZE_ASSERT(Police, 0x110)
 Police::Police()
 {
 	m_policeState = NULL;
-	m_transitionDestination = LegoGameState::e_noArea;
+	m_destLocation = LegoGameState::e_undefined;
 	NotificationManager()->Register(this);
 }
 
@@ -82,7 +82,7 @@ MxLong Police::Notify(MxParam& p_param)
 			result = HandleClick((LegoControlManagerEvent&) p_param);
 			break;
 		case c_notificationTransitioned:
-			GameState()->SwitchArea(m_transitionDestination);
+			GameState()->SwitchArea(m_destLocation);
 			break;
 		}
 	}
@@ -110,7 +110,7 @@ MxLong Police::HandleClick(LegoControlManagerEvent& p_param)
 			}
 
 			BackgroundAudioManager()->Stop();
-			m_transitionDestination = LegoGameState::Area::e_polidoor;
+			m_destLocation = LegoGameState::Area::e_polidoor;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Info_Ctl:
@@ -119,7 +119,7 @@ MxLong Police::HandleClick(LegoControlManagerEvent& p_param)
 			}
 
 			BackgroundAudioManager()->Stop();
-			m_transitionDestination = LegoGameState::Area::e_infomain;
+			m_destLocation = LegoGameState::Area::e_infomain;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Door_Ctl:
@@ -128,7 +128,7 @@ MxLong Police::HandleClick(LegoControlManagerEvent& p_param)
 			}
 
 			BackgroundAudioManager()->Stop();
-			m_transitionDestination = LegoGameState::Area::e_copter;
+			m_destLocation = LegoGameState::Area::e_copter;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Donut_Ctl:
@@ -190,6 +190,6 @@ void Police::Enable(MxBool p_enable)
 MxBool Police::VTable0x64()
 {
 	DeleteObjects(&m_atom, PoliceScript::c_nps001ni_RunAnim, 510);
-	m_transitionDestination = LegoGameState::e_infomain;
+	m_destLocation = LegoGameState::e_infomain;
 	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/worlds/score.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/score.cpp
@@ -21,7 +21,7 @@ DECOMP_SIZE_ASSERT(Score, 0x104)
 // FUNCTION: LEGO1 0x10001000
 Score::Score()
 {
-	m_unk0xf8 = LegoGameState::e_noArea;
+	m_destLocation = LegoGameState::e_undefined;
 	NotificationManager()->Register(this);
 }
 
@@ -100,8 +100,8 @@ MxLong Score::Notify(MxParam& p_param)
 			break;
 		case c_notificationTransitioned:
 			DeleteObjects(g_infoscorScript, 7, 9);
-			if (m_unk0xf8) {
-				GameState()->SwitchArea(m_unk0xf8);
+			if (m_destLocation) {
+				GameState()->SwitchArea(m_destLocation);
 			}
 			ret = 1;
 			break;
@@ -121,7 +121,7 @@ MxLong Score::FUN_10001510(MxEndActionNotificationParam& p_param)
 		MxU32 id = action->GetObjectId();
 		switch (action->GetObjectId()) {
 		case 10:
-			m_unk0xf8 = LegoGameState::e_histbook;
+			m_destLocation = LegoGameState::e_histbook;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 0x32, 0, 0);
 			break;
 		case 0x1f5:
@@ -165,12 +165,12 @@ MxLong Score::FUN_100016d0(LegoControlManagerEvent& p_param)
 	if (l == 1 || p_param.GetClickedObjectId() == 4) {
 		switch (p_param.GetClickedObjectId()) {
 		case 1:
-			m_unk0xf8 = LegoGameState::e_infomain;
+			m_destLocation = LegoGameState::e_infomain;
 			DeleteScript();
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 0x32, 0, 0);
 			break;
 		case 2:
-			m_unk0xf8 = LegoGameState::e_infodoor;
+			m_destLocation = LegoGameState::e_infodoor;
 			DeleteScript();
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 0x32, 0, 0);
 			break;
@@ -332,6 +332,6 @@ void Score::FillArea(MxU32 p_x, MxU32 p_y, MxS16 p_color)
 MxBool Score::VTable0x64()
 {
 	DeleteScript();
-	m_unk0xf8 = LegoGameState::e_infomain;
+	m_destLocation = LegoGameState::e_infomain;
 	return TRUE;
 }


### PR DESCRIPTION
An assert in the Beta 1.0 debug build reveals the real name of the `e_noArea` enum value, and the `LegoWorld` derived class members that use this enum to track their destination location:

![image](https://github.com/isledecomp/isle/assets/64166386/e2d44e3b-8583-4353-9498-13fa74dde3f8)

I've renamed all instances of `m_transitionDestination` here to reflect the real member name. Some of these members were still labeled as `unk`, and so I've corrected all of them to use `m_destLocation`.