### PR TITLE
Implement MxMemoryPool

### DIFF
--- a/LEGO1/omni/include/mxbitset.h
+++ b/LEGO1/omni/include/mxbitset.h
@@ -11,83 +11,84 @@
 template <size_t N>
 class MxBitset {
 public:
-	MxBitset() { _Tidy(); }
+	MxBitset() { Tidy(); }
 
-	class reference {
+	class Reference {
 		friend class MxBitset<N>;
 
 	public:
-		reference& flip()
+		Reference& Flip()
 		{
-			m_bitset->flip(m_offset);
+			m_bitset->Flip(m_offset);
 			return (*this);
 		}
-		bool operator~() const { return (!m_bitset->test(m_offset)); }
-		operator bool() const { return (m_bitset->test(m_offset)); }
+		bool operator~() const { return (!m_bitset->Test(m_offset)); }
+		operator bool() const { return (m_bitset->Test(m_offset)); }
 
 	private:
-		reference(MxBitset<N>& _X, size_t _P) : m_bitset(&_X), m_offset(_P) {}
+		Reference(MxBitset<N>& p_bitset, size_t p_offset) : m_bitset(&p_bitset), m_offset(p_offset) {}
 		MxBitset<N>* m_bitset;
 		size_t m_offset;
 	};
 
-	reference operator[](size_t p_bit) { return (reference(*this, p_bit)); }
+	Reference operator[](size_t p_bit) { return (Reference(*this, p_bit)); }
 
-	MxBitset<N>& flip(size_t p_bit)
+	MxBitset<N>& Flip(size_t p_bit)
 	{
 		if (N <= p_bit) {
-			_Xran();
+			Xran();
 		}
-		m_blocks[p_bit / _bits_per_block] ^= 1 << p_bit % _bits_per_block;
+		m_blocks[p_bit / e_bitsPerBlock] ^= 1 << p_bit % e_bitsPerBlock;
 		return (*this);
 	}
 
-	size_t count()
+	size_t Count()
 	{
 		// debug only
 		return 0;
 	}
 
-	bool test(MxU32 p_bit)
+	bool Test(MxU32 p_bit)
 	{
 		if (p_bit >= N) {
-			_Xran();
+			Xran();
 		}
 
-		return (m_blocks[p_bit / _bits_per_block] & (1 << p_bit % _bits_per_block)) != 0;
+		return (m_blocks[p_bit / e_bitsPerBlock] & (1 << p_bit % e_bitsPerBlock)) != 0;
 	}
 
-	MxU32 size() const { return N; }
+	MxU32 Size() const { return N; }
 
 private:
-	void _Tidy(MxU32 p_value = 0)
+	void Tidy(MxU32 p_value = 0)
 	{
-		for (MxS32 i = _blocks_required; i >= 0; --i) {
+		for (MxS32 i = e_blocksRequired; i >= 0; --i) {
 			m_blocks[i] = p_value;
 		}
 
 		// No need to trim if all bits were zeroed out
 		if (p_value != 0) {
-			_Trim();
+			Trim();
 		}
 	}
 
 	// Apply bit mask to most significant block
-	void _Trim()
+	void Trim()
 	{
-		if (N % _bits_per_block != 0) {
-			m_blocks[_blocks_required] &= ((1 << (N % _bits_per_block)) - 1);
+		if (N % e_bitsPerBlock != 0) {
+			m_blocks[e_blocksRequired] &= ((1 << (N % e_bitsPerBlock)) - 1);
 		}
 	}
 
-	void _Xran() { assert("invalid MxBitset<N> position" == NULL); }
+	void Xran() { assert("invalid MxBitset<N> position" == NULL); }
 
+	// Not a real enum. This is how STL BITSET defines these constants.
 	enum {
-		_bits_per_block = CHAR_BIT * sizeof(MxU32),
-		_blocks_required = N == 0 ? 0 : (N - 1) / _bits_per_block
+		e_bitsPerBlock = CHAR_BIT * sizeof(MxU32),
+		e_blocksRequired = N == 0 ? 0 : (N - 1) / e_bitsPerBlock
 	};
 
-	MxU32 m_blocks[_blocks_required + 1]; // 0x0
+	MxU32 m_blocks[e_blocksRequired + 1]; // 0x0
 };
 
 #endif // MXBITSET_H

--- a/LEGO1/omni/include/mxbitset.h
+++ b/LEGO1/omni/include/mxbitset.h
@@ -1,0 +1,93 @@
+#ifndef MXBITSET_H
+#define MXBITSET_H
+
+#pragma warning(disable : 4237)
+
+#include "mxtypes.h"
+
+#include <assert.h>
+#include <limits.h> // CHAR_BIT
+
+template <size_t N>
+class MxBitset {
+public:
+	MxBitset() { _Tidy(); }
+
+	class reference {
+		friend class MxBitset<N>;
+
+	public:
+		reference& flip()
+		{
+			m_bitset->flip(m_offset);
+			return (*this);
+		}
+		bool operator~() const { return (!m_bitset->test(m_offset)); }
+		operator bool() const { return (m_bitset->test(m_offset)); }
+
+	private:
+		reference(MxBitset<N>& _X, size_t _P) : m_bitset(&_X), m_offset(_P) {}
+		MxBitset<N>* m_bitset;
+		size_t m_offset;
+	};
+
+	reference operator[](size_t p_bit) { return (reference(*this, p_bit)); }
+
+	MxBitset<N>& flip(size_t p_bit)
+	{
+		if (N <= p_bit) {
+			_Xran();
+		}
+		m_blocks[p_bit / _bits_per_block] ^= 1 << p_bit % _bits_per_block;
+		return (*this);
+	}
+
+	size_t count()
+	{
+		// debug only
+		return 0;
+	}
+
+	bool test(MxU32 p_bit)
+	{
+		if (p_bit >= N) {
+			_Xran();
+		}
+
+		return (m_blocks[p_bit / _bits_per_block] & (1 << p_bit % _bits_per_block)) != 0;
+	}
+
+	MxU32 size() const { return N; }
+
+private:
+	void _Tidy(MxU32 p_value = 0)
+	{
+		for (MxS32 i = _blocks_required; i >= 0; --i) {
+			m_blocks[i] = p_value;
+		}
+
+		// No need to trim if all bits were zeroed out
+		if (p_value != 0) {
+			_Trim();
+		}
+	}
+
+	// Apply bit mask to most significant block
+	void _Trim()
+	{
+		if (N % _bits_per_block != 0) {
+			m_blocks[_blocks_required] &= ((1 << (N % _bits_per_block)) - 1);
+		}
+	}
+
+	void _Xran() { assert("invalid MxBitset<N> position" == NULL); }
+
+	enum {
+		_bits_per_block = CHAR_BIT * sizeof(MxU32),
+		_blocks_required = N == 0 ? 0 : (N - 1) / _bits_per_block
+	};
+
+	MxU32 m_blocks[_blocks_required + 1]; // 0x0
+};
+
+#endif // MXBITSET_H

--- a/LEGO1/omni/include/mxbitset.h
+++ b/LEGO1/omni/include/mxbitset.h
@@ -13,6 +13,7 @@ class MxBitset {
 public:
 	MxBitset() { Tidy(); }
 
+	// SIZE 0x8
 	class Reference {
 		friend class MxBitset<N>;
 
@@ -27,8 +28,8 @@ public:
 
 	private:
 		Reference(MxBitset<N>& p_bitset, size_t p_offset) : m_bitset(&p_bitset), m_offset(p_offset) {}
-		MxBitset<N>* m_bitset;
-		size_t m_offset;
+		MxBitset<N>* m_bitset; // 0x00
+		size_t m_offset;       // 0x04
 	};
 
 	Reference operator[](size_t p_bit) { return (Reference(*this, p_bit)); }
@@ -44,7 +45,7 @@ public:
 
 	size_t Count()
 	{
-		// debug only
+		// debug only, intentionally unimplemented
 		return 0;
 	}
 
@@ -88,7 +89,7 @@ private:
 		e_blocksRequired = N == 0 ? 0 : (N - 1) / e_bitsPerBlock
 	};
 
-	MxU32 m_blocks[e_blocksRequired + 1]; // 0x0
+	MxU32 m_blocks[e_blocksRequired + 1]; // 0x00
 };
 
 #endif // MXBITSET_H

--- a/LEGO1/omni/include/mxbitset.h
+++ b/LEGO1/omni/include/mxbitset.h
@@ -13,7 +13,7 @@ class MxBitset {
 public:
 	MxBitset() { Tidy(); }
 
-	// SIZE 0x8
+	// SIZE 0x08
 	class Reference {
 		friend class MxBitset<N>;
 

--- a/LEGO1/omni/include/mxdsbuffer.h
+++ b/LEGO1/omni/include/mxdsbuffer.h
@@ -66,7 +66,7 @@ public:
 	inline MxU8* GetBuffer() { return m_pBuffer; }
 	inline MxU8** GetBufferRef() { return &m_pBuffer; }
 	inline undefined4 GetUnknown14() { return m_unk0x14; }
-	inline MxU16 GetRefCount() { return m_refcount; }
+	inline MxU16 GetRefCount() { return m_referenceCount; }
 	inline Type GetMode() { return m_mode; }
 	inline MxU32 GetWriteOffset() { return m_writeOffset; }
 	inline MxU32 GetBytesRemaining() { return m_bytesRemaining; }
@@ -85,7 +85,7 @@ private:
 	undefined4 m_unk0x14;           // 0x14
 	undefined4 m_unk0x18;           // 0x18
 	undefined4 m_unk0x1c;           // 0x1c
-	MxU16 m_refcount;               // 0x20
+	MxU16 m_referenceCount;         // 0x20
 	Type m_mode;                    // 0x24
 	MxU32 m_writeOffset;            // 0x28
 	MxU32 m_bytesRemaining;         // 0x2c

--- a/LEGO1/omni/include/mxmemorypool.h
+++ b/LEGO1/omni/include/mxmemorypool.h
@@ -10,7 +10,7 @@
 template <size_t BS, size_t NB>
 class MxMemoryPool {
 public:
-	MxMemoryPool() : m_pool(NULL), m_blockSize(BS){};
+	MxMemoryPool() : m_pool(NULL), m_blockSize(BS) {}
 	~MxMemoryPool() { delete[] m_pool; }
 
 	MxResult Allocate();
@@ -20,9 +20,9 @@ public:
 	MxU32 GetPoolSize() const { return m_blockRef.Size(); }
 
 private:
-	MxU8* m_pool;
-	MxU32 m_blockSize;
-	MxBitset<NB> m_blockRef;
+	MxU8* m_pool;            // 0x00
+	MxU32 m_blockSize;       // 0x04
+	MxBitset<NB> m_blockRef; // 0x08
 };
 
 template <size_t BS, size_t NB>

--- a/LEGO1/omni/include/mxmemorypool.h
+++ b/LEGO1/omni/include/mxmemorypool.h
@@ -1,0 +1,86 @@
+#ifndef MXMEMORYPOOL_H
+#define MXMEMORYPOOL_H
+
+#include "decomp.h"
+#include "mxbitset.h"
+#include "mxtypes.h"
+
+#include <assert.h>
+
+template <size_t BS, size_t NB>
+class MxMemoryPool {
+public:
+	MxMemoryPool() : m_pool(NULL), m_blockSize(BS){};
+	~MxMemoryPool() { delete[] m_pool; }
+
+	MxResult Allocate();
+	MxU8* Get();
+	void Release(MxU8*);
+
+	MxU32 GetPoolSize() const { return m_blockRef.size(); }
+
+private:
+	MxU8* m_pool;
+	MxU32 m_blockSize;
+	MxBitset<NB> m_blockRef;
+};
+
+template <size_t BS, size_t NB>
+MxResult MxMemoryPool<BS, NB>::Allocate()
+{
+	assert(m_pool == NULL);
+	assert(m_blockSize);
+	assert(m_blockRef.size());
+
+	m_pool = new MxU8[GetPoolSize() * m_blockSize * 1024];
+	assert(m_pool);
+
+	return m_pool ? SUCCESS : FAILURE;
+}
+
+template <size_t BS, size_t NB>
+MxU8* MxMemoryPool<BS, NB>::Get()
+{
+	assert(m_pool != NULL);
+	assert(m_blockSize);
+	assert(m_blockRef.size());
+
+	for (MxU32 i = 0; i < GetPoolSize(); i++) {
+		if (!m_blockRef[i]) {
+			m_blockRef[i].flip();
+
+#ifdef _DEBUG
+			// TODO: This is actually some debug print function, but
+			// we just need any func with variatic args to eliminate diff noise.
+			printf("Get> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.count());
+#endif
+
+			return &m_pool[i * m_blockSize * 1024];
+		}
+	}
+
+	return NULL;
+}
+
+template <size_t BS, size_t NB>
+void MxMemoryPool<BS, NB>::Release(MxU8* p_buf)
+{
+	assert(m_pool != NULL);
+	assert(m_blockSize);
+	assert(m_blockRef.size());
+
+	MxU32 i = (MxU32) (p_buf - m_pool) / (m_blockSize * 1024);
+
+	assert(i >= 0 && i < GetPoolSize());
+	assert(m_blockRef[i]);
+
+	if (m_blockRef[i]) {
+		m_blockRef[i].flip();
+	}
+
+#ifdef _DEBUG
+	printf("Release> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.count());
+#endif
+}
+
+#endif // MXMEMORYPOOL_H

--- a/LEGO1/omni/include/mxmemorypool.h
+++ b/LEGO1/omni/include/mxmemorypool.h
@@ -17,7 +17,7 @@ public:
 	MxU8* Get();
 	void Release(MxU8*);
 
-	MxU32 GetPoolSize() const { return m_blockRef.size(); }
+	MxU32 GetPoolSize() const { return m_blockRef.Size(); }
 
 private:
 	MxU8* m_pool;
@@ -30,7 +30,7 @@ MxResult MxMemoryPool<BS, NB>::Allocate()
 {
 	assert(m_pool == NULL);
 	assert(m_blockSize);
-	assert(m_blockRef.size());
+	assert(m_blockRef.Size());
 
 	m_pool = new MxU8[GetPoolSize() * m_blockSize * 1024];
 	assert(m_pool);
@@ -43,16 +43,16 @@ MxU8* MxMemoryPool<BS, NB>::Get()
 {
 	assert(m_pool != NULL);
 	assert(m_blockSize);
-	assert(m_blockRef.size());
+	assert(m_blockRef.Size());
 
 	for (MxU32 i = 0; i < GetPoolSize(); i++) {
 		if (!m_blockRef[i]) {
-			m_blockRef[i].flip();
+			m_blockRef[i].Flip();
 
 #ifdef _DEBUG
 			// TODO: This is actually some debug print function, but
 			// we just need any func with variatic args to eliminate diff noise.
-			printf("Get> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.count());
+			printf("Get> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
 #endif
 
 			return &m_pool[i * m_blockSize * 1024];
@@ -67,7 +67,7 @@ void MxMemoryPool<BS, NB>::Release(MxU8* p_buf)
 {
 	assert(m_pool != NULL);
 	assert(m_blockSize);
-	assert(m_blockRef.size());
+	assert(m_blockRef.Size());
 
 	MxU32 i = (MxU32) (p_buf - m_pool) / (m_blockSize * 1024);
 
@@ -75,11 +75,11 @@ void MxMemoryPool<BS, NB>::Release(MxU8* p_buf)
 	assert(m_blockRef[i]);
 
 	if (m_blockRef[i]) {
-		m_blockRef[i].flip();
+		m_blockRef[i].Flip();
 	}
 
 #ifdef _DEBUG
-	printf("Release> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.count());
+	printf("Release> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
 #endif
 }
 

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -4,50 +4,13 @@
 #include "decomp.h"
 #include "mxcore.h"
 #include "mxdsobject.h"
+#include "mxmemorypool.h"
 #include "mxnotificationparam.h"
 #include "mxstreamcontroller.h"
 #include "mxtypes.h"
 
+#include <assert.h>
 #include <list>
-
-// NOTE: This feels like some kind of templated class, maybe something from the
-//       STL. But I haven't figured out what yet (it's definitely not a vector).
-class MxStreamerSubClass1 {
-public:
-	inline MxStreamerSubClass1(undefined4 p_size)
-	{
-		m_buffer = NULL;
-		m_size = p_size;
-		undefined4* ptr = &m_unk0x08;
-		for (int i = 0; i >= 0; i--) {
-			ptr[i] = 0;
-		}
-	}
-
-	// FUNCTION: LEGO1 0x100b9110
-	~MxStreamerSubClass1() { delete[] m_buffer; }
-
-	undefined4 GetSize() const { return m_size; }
-
-	void SetBuffer(undefined* p_buf) { m_buffer = p_buf; }
-	inline undefined* GetBuffer() const { return m_buffer; }
-	inline undefined* GetUnk08Ref() const { return (undefined*) &m_unk0x08; }
-
-private:
-	undefined* m_buffer;
-	undefined4 m_size;
-	undefined4 m_unk0x08;
-};
-
-class MxStreamerSubClass2 : public MxStreamerSubClass1 {
-public:
-	inline MxStreamerSubClass2() : MxStreamerSubClass1(0x40) {}
-};
-
-class MxStreamerSubClass3 : public MxStreamerSubClass1 {
-public:
-	inline MxStreamerSubClass3() : MxStreamerSubClass1(0x80) {}
-};
 
 // VTABLE: LEGO1 0x100dc760
 class MxStreamerNotification : public MxNotificationParam {
@@ -105,19 +68,56 @@ public:
 	MxResult FUN_100b99b0(MxDSAction* p_action);
 	MxResult DeleteObject(MxDSAction* p_dsAction);
 
-	inline const MxStreamerSubClass2& GetSubclass1() { return m_subclass1; }
-	inline const MxStreamerSubClass3& GetSubclass2() { return m_subclass2; }
+	MxU8* GetMemoryBlock(MxU32 p_blockSize)
+	{
+		switch (p_blockSize) {
+		case 0x40:
+			return m_pool1.Get();
+
+		case 0x80:
+			return m_pool2.Get();
+
+		default:
+			assert("Invalid block size for memory pool" == NULL);
+			break;
+		}
+
+		return NULL;
+	}
+
+	void ReleaseMemoryBlock(MxU8* p_block, MxU32 p_blockSize)
+	{
+		switch (p_blockSize) {
+		case 0x40:
+			m_pool1.Release(p_block);
+			break;
+
+		case 0x80:
+			m_pool2.Release(p_block);
+			break;
+
+		default:
+			assert("Invalid block size for memory pool" == NULL);
+			break;
+		}
+	}
 
 private:
 	list<MxStreamController*> m_openStreams; // 0x08
-	MxStreamerSubClass2 m_subclass1;         // 0x14
-	MxStreamerSubClass3 m_subclass2;         // 0x20
+	MxMemoryPool<0x40, 22> m_pool1;          // 0x14
+	MxMemoryPool<0x80, 2> m_pool2;           // 0x20
 };
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100b9090
 // list<MxStreamController *,allocator<MxStreamController *> >::~list<MxStreamController *,allocator<MxStreamController *> >
 // clang-format on
+
+// TEMPLATE: LEGO1 0x100b9100
+// MxMemoryPool<64,22>::~MxMemoryPool<64,22>
+
+// TEMPLATE: LEGO1 0x100b9110
+// MxMemoryPool<128,2>::~MxMemoryPool<128,2>
 
 // SYNTHETIC: LEGO1 0x100b9120
 // MxStreamer::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -12,6 +12,9 @@
 #include <assert.h>
 #include <list>
 
+typedef MxMemoryPool<64, 22> MxMemoryPool64;
+typedef MxMemoryPool<128, 2> MxMemoryPool128;
+
 // VTABLE: LEGO1 0x100dc760
 class MxStreamerNotification : public MxNotificationParam {
 public:
@@ -72,10 +75,10 @@ public:
 	{
 		switch (p_blockSize) {
 		case 0x40:
-			return m_pool1.Get();
+			return m_pool64.Get();
 
 		case 0x80:
-			return m_pool2.Get();
+			return m_pool128.Get();
 
 		default:
 			assert("Invalid block size for memory pool" == NULL);
@@ -89,11 +92,11 @@ public:
 	{
 		switch (p_blockSize) {
 		case 0x40:
-			m_pool1.Release(p_block);
+			m_pool64.Release(p_block);
 			break;
 
 		case 0x80:
-			m_pool2.Release(p_block);
+			m_pool128.Release(p_block);
 			break;
 
 		default:
@@ -104,8 +107,8 @@ public:
 
 private:
 	list<MxStreamController*> m_openStreams; // 0x08
-	MxMemoryPool<0x40, 22> m_pool1;          // 0x14
-	MxMemoryPool<0x80, 2> m_pool2;           // 0x20
+	MxMemoryPool64 m_pool64;                 // 0x14
+	MxMemoryPool128 m_pool128;               // 0x20
 };
 
 // clang-format off

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -18,17 +18,11 @@ MxStreamer::MxStreamer()
 // FUNCTION: LEGO1 0x100b9190
 MxResult MxStreamer::Create()
 {
-	undefined* b = new undefined[m_subclass1.GetSize() * 0x5800];
-	m_subclass1.SetBuffer(b);
-	if (b) {
-		b = new undefined[m_subclass2.GetSize() * 0x800];
-		m_subclass2.SetBuffer(b);
-		if (b) {
-			return SUCCESS;
-		}
+	if (m_pool1.Allocate() || m_pool2.Allocate()) {
+		return FAILURE;
 	}
 
-	return FAILURE;
+	return SUCCESS;
 }
 
 // FUNCTION: LEGO1 0x100b91d0

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -8,10 +8,10 @@
 #include <algorithm>
 
 DECOMP_SIZE_ASSERT(MxStreamer, 0x2c);
-DECOMP_SIZE_ASSERT(MxMemoryPool64, 0xc);
-DECOMP_SIZE_ASSERT(MxMemoryPool128, 0xc);
-DECOMP_SIZE_ASSERT(MxBitset<22>, 0x4);
-DECOMP_SIZE_ASSERT(MxBitset<2>, 0x4);
+DECOMP_SIZE_ASSERT(MxMemoryPool64, 0x0c);
+DECOMP_SIZE_ASSERT(MxMemoryPool128, 0x0c);
+DECOMP_SIZE_ASSERT(MxBitset<22>, 0x04);
+DECOMP_SIZE_ASSERT(MxBitset<2>, 0x04);
 
 // FUNCTION: LEGO1 0x100b8f00
 MxStreamer::MxStreamer()

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -8,6 +8,10 @@
 #include <algorithm>
 
 DECOMP_SIZE_ASSERT(MxStreamer, 0x2c);
+DECOMP_SIZE_ASSERT(MxMemoryPool64, 0xc);
+DECOMP_SIZE_ASSERT(MxMemoryPool128, 0xc);
+DECOMP_SIZE_ASSERT(MxBitset<22>, 0x4);
+DECOMP_SIZE_ASSERT(MxBitset<2>, 0x4);
 
 // FUNCTION: LEGO1 0x100b8f00
 MxStreamer::MxStreamer()
@@ -18,7 +22,7 @@ MxStreamer::MxStreamer()
 // FUNCTION: LEGO1 0x100b9190
 MxResult MxStreamer::Create()
 {
-	if (m_pool1.Allocate() || m_pool2.Allocate()) {
+	if (m_pool64.Allocate() || m_pool128.Allocate()) {
 		return FAILURE;
 	}
 


### PR DESCRIPTION
Another insight from the beta. The MxStreamer class has two nearly identical members with a constructor that does some odd things:
```cpp
    inline MxStreamerSubClass1(undefined4 p_size)
    {
        m_buffer = NULL;
        m_size = p_size;
        undefined4* ptr = &m_unk0x08;
        for (int i = 0; i >= 0; i--) {
            ptr[i] = 0;
        }
    }
```

They are referenced in MxDSBuffer where there is equally strange bit twiddling in AllocateBuffer and the destructor.

The beta showed that the two members of MxStreamer are MxMemoryPool objects, wrappers around an MxBitset datatype. STL `bitset` provides a convenient way to access and flip individual bits while using a minimal memory footprint. MxBitset is just a reimplementation of that, and I copied most of the structure from the STL file, as I assume Mindscape did. This is almost entirely inlined in the retail LEGO1, but I confirmed that they did _not_ switch to using the STL version because doing so adds more code.

I made the required changes to MxDSBuffer and MxStreamer and the result looks very good. The functions that decreased in MxDSBuffer are definite entropy; they go back to normal when I add one of the weirdo code blocks. e.g.: (credit @foxtacles )
```cpp
class X {
  int y;
  inline void QWE() {}
};
```