### PR TITLE
Make reccmp more compatible with debug builds

### DIFF
--- a/tools/isledecomp/tests/test_islebin.py
+++ b/tools/isledecomp/tests/test_islebin.py
@@ -144,3 +144,9 @@ THUNKS = (
 @pytest.mark.parametrize("thunk_ref", THUNKS)
 def test_thunks(thunk_ref: Tuple[int, int], binfile: IsleBin):
     assert thunk_ref in binfile.thunks
+
+
+def test_exports(binfile: IsleBin):
+    assert len(binfile.exports) == 130
+    assert (0x1003BFB0, b"??0LegoBackgroundColor@@QAE@PBD0@Z") in binfile.exports
+    assert (0x10091EE0, b"_DllMain@12") in binfile.exports


### PR DESCRIPTION
Some small changes to make it easier to run `reccmp` against any of the beta builds. Should not affect our work with the retail files.

First: When `reccmp` scans the decomp markers/annotations in the code files, we focus only on the ones that match our "module name". e.g. `LEGO1` vs `ISLE`. We currently decide the module name for this session by looking at the base file name of the PDB that you provided.

This change reverts back to using the base file name of the original binary. This is how `reccmp` worked in the original script; I changed it to use the PDB filename at some point and I don't remember why. In practice, when comparing the retail files, this doesn't matter. The name will always be one of `("CONFIG", "ISLE", "LEGO1")` but this gets tricky as we introduce new files.

We haven't established any naming convention for any of the beta files, and I don't know whether we plan to commit any of the annotations to the repo. On my system I renamed `LEGO1D.DLL` to `BETA10.DLL` and so I've been using `BETA10` in my annotations. Using the original binary name as the basis for module name makes this possible; your build artifact will probably still be `LEGO1.DLL` regardless of the build mode.

Second: Because we are starting from scratch with the beta files, `reccmp` will now automatically match any exported symbols between the orig and recomp files. This is a simple string match against the mangled/decorated name. This is not much in the grand scheme of things, but it is helpful. The public getter functions from `MxMisc` are used pretty frequently.