### PR TITLE
refactor action headers

### DIFF
--- a/LEGO1/lego/legoomni/include/actions/isle_actions.h
+++ b/LEGO1/lego/legoomni/include/actions/isle_actions.h
@@ -2014,7 +2014,14 @@ enum Script {
 	c_frt139df_7_sfx = 2002,
 	c_frt139df_8_sfx = 2003,
 	c_frt139df_9_sfx = 2004,
-	c_frt139df_10_sfx = 2005,
+	c_frt139df_10_sfx = 2005
+};
+
+#ifdef COMPAT_MODE
+enum Script2 : int {
+#else
+enum Script2 {
+#endif
 	c_frt139df_11_sfx = 2006,
 	c_frt139df_12_sfx = 2007,
 	c_frt139df_13_sfx = 2008,
@@ -2439,12 +2446,6 @@ enum Script {
 	c_hho141cl_Pho_684 = 2427,
 	c_hho142cl_0_sfx = 2428,
 	c_hho142cl_1_sfx = 2429,
-};
-#ifdef COMPAT_MODE
-enum Script2 : int {
-#else
-enum Script2 {
-#endif
 	c_hho142cl_2_sfx = 2430,
 	c_hho142cl_3_sfx = 2431,
 	c_hho142cl_4_sfx = 2432,
@@ -3681,7 +3682,7 @@ enum Script2 {
 	c_srt004in_Anim = 3663,
 	c_IRTX08RA_Wav_868 = 3664,
 	c_nrtflag0_Anim = 3665,
-	c_WNS050P1_Wav_X = 3666,
+	c_WNS050P1_Wav_3666 = 3666,
 	c_wns050p1_0_sfx = 3667,
 	c_wns050p1_1_sfx = 3668,
 	c_wns050p1_Anim = 3669,
@@ -3693,7 +3694,7 @@ enum Script2 {
 	c_wns046mg_Anim = 3675,
 	c_wns051bd_Anim = 3676,
 	c_pns122pr_Anim = 3677,
-	c_WNS050P1_Wav = 3678,
+	c_WNS050P1_Wav_3678 = 3678,
 	c_pns050p1_Anim = 3679,
 	c_pns069pr_Anim = 3680,
 	c_pns066db_Anim = 3681,


### PR DESCRIPTION
This PR refactors the action headers by regenerating them with the latest actionheadergen, which includes several changes. There is only one actual diff due to the manual refactoring done in #683, but I'll give context to what changed regardless:

* Duplicates are now properly removed by not assuming they were always in pairs.
* Enums now split into two at 2000 entries (not action IDs, these can sometimes be mutually exclusive). This prevents compiler errors from the parsing of giant enums.
* Conditional compilation was added so these enums can be forward declared.