### PR TITLE
Implement/match Isle::HandleEndAction and Isle::HandleElevatorEndAction

### DIFF
--- a/LEGO1/lego/legoomni/include/act1state.h
+++ b/LEGO1/lego/legoomni/include/act1state.h
@@ -101,7 +101,7 @@ protected:
 	MxS32 m_unk0x014;             // 0x014
 	MxU32 m_unk0x018;             // 0x018
 	MxS16 m_elevFloor;            // 0x01c
-	undefined m_unk0x01e;         // 0x01e
+	MxBool m_unk0x01e;            // 0x01e
 	MxBool m_unk0x01f;            // 0x01f
 	MxBool m_planeActive;         // 0x020
 	undefined m_unk0x021;         // 0x021

--- a/LEGO1/lego/legoomni/include/isle.h
+++ b/LEGO1/lego/legoomni/include/isle.h
@@ -78,10 +78,11 @@ public:
 	void Enable(MxBool p_enable) override;           // vtable+68
 	virtual void VTable0x6c(IslePathActor* p_actor); // vtable+6c
 
-	MxLong StopAction(MxParam& p_param);
+	MxLong HandleEndAction(MxEndActionNotificationParam& p_param);
 	MxLong HandleClick(LegoControlManagerEvent& p_param);
 	MxLong HandleType19Notification(MxParam& p_param);
 	MxLong HandleTransitionEnd();
+	void HandleElevatorEndAction();
 	void FUN_10031590();
 	void FUN_10032620();
 	void FUN_100330e0();

--- a/LEGO1/lego/legoomni/include/jukeboxentity.h
+++ b/LEGO1/lego/legoomni/include/jukeboxentity.h
@@ -3,6 +3,15 @@
 
 #include "legoentity.h"
 
+namespace JukeboxScript
+{
+#ifdef COMPAT_MODE
+enum Script : int;
+#else
+enum Script;
+#endif
+} // namespace JukeboxScript
+
 // VTABLE: LEGO1 0x100da8a0
 // SIZE 0x6c
 class JukeBoxEntity : public LegoEntity {
@@ -26,7 +35,7 @@ public:
 	}
 
 	void StartAction();
-	void StopAction(MxU32 p_state);
+	void StopAction(JukeboxScript::Script p_script);
 
 	inline MxBool IsBackgroundAudioEnabled() { return m_audioEnabled; }
 

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -17,6 +17,15 @@ struct ColorStringStruct {
 	const char* m_colorName;
 };
 
+namespace JukeboxScript
+{
+#ifdef COMPAT_MODE
+enum Script : int;
+#else
+enum Script;
+#endif
+} // namespace JukeboxScript
+
 // SIZE 0x430
 class LegoGameState {
 public:
@@ -159,7 +168,7 @@ public:
 	inline Act GetLoadedAct() { return m_loadedAct; }
 	inline Area GetCurrentArea() { return m_currentArea; }
 	inline Area GetPreviousArea() { return m_previousArea; }
-	inline MxU32 GetUnknown0x41c() { return m_unk0x41c; }
+	inline JukeboxScript::Script GetUnknown0x41c() { return m_unk0x41c; }
 	inline Area GetUnknown0x42c() { return m_unk0x42c; }
 	inline History* GetHistory() { return &m_history; }
 
@@ -167,7 +176,7 @@ public:
 	inline void SetCurrentArea(Area p_currentArea) { m_currentArea = p_currentArea; }
 	inline void SetPreviousArea(Area p_previousArea) { m_previousArea = p_previousArea; }
 	inline void SetActorId(MxU8 p_actorId) { m_actorId = p_actorId; }
-	inline void SetUnknown0x41c(undefined4 p_unk0x41c) { m_unk0x41c = p_unk0x41c; }
+	inline void SetUnknown0x41c(JukeboxScript::Script p_unk0x41c) { m_unk0x41c = p_unk0x41c; }
 	inline void SetUnknown0x42c(Area p_unk0x42c) { m_unk0x42c = p_unk0x42c; }
 	inline Username* GetPlayersIndex(MxS32 p_index) { return &m_players[p_index]; }
 	inline MxS16 GetPlayerCount() { return m_playerCount; }
@@ -202,10 +211,10 @@ public:
 	Username m_players[9]; // 0x28
 
 private:
-	History m_history;     // 0xa6
-	undefined2 m_unk0x41a; // 0x41a
-	undefined4 m_unk0x41c; // 0x41c
-	MxBool m_isDirty;      // 0x420
+	History m_history;                // 0xa6
+	undefined2 m_unk0x41a;            // 0x41a
+	JukeboxScript::Script m_unk0x41c; // 0x41c
+	MxBool m_isDirty;                 // 0x420
 
 public:
 	Area m_currentArea;  // 0x424

--- a/LEGO1/lego/legoomni/src/act1/act1state.cpp
+++ b/LEGO1/lego/legoomni/src/act1/act1state.cpp
@@ -17,7 +17,7 @@ extern MxAtomId* g_isleScript;
 // STUB: LEGO1 0x100334b0
 Act1State::Act1State() : m_unk0x00c(0), m_unk0x00e(0), m_unk0x008(NULL), m_unk0x010(0)
 {
-	m_unk0x01e = 0;
+	m_unk0x01e = FALSE;
 	m_unk0x018 = 1;
 	m_unk0x010 = 0;
 	m_planeActive = FALSE;

--- a/LEGO1/lego/legoomni/src/actors/jukeboxentity.cpp
+++ b/LEGO1/lego/legoomni/src/actors/jukeboxentity.cpp
@@ -1,7 +1,9 @@
 #include "jukeboxentity.h"
 
 #include "isle.h"
+#include "isle_actions.h"
 #include "islepathactor.h"
+#include "jukebox_actions.h"
 #include "jukeboxstate.h"
 #include "legogamestate.h"
 #include "legoomni.h"
@@ -54,28 +56,28 @@ void JukeBoxEntity::StartAction()
 
 	switch (state->GetState()) {
 	case 0:
-		InvokeAction(Extra::e_start, *g_isleScript, 0x319, NULL);
-		GameState()->SetUnknown0x41c(0x37);
+		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_npz001bd_RunAnim, NULL);
+		GameState()->SetUnknown0x41c(JukeboxScript::c_JBMusic1);
 		break;
 	case 1:
-		InvokeAction(Extra::e_start, *g_isleScript, 0x31e, NULL);
-		GameState()->SetUnknown0x41c(0x38);
+		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_npz006bd_RunAnim, NULL);
+		GameState()->SetUnknown0x41c(JukeboxScript::c_JBMusic2);
 		break;
 	case 2:
-		InvokeAction(Extra::e_start, *g_isleScript, 0x31b, NULL);
-		GameState()->SetUnknown0x41c(0x39);
+		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_npz003bd_RunAnim, NULL);
+		GameState()->SetUnknown0x41c(JukeboxScript::c_JBMusic3);
 		break;
 	case 3:
-		InvokeAction(Extra::e_start, *g_isleScript, 0x31a, NULL);
-		GameState()->SetUnknown0x41c(0x3a);
+		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_npz002bd_RunAnim, NULL);
+		GameState()->SetUnknown0x41c(JukeboxScript::c_JBMusic4);
 		break;
 	case 4:
-		InvokeAction(Extra::e_start, *g_isleScript, 0x31f, NULL);
-		GameState()->SetUnknown0x41c(0x3b);
+		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_npz007bd_RunAnim, NULL);
+		GameState()->SetUnknown0x41c(JukeboxScript::c_JBMusic5);
 		break;
 	case 5:
-		InvokeAction(Extra::e_start, *g_isleScript, 0x31c, NULL);
-		GameState()->SetUnknown0x41c(0x3c);
+		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_npz004bd_RunAnim, NULL);
+		GameState()->SetUnknown0x41c(JukeboxScript::c_JBMusic6);
 		break;
 	}
 
@@ -91,35 +93,35 @@ void JukeBoxEntity::StartAction()
 }
 
 // FUNCTION: LEGO1 0x100860f0
-void JukeBoxEntity::StopAction(MxU32 p_state)
+void JukeBoxEntity::StopAction(JukeboxScript::Script p_script)
 {
 	JukeBoxState* state = (JukeBoxState*) GameState()->GetState("JukeBoxState");
 
 	if (state && state->IsActive()) {
-		switch (p_state) {
-		case 0x37:
+		switch (p_script) {
+		case JukeboxScript::c_JBMusic1:
 			state->SetActive(FALSE);
-			InvokeAction(Extra::e_stop, *g_isleScript, 0x319, NULL);
+			InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_npz001bd_RunAnim, NULL);
 			break;
-		case 0x38:
+		case JukeboxScript::c_JBMusic2:
 			state->SetActive(FALSE);
-			InvokeAction(Extra::e_stop, *g_isleScript, 0x31e, NULL);
+			InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_npz006bd_RunAnim, NULL);
 			break;
-		case 0x39:
+		case JukeboxScript::c_JBMusic3:
 			state->SetActive(FALSE);
-			InvokeAction(Extra::e_stop, *g_isleScript, 0x31b, NULL);
+			InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_npz003bd_RunAnim, NULL);
 			break;
-		case 0x3a:
+		case JukeboxScript::c_JBMusic4:
 			state->SetActive(FALSE);
-			InvokeAction(Extra::e_stop, *g_isleScript, 0x31a, NULL);
+			InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_npz002bd_RunAnim, NULL);
 			break;
-		case 0x3b:
+		case JukeboxScript::c_JBMusic5:
 			state->SetActive(FALSE);
-			InvokeAction(Extra::e_stop, *g_isleScript, 0x31f, NULL);
+			InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_npz007bd_RunAnim, NULL);
 			break;
-		case 0x3c:
+		case JukeboxScript::c_JBMusic6:
 			state->SetActive(FALSE);
-			InvokeAction(Extra::e_stop, *g_isleScript, 0x31c, NULL);
+			InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_npz004bd_RunAnim, NULL);
 			break;
 		}
 

--- a/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
@@ -232,7 +232,7 @@ void MxBackgroundAudioManager::StopAction(MxParam& p_param)
 		m_action2.SetObjectId(-1);
 	}
 
-	Lego()->HandleActionEnd(p_param);
+	Lego()->HandleEndAction(p_param);
 }
 
 // FUNCTION: LEGO1 0x1007f2f0

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -8,6 +8,7 @@
 #include "isle.h"
 #include "islepathactor.h"
 #include "jetski.h"
+#include "jukebox_actions.h"
 #include "legoanimationmanager.h"
 #include "legobuildingmanager.h"
 #include "legocharactermanager.h"
@@ -93,7 +94,7 @@ LegoGameState::LegoGameState()
 	m_actorId = 0;
 	m_savePath = NULL;
 	m_stateArray = NULL;
-	m_unk0x41c = -1;
+	m_unk0x41c = JukeboxScript::c_noneJukebox;
 	m_currentArea = e_undefined;
 	m_previousArea = e_undefined;
 	m_unk0x42c = e_undefined;

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -193,23 +193,26 @@ MxLong Isle::HandleEndAction(MxEndActionNotificationParam& p_param)
 		if (result == 0) {
 			MxDSAction* action = p_param.GetAction();
 
+			// TODO: Should be signed, but worsens match
+			MxU32 script;
+
 			if (action->GetAtomId() == *g_jukeboxScript) {
-				JukeboxScript::Script script = (JukeboxScript::Script) action->GetObjectId();
+				script = action->GetObjectId();
 
 				if (script >= JukeboxScript::c_JBMusic1 && script <= JukeboxScript::c_JBMusic6) {
-					m_jukebox->StopAction(script);
+					m_jukebox->StopAction((JukeboxScript::Script) script);
 					result = 1;
 				}
 			}
 			else if (m_act1state->m_planeActive) {
-				IsleScript::Script script = (IsleScript::Script) action->GetObjectId();
+				script = action->GetObjectId();
 
 				if (script >= IsleScript::c_nic002pr_RunAnim && script <= IsleScript::c_nic004pr_RunAnim) {
 					m_act1state->m_planeActive = FALSE;
 				}
 			}
 			else {
-				IsleScript::Script script = (IsleScript::Script) action->GetObjectId();
+				script = action->GetObjectId();
 
 				if (script == IsleScript::c_Avo917In_PlayWav ||
 					(script >= IsleScript::c_Avo900Ps_PlayWav && script <= IsleScript::c_Avo907Ps_PlayWav)) {
@@ -222,10 +225,33 @@ MxLong Isle::HandleEndAction(MxEndActionNotificationParam& p_param)
 	return result;
 }
 
-// STUB: LEGO1 0x10030ef0
+// FUNCTION: LEGO1 0x10030ef0
 void Isle::HandleElevatorEndAction()
 {
-	// TODO
+	switch (m_act1state->m_elevFloor) {
+	case Act1State::c_floor1:
+		m_destLocation = LegoGameState::e_infomain;
+		TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
+		m_act1state->m_unk0x018 = 0;
+		break;
+	case Act1State::c_floor2:
+		if (m_act1state->m_unk0x01e) {
+			m_act1state->m_unk0x01e = FALSE;
+			m_act1state->m_unk0x018 = 0;
+			InputManager()->EnableInputProcessing();
+		}
+		else {
+			InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_Floor2, NULL);
+			InputManager()->EnableInputProcessing();
+			m_act1state->m_unk0x01e = TRUE;
+		}
+		break;
+	case Act1State::c_floor3:
+		m_destLocation = LegoGameState::e_elevopen;
+		TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
+		m_act1state->m_unk0x018 = 0;
+		break;
+	}
 }
 
 // FUNCTION: LEGO1 0x10030fc0
@@ -283,7 +309,7 @@ MxLong Isle::HandleClick(LegoControlManagerEvent& p_param)
 				break;
 			case Act1State::c_floor2:
 				InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_Floor2, NULL);
-				m_act1state->m_unk0x01e = 1;
+				m_act1state->m_unk0x01e = TRUE;
 				break;
 			case Act1State::c_floor3:
 				InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_Elev3_2_Ride, NULL);

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -70,7 +70,7 @@ public:
 	MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
 	MxEventManager* GetEventManager() const { return this->m_eventManager; }
 	MxAtomIdCounterSet* GetAtomIdCounterSet() const { return this->m_atomIdCounterSet; }
-	MxLong HandleActionEnd(MxParam& p_param);
+	MxLong HandleEndAction(MxParam& p_param);
 
 	// SYNTHETIC: LEGO1 0x100aefd0
 	// MxOmni::`scalar deleting destructor'

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -344,11 +344,11 @@ MxLong MxOmni::Notify(MxParam& p_param)
 		return 0;
 	}
 
-	return HandleActionEnd(p_param);
+	return HandleEndAction(p_param);
 }
 
 // FUNCTION: LEGO1 0x100b0880
-MxLong MxOmni::HandleActionEnd(MxParam& p_param)
+MxLong MxOmni::HandleEndAction(MxParam& p_param)
 {
 	MxDSAction* action = ((MxEndActionNotificationParam&) p_param).GetAction();
 	MxStreamController* controller = Streamer()->GetOpenStream(action->GetAtomId().GetInternal());


### PR DESCRIPTION
`Isle::HandleEndAction` - match at ~88%, can't fix the signage of the object ID comparison without breaking the match right now.

`Isle::HandleElevatorEndAction` - 100% match.

The elevator navigation now works and floor 2 plays the sea animation:


https://github.com/isledecomp/isle/assets/1135351/501d1d02-1480-4e4d-b1ef-34bc0a94dee3

Observation deck:

![image](https://github.com/isledecomp/isle/assets/1135351/09149439-45e3-471c-8025-7577857472cc)

![image](https://github.com/isledecomp/isle/assets/1135351/615c10b8-66f9-458f-8e08-4b8c653e15bf)

