### PR TITLE
Keep capstone working on Python 3.12

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -6,3 +6,6 @@ isledecomp
 pystache
 pyyaml
 git+https://github.com/wbenny/pydemangler.git
+# requirement of capstone due to python dropping distutils.
+# see: https://github.com/capstone-engine/capstone/issues/2223
+setuptools ; python_version >= "3.12"


### PR DESCRIPTION
The [`capstone`](https://github.com/capstone-engine/capstone/) library that we use for bytes-to-assembly conversion has a compatibility problem with Python 3.12. Python has [deprecated and removed the `distutils` package](https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated) in that version, and `capstone` depends on it.

The people working on `capstone` are aware of this: https://github.com/capstone-engine/capstone/issues/2223

In the meantime, to keep our tools working, we will add `setuptools` as a dependency if Python is 3.12 or newer.