### PR TITLE
Bugfix for virtual inheritance comparing

### DIFF
--- a/tools/isledecomp/isledecomp/cvdump/analysis.py
+++ b/tools/isledecomp/isledecomp/cvdump/analysis.py
@@ -43,6 +43,13 @@ class CvdumpNode:
             self.node_type = SymbolType.VTABLE
             self.friendly_name = demangle_vtable(self.decorated_name)
 
+        elif self.decorated_name.startswith("??_8"):
+            # This is the `vbtable' symbol for virtual inheritance.
+            # Should be okay to reuse demangle_vtable. We still want to
+            # remove things like "const" from the output.
+            self.node_type = SymbolType.DATA
+            self.friendly_name = demangle_vtable(self.decorated_name)
+
         elif self.decorated_name.startswith("??_C@"):
             self.node_type = SymbolType.STRING
             (strlen, _) = demangle_string_const(self.decorated_name)


### PR DESCRIPTION
Bugfix for the virtual inheritance feature in #717, identified by @tahg.

Broadly, there are three kinds of vftable symbols we have to contend with:

1. ``LegoAnimActor::`vftable'``, the "bare" vftable
2. ``LegoAnimActor::`vftable'{for `LegoPathActor'}``, for methods overriden from a virtual superclass
3. ``LegoAnimActor::`vftable'{for `LegoAnimActor'}``, for methods introduced by this class that is itself virtually extended

I changed some code at the last minute to prevent type 2 vftables from matching against type 1, but this broke matching on type 3.

This is now fixed. I assume that the use of a type 3 means that the type 1 symbol could not be there. If we find that this is wrong, we can fix it but we will lose some slight flexibility in the `// VTABLE` annotations. You would have to be explicit about including or excluding the fourth "extra" parameter to specify what kind of vftable you want to match.

I added one new feature/convenience: the `vbtable` (with a B) symbols now appear in their demangled form instead of using the `??_8` prefix, so the diffs are easier to read. If you add `// GLOBAL` annotations for these, the functions will match better. We can also compare the data as if these were variables. e.g.

```
// GLOBAL: LEGO1 0x100d5890
// LegoRaceCar::`vbtable'{for `LegoCarRaceActor'}
```

But... if there's a way to reliably tell where these are _without_ annotating, we should do that instead.