### PR TITLE
Ignore annotations that would cause an exception

### DIFF
--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -174,6 +174,21 @@ class Compare:
         codefiles = list(walk_source_dir(self.code_dir))
         codebase = DecompCodebase(codefiles, module.upper())
 
+        def orig_bin_checker(addr: int) -> bool:
+            return self.orig_bin.is_valid_vaddr(addr)
+
+        # If the address of any annotation would cause an exception,
+        # remove it and report an error.
+        bad_annotations = codebase.prune_invalid_addrs(orig_bin_checker)
+
+        for sym in bad_annotations:
+            logger.error(
+                "Invalid address 0x%x on %s annotation in file: %s",
+                sym.offset,
+                sym.type.name,
+                sym.filename,
+            )
+
         # Match lineref functions first because this is a guaranteed match.
         # If we have two functions that share the same name, and one is
         # a lineref, we can match the nameref correctly because the lineref

--- a/tools/isledecomp/isledecomp/parser/codebase.py
+++ b/tools/isledecomp/isledecomp/parser/codebase.py
@@ -1,5 +1,5 @@
 """For aggregating decomp markers read from an entire directory and for a single module."""
-from typing import Iterable, Iterator, List
+from typing import Callable, Iterable, Iterator, List
 from .parser import DecompParser
 from .node import (
     ParserSymbol,
@@ -23,6 +23,15 @@ class DecompCodebase:
             for sym in parser.iter_symbols(module):
                 sym.filename = filename
                 self._symbols.append(sym)
+
+    def prune_invalid_addrs(self, is_valid: Callable[int, bool]) -> List[ParserSymbol]:
+        """Some decomp annotations might have an invalid address.
+        Return the list of addresses where we fail the is_valid check,
+        and remove those from our list of symbols."""
+        invalid_symbols = [sym for sym in self._symbols if not is_valid(sym.offset)]
+        self._symbols = [sym for sym in self._symbols if is_valid(sym.offset)]
+
+        return invalid_symbols
 
     def iter_line_functions(self) -> Iterator[ParserFunction]:
         """Return lineref functions separately from nameref. Assuming the PDB matches


### PR DESCRIPTION
The `isledecomp.bin` module is our way of emulating a virtual address lookup. If you try to reference a virtual address outside the bounds of the file image, this will throw the `InvalidVirtualAddressError` exception. The common reason for this is that your decomp annotation is missing one of the digits, and so it is under the defined imagebase value (`0x10000000` for LEGO1) and there is no data at that location.

We don't catch this exception in `reccmp`, and this leads to a pretty rude looking error stack for a simple typo:

```
Traceback (most recent call last):
  File "X:\isle\tools\reccmp\reccmp.py", line 341, in <module>
    raise SystemExit(main())
                     ^^^^^^
  File "X:\isle\tools\reccmp\reccmp.py", line 242, in main
    isle_compare = IsleCompare(origfile, recompfile, args.pdb, args.decomp_dir)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "X:\isle\tools\isledecomp\isledecomp\compare\core.py", line 85, in __init__
    self._load_markers()
  File "X:\isle\tools\isledecomp\isledecomp\compare\core.py", line 224, in _load_markers
    orig = self.orig_bin.read_string(string.offset).decode("latin1")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "X:\isle\tools\isledecomp\isledecomp\bin.py", line 459, in read_string
    b = self.read(offset, chunk_size)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "X:\isle\tools\isledecomp\isledecomp\bin.py", line 472, in read
    (section_id, offset) = self.get_relative_addr(vaddr)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "X:\isle\tools\isledecomp\isledecomp\bin.py", line 437, in get_relative_addr
    raise InvalidVirtualAddressError(f"{self.filename} : {hex(addr)}")
isledecomp.bin.InvalidVirtualAddressError: X:\LEGO1.dll : 0x100f043
```

This change identifies annotations that would cause a problem, removes them from consideration, and reports an error for each.

To test, just add or remove a number from any decomp annotation.