### PR TITLE
reccmp: Detect when we exceed original function size

### DIFF
--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -384,7 +384,16 @@ class Compare:
                     self._db.set_function_pair(orig_addr, recomp_addr)
 
     def _compare_function(self, match: MatchInfo) -> DiffReport:
-        orig_raw = self.orig_bin.read(match.orig_addr, match.size)
+        # Detect when the recomp function size would cause us to read
+        # enough bytes from the original function that we cross into
+        # the next annotated function.
+        next_orig = self._db.get_next_orig_addr(match.orig_addr)
+        if next_orig is not None:
+            orig_size = min(next_orig - match.orig_addr, match.size)
+        else:
+            orig_size = match.size
+
+        orig_raw = self.orig_bin.read(match.orig_addr, orig_size)
         recomp_raw = self.recomp_bin.read(match.recomp_addr, match.size)
 
         # It's unlikely that a function other than an adjuster thunk would

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -73,6 +73,7 @@ logger = logging.getLogger(__name__)
 
 
 class CompareDb:
+    # pylint: disable=too-many-public-methods
     def __init__(self):
         self._db = sqlite3.connect(":memory:")
         self._db.executescript(_SETUP_SQL)
@@ -347,6 +348,21 @@ class CompareDb:
             return False
 
         return self.set_pair(addr, recomp_addr, compare_type)
+
+    def get_next_orig_addr(self, addr: int) -> Optional[int]:
+        """Return the original address (matched or not) that follows
+        the one given. If our recomp function size would cause us to read
+        too many bytes for the original function, we can adjust it."""
+        result = self._db.execute(
+            """SELECT orig_addr
+            FROM `symbols`
+            WHERE orig_addr > ?
+            ORDER BY orig_addr
+            LIMIT 1""",
+            (addr,),
+        ).fetchone()
+
+        return result[0] if result is not None else None
 
     def match_function(self, addr: int, name: str) -> bool:
         did_match = self._match_on(SymbolType.FUNCTION, addr, name)


### PR DESCRIPTION
We base our function comparison on the known size of the recomp function via the PDB. We use that size to read the same number of bytes for the original function. If we read so many bytes that we stray into the function that follows, our comparison will get worse as the function size increases.

If we have the second function also marked, we can detect that this has occurred and shrink the original function footprint. This gives a marginal increase in match percentage, but these functions are still wrong because they are longer (in recomp) than they should be.

Two adjuster thunk functions went down in accuracy, but the real reason is that the annotations point to the wrong place.