### PR TITLE
Implement LegoExtraActor::VTable0x90

### DIFF
--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -27,12 +27,12 @@ public:
 		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(p_name);
 	}
 
-	void VTable0x6c() override;              // vtable+0x6c
-	void VTable0x70(float p_float) override; // vtable+0x70
-	MxS32 VTable0x90() override;             // vtable+0x90
-	MxS32 VTable0x94() override;             // vtable+0x94
-	void VTable0x98() override;              // vtable+0x98
-	void VTable0x9c() override;              // vtable+0x9c
+	void VTable0x6c() override;                  // vtable+0x6c
+	void VTable0x70(float p_float) override;     // vtable+0x70
+	MxU32 VTable0x90(float, MxMatrix&) override; // vtable+0x90
+	MxS32 VTable0x94() override;                 // vtable+0x94
+	void VTable0x98() override;                  // vtable+0x98
+	void VTable0x9c() override;                  // vtable+0x9c
 
 	virtual void FUN_10080590();
 

--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -27,12 +27,12 @@ public:
 		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(p_name);
 	}
 
-	void VTable0x6c() override;                  // vtable+0x6c
-	void VTable0x70(float p_float) override;     // vtable+0x70
-	MxU32 VTable0x90(float, MxMatrix&) override; // vtable+0x90
-	MxS32 VTable0x94() override;                 // vtable+0x94
-	void VTable0x98() override;                  // vtable+0x98
-	void VTable0x9c() override;                  // vtable+0x9c
+	void VTable0x6c() override;                 // vtable+0x6c
+	void VTable0x70(float p_float) override;    // vtable+0x70
+	MxU32 VTable0x90(float, Matrix4&) override; // vtable+0x90
+	MxS32 VTable0x94() override;                // vtable+0x94
+	void VTable0x98() override;                 // vtable+0x98
+	void VTable0x9c() override;                 // vtable+0x9c
 
 	virtual void FUN_10080590();
 

--- a/LEGO1/lego/legoomni/include/legoextraactor.h
+++ b/LEGO1/lego/legoomni/include/legoextraactor.h
@@ -9,6 +9,13 @@
 // SIZE 0x1dc
 class LegoExtraActor : public virtual LegoAnimActor {
 public:
+	enum Axis {
+		e_posz,
+		e_negz,
+		e_posx,
+		e_negx
+	};
+
 	LegoExtraActor();
 	~LegoExtraActor() override;
 
@@ -27,15 +34,15 @@ public:
 
 	void SetWorldSpeed(MxFloat p_worldSpeed) override; // vtable+0x30
 	void VTable0x68(Mx3DPointFloat& p_point1, Mx3DPointFloat& p_point2, Mx3DPointFloat& p_point3)
-		override;                                   // vtable+0x68
-	void VTable0x6c() override;                     // vtable+0x6c
-	void VTable0x70(float) override;                // vtable+0x70
-	void VTable0x74(Matrix4& p_transform) override; // vtable+0x74
-	MxS32 VTable0x90() override;                    // vtable+0x90
-	MxS32 VTable0x94() override;                    // vtable+0x94
-	void VTable0x9c() override;                     // vtable+0x9c
-	void VTable0xa4() override;                     // vtable+0xa4
-	void VTable0xc4() override;                     // vtable+0xc4
+		override;                                                 // vtable+0x68
+	void VTable0x6c() override;                                   // vtable+0x6c
+	void VTable0x70(float) override;                              // vtable+0x70
+	void VTable0x74(Matrix4& p_transform) override;               // vtable+0x74
+	MxU32 VTable0x90(float p_float, MxMatrix& p_matrix) override; // vtable+0x90
+	MxS32 VTable0x94() override;                                  // vtable+0x94
+	void VTable0x9c() override;                                   // vtable+0x9c
+	void VTable0xa4() override;                                   // vtable+0xa4
+	void VTable0xc4() override;                                   // vtable+0xc4
 
 	virtual MxResult FUN_1002aae0();
 
@@ -43,9 +50,9 @@ public:
 	// LegoExtraActor::`scalar deleting destructor'
 
 private:
-	undefined4 m_unk0x08;           // 0x08
+	MxFloat m_scheduledTime;        // 0x08
 	undefined m_unk0x0c;            // 0x0c
-	undefined m_unk0x0d;            // 0x0d
+	MxU8 m_axis;                    // 0x0d
 	undefined m_unk0x0e;            // 0x0e
 	undefined4 m_unk0x10;           // 0x10
 	MxU8 m_unk0x14;                 // 0x14

--- a/LEGO1/lego/legoomni/include/legoextraactor.h
+++ b/LEGO1/lego/legoomni/include/legoextraactor.h
@@ -34,15 +34,15 @@ public:
 
 	void SetWorldSpeed(MxFloat p_worldSpeed) override; // vtable+0x30
 	void VTable0x68(Mx3DPointFloat& p_point1, Mx3DPointFloat& p_point2, Mx3DPointFloat& p_point3)
-		override;                                                 // vtable+0x68
-	void VTable0x6c() override;                                   // vtable+0x6c
-	void VTable0x70(float) override;                              // vtable+0x70
-	void VTable0x74(Matrix4& p_transform) override;               // vtable+0x74
-	MxU32 VTable0x90(float p_float, MxMatrix& p_matrix) override; // vtable+0x90
-	MxS32 VTable0x94() override;                                  // vtable+0x94
-	void VTable0x9c() override;                                   // vtable+0x9c
-	void VTable0xa4() override;                                   // vtable+0xa4
-	void VTable0xc4() override;                                   // vtable+0xc4
+		override;                                                // vtable+0x68
+	void VTable0x6c() override;                                  // vtable+0x6c
+	void VTable0x70(float) override;                             // vtable+0x70
+	void VTable0x74(Matrix4& p_transform) override;              // vtable+0x74
+	MxU32 VTable0x90(float p_float, Matrix4& p_matrix) override; // vtable+0x90
+	MxS32 VTable0x94() override;                                 // vtable+0x94
+	void VTable0x9c() override;                                  // vtable+0x9c
+	void VTable0xa4() override;                                  // vtable+0xa4
+	void VTable0xc4() override;                                  // vtable+0xc4
 
 	virtual MxResult FUN_1002aae0();
 

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -46,7 +46,7 @@ public:
 	virtual void VTable0x8c(); // vtable+0x8c
 
 	// FUNCTION: LEGO1 0x10002d40
-	virtual MxU32 VTable0x90(float, MxMatrix&) { return FALSE; } // vtable+0x90
+	virtual MxU32 VTable0x90(float, Matrix4&) { return FALSE; } // vtable+0x90
 
 	// FUNCTION: LEGO1 0x10002d50
 	virtual MxS32 VTable0x94() { return 0; } // vtable+0x94

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -46,7 +46,7 @@ public:
 	virtual void VTable0x8c(); // vtable+0x8c
 
 	// FUNCTION: LEGO1 0x10002d40
-	virtual MxS32 VTable0x90() { return 0; } // vtable+0x90
+	virtual MxU32 VTable0x90(float, MxMatrix&) { return FALSE; } // vtable+0x90
 
 	// FUNCTION: LEGO1 0x10002d50
 	virtual MxS32 VTable0x94() { return 0; } // vtable+0x94
@@ -97,8 +97,8 @@ public:
 protected:
 	MxFloat m_BADuration;             // 0x78
 	undefined4 m_unk0x7c;             // 0x7c
-	MxFloat m_unk0x80;                // 0x80
-	MxFloat m_unk0x84;                // 0x84
+	MxFloat m_actorTime;              // 0x80
+	MxFloat m_lastTime;               // 0x84
 	LegoPathBoundary* m_boundary;     // 0x88
 	undefined m_unk0x8c[0x14];        // 0x8c
 	MxFloat m_unk0xa0;                // 0xa0

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -31,7 +31,7 @@ public:
 	void VTable0x68(Mx3DPointFloat&, Mx3DPointFloat&, Mx3DPointFloat&) override; // vtable+0x68
 	void VTable0x70(float p_float) override;                                     // vtable+0x70
 	void VTable0x74(Matrix4& p_transform) override;                              // vtable+0x74
-	MxU32 VTable0x90(float, MxMatrix&) override;                                 // vtable+0x90
+	MxU32 VTable0x90(float, Matrix4&) override;                                  // vtable+0x90
 	MxS32 VTable0x94() override;                                                 // vtable+0x94
 
 	// FUNCTION: LEGO1 0x10014aa0

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -31,7 +31,7 @@ public:
 	void VTable0x68(Mx3DPointFloat&, Mx3DPointFloat&, Mx3DPointFloat&) override; // vtable+0x68
 	void VTable0x70(float p_float) override;                                     // vtable+0x70
 	void VTable0x74(Matrix4& p_transform) override;                              // vtable+0x74
-	MxS32 VTable0x90() override;                                                 // vtable+0x90
+	MxU32 VTable0x90(float, MxMatrix&) override;                                 // vtable+0x90
 	MxS32 VTable0x94() override;                                                 // vtable+0x94
 
 	// FUNCTION: LEGO1 0x10014aa0

--- a/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
@@ -10,7 +10,7 @@ DECOMP_SIZE_ASSERT(LegoCarRaceActor, 0x1a0)
 const char* g_fuel = "FUEL";
 
 // STUB: LEGO1 0x100141a0
-MxU32 LegoCarRaceActor::VTable0x90(float, MxMatrix&)
+MxU32 LegoCarRaceActor::VTable0x90(float, Matrix4&)
 {
 	// TODO
 	return 0;

--- a/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
@@ -10,7 +10,7 @@ DECOMP_SIZE_ASSERT(LegoCarRaceActor, 0x1a0)
 const char* g_fuel = "FUEL";
 
 // STUB: LEGO1 0x100141a0
-MxS32 LegoCarRaceActor::VTable0x90()
+MxU32 LegoCarRaceActor::VTable0x90(float, MxMatrix&)
 {
 	// TODO
 	return 0;

--- a/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
@@ -46,7 +46,7 @@ LegoAnimActor::~LegoAnimActor()
 MxResult LegoAnimActor::FUN_1001c1f0(float& p_und)
 {
 	float duration = (float) m_animMaps[m_curAnim]->m_AnimTreePtr->GetDuration();
-	p_und = m_unk0x80 - duration * ((MxS32) (m_unk0x80 / duration));
+	p_und = m_actorTime - duration * ((MxS32) (m_actorTime / duration));
 	return SUCCESS;
 }
 
@@ -65,8 +65,8 @@ void LegoAnimActor::VTable0x74(Matrix4& p_transform)
 // FUNCTION: LEGO1 0x1001c290
 void LegoAnimActor::VTable0x70(float p_float)
 {
-	if (m_unk0x84 == 0) {
-		m_unk0x84 = p_float - 1.0f;
+	if (m_lastTime == 0) {
+		m_lastTime = p_float - 1.0f;
 	}
 
 	if (m_unk0xdc == 0 && !m_userNavFlag && m_worldSpeed <= 0) {
@@ -77,7 +77,7 @@ void LegoAnimActor::VTable0x70(float p_float)
 			FUN_1001c360(f, matrix);
 		}
 
-		m_unk0x84 = m_unk0x80 = p_float;
+		m_lastTime = m_actorTime = p_float;
 	}
 	else {
 		LegoPathActor::VTable0x70(p_float);

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -26,7 +26,7 @@ LegoExtraActor::~LegoExtraActor()
 }
 
 // FUNCTION: LEGO1 0x1002a720
-MxU32 LegoExtraActor::VTable0x90(float p_time, MxMatrix& p_transform)
+MxU32 LegoExtraActor::VTable0x90(float p_time, Matrix4& p_transform)
 {
 	switch (m_unk0xdc & 0xff) {
 	case 0:
@@ -39,25 +39,37 @@ MxU32 LegoExtraActor::VTable0x90(float p_time, MxMatrix& p_transform)
 		m_lastTime = p_time;
 		return FALSE;
 	case 3: {
-		Vector3 positionRef = Vector3(p_transform[3]);
+		Vector3 positionRef(p_transform[3]);
 		p_transform = m_roi->GetLocal2World();
+
 		if (p_time < m_scheduledTime) {
-			Mx3DPointFloat position = positionRef;
+			Mx3DPointFloat position;
+			position = positionRef;
 			positionRef.Clear();
+
 			switch (m_axis) {
-			case e_posz:
-				p_transform.RotateZ(0.7f);
-				break;
-			case e_negz:
-				p_transform.RotateZ(-0.7f);
-				break;
-			case e_posx:
-				p_transform.RotateX(0.7f);
-				break;
-			case e_negx:
-				p_transform.RotateX(-0.7f);
+			case e_posz: {
+				float angle = 0.7f;
+				p_transform.RotateZ(angle);
 				break;
 			}
+			case e_negz: {
+				float angle = -0.7f;
+				p_transform.RotateZ(angle);
+				break;
+			}
+			case e_posx: {
+				float angle = 0.7f;
+				p_transform.RotateX(angle);
+				break;
+			}
+			case e_negx: {
+				float angle = -0.7f;
+				p_transform.RotateX(angle);
+				break;
+			}
+			}
+
 			positionRef = position;
 			m_actorTime += (p_time - m_lastTime) * m_worldSpeed;
 			m_lastTime = p_time;
@@ -67,7 +79,7 @@ MxU32 LegoExtraActor::VTable0x90(float p_time, MxMatrix& p_transform)
 		else {
 			m_unk0xdc = 0;
 			m_scheduledTime = 0.0f;
-			positionRef.Sub(&g_unk0x10104c18);
+			((Vector3&) positionRef).Sub(&g_unk0x10104c18); // TODO: Fix call
 			m_roi->FUN_100a58f0(p_transform);
 			return TRUE;
 		}

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -49,23 +49,19 @@ MxU32 LegoExtraActor::VTable0x90(float p_time, Matrix4& p_transform)
 
 			switch (m_axis) {
 			case e_posz: {
-				float angle = 0.7f;
-				p_transform.RotateZ(angle);
+				p_transform.RotateZ(0.7f);
 				break;
 			}
 			case e_negz: {
-				float angle = -0.7f;
-				p_transform.RotateZ(angle);
+				p_transform.RotateZ(-0.7f);
 				break;
 			}
 			case e_posx: {
-				float angle = 0.7f;
-				p_transform.RotateX(angle);
+				p_transform.RotateX(0.7f);
 				break;
 			}
 			case e_negx: {
-				float angle = -0.7f;
-				p_transform.RotateX(angle);
+				p_transform.RotateX(-0.7f);
 				break;
 			}
 			}

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -2,11 +2,14 @@
 
 DECOMP_SIZE_ASSERT(LegoExtraActor, 0x1dc)
 
+// GLOBAL: LEGO1 0x10104c18
+Mx3DPointFloat g_unk0x10104c18 = Mx3DPointFloat(0.0f, 2.5f, 0.0f);
+
 // FUNCTION: LEGO1 0x1002a500
 LegoExtraActor::LegoExtraActor()
 {
 	m_unk0x70 = 0.0f;
-	m_unk0x08 = 0;
+	m_scheduledTime = 0;
 	m_unk0x0c = 0;
 	m_unk0x0e = 0;
 	m_unk0x14 = 0;
@@ -22,10 +25,57 @@ LegoExtraActor::~LegoExtraActor()
 	delete m_unk0x64;
 }
 
-// STUB: LEGO1 0x1002a720
-MxS32 LegoExtraActor::VTable0x90()
+// FUNCTION: LEGO1 0x1002a720
+MxU32 LegoExtraActor::VTable0x90(float p_time, MxMatrix& p_transform)
 {
-	return 0;
+	switch (m_unk0xdc & 0xff) {
+	case 0:
+	case 1:
+		return TRUE;
+	case 2:
+		m_scheduledTime = p_time + 2000.0f;
+		m_unk0xdc = 3;
+		m_actorTime += (p_time - m_lastTime) * m_worldSpeed;
+		m_lastTime = p_time;
+		return FALSE;
+	case 3: {
+		Vector3 positionRef = Vector3(p_transform[3]);
+		p_transform = m_roi->GetLocal2World();
+		if (p_time < m_scheduledTime) {
+			Mx3DPointFloat position = positionRef;
+			positionRef.Clear();
+			switch (m_axis) {
+			case e_posz:
+				p_transform.RotateZ(0.7f);
+				break;
+			case e_negz:
+				p_transform.RotateZ(-0.7f);
+				break;
+			case e_posx:
+				p_transform.RotateX(0.7f);
+				break;
+			case e_negx:
+				p_transform.RotateX(-0.7f);
+				break;
+			}
+			positionRef = position;
+			m_actorTime += (p_time - m_lastTime) * m_worldSpeed;
+			m_lastTime = p_time;
+			VTable0x74(p_transform);
+			return FALSE;
+		}
+		else {
+			m_unk0xdc = 0;
+			m_scheduledTime = 0.0f;
+			positionRef.Sub(&g_unk0x10104c18);
+			m_roi->FUN_100a58f0(p_transform);
+			return TRUE;
+		}
+	}
+
+	default:
+		return FALSE;
+	}
 }
 
 // STUB: LEGO1 0x1002aa90

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -34,7 +34,7 @@ void LegoRaceActor::VTable0x70(float p_float)
 }
 
 // STUB: LEGO1 0x10014ce0
-MxU32 LegoRaceActor::VTable0x90(float, MxMatrix&)
+MxU32 LegoRaceActor::VTable0x90(float, Matrix4&)
 {
 	// TODO
 	return 0;

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -34,7 +34,7 @@ void LegoRaceActor::VTable0x70(float p_float)
 }
 
 // STUB: LEGO1 0x10014ce0
-MxS32 LegoRaceActor::VTable0x90()
+MxU32 LegoRaceActor::VTable0x90(float, MxMatrix&)
 {
 	// TODO
 	return 0;

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -114,7 +114,7 @@ public:
 		}
 	}
 
-	inline void RotateX(const float p_angle)
+	inline void RotateX(const float& p_angle)
 	{
 		float s = sin(p_angle);
 		float c = cos(p_angle);
@@ -126,7 +126,7 @@ public:
 		}
 	}
 
-	inline void RotateZ(const float p_angle)
+	inline void RotateZ(const float& p_angle)
 	{
 		float s = sin(p_angle);
 		float c = cos(p_angle);

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -114,6 +114,30 @@ public:
 		}
 	}
 
+	inline void RotateX(const float p_angle)
+	{
+		float s = sin(p_angle);
+		float c = cos(p_angle);
+		float matrix[4][4];
+		memcpy(matrix, m_data, sizeof(float) * 16);
+		for (int i = 0; i < 4; i++) {
+			m_data[i][1] = matrix[i][1] * c - matrix[i][2] * s;
+			m_data[i][2] = matrix[i][2] * c + matrix[i][1] * s;
+		}
+	}
+
+	inline void RotateZ(const float p_angle)
+	{
+		float s = sin(p_angle);
+		float c = cos(p_angle);
+		float matrix[4][4];
+		memcpy(matrix, m_data, sizeof(float) * 16);
+		for (int i = 0; i < 4; i++) {
+			m_data[i][0] = matrix[i][0] * c - matrix[i][1] * s;
+			m_data[i][1] = matrix[i][1] * c + matrix[i][0] * s;
+		}
+	}
+
 	inline virtual void ToQuaternion(Vector4& p_resultQuat); // vtable+0x40
 	inline virtual int FromQuaternion(const Vector4& p_vec); // vtable+0x44
 


### PR DESCRIPTION
Implemented but not matched. Despite reccmp's really low rating of 45% it's not that bad. Some sort of unused stack variable that is in the original but not present in my version is throwing off offsets. Afaict it should exist between the two vectors. Unless it's a PACK issue that requires Vector3 to be on an 8 byte boundary?  There's some issues with inlining of vector functions too which is causing a few additional differences. The inlined matrix code seems to match exactly, barring the shifted stack pointer.