### PR TITLE
implement/match UpdateLightPosition()

### DIFF
--- a/LEGO1/lego/legoomni/include/legoutils.h
+++ b/LEGO1/lego/legoomni/include/legoutils.h
@@ -25,7 +25,7 @@ void FUN_1003ef00(MxBool);
 void SetAppCursor(WPARAM p_wparam);
 MxBool FUN_1003ef60();
 MxBool RemoveFromWorld(MxAtomId& p_entityAtom, MxS32 p_entityId, MxAtomId& p_worldAtom, MxS32 p_worldEntityId);
-MxS32 FUN_1003f050(MxS32);
+MxS32 UpdateLightPosition(MxS32 p_value);
 void SetLightPosition(MxU32);
 LegoNamedTexture* ReadNamedTexture(LegoFile* p_file);
 void FUN_1003f540(LegoFile* p_file, const char* p_filename);

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -314,11 +314,37 @@ MxBool FUN_1003ef60()
 	return TRUE;
 }
 
-// STUB: LEGO1 0x1003f050
-MxS32 FUN_1003f050(MxS32)
+// FUNCTION: LEGO1 0x1003f050
+MxS32 UpdateLightPosition(MxS32 p_value)
 {
-	// TODO
-	return 0;
+	// This function updates the light position
+	// relatively by the amount passed in p_value.
+	// Because it operates relatively, it does not set
+	// the light position to an arbitrary value.
+
+	MxS32 lightPosition = atoi(VariableTable()->GetVariable("lightposition"));
+
+	if (p_value > 0) {
+		lightPosition += 1;
+		if (lightPosition > 5) {
+			lightPosition = 5;
+		}
+	}
+	else {
+		lightPosition -= 1;
+		if (lightPosition < 0) {
+			lightPosition = 0;
+		}
+	}
+
+	SetLightPosition(lightPosition);
+
+	char lightPositionBuffer[32];
+	sprintf(lightPositionBuffer, "%d", lightPosition);
+
+	VariableTable()->SetVariable("lightposition", lightPositionBuffer);
+
+	return lightPosition;
 }
 
 // STUB: LEGO1 0x1003f0d0

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -399,11 +399,11 @@ MxLong Isle::HandleClick(LegoControlManagerEvent& p_param)
 			FUN_10031590();
 			break;
 		case IsleScript::c_Observe_GlobeLArrow_Ctl:
-			FUN_1003f050(-1);
+			UpdateLightPosition(-1);
 			FUN_10031590();
 			break;
 		case IsleScript::c_Observe_GlobeRArrow_Ctl:
-			FUN_1003f050(1);
+			UpdateLightPosition(1);
 			FUN_10031590();
 			break;
 		case IsleScript::c_Observe_Draw1_Ctl:


### PR DESCRIPTION
100% match. This function handles updating the world's light position relatively using the globe controls on the Observation Deck.