### PR TITLE
Add variable comparison to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,13 @@ jobs:
         python3 tools/vtable/vtable.py legobin/ISLE.EXE build/ISLE.EXE build/ISLE.PDB .
         python3 tools/vtable/vtable.py legobin/LEGO1.DLL build/LEGO1.DLL build/LEGO1.PDB .
 
+    - name: Check Variables
+      shell: bash
+      run: |
+        python3 tools/datacmp.py legobin/CONFIG.EXE build/CONFIG.EXE build/CONFIG.PDB .
+        python3 tools/datacmp.py legobin/ISLE.EXE build/ISLE.EXE build/ISLE.PDB .
+        python3 tools/datacmp.py legobin/LEGO1.DLL build/LEGO1.DLL build/LEGO1.PDB .
+
     - name: Upload Artifact
       uses: actions/upload-artifact@master
       with:

--- a/ISLE/library_smartheap.h
+++ b/ISLE/library_smartheap.h
@@ -297,7 +297,7 @@
 // GLOBAL: ISLE 0x4105b0
 // __shi_TaskRecord
 
-// GLOBAL: ISLE 0x4125f8
+// ~GLOBAL: ISLE 0x4125f8
 // ?_pnhHeap@@3P6AHI@ZA
 
 // GLOBAL: ISLE 0x412830

--- a/tools/datacmp.py
+++ b/tools/datacmp.py
@@ -48,6 +48,13 @@ def parse_args() -> argparse.Namespace:
         "--no-color", "-n", action="store_true", help="Do not color the output"
     )
     parser.add_argument(
+        "--all",
+        "-a",
+        dest="show_all",
+        action="store_true",
+        help="Only show variables with a problem",
+    )
+    parser.add_argument(
         "--print-rec-addr",
         action="store_true",
         help="Print addresses of recompiled functions too",
@@ -236,7 +243,7 @@ def do_the_comparison(args: argparse.Namespace) -> Iterable[ComparisonItem]:
 
             # If we are here, we can do the type-aware comparison.
             compared = []
-            compare_items = mini_cvdump.types.get_scalars(type_name)
+            compare_items = mini_cvdump.types.get_scalars_gapless(type_name)
             format_str = mini_cvdump.types.get_format_string(type_name)
 
             orig_data = unpack(format_str, orig_raw)
@@ -308,8 +315,15 @@ def main():
         )
         return f"{match_color}{result.name}{colorama.Style.RESET_ALL}"
 
+    var_count = 0
+    problems = 0
+
     for item in do_the_comparison(args):
-        if not args.verbose and item.result == CompareResult.MATCH:
+        var_count += 1
+        if item.result in (CompareResult.DIFF, CompareResult.ERROR):
+            problems += 1
+
+        if not args.show_all and item.result == CompareResult.MATCH:
             continue
 
         address_display = (
@@ -334,8 +348,14 @@ def main():
                     f"  {c.offset:5} {value_get(c.name, '(value)'):30} {value_a} : {value_b}"
                 )
 
-        print()
+        if args.verbose:
+            print()
+
+    print(
+        f"{os.path.basename(args.original)} - Variables: {var_count}. Issues: {problems}"
+    )
+    return 0 if problems == 0 else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tools/isledecomp/tests/test_cvdump_types.py
+++ b/tools/isledecomp/tests/test_cvdump_types.py
@@ -313,14 +313,27 @@ def test_struct(parser):
 
 
 def test_struct_padding(parser):
-    """Struct format string should insert padding characters 'x'
-    where a value is padded to alignment size (probably 4 bytes)"""
+    """For data comparison purposes, make sure we have no gaps in the
+    list of scalar types. Any gap is filled by an unsigned char."""
 
+    # MxString, padded to 16 bytes. 4 actual members. 2 bytes of padding.
+    assert len(parser.get_scalars("0x4db6")) == 4
+    assert len(parser.get_scalars_gapless("0x4db6")) == 6
+
+    # MxVariable, with two MxStrings (and a vtable)
+    # Fill in the middle gap and the outer gap.
+    assert len(parser.get_scalars("0x22d5")) == 9
+    assert len(parser.get_scalars_gapless("0x22d5")) == 13
+
+
+def test_struct_format_string(parser):
+    """Generate the struct.unpack format string using the
+    list of scalars with padding filled in."""
     # MxString, padded to 16 bytes.
-    assert parser.get_format_string("0x4db6") == "<LLLHxx"
+    assert parser.get_format_string("0x4db6") == "<LLLHBB"
 
     # MxVariable, with two MxString members.
-    assert parser.get_format_string("0x22d5") == "<LLLLHxxLLLHxx"
+    assert parser.get_format_string("0x22d5") == "<LLLLHBBLLLHBB"
 
 
 def test_array(parser):


### PR DESCRIPTION
Expanding the `datacmp` tool from #618 and adding it to our CI actions. If you're unfamiliar, this takes the same argument list as `reccmp` but compares variables only. For any struct or array datatype, the tool will compare each index or member.

By default, `datacmp` shows a brief summary and any diffs it found. If you want to see all the variables, add the `--all` or `-a` parameter. If a diff is found, you will see the members that didn't match. If you want to see everything in that variable, add the `--verbose` or `-v` flag. You can combine `-a` and `-v` to see all details of every variable.

There was a design flaw that I have now fixed: the tool did not consider data that fell outside of the defined members in a struct (i.e. padding). We are now comparing everything in the footprint of the given datatype.

As I wrote on #743, you can describe a complex variable by partially defining it in the code, then running `datacmp`. It will print out all the members in the correct datatype (for any non-zero value) so you can add them to the code.

Much like comparing vtables, there is no compiler variance to worry about when matching variables, so a diff will be reported as build failure. The exception is a case where we cannot get complete type information from the PDB. If this happens, we can only do a byte-comparison. If one of the members of this variable is a pointer, or if we are comparing more bytes than necessary, we could have a diff even if there is nothing wrong. These are reported as warnings and will not fail the build.

Three issues from SmartHeap variables in ISLE:
- `?_pnhHeap@@3P6AHI@ZA`. Recomp sets this variable at the start of undefined data in the `.data` section, but it is has the initial value of zero in the original. I had to take this one offline to get things moving, but we could just as easily not have annotated it in the first place.
- `_shi_mutexMovShr`. There is a diff here, presumably because we do not have the exact version of SmartHeap from retail. It gets flagged as a warning because we cannot establish the type.
- `__shi_TaskRecord`. Some of this matches, but we are reading too much data. No type information to tell us when to stop, so we are going off of the not-really-accurate "section contribution" size from the PDB.