### PR TITLE
fix typo in reccmp effective match string

### DIFF
--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -107,7 +107,7 @@ def print_match_verbose(match, show_both_addrs: bool = False, is_plain: bool = F
             print(f"{addrs}: {match.name} 100% match.\n\n{ok_text}\n\n")
         else:
             print(
-                f"{addrs}: {match.name} Effective 100%% match. (Differs in register allocation only)\n\n{ok_text} (still differs in register allocation)\n\n"
+                f"{addrs}: {match.name} Effective 100% match. (Differs in register allocation only)\n\n{ok_text} (still differs in register allocation)\n\n"
             )
     else:
         print_combined_diff(match.udiff, is_plain, show_both_addrs)


### PR DESCRIPTION
Noticed this while working on #753.

<img width="608" alt="image" src="https://github.com/isledecomp/isle/assets/64166386/451ba7b4-3cee-4d1d-a18e-6de6bdbf0532">