### PR TITLE
parser: don't enforce variable naming convention

### DIFF
--- a/tools/isledecomp/isledecomp/parser/parser.py
+++ b/tools/isledecomp/isledecomp/parser/parser.py
@@ -535,13 +535,6 @@ class DecompParser:
                     variable_name = get_synthetic_name(line)
                 else:
                     variable_name = get_variable_name(line)
-                    # This is out of our control for library variables, but all of our
-                    # variables should start with "g_".
-                    if variable_name is not None:
-                        # Before checking for the prefix, remove the
-                        # namespace chain if there is one.
-                        if not variable_name.split("::")[-1].startswith("g_"):
-                            self._syntax_warning(ParserError.GLOBAL_MISSING_PREFIX)
 
             string_name = get_string_contents(line)
 

--- a/tools/isledecomp/tests/test_parser.py
+++ b/tools/isledecomp/tests/test_parser.py
@@ -377,6 +377,7 @@ def test_unexpected_eof(parser):
     assert parser.alerts[0].code == ParserError.UNEXPECTED_END_OF_FILE
 
 
+@pytest.mark.xfail(reason="no longer applies")
 def test_global_variable_prefix(parser):
     """Global and static variables should have the g_ prefix."""
     parser.read_lines(
@@ -576,6 +577,7 @@ def test_namespace_vtable(parser):
     assert parser.vtables[1].name == "Hello"
 
 
+@pytest.mark.xfail(reason="no longer applies")
 def test_global_prefix_namespace(parser):
     """Should correctly identify namespaces before checking for the g_ prefix"""
 


### PR DESCRIPTION
According to Mindscape style docs and the 96 source, global variables should have the prefix `g_` as in `Character g_characters[47]`.

The assert strings in Beta 1.0 have shown that many of these global variables might actually be static variables from a class, and that they used the `m_` prefix, much like instance members.

This problem of naming convention overlaps with the decomp parser because we have been checking any annotated variable for the `g_` prefix. We now have the `ncc` script that can more comprehensively enforce naming convention, so we are taking this warning out of the parser.