### PR TITLE
Implement/match LegoCharacterManager::FUN_10085870

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -11,6 +11,8 @@
 #include "roi/legolod.h"
 #include "roi/legoroi.h"
 
+#include <vec.h>
+
 DECOMP_SIZE_ASSERT(LegoCharacter, 0x08)
 DECOMP_SIZE_ASSERT(LegoCharacterManager, 0x08)
 
@@ -554,11 +556,46 @@ LegoROI* LegoCharacterManager::FUN_10085210(const char* p_name, const char* p_lo
 	return roi;
 }
 
-// STUB: LEGO1 0x10085870
+// FUNCTION: LEGO1 0x10085870
 MxResult LegoCharacterManager::FUN_10085870(LegoROI* p_roi)
 {
-	// TODO
-	return SUCCESS;
+	MxResult result = FAILURE;
+
+	BoundingSphere boundingSphere;
+	BoundingBox boundingBox;
+
+	const Tgl::MeshBuilder* meshBuilder = ((ViewLOD*) p_roi->GetLOD(0))->GetMeshBuilder();
+
+	if (meshBuilder != NULL) {
+		float min[3], max[3];
+
+		FILLVEC3(min, 88888.0);
+		FILLVEC3(max, -88888.0);
+		meshBuilder->GetBoundingBox(min, max);
+
+		float center[3];
+		center[0] = (min[0] + max[0]) / 2.0f;
+		center[1] = (min[1] + max[1]) / 2.0f;
+		center[2] = (min[2] + max[2]) / 2.0f;
+		SET3(boundingSphere.Center(), center);
+
+		float radius[3];
+		VMV3(radius, max, min);
+		boundingSphere.Radius() = sqrt(NORMSQRD3(radius)) / 2.0;
+
+		p_roi->SetBoundingSphere(boundingSphere);
+
+		SET3(boundingBox.Min(), min);
+		SET3(boundingBox.Max(), max);
+
+		p_roi->SetUnknown0x80(boundingBox);
+
+		p_roi->VTable0x14();
+
+		result = SUCCESS;
+	}
+
+	return result;
 }
 
 // FUNCTION: LEGO1 0x10085a80

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -362,7 +362,7 @@ public:
 		unsigned long (*pTextureIndices)[3],
 		ShadingModel shadingModel
 	) override;
-	Result GetBoundingBox(float min[3], float max[3]) override;
+	Result GetBoundingBox(float min[3], float max[3]) const override;
 
 	// vtable+0x10
 	MeshBuilder* Clone() override;

--- a/LEGO1/tgl/d3drm/meshbuilder.cpp
+++ b/LEGO1/tgl/d3drm/meshbuilder.cpp
@@ -159,7 +159,7 @@ inline Result MeshBuilderImpl::CreateMeshImpl(
 }
 
 // FUNCTION: LEGO1 0x100a3ae0
-Result MeshBuilderImpl::GetBoundingBox(float min[3], float max[3])
+Result MeshBuilderImpl::GetBoundingBox(float min[3], float max[3]) const
 {
 	D3DRMBOX box;
 	Result result = ResultVal(m_data->GetBox(&box));

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -330,7 +330,7 @@ public:
 		unsigned long (*pTextureIndices)[3],
 		ShadingModel shadingModel
 	) = 0;
-	virtual Result GetBoundingBox(float min[3], float max[3]) = 0;
+	virtual Result GetBoundingBox(float min[3], float max[3]) const = 0;
 	virtual MeshBuilder* Clone() = 0;
 
 	// SYNTHETIC: LEGO1 0x100a27b0


### PR DESCRIPTION
Match is ~88%, one function isn't properly inlined right now. Figuring this out is tricky because the compiler treats generated/synthetic inline functions differently than user-defined ones (even if code equivalent), and it's not possible to distinguish them even in the beta. In particular this affects functions like the assignment operators of the vector classes.