### PR TITLE
Use colorama.just_fix_windows_console

### DIFF
--- a/tools/datacmp.py
+++ b/tools/datacmp.py
@@ -16,7 +16,7 @@ from isledecomp.cvdump.types import (
 from isledecomp.bin import Bin as IsleBin
 import colorama
 
-colorama.init()
+colorama.just_fix_windows_console()
 
 
 # Ignore all compare-db messages.

--- a/tools/decomplint/decomplint.py
+++ b/tools/decomplint/decomplint.py
@@ -7,7 +7,7 @@ import colorama
 from isledecomp.dir import walk_source_dir, is_file_cpp
 from isledecomp.parser import DecompLinter
 
-colorama.init()
+colorama.just_fix_windows_console()
 
 
 def display_errors(alerts, filename):

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -19,7 +19,7 @@ from isledecomp.types import SymbolType
 from pystache import Renderer
 import colorama
 
-colorama.init()
+colorama.just_fix_windows_console()
 
 
 def gen_json(json_file: str, orig_file: str, data):

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,7 +1,7 @@
 tools/isledecomp
 capstone
 clang==16.*
-colorama
+colorama>=0.4.6
 isledecomp
 pystache
 pyyaml

--- a/tools/vtable/vtable.py
+++ b/tools/vtable/vtable.py
@@ -12,7 +12,7 @@ from isledecomp.utils import print_combined_diff
 # Ignore all compare-db messages.
 logging.getLogger("isledecomp.compare").addHandler(logging.NullHandler())
 
-colorama.init()
+colorama.just_fix_windows_console()
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
To enable ANSI colors for our Python scripts, we are using the `colorama` module and we have been calling `colorama.init()` to set this up. Our main reason for doing this is to support the ANSI codes on Windows terminals; for this situation the colorama folks recommend calling [`colorama.just_fix_windows_console()`](https://github.com/tartley/colorama?tab=readme-ov-file#initialisation) instead.

This is available on colorama 0.4.6 and later. Our github CI environments use 0.4.4. This is either cached somewhere or built-in with the container/VM image. I changed requirements.txt to 0.4.6 to force the newer version.

Users might have to update colorama but probably not. Aside from that, there should be no impact to user text display. Where this _will_ change things is on the github CI output, and we should now have colors there. The "compare accuracy" text will register a near-100% diff because the ANSI codes are different, so please ignore that. 😉