### PR TITLE
Use reference on MxDSObject Deserialize calls

### DIFF
--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -45,7 +45,7 @@ public:
 
 	undefined4 VTable0x14() override;                            // vtable+14;
 	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8** p_source, MxS16 p_unk0x24) override; // vtable+1c;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	virtual MxLong GetDuration();                                // vtable+24;
 	virtual void SetDuration(MxLong p_duration);                 // vtable+28;
 	virtual MxDSAction* Clone();                                 // vtable+2c;

--- a/LEGO1/omni/include/mxdsmediaaction.h
+++ b/LEGO1/omni/include/mxdsmediaaction.h
@@ -33,7 +33,7 @@ public:
 
 	undefined4 VTable0x14() override;                            // vtable+14;
 	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8** p_source, MxS16 p_unk0x24) override; // vtable+1c;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	MxDSAction* Clone() override;                                // vtable+2c;
 
 	void CopyMediaSrcPath(const char* p_mediaSrcPath);

--- a/LEGO1/omni/include/mxdsmultiaction.h
+++ b/LEGO1/omni/include/mxdsmultiaction.h
@@ -29,7 +29,7 @@ public:
 
 	undefined4 VTable0x14() override;                            // vtable+14;
 	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8** p_source, MxS16 p_unk0x24) override; // vtable+1c;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	void SetAtomId(MxAtomId p_atomId) override;                  // vtable+20;
 	MxDSAction* Clone() override;                                // vtable+2c;
 	void MergeFrom(MxDSAction& p_dsAction) override;             // vtable+30;

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -46,7 +46,7 @@ public:
 
 	virtual undefined4 VTable0x14();                                                // vtable+14;
 	virtual MxU32 GetSizeOnDisk();                                                  // vtable+18;
-	virtual void Deserialize(MxU8** p_source, MxS16 p_unk0x24);                     // vtable+1c;
+	virtual void Deserialize(MxU8*& p_source, MxS16 p_unk0x24);                     // vtable+1c;
 	inline virtual void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; } // vtable+20;
 
 	inline Type GetType() const { return (Type) this->m_type; }
@@ -79,7 +79,7 @@ private:
 	MxPresenter* m_unk0x28; // 0x28
 };
 
-MxDSObject* DeserializeDSObjectDispatch(MxU8**, MxS16);
+MxDSObject* DeserializeDSObjectDispatch(MxU8*&, MxS16);
 
 // FUNCTION: ISLE 0x401c40
 // MxDSObject::SetAtomId

--- a/LEGO1/omni/include/mxdsselectaction.h
+++ b/LEGO1/omni/include/mxdsselectaction.h
@@ -29,7 +29,7 @@ public:
 	}
 
 	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8** p_source, MxS16 p_unk0x24) override; // vtable+1c;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	MxDSAction* Clone() override;                                // vtable+2c;
 
 	// SYNTHETIC: LEGO1 0x100cb840

--- a/LEGO1/omni/include/mxdssound.h
+++ b/LEGO1/omni/include/mxdssound.h
@@ -27,7 +27,7 @@ public:
 	}
 
 	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8** p_source, MxS16 p_unk0x24) override; // vtable+1c;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	MxDSAction* Clone() override;                                // vtable+2c;
 
 	inline MxS32 GetVolume() const { return m_volume; }

--- a/LEGO1/omni/include/mxutilities.h
+++ b/LEGO1/omni/include/mxutilities.h
@@ -30,32 +30,32 @@ inline T Max(T p_t1, T p_t2)
 }
 
 template <class T>
-inline void GetScalar(MxU8** p_source, T& p_dest)
+inline void GetScalar(MxU8*& p_source, T& p_dest)
 {
-	p_dest = *(T*) *p_source;
-	*p_source += sizeof(T);
+	p_dest = *(T*) p_source;
+	p_source += sizeof(T);
 }
 
 template <class T>
-inline T GetScalar(T** p_source)
+inline T GetScalar(T*& p_source)
 {
-	T val = **p_source;
-	*p_source += 1;
+	T val = *p_source;
+	p_source += 1;
 	return val;
 }
 
 template <class T>
-inline void GetDouble(MxU8** p_source, T& p_dest)
+inline void GetDouble(MxU8*& p_source, T& p_dest)
 {
-	p_dest = *(double*) *p_source;
-	*p_source += sizeof(double);
+	p_dest = *(double*) p_source;
+	p_source += sizeof(double);
 }
 
 template <class T>
-inline void GetString(MxU8** p_source, char** p_dest, T* p_obj, void (T::*p_setter)(const char*))
+inline void GetString(MxU8*& p_source, char*& p_dest, T* p_obj, void (T::*p_setter)(const char*))
 {
-	(p_obj->*p_setter)((char*) *p_source);
-	*p_source += strlen(*p_dest) + 1;
+	(p_obj->*p_setter)((char*) p_source);
+	p_source += strlen(p_dest) + 1;
 }
 
 MxBool GetRectIntersection(

--- a/LEGO1/omni/src/action/mxdsaction.cpp
+++ b/LEGO1/omni/src/action/mxdsaction.cpp
@@ -221,7 +221,7 @@ void MxDSAction::AppendData(MxU16 p_extraLength, const char* p_extraData)
 }
 
 // FUNCTION: LEGO1 0x100adf70
-void MxDSAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
+void MxDSAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSObject::Deserialize(p_source, p_unk0x24);
 
@@ -239,9 +239,11 @@ void MxDSAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
 	GetDouble(p_source, this->m_up[1]);
 	GetDouble(p_source, this->m_up[2]);
 
-	MxU16 extraLength = GetScalar((MxU16**) p_source);
+	MxU16 extraLength = *(MxU16*) p_source;
+	p_source += 2;
+
 	if (extraLength) {
-		AppendData(extraLength, (char*) *p_source);
-		*p_source += extraLength;
+		AppendData(extraLength, (char*) p_source);
+		p_source += extraLength;
 	}
 }

--- a/LEGO1/omni/src/action/mxdsmediaaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmediaaction.cpp
@@ -104,11 +104,11 @@ MxU32 MxDSMediaAction::GetSizeOnDisk()
 }
 
 // FUNCTION: LEGO1 0x100c8f60
-void MxDSMediaAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
+void MxDSMediaAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSAction::Deserialize(p_source, p_unk0x24);
 
-	GetString(p_source, &this->m_mediaSrcPath, this, &MxDSMediaAction::CopyMediaSrcPath);
+	GetString(p_source, this->m_mediaSrcPath, this, &MxDSMediaAction::CopyMediaSrcPath);
 	GetScalar(p_source, this->m_unk0x9c.m_unk0x00);
 	GetScalar(p_source, this->m_unk0x9c.m_unk0x04);
 	GetScalar(p_source, this->m_framesPerSecond);

--- a/LEGO1/omni/src/action/mxdsmultiaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmultiaction.cpp
@@ -129,29 +129,29 @@ MxU32 MxDSMultiAction::GetSizeOnDisk()
 }
 
 // FUNCTION: LEGO1 0x100ca7b0
-void MxDSMultiAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
+void MxDSMultiAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSAction::Deserialize(p_source, p_unk0x24);
 
-	MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
-	*p_source += 12;
+	MxU32 extraFlag = *(MxU32*) (p_source + 4) & 1;
+	p_source += 12;
 
-	MxU32 count = *(MxU32*) *p_source;
-	*p_source += sizeof(count);
+	MxU32 count = *(MxU32*) p_source;
+	p_source += sizeof(count);
 
 	if (count) {
 		while (count--) {
-			MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
-			*p_source += 8;
+			MxU32 extraFlag = *(MxU32*) (p_source + 4) & 1;
+			p_source += 8;
 
 			MxDSAction* action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk0x24);
-			*p_source += extraFlag;
+			p_source += extraFlag;
 
 			this->m_actions->Append(action);
 		}
 	}
 
-	*p_source += extraFlag;
+	p_source += extraFlag;
 }
 
 // FUNCTION: LEGO1 0x100ca8c0

--- a/LEGO1/omni/src/action/mxdsobject.cpp
+++ b/LEGO1/omni/src/action/mxdsobject.cpp
@@ -131,21 +131,21 @@ MxU32 MxDSObject::GetSizeOnDisk()
 }
 
 // FUNCTION: LEGO1 0x100bfa20
-void MxDSObject::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
+void MxDSObject::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
-	GetString(p_source, &this->m_sourceName, this, &MxDSObject::SetSourceName);
+	GetString(p_source, this->m_sourceName, this, &MxDSObject::SetSourceName);
 	GetScalar(p_source, this->m_unk0x14);
-	GetString(p_source, &this->m_objectName, this, &MxDSObject::SetObjectName);
+	GetString(p_source, this->m_objectName, this, &MxDSObject::SetObjectName);
 	GetScalar(p_source, this->m_objectId);
 
 	this->m_unk0x24 = p_unk0x24;
 }
 
 // FUNCTION: LEGO1 0x100bfb30
-MxDSObject* DeserializeDSObjectDispatch(MxU8** p_source, MxS16 p_flags)
+MxDSObject* DeserializeDSObjectDispatch(MxU8*& p_source, MxS16 p_flags)
 {
-	MxU16 type = *(MxU16*) *p_source;
-	*p_source += 2;
+	MxU16 type = *(MxU16*) p_source;
+	p_source += 2;
 
 	MxDSObject* obj = NULL;
 

--- a/LEGO1/omni/src/action/mxdsselectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsselectaction.cpp
@@ -81,15 +81,15 @@ MxU32 MxDSSelectAction::GetSizeOnDisk()
 }
 
 // FUNCTION: LEGO1 0x100cbf60
-void MxDSSelectAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
+void MxDSSelectAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxString string;
 	MxDSAction::Deserialize(p_source, p_unk0x24);
 
-	MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
-	*p_source += 12;
+	MxU32 extraFlag = *(MxU32*) (p_source + 4) & 1;
+	p_source += 12;
 
-	this->m_unk0x9c = (char*) *p_source;
+	this->m_unk0x9c = (char*) p_source;
 
 	if (!strnicmp(this->m_unk0x9c.GetData(), "RANDOM_", strlen("RANDOM_"))) {
 		char buffer[10];
@@ -100,13 +100,13 @@ void MxDSSelectAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
 		string = itoa((MxS16) random, buffer, 10);
 	}
 	else {
-		string = VariableTable()->GetVariable((char*) *p_source);
+		string = VariableTable()->GetVariable((char*) p_source);
 	}
 
-	*p_source += strlen((char*) *p_source) + 1;
+	p_source += strlen((char*) p_source) + 1;
 
-	MxU32 count = *(MxU32*) *p_source;
-	*p_source += sizeof(MxU32);
+	MxU32 count = *(MxU32*) p_source;
+	p_source += sizeof(MxU32);
 
 	if (count) {
 		MxS32 index = -1;
@@ -114,17 +114,17 @@ void MxDSSelectAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
 
 		MxU32 i;
 		for (i = 0; i < count; i++) {
-			if (!strcmp(string.GetData(), (char*) *p_source)) {
+			if (!strcmp(string.GetData(), (char*) p_source)) {
 				index = i;
 			}
 
-			this->m_unk0xac->Append((char*) *p_source);
-			*p_source += strlen((char*) *p_source) + 1;
+			this->m_unk0xac->Append((char*) p_source);
+			p_source += strlen((char*) p_source) + 1;
 		}
 
 		for (i = 0; i < count; i++) {
-			MxU32 extraFlag = *(MxU32*) (*p_source + 4) & 1;
-			*p_source += 8;
+			MxU32 extraFlag = *(MxU32*) (p_source + 4) & 1;
+			p_source += 8;
 
 			MxDSAction* action = (MxDSAction*) DeserializeDSObjectDispatch(p_source, p_unk0x24);
 
@@ -135,9 +135,9 @@ void MxDSSelectAction::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
 				delete action;
 			}
 
-			*p_source += extraFlag;
+			p_source += extraFlag;
 		}
 	}
 
-	*p_source += extraFlag;
+	p_source += extraFlag;
 }

--- a/LEGO1/omni/src/action/mxdssound.cpp
+++ b/LEGO1/omni/src/action/mxdssound.cpp
@@ -48,7 +48,7 @@ MxDSAction* MxDSSound::Clone()
 }
 
 // FUNCTION: LEGO1 0x100c95a0
-void MxDSSound::Deserialize(MxU8** p_source, MxS16 p_unk0x24)
+void MxDSSound::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSMediaAction::Deserialize(p_source, p_unk0x24);
 

--- a/LEGO1/omni/src/common/mxutilities.cpp
+++ b/LEGO1/omni/src/common/mxutilities.cpp
@@ -185,7 +185,7 @@ MxDSObject* CreateStreamObject(MxDSFile* p_file, MxS16 p_ofs)
 			// Save a copy so we can clean up properly, because
 			// this function will alter the pointer value.
 			MxU8* copy = buf;
-			MxDSObject* obj = DeserializeDSObjectDispatch(&buf, -1);
+			MxDSObject* obj = DeserializeDSObjectDispatch(buf, -1);
 			delete[] copy;
 			return obj;
 		}

--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -322,7 +322,7 @@ MxCore* MxDSBuffer::ReadChunk(MxDSBuffer* p_buffer, MxU32* p_chunkData, MxU16 p_
 
 	switch (*p_chunkData) {
 	case FOURCC('M', 'x', 'O', 'b'):
-		result = DeserializeDSObjectDispatch(&dataStart, p_flags);
+		result = DeserializeDSObjectDispatch(dataStart, p_flags);
 		break;
 	case FOURCC('M', 'x', 'C', 'h'):
 		result = new MxStreamChunk();

--- a/LEGO1/omni/src/stream/mxramstreamprovider.cpp
+++ b/LEGO1/omni/src/stream/mxramstreamprovider.cpp
@@ -113,7 +113,7 @@ MxU32 ReadData(MxU8* p_buffer, MxU32 p_size)
 				data2 = data;
 				data += 8;
 
-				MxDSObject* obj = DeserializeDSObjectDispatch(&data, -1);
+				MxDSObject* obj = DeserializeDSObjectDispatch(data, -1);
 				id = obj->GetObjectId();
 				delete obj;
 

--- a/LEGO1/omni/src/stream/mxstreamchunk.cpp
+++ b/LEGO1/omni/src/stream/mxstreamchunk.cpp
@@ -36,12 +36,19 @@ MxU32 MxStreamChunk::ReadChunkHeader(MxU8* p_chunkData)
 	MxU32 headersize = 0;
 	if (p_chunkData) {
 		MxU8* chunkData = p_chunkData;
-		// Note: the alpha debug version uses memcpy calls here,
-		// but the code generation is the same.
-		GetScalar(&p_chunkData, m_flags);
-		GetScalar(&p_chunkData, m_objectId);
-		GetScalar(&p_chunkData, m_time);
-		GetScalar(&p_chunkData, m_length);
+
+		memcpy(&m_flags, p_chunkData, sizeof(m_flags));
+		p_chunkData += sizeof(m_flags);
+
+		memcpy(&m_objectId, p_chunkData, sizeof(m_objectId));
+		p_chunkData += sizeof(m_objectId);
+
+		memcpy(&m_time, p_chunkData, sizeof(m_time));
+		p_chunkData += sizeof(m_time);
+
+		memcpy(&m_length, p_chunkData, sizeof(m_length));
+		p_chunkData += sizeof(m_length);
+
 		m_data = p_chunkData;
 		headersize = p_chunkData - chunkData;
 	}


### PR DESCRIPTION
`DeserializeDSObjectDispatch()` and each `Deserialize()` function for `MxDSObject` and children take a buffer as an argument. The expectation is that the function will modify the caller's buffer as we seek through the data read in from the file.

We had been using a double pointer `MxU8**` for this, but I think it's cleaner to use a reference `MxU8*&` instead. No diff except register swap on one function.

`MxStreamChunk::ReadChunkHeader` wasn't playing along so I changed the code to use `memcpy` instead to get back to 100%. This matches Beta 1.0 and the Alpha, per the code comment.