### PR TITLE
Implement LegoPathActor::VTable0x88

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,11 @@ add_library(geom STATIC
   LEGO1/lego/sources/geom/legoedge.cpp
   LEGO1/lego/sources/geom/legomesh.cpp
   LEGO1/lego/sources/geom/legosphere.cpp
+  LEGO1/lego/sources/geom/legounkown100db7f4.cpp
   LEGO1/lego/sources/geom/legovertex.cpp
   LEGO1/lego/sources/geom/legoweedge.cpp
   LEGO1/lego/sources/geom/legowegedge.cpp
+
 )
 register_lego1_target(geom)
 set_property(TARGET geom PROPERTY ARCHIVE_OUTPUT_NAME "geom$<$<CONFIG:Debug>:d>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,6 @@ add_library(geom STATIC
   LEGO1/lego/sources/geom/legovertex.cpp
   LEGO1/lego/sources/geom/legoweedge.cpp
   LEGO1/lego/sources/geom/legowegedge.cpp
-
 )
 register_lego1_target(geom)
 set_property(TARGET geom PROPERTY ARCHIVE_OUTPUT_NAME "geom$<$<CONFIG:Debug>:d>")

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -48,7 +48,14 @@ public:
 		Vector3& p_point4
 	);                         // vtable+0x80
 	virtual void VTable0x84(); // vtable+0x84
-	virtual void VTable0x88(); // vtable+0x88
+	virtual MxResult VTable0x88(
+		LegoPathBoundary* p_boundary,
+		float p_time,
+		LegoEdge& p_edge1,
+		float p_scale1,
+		LegoEdge& p_edge2,
+		float p_scale2
+	);                         // vtable+0x88
 	virtual void VTable0x8c(); // vtable+0x8c
 
 	// FUNCTION: LEGO1 0x10002d40
@@ -110,7 +117,7 @@ protected:
 	LegoUnknown m_unk0x8c;            // 0x8c
 	MxU32 m_state;                    // 0xdc
 	LegoEdge* m_destEdge;             // 0xe0
-	undefined4 m_unk0xe4;             // 0xe4
+	MxFloat m_unk0xe4;                // 0xe4
 	undefined m_unk0xe8;              // 0xe8
 	undefined m_unk0xe9;              // 0xe9
 	MxBool m_userNavFlag;             // 0xea

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -52,10 +52,10 @@ public:
 	virtual MxResult VTable0x88(
 		LegoPathBoundary* p_boundary,
 		float p_time,
-		LegoEdge& p_edge1,
-		float p_scale1,
-		LegoUnknown100db7f4& p_edge2,
-		float p_scale2
+		LegoEdge& p_srcEdge,
+		float p_srcScale,
+		LegoUnknown100db7f4& p_destEdge,
+		float p_destScale
 	);                         // vtable+0x88
 	virtual void VTable0x8c(); // vtable+0x8c
 

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -1,6 +1,7 @@
 #ifndef LEGOPATHACTOR_H
 #define LEGOPATHACTOR_H
 
+#include "geom/legounkown100db7f4.h"
 #include "legoactor.h"
 #include "legopathboundary.h"
 #include "misc/legounknown.h"
@@ -53,7 +54,7 @@ public:
 		float p_time,
 		LegoEdge& p_edge1,
 		float p_scale1,
-		LegoEdge& p_edge2,
+		LegoUnknown100db7f4& p_edge2,
 		float p_scale2
 	);                         // vtable+0x88
 	virtual void VTable0x8c(); // vtable+0x8c

--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -6,14 +6,20 @@
 #include "mxstl/stlcompat.h"
 #include "mxtypes.h"
 
-struct LegoPathBoundaryComparator {
-	MxBool operator()(const undefined*, const undefined*) const { return 0; }
+class LegoPathActor;
+
+struct LegoPathActorSetCompare {
+	MxU32 operator()(const LegoPathActor* p_lhs, const LegoPathActor* p_rhs) const
+	{
+		return (MxS32) p_lhs < (MxS32) p_rhs;
+	}
 };
 
 struct LegoAnimPresenterSetCompare {
-	MxBool operator()(const LegoAnimPresenter*, const LegoAnimPresenter*) const { return 0; }
+	MxBool operator()(const LegoAnimPresenter* p_lhs, const LegoAnimPresenter* p_rhs) const { return 0; }
 };
 
+typedef set<LegoPathActor*, LegoPathActorSetCompare> LegoPathActorSet;
 typedef set<LegoAnimPresenter*, LegoAnimPresenterSetCompare> LegoAnimPresenterSet;
 
 // VTABLE: LEGO1 0x100d8618
@@ -22,16 +28,28 @@ class LegoPathBoundary : public LegoWEGEdge {
 public:
 	LegoPathBoundary();
 
-	// STUB: LEGO1 0x10047a80
-	// LegoPathBoundary::`scalar deleting destructor'
+	MxResult AddActor(LegoPathActor* p_actor);
+
 	inline LegoAnimPresenterSet* GetUnknown0x64() { return &m_unk0x64; }
 
+	// STUB: LEGO1 0x10047a80
+	// LegoPathBoundary::`scalar deleting destructor'
+
 private:
-	map<undefined*, undefined*, LegoPathBoundaryComparator> m_unk0x54; // 0x54
-	LegoAnimPresenterSet m_unk0x64;                                    // 0x64
+	LegoPathActorSet m_unk0x54;     // 0x54
+	LegoAnimPresenterSet m_unk0x64; // 0x64
 };
 
 // clang-format off
+// TEMPLATE: LEGO1 0x10045d80
+// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::iterator::_Dec
+
+// TEMPLATE: LEGO1 0x10045dd0
+// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Insert
+
+// GLOBAL: LEGO1 0x100f11a4
+// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Nil
+
 // GLOBAL: LEGO1 0x100f3200
 // _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Nil
 // clang-format on

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -217,8 +217,8 @@ MxU32 Helicopter::VTable0xd4(LegoControlManagerEvent& p_param)
 				lookat.Add(&loc);
 				Mx3DPointFloat v68, v7c, v90(0, 1, 0), va4;
 				v68 = m_world->GetCamera()->GetWorldUp();
-				va4.EqualsCross(v68, dir);
-				v7c.EqualsCross(va4, v90);
+				va4.EqualsCross(&v68, &dir);
+				v7c.EqualsCross(&va4, &v90);
 				if (ret) {
 					if (((Act3*) m_world)->FUN_100727e0(m_controller, loc, dir, v7c)) {
 						break;

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -52,10 +52,79 @@ MxResult LegoPathActor::VTable0x80(Vector3& p_point1, Vector3& p_point2, Vector3
 	return FAILURE;
 }
 
-// STUB: LEGO1 0x1002d9c0
-void LegoPathActor::VTable0x88()
+// FUNCTION: LEGO1 0x1002d9c0
+MxResult LegoPathActor::VTable0x88(
+	LegoPathBoundary* p_boundary,
+	float p_time,
+	LegoEdge& p_srcEdge,
+	float p_srcScale,
+	LegoEdge& p_dstEdge,
+	float p_dstScale
+)
 {
-	// TODO
+	Vector3* v1 = p_srcEdge.GetOpposingPoint(p_boundary);
+	Vector3* v2 = p_srcEdge.GetPoint(p_boundary);
+	Vector3* v3 = p_dstEdge.GetOpposingPoint(p_boundary);
+	Vector3* v4 = p_dstEdge.GetPoint(p_boundary);
+	Mx3DPointFloat p1, p2, p3, p4, p5;
+	p1 = *v2;
+	((Vector3&) p1).Sub(v1);
+	((Vector3&) p1).Mul(p_srcScale);
+	((Vector3&) p1).Add(v1);
+	p2 = *v4;
+	((Vector3&) p2).Sub(v3);
+	((Vector3&) p2).Mul(p_dstScale);
+	((Vector3&) p2).Add(v3);
+	m_boundary = p_boundary;
+	m_destEdge = &p_dstEdge;
+	m_unk0xe4 = p_dstScale;
+	m_lastTime = p_time;
+	m_actorTime = p_time;
+	m_unk0x7c = 0;
+	p_dstEdge.FUN_1002ddc0(m_boundary, p3);
+	p4 = p2;
+	((Vector3&) p4).Sub(&p1);
+	float len = ((Vector3&) p4).LenSquared();
+	if (len > 0) {
+		len = sqrtf(len);
+		if (len > 0) {
+			p4.Div(len);
+		}
+	}
+	MxMatrix matrix;
+	Vector3 pos(matrix[3]);
+	Vector3 dir(matrix[2]);
+	Vector3 up(matrix[1]);
+	Vector3 right(matrix[0]);
+	matrix.SetIdentity();
+	pos = p1;
+	dir = p4;
+	up = *m_boundary->GetUnknown0x14();
+	if (!m_cameraFlag || !m_userNavFlag) {
+		((Vector3&) dir).Mul(-1.0f);
+	}
+	right.EqualsCross(&up, &dir);
+	m_roi->FUN_100a46b0(matrix);
+	if (m_cameraFlag && m_userNavFlag) {
+		m_boundary->AddActor(this);
+		FUN_10010c30();
+	}
+	else {
+		((Vector3&) p5).EqualsCrossImpl(p_boundary->GetUnknown0x14()->GetData(), p3.GetData());
+		float len2 = ((Vector3&) p5).LenSquared();
+		if (len2 > 0) {
+			len2 = sqrtf(len2);
+			if (len2 > 0) {
+				p5.Div(len2);
+			}
+		}
+		if (VTable0x80(p1, p4, p2, p5) != SUCCESS) {
+			return FAILURE;
+		}
+		m_boundary->AddActor(this);
+	}
+	m_unk0xec = m_roi->GetLocal2World();
+	return SUCCESS;
 }
 
 // STUB: LEGO1 0x1002de10

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -67,11 +67,7 @@ MxResult LegoPathActor::VTable0x88(
 	Vector3* v3 = p_destEdge.GetOpposingPoint(p_boundary);
 	Vector3* v4 = p_destEdge.GetPoint(p_boundary);
 
-	Mx3DPointFloat p1;
-	Mx3DPointFloat p2;
-	Mx3DPointFloat p3;
-	Mx3DPointFloat p4;
-	Mx3DPointFloat p5;
+	Mx3DPointFloat p1, p2, p3, p4, p5;
 
 	p1 = *v2;
 	((Vector3&) p1).Sub(v1);

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -58,71 +58,77 @@ MxResult LegoPathActor::VTable0x88(
 	float p_time,
 	LegoEdge& p_srcEdge,
 	float p_srcScale,
-	LegoUnknown100db7f4& p_dstEdge,
-	float p_dstScale
+	LegoUnknown100db7f4& p_destEdge,
+	float p_destScale
 )
 {
 	Vector3* v1 = p_srcEdge.GetOpposingPoint(p_boundary);
 	Vector3* v2 = p_srcEdge.GetPoint(p_boundary);
-	Vector3* v3 = p_dstEdge.GetOpposingPoint(p_boundary);
-	Vector3* v4 = p_dstEdge.GetPoint(p_boundary);
-	Mx3DPointFloat p1, p2, p3, p4, p5;
+	Vector3* v3 = p_destEdge.GetOpposingPoint(p_boundary);
+	Vector3* v4 = p_destEdge.GetPoint(p_boundary);
+
+	Mx3DPointFloat p1;
+	Mx3DPointFloat p2;
+	Mx3DPointFloat p3;
+	Mx3DPointFloat p4;
+	Mx3DPointFloat p5;
+
 	p1 = *v2;
 	((Vector3&) p1).Sub(v1);
 	((Vector3&) p1).Mul(p_srcScale);
 	((Vector3&) p1).Add(v1);
+
 	p2 = *v4;
 	((Vector3&) p2).Sub(v3);
-	((Vector3&) p2).Mul(p_dstScale);
+	((Vector3&) p2).Mul(p_destScale);
 	((Vector3&) p2).Add(v3);
+
 	m_boundary = p_boundary;
-	m_destEdge = &p_dstEdge;
-	m_unk0xe4 = p_dstScale;
+	m_destEdge = &p_destEdge;
+	m_unk0xe4 = p_destScale;
+	m_unk0x7c = 0;
 	m_lastTime = p_time;
 	m_actorTime = p_time;
-	m_unk0x7c = 0;
-	p_dstEdge.FUN_1002ddc0(m_boundary, p3);
+	p_destEdge.FUN_1002ddc0(*p_boundary, p3);
+
 	p4 = p2;
 	((Vector3&) p4).Sub(&p1);
-	float len = ((Vector3&) p4).LenSquared();
-	if (len > 0) {
-		len = sqrtf(len);
-		if (len > 0) {
-			p4.Div(len);
-		}
-	}
+	p4.Unitize();
+
 	MxMatrix matrix;
 	Vector3 pos(matrix[3]);
 	Vector3 dir(matrix[2]);
 	Vector3 up(matrix[1]);
 	Vector3 right(matrix[0]);
+
 	matrix.SetIdentity();
 	pos = p1;
 	dir = p4;
-	up = *m_boundary->GetUnknown0x14();
+	up = *m_boundary->GetUnknown0x14(); // TODO
+
 	if (!m_cameraFlag || !m_userNavFlag) {
 		((Vector3&) dir).Mul(-1.0f);
 	}
+
 	right.EqualsCross(&up, &dir);
 	m_roi->FUN_100a46b0(matrix);
-	if (m_cameraFlag && m_userNavFlag) {
+
+	if (!m_cameraFlag || !m_userNavFlag) {
+		p5.EqualsCross(p_boundary->GetUnknown0x14(), &p3);
+		p5.Unitize();
+
+		if (VTable0x80(p1, p4, p2, p5) == SUCCESS) {
+			m_boundary->AddActor(this);
+		}
+		else {
+			return FAILURE;
+		}
+	}
+	else {
 		m_boundary->AddActor(this);
 		FUN_10010c30();
 	}
-	else {
-		((Vector3&) p5).EqualsCrossImpl(p_boundary->GetUnknown0x14()->GetData(), p3.GetData());
-		float len2 = ((Vector3&) p5).LenSquared();
-		if (len2 > 0) {
-			len2 = sqrtf(len2);
-			if (len2 > 0) {
-				p5.Div(len2);
-			}
-		}
-		if (VTable0x80(p1, p4, p2, p5) != SUCCESS) {
-			return FAILURE;
-		}
-		m_boundary->AddActor(this);
-	}
+
 	m_unk0xec = m_roi->GetLocal2World();
 	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -58,7 +58,7 @@ MxResult LegoPathActor::VTable0x88(
 	float p_time,
 	LegoEdge& p_srcEdge,
 	float p_srcScale,
-	LegoEdge& p_dstEdge,
+	LegoUnknown100db7f4& p_dstEdge,
 	float p_dstScale
 )
 {

--- a/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
@@ -1,10 +1,19 @@
 #include "legopathboundary.h"
 
 #include "decomp.h"
+#include "legopathactor.h"
 
 DECOMP_SIZE_ASSERT(LegoPathBoundary, 0x74)
 
 // STUB: LEGO1 0x10056a70
 LegoPathBoundary::LegoPathBoundary()
 {
+}
+
+// FUNCTION: LEGO1 0x100573f0
+MxResult LegoPathBoundary::AddActor(LegoPathActor* p_actor)
+{
+	m_unk0x54.insert(p_actor);
+	p_actor->SetBoundary(this);
+	return SUCCESS;
 }

--- a/LEGO1/lego/sources/geom/legoedge.cpp
+++ b/LEGO1/lego/sources/geom/legoedge.cpp
@@ -4,14 +4,6 @@
 
 DECOMP_SIZE_ASSERT(LegoEdge, 0x24)
 
-// TODO Based on the offset, this should be in the header, but as a stub it's getting inlined when there...
-// STUB: LEGO1 0x1002ddc0
-LegoResult LegoEdge::FUN_1002ddc0(LegoWEEdge* p_face, Vector3& p_point)
-{
-	// TODO
-	return SUCCESS;
-}
-
 // FUNCTION: LEGO1 0x1009a470
 LegoEdge::LegoEdge()
 {

--- a/LEGO1/lego/sources/geom/legoedge.cpp
+++ b/LEGO1/lego/sources/geom/legoedge.cpp
@@ -4,6 +4,14 @@
 
 DECOMP_SIZE_ASSERT(LegoEdge, 0x24)
 
+// TODO Based on the offset, this should be in the header, but as a stub it's getting inlined when there...
+// STUB: LEGO1 0x1002ddc0
+LegoResult LegoEdge::FUN_1002ddc0(LegoWEEdge* p_face, Vector3& p_point)
+{
+	// TODO
+	return SUCCESS;
+}
+
 // FUNCTION: LEGO1 0x1009a470
 LegoEdge::LegoEdge()
 {

--- a/LEGO1/lego/sources/geom/legoedge.h
+++ b/LEGO1/lego/sources/geom/legoedge.h
@@ -1,6 +1,7 @@
 #ifndef __LEGOEDGE_H
 #define __LEGOEDGE_H
 
+#include "misc/legotypes.h"
 #include "realtime/vector.h"
 
 class LegoWEEdge;
@@ -15,6 +16,8 @@ struct LegoEdge {
 	LegoEdge* GetCounterclockwiseEdge(LegoWEEdge* face);
 	Vector3* GetOpposingPoint(LegoWEEdge* face);
 	Vector3* GetPoint(LegoWEEdge* face);
+
+	LegoResult FUN_1002ddc0(LegoWEEdge* p_face, Vector3& p_point);
 
 	// SYNTHETIC: LEGO1 0x1009a4a0
 	// LegoEdge::`scalar deleting destructor'

--- a/LEGO1/lego/sources/geom/legounkown100db7f4.cpp
+++ b/LEGO1/lego/sources/geom/legounkown100db7f4.cpp
@@ -1,0 +1,3 @@
+#include "legounkown100db7f4.h"
+
+DECOMP_SIZE_ASSERT(LegoUnknown100db7f4, 0x40)

--- a/LEGO1/lego/sources/geom/legounkown100db7f4.h
+++ b/LEGO1/lego/sources/geom/legounkown100db7f4.h
@@ -1,0 +1,31 @@
+#ifndef __LEGOUNKNOWN100DB7F4_H
+#define __LEGOUNKNOWN100DB7F4_H
+
+#include "legoedge.h"
+#include "mxgeometry/mxgeometry3d.h"
+
+// VTABLE: LEGO1 0x100db7f4
+// SIZE 0x40
+class LegoUnknown100db7f4 : public LegoEdge {
+public:
+	// FUNCTION: LEGO1 0x1002ddc0
+	LegoResult FUN_1002ddc0(LegoWEEdge* p_face, Vector3& p_point)
+	{
+		if (p_face == m_faceA) {
+			p_point[0] = -m_unk0x28[0];
+			p_point[1] = -m_unk0x28[1];
+			p_point[2] = -m_unk0x28[2];
+		}
+		else {
+			p_point = m_unk0x28;
+		}
+		return SUCCESS;
+	}
+
+private:
+	LegoU16 m_unk0x24;        // 0x24
+	Mx3DPointFloat m_unk0x28; // 0x28
+	LegoU32 m_unk0x3c;        // 0x3c
+};
+
+#endif // __LEGOUNKNOWN100DB7F4_H

--- a/LEGO1/lego/sources/geom/legounkown100db7f4.h
+++ b/LEGO1/lego/sources/geom/legounkown100db7f4.h
@@ -2,6 +2,7 @@
 #define __LEGOUNKNOWN100DB7F4_H
 
 #include "legoedge.h"
+#include "legoweedge.h"
 #include "mxgeometry/mxgeometry3d.h"
 
 // VTABLE: LEGO1 0x100db7f4
@@ -9,9 +10,9 @@
 class LegoUnknown100db7f4 : public LegoEdge {
 public:
 	// FUNCTION: LEGO1 0x1002ddc0
-	LegoResult FUN_1002ddc0(LegoWEEdge* p_face, Vector3& p_point)
+	LegoResult FUN_1002ddc0(LegoWEEdge& p_f, Vector3& p_point)
 	{
-		if (p_face == m_faceA) {
+		if (p_f.IsEqual(*m_faceA)) {
 			p_point[0] = -m_unk0x28[0];
 			p_point[1] = -m_unk0x28[1];
 			p_point[2] = -m_unk0x28[2];
@@ -19,6 +20,7 @@ public:
 		else {
 			p_point = m_unk0x28;
 		}
+
 		return SUCCESS;
 	}
 

--- a/LEGO1/lego/sources/geom/legoweedge.h
+++ b/LEGO1/lego/sources/geom/legoweedge.h
@@ -15,6 +15,7 @@ public:
 	virtual LegoResult VTable0x04(); // vtable+0x04
 
 	inline LegoU8 GetNumEdges() { return m_numEdges; }
+	inline LegoU32 IsEqual(LegoWEEdge& p_other) { return this == &p_other; }
 
 	// SYNTHETIC: LEGO1 0x1009a570
 	// LegoWEEdge::`scalar deleting destructor'

--- a/LEGO1/lego/sources/geom/legowegedge.h
+++ b/LEGO1/lego/sources/geom/legowegedge.h
@@ -15,6 +15,7 @@ public:
 	LegoResult VTable0x04() override; // vtable+0x04
 
 	inline LegoU32 GetFlag0x10() { return m_unk0x0c & 0x10 ? FALSE : TRUE; }
+	inline Mx4DPointFloat* GetUnknown0x14() { return &m_unk0x14; }
 	inline Mx4DPointFloat* GetEdgeNormal(int index) { return &m_edgeNormals[index]; }
 
 	// SYNTHETIC: LEGO1 0x1009a7e0

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -38,8 +38,6 @@ public:
 	// SYNTHETIC: LEGO1 0x10010c00
 	// Mx3DPointFloat::operator=
 
-	inline void EqualsCross(Mx3DPointFloat& p_a, Mx3DPointFloat& p_b) { EqualsCrossImpl(p_a.m_data, p_b.m_data); }
-
 private:
 	float m_elements[3]; // 0x08
 };

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -101,6 +101,7 @@ public:
 	virtual int Unitize()
 	{
 		float sq = LenSquared();
+
 		if (sq > 0.0f) {
 			float root = sqrt(sq);
 			if (root > 0) {
@@ -108,6 +109,7 @@ public:
 				return 0;
 			}
 		}
+
 		return -1;
 	} // vtable+0x44
 


### PR DESCRIPTION
More problems with vectors, sigh.  I'm not sure what's different about this function that it calls the Vector2 constructor. (but only for 4 of the 5?) Aside from that, the main thing affecting the match is there's an extra stack variable somewhere.  I'm pretty sure the compiler reused a stack offset in the original code that it's not doing for some reason now.  Other minor issues:

the return FAILURE is wrong, but does match how it is in beta (function at 0x100ae9da), so not sure what changed.

the call at line 113 should be EqualsCross at 0x80 (same as line 106) and then inlined to 0x74 according to the beta, but I couldn't figure out what cast would call that. The inline declaration at mxgeomtry3d.h line 41 seems to be masking the parent class method, even though the parameter types are different.  The direct call I have now does make the code match, but it's hacky.

Clean up LegoPathBoundary some and implement AddActor, 100% match.