### PR TITLE
Fix some minor diffs

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -125,6 +125,15 @@ protected:
 // TEMPLATE: LEGO1 0x10069d80
 // _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::~_Tree<char const *,pair<char const * const,LegoAni
 
+// TEMPLATE: LEGO1 0x10069e50
+// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::iterator::_Inc
+
+// TEMPLATE: LEGO1 0x10069e90
+// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::erase
+
+// TEMPLATE: LEGO1 0x1006a2e0
+// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Erase
+
 // TEMPLATE: LEGO1 0x1006a320
 // Map<char const *,LegoAnimStruct,LegoAnimStructComparator>::~Map<char const *,LegoAnimStruct,LegoAnimStructComparator>
 

--- a/LEGO1/lego/legoomni/include/legobuildingmanager.h
+++ b/LEGO1/lego/legoomni/include/legobuildingmanager.h
@@ -33,7 +33,7 @@ public:
 	MxResult Save(LegoStorage* p_storage);
 	MxResult Load(LegoStorage* p_storage);
 	MxBool FUN_1002fdb0(LegoEntity* p_entity);
-	MxU32 FUN_1002ff40(LegoROI*, MxBool);
+	MxU32 FUN_1002ff40(LegoEntity*, MxBool);
 	void FUN_10030000(LegoEntity* p_entity);
 	void FUN_10030590();
 

--- a/LEGO1/lego/legoomni/include/legocachesoundmanager.h
+++ b/LEGO1/lego/legoomni/include/legocachesoundmanager.h
@@ -100,7 +100,7 @@ private:
 // _Tree<LegoCacheSoundEntry,LegoCacheSoundEntry,set<LegoCacheSoundEntry,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_Kfn,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::iterator::_Dec
 
 // TEMPLATE: LEGO1 0x1003d740
-// _Tree<LegoCacheSoundEntry,LegoCacheSoundEntry,set<LegoCacheSoundEntry,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_Kfn,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_BuyNode
+// _Tree<LegoCacheSoundEntry,LegoCacheSoundEntry,set<LegoCacheSoundEntry,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_Kfn,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_Buynode
 
 // TEMPLATE: LEGO1 0x1003d760
 // _Tree<LegoCacheSoundEntry,LegoCacheSoundEntry,set<LegoCacheSoundEntry,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_Kfn,Set100d6b4cComparator,allocator<LegoCacheSoundEntry> >::_Insert

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -30,7 +30,7 @@ public:
 	void Save(LegoStorage* p_storage);
 	MxResult Load(LegoStorage* p_storage);
 	MxBool FUN_100269e0(LegoEntity* p_entity);
-	MxU32 FUN_10026ba0(LegoROI*, MxBool);
+	MxU32 FUN_10026ba0(LegoEntity*, MxBool);
 	void FUN_10026c50(LegoEntity* p_entity);
 	void FUN_10027120();
 

--- a/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
@@ -64,7 +64,7 @@ MxBool LegoBuildingManager::FUN_1002fdb0(LegoEntity* p_entity)
 }
 
 // STUB: LEGO1 0x1002ff40
-MxU32 LegoBuildingManager::FUN_1002ff40(LegoROI*, MxBool)
+MxU32 LegoBuildingManager::FUN_1002ff40(LegoEntity*, MxBool)
 {
 	// TODO
 	return 0;

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -57,7 +57,7 @@ MxBool LegoPlantManager::FUN_100269e0(LegoEntity* p_entity)
 }
 
 // STUB: LEGO1 0x10026ba0
-MxU32 LegoPlantManager::FUN_10026ba0(LegoROI*, MxBool)
+MxU32 LegoPlantManager::FUN_10026ba0(LegoEntity*, MxBool)
 {
 	// TODO
 	return 0;

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -254,10 +254,10 @@ void LegoEntity::VTable0x34(MxBool p_und)
 		case 1:
 			break;
 		case 2:
-			objectId = PlantManager()->FUN_10026ba0(m_roi, p_und);
+			objectId = PlantManager()->FUN_10026ba0(this, p_und);
 			break;
 		case 3:
-			objectId = BuildingManager()->FUN_1002ff40(m_roi, p_und);
+			objectId = BuildingManager()->FUN_1002ff40(this, p_und);
 			break;
 		}
 

--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -120,4 +120,9 @@ private:
 // TEMPLATE: LEGO1 0x100afe40
 // Set<MxAtomIdCounter *,MxAtomIdCounterCompare>::~Set<MxAtomIdCounter *,MxAtomIdCounterCompare>
 
+// clang-format off
+// GLOBAL: LEGO1 0x101013f0
+// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Nil
+// clang-format on
+
 #endif // MXATOM_H

--- a/LEGO1/omni/src/video/mxbitmap.cpp
+++ b/LEGO1/omni/src/video/mxbitmap.cpp
@@ -6,9 +6,7 @@
 DECOMP_SIZE_ASSERT(MxBitmap, 0x20);
 DECOMP_SIZE_ASSERT(MxBITMAPINFO, 0x428);
 
-// Bitmap header magic string "BM" (42 4d)
-// Sources: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader, DirectX Complete
-// (1998) GLOBAL: LEGO1 0x10102184
+// GLOBAL: LEGO1 0x10102184
 MxU16 g_bitmapSignature = TWOCC('B', 'M');
 
 // FUNCTION: LEGO1 0x100bc980


### PR DESCRIPTION
Fixing some small stuff that keeps popping up while looking for effective match candidates.

- Fixed the diff from `LegoEntity::VTable0x34` that was (until recently) wrongly reported as an effective match.
- clang-format mangled the annotation for `g_bitmapSignature` from `MxBitmap`, now fixed.
- Added annotation for the `_Nil` node from the `<set>` used by `MxAtomIdCounter`, which solved some diffs in the various `_Tree` functions.
- Typo on `_Buynode` annotation for `LegoCacheSoundEntry` set.
- Annotate more functions from the `<map>` of `LegoAnimStruct`.
