### PR TITLE
Beta matching MxVariableTable

### DIFF
--- a/LEGO1/omni/include/mxcore.h
+++ b/LEGO1/omni/include/mxcore.h
@@ -9,6 +9,7 @@
 class MxParam;
 
 // VTABLE: LEGO1 0x100dc0f8
+// VTABLE: BETA10 0x101c1bc8
 // SIZE 0x08
 class MxCore {
 public:
@@ -17,9 +18,11 @@ public:
 	virtual MxLong Notify(MxParam& p_param); // vtable+04
 
 	// FUNCTION: LEGO1 0x10001f70
+	// FUNCTION: BETA10 0x1000f380
 	virtual MxResult Tickle() { return SUCCESS; } // vtable+08
 
 	// FUNCTION: LEGO1 0x100144c0
+	// FUNCTION: BETA10 0x100126d0
 	inline virtual const char* ClassName() const // vtable+0c
 	{
 		// STRING: LEGO1 0x100f007c
@@ -27,6 +30,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100140d0
+	// FUNCTION: BETA10 0x10012680
 	inline virtual MxBool IsA(const char* p_name) const // vtable+10
 	{
 		return !strcmp(p_name, MxCore::ClassName());
@@ -35,6 +39,7 @@ public:
 	inline MxU32 GetId() { return m_id; }
 
 	// SYNTHETIC: LEGO1 0x100ae1c0
+	// SYNTHETIC: BETA10 0x1012c0d0
 	// MxCore::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/include/mxvariable.h
+++ b/LEGO1/omni/include/mxvariable.h
@@ -5,31 +5,38 @@
 #include "mxstring.h"
 
 // VTABLE: LEGO1 0x100d7498
+// VTABLE: BETA10 0x101bc038
 // SIZE 0x24
 class MxVariable {
 public:
 	MxVariable() {}
-	MxVariable(const char* p_key)
-	{
-		m_key = p_key;
-		m_key.ToUpperCase();
-	}
+	// FUNCTION: BETA10 0x1012a840
 	MxVariable(const char* p_key, const char* p_value)
 	{
 		m_key = p_key;
 		m_key.ToUpperCase();
 		m_value = p_value;
 	}
+	// FUNCTION: BETA10 0x1012aa30
+	MxVariable(const char* p_key)
+	{
+		m_key = p_key;
+		m_key.ToUpperCase();
+	}
 
 	// FUNCTION: LEGO1 0x1003bea0
+	// FUNCTION: BETA10 0x1007b810
 	virtual MxString* GetValue() { return &m_value; } // vtable+0x00
 
 	// FUNCTION: LEGO1 0x1003beb0
+	// FUNCTION: BETA10 0x1007b840
 	virtual void SetValue(const char* p_value) { m_value = p_value; } // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1003bec0
+	// FUNCTION: BETA10 0x1007b870
 	virtual void Destroy() { delete this; } // vtable+0x08
 
+	// FUNCTION: BETA10 0x1012a7f0
 	inline const MxString* GetKey() const { return &m_key; }
 
 protected:

--- a/LEGO1/omni/include/mxvariabletable.h
+++ b/LEGO1/omni/include/mxvariabletable.h
@@ -6,66 +6,115 @@
 #include "mxvariable.h"
 
 // VTABLE: LEGO1 0x100dc1c8
+// VTABLE: BETA10 0x101c1c78
 // SIZE 0x28
 class MxVariableTable : public MxHashTable<MxVariable*> {
 public:
-	MxVariableTable() { m_customDestructor = Destroy; }
+	// FUNCTION: BETA10 0x10130e50
+	MxVariableTable() { SetDestroy(Destroy); }
 	void SetVariable(const char* p_key, const char* p_value);
 	void SetVariable(MxVariable* p_var);
 	const char* GetVariable(const char* p_key);
 
+	// FUNCTION: LEGO1 0x100afdb0
+	// FUNCTION: BETA10 0x10130f00
 	static void Destroy(MxVariable* p_obj) { p_obj->Destroy(); }
 
 	MxS8 Compare(MxVariable*, MxVariable*) override; // vtable+0x14
 	MxU32 Hash(MxVariable*) override;                // vtable+0x18
 
 	// SYNTHETIC: LEGO1 0x100afdd0
+	// SYNTHETIC: BETA10 0x10130f20
 	// MxVariableTable::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dc1b0
+// VTABLE: BETA10 0x101c1cd0
 // class MxCollection<MxVariable *>
 
 // VTABLE: LEGO1 0x100dc1e8
+// VTABLE: BETA10 0x101c1cb0
 // class MxHashTable<MxVariable *>
 
 // VTABLE: LEGO1 0x100dc680
+// VTABLE: BETA10 0x101c1b48
 // class MxHashTableCursor<MxVariable *>
 
 // TEMPLATE: LEGO1 0x100afcd0
+// TEMPLATE: BETA10 0x10132950
 // MxCollection<MxVariable *>::Compare
 
 // TEMPLATE: LEGO1 0x100afce0
+// TEMPLATE: BETA10 0x10132a00
 // MxCollection<MxVariable *>::~MxCollection<MxVariable *>
 
 // TEMPLATE: LEGO1 0x100afd30
+// TEMPLATE: BETA10 0x10132a70
 // MxCollection<MxVariable *>::Destroy
 
 // SYNTHETIC: LEGO1 0x100afd40
+// SYNTHETIC: BETA10 0x10132a80
 // MxCollection<MxVariable *>::`scalar deleting destructor'
 
-// TEMPLATE: LEGO1 0x100afdb0
-// MxVariableTable::Destroy
-
 // TEMPLATE: LEGO1 0x100afdc0
+// TEMPLATE: BETA10 0x10132ac0
 // MxHashTable<MxVariable *>::Hash
 
 // TEMPLATE: LEGO1 0x100b0bd0
+// TEMPLATE: BETA10 0x10132ae0
 // MxHashTable<MxVariable *>::~MxHashTable<MxVariable *>
 
 // SYNTHETIC: LEGO1 0x100b0ca0
+// SYNTHETIC: BETA10 0x10132b70
 // MxHashTable<MxVariable *>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b7680
+// TEMPLATE: BETA10 0x1012a990
 // MxHashTableCursor<MxVariable *>::~MxHashTableCursor<MxVariable *>
 
 // SYNTHETIC: LEGO1 0x100b76d0
+// SYNTHETIC: BETA10 0x1012a9f0
 // MxHashTableCursor<MxVariable *>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b7ab0
+// TEMPLATE: BETA10 0x1012adc0
 // MxHashTable<MxVariable *>::Resize
 
 // TEMPLATE: LEGO1 0x100b7b80
+// TEMPLATE: BETA10 0x1012af10
 // MxHashTable<MxVariable *>::NodeInsert
+
+// TEMPLATE: BETA10 0x1012a900
+// MxHashTableCursor<MxVariable *>::MxHashTableCursor<MxVariable *>
+
+// TEMPLATE: BETA10 0x1012aae0
+// MxHashTable<MxVariable *>::Add
+
+// TEMPLATE: BETA10 0x1012abd0
+// MxHashTableCursor<MxVariable *>::Current
+
+// TEMPLATE: BETA10 0x1012ac20
+// MxHashTableCursor<MxVariable *>::DeleteMatch
+
+// TEMPLATE: BETA10 0x1012ad00
+// MxHashTableCursor<MxVariable *>::Find
+
+// TEMPLATE: BETA10 0x1012af90
+// MxHashTableNode<MxVariable *>::MxHashTableNode<MxVariable *>
+
+// TEMPLATE: BETA10 0x10132890
+// MxHashTable<MxVariable *>::MxHashTable<MxVariable *>
+
+// TEMPLATE: BETA10 0x10130ed0
+// MxCollection<MxVariable *>::SetDestroy
+
+// SYNTHETIC: BETA10 0x10130f60
+// MxVariableTable::~MxVariableTable
+
+// SYNTHETIC: BETA10 0x10132970
+// MxCollection<MxVariable *>::MxCollection<MxVariable *>
+
+// TEMPLATE: BETA10 0x10132bb0
+// MxHashTable<MxVariable *>::DeleteAll
 
 #endif // MXVARIABLETABLE_H

--- a/LEGO1/omni/src/common/mxcore.cpp
+++ b/LEGO1/omni/src/common/mxcore.cpp
@@ -3,9 +3,11 @@
 #include <assert.h>
 
 // GLOBAL: LEGO1 0x1010141c
+// GLOBAL: BETA10 0x10201f88
 MxU32 MxCore::g_nextCoreId = 0;
 
 // FUNCTION: LEGO1 0x100ae1a0
+// FUNCTION: BETA10 0x1012c020
 MxCore::MxCore()
 {
 	m_id = g_nextCoreId++;
@@ -13,11 +15,13 @@ MxCore::MxCore()
 }
 
 // FUNCTION: LEGO1 0x100ae1e0
+// FUNCTION: BETA10 0x1012c077
 MxCore::~MxCore()
 {
 }
 
 // FUNCTION: LEGO1 0x100ae1f0
+// FUNCTION: BETA10 0x1012c096
 MxLong MxCore::Notify(MxParam& p_param)
 {
 	assert(0);

--- a/LEGO1/omni/src/common/mxvariabletable.cpp
+++ b/LEGO1/omni/src/common/mxvariabletable.cpp
@@ -1,18 +1,20 @@
 #include "mxvariabletable.h"
 
 // FUNCTION: LEGO1 0x100b7330
+// FUNCTION: BETA10 0x1012a470
 MxS8 MxVariableTable::Compare(MxVariable* p_var0, MxVariable* p_var1)
 {
 	return p_var0->GetKey()->Compare(*p_var1->GetKey());
 }
 
 // FUNCTION: LEGO1 0x100b7370
+// FUNCTION: BETA10 0x1012a4a0
 MxU32 MxVariableTable::Hash(MxVariable* p_var)
 {
 	const char* str = p_var->GetKey()->GetData();
 	MxU32 value = 0;
 
-	for (int i = 0; str[i]; i++) {
+	for (MxS32 i = 0; str[i]; i++) {
 		value += str[i];
 	}
 
@@ -20,6 +22,7 @@ MxU32 MxVariableTable::Hash(MxVariable* p_var)
 }
 
 // FUNCTION: LEGO1 0x100b73a0
+// FUNCTION: BETA10 0x1012a507
 void MxVariableTable::SetVariable(const char* p_key, const char* p_value)
 {
 	MxHashTableCursor<MxVariable*> cursor(this);
@@ -36,12 +39,12 @@ void MxVariableTable::SetVariable(const char* p_key, const char* p_value)
 }
 
 // FUNCTION: LEGO1 0x100b7740
+// FUNCTION: BETA10 0x1012a629
 void MxVariableTable::SetVariable(MxVariable* p_var)
 {
 	MxHashTableCursor<MxVariable*> cursor(this);
-	MxBool found = cursor.Find(p_var);
 
-	if (found) {
+	if (cursor.Find(p_var)) {
 		cursor.DeleteMatch();
 	}
 
@@ -49,6 +52,7 @@ void MxVariableTable::SetVariable(MxVariable* p_var)
 }
 
 // FUNCTION: LEGO1 0x100b78f0
+// FUNCTION: BETA10 0x1012a6bd
 const char* MxVariableTable::GetVariable(const char* p_key)
 {
 	// STRING: ISLE 0x41008c

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -77,6 +77,7 @@ void MxOmni::SetInstance(MxOmni* p_instance)
 }
 
 // FUNCTION: LEGO1 0x100af0c0
+// FUNCTION: BETA10 0x1012f3ff
 MxResult MxOmni::Create(MxOmniCreateParam& p_param)
 {
 	MxResult result = FAILURE;


### PR DESCRIPTION
Matching `MxVariableTable`, `MxHashTable`, and `MxVariable` to Beta 1.0. I added new `BETA10` annotations for the functions from these modules, including `MxOmni::Create` where the variable table gets constructed. I also added them for `MxCore` which I already beta patched in #663.

There's an unused dword each time something gets new'd in `MxHashTable`. This doesn't seem like it's the SEH `__$EHRec$` variable but no way to know what the intended use was.

Some diff thrashing everywhere but the functions changed here. We can probably expect that any time a header file gets changed.