### PR TITLE
Implement/match LegoROI/LegoLOD::GetTexture

### DIFF
--- a/LEGO1/lego/legoomni/include/legotextureinfo.h
+++ b/LEGO1/lego/legoomni/include/legotextureinfo.h
@@ -17,6 +17,7 @@ public:
 
 	static LegoTextureInfo* Create(const char* p_name, LegoTexture* p_texture);
 	static BOOL SetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo* p_textureInfo);
+	static BOOL GetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo*& p_textureInfo);
 
 	LegoResult FUN_10066010(LegoU8* p_bits);
 
@@ -26,5 +27,8 @@ public:
 	LPDIRECTDRAWPALETTE m_palette;  // 0x08
 	LPDIRECT3DRMTEXTURE2 m_texture; // 0x0c
 };
+
+// GLOBAL: LEGO1 0x100db6f0
+// IID_IDirect3DRMTexture2
 
 #endif // LEGOTEXTUREINFO_H

--- a/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp
+++ b/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp
@@ -160,6 +160,30 @@ BOOL LegoTextureInfo::SetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo* p_textu
 	return TRUE;
 }
 
+// FUNCTION: LEGO1 0x10065f90
+BOOL LegoTextureInfo::GetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo*& p_textureInfo)
+{
+	TglImpl::MeshImpl::MeshData* data = ((TglImpl::MeshImpl*) pMesh)->ImplementationData();
+
+	IDirect3DRMMesh* mesh = data->groupMesh;
+	D3DRMGROUPINDEX id = data->groupIndex;
+	LPDIRECT3DRMTEXTURE returnPtr = NULL;
+	LPDIRECT3DRMTEXTURE2 texture = NULL;
+
+	if (mesh->GetGroupTexture(id, &returnPtr) == D3DRM_OK) {
+		if (returnPtr->QueryInterface(IID_IDirect3DRMTexture2, (LPVOID*) &texture) == D3DRM_OK) {
+			p_textureInfo = (LegoTextureInfo*) texture->GetAppData();
+
+			texture->Release();
+			returnPtr->Release();
+		}
+
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
 // STUB: LEGO1 0x10066010
 LegoResult LegoTextureInfo::FUN_10066010(LegoU8* p_bits)
 {

--- a/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
+++ b/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
@@ -66,7 +66,7 @@ MxBool LegoControlManager::FUN_10029210(LegoEventNotificationParam& p_param, MxP
 			m_event.SetKey(p_param.GetKey());
 
 			if (p_param.GetType() == c_notificationButtonUp) {
-				if (m_unk0x10) {
+				if (m_unk0x10 == TRUE) {
 					m_unk0x10 = FALSE;
 					return TRUE;
 				}

--- a/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
+++ b/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
@@ -66,7 +66,7 @@ MxBool LegoControlManager::FUN_10029210(LegoEventNotificationParam& p_param, MxP
 			m_event.SetKey(p_param.GetKey());
 
 			if (p_param.GetType() == c_notificationButtonUp) {
-				if (m_unk0x10 == TRUE) {
+				if (m_unk0x10) {
 					m_unk0x10 = FALSE;
 					return TRUE;
 				}

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -125,7 +125,7 @@ void LegoTextureContainer::EraseFromList(LegoTextureInfo* p_textureInfo)
 		if ((*it).first == p_textureInfo) {
 			(*it).second = FALSE;
 
-			if (p_textureInfo->m_texture->Release() == TRUE) {
+			if (p_textureInfo->m_texture->Release()) {
 				delete p_textureInfo;
 				m_list.erase(it);
 			}

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -54,7 +54,7 @@ LegoTextureInfo* LegoTextureContainer::AddToList(LegoTextureInfo* p_textureInfo)
 	LegoTextureInfo* textureInfo = new LegoTextureInfo();
 
 	textureInfo->m_palette = p_textureInfo->m_palette;
-	p_textureInfo->m_palette->Release();
+	textureInfo->m_palette->AddRef();
 
 	memset(&newDesc, 0, sizeof(newDesc));
 	newDesc.dwWidth = desc.dwWidth;

--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -125,7 +125,7 @@ void LegoTextureContainer::EraseFromList(LegoTextureInfo* p_textureInfo)
 		if ((*it).first == p_textureInfo) {
 			(*it).second = FALSE;
 
-			if (p_textureInfo->m_texture->Release()) {
+			if (p_textureInfo->m_texture->Release() == TRUE) {
 				delete p_textureInfo;
 				m_list.erase(it);
 			}

--- a/LEGO1/lego/sources/roi/legolod.cpp
+++ b/LEGO1/lego/sources/roi/legolod.cpp
@@ -367,7 +367,7 @@ LegoResult LegoLOD::GetTexture(LegoTextureInfo*& p_textureInfo)
 {
 	for (LegoU32 i = m_unk0x1c; i < m_numMeshes; i++) {
 		if (m_melems[i].m_unk0x04) {
-			if (LegoTextureInfo::GetGroupTexture(m_melems[i].m_tglMesh, p_textureInfo)) {
+			if (LegoTextureInfo::GetGroupTexture(m_melems[i].m_tglMesh, p_textureInfo) == TRUE) {
 				return SUCCESS;
 			}
 		}

--- a/LEGO1/lego/sources/roi/legolod.cpp
+++ b/LEGO1/lego/sources/roi/legolod.cpp
@@ -362,6 +362,20 @@ LegoResult LegoLOD::FUN_100aad70(LegoTextureInfo* p_textureInfo)
 	return SUCCESS;
 }
 
+// FUNCTION: LEGO1 0x100aadc0
+LegoResult LegoLOD::GetTexture(LegoTextureInfo*& p_textureInfo)
+{
+	for (LegoU32 i = m_unk0x1c; i < m_numMeshes; i++) {
+		if (m_melems[i].m_unk0x04) {
+			if (LegoTextureInfo::GetGroupTexture(m_melems[i].m_tglMesh, p_textureInfo) == TRUE) {
+				return SUCCESS;
+			}
+		}
+	}
+
+	return FAILURE;
+}
+
 // FUNCTION: LEGO1 0x100aae20
 LegoBool LegoLOD::FUN_100aae20(const LegoChar* p_name)
 {

--- a/LEGO1/lego/sources/roi/legolod.cpp
+++ b/LEGO1/lego/sources/roi/legolod.cpp
@@ -367,7 +367,7 @@ LegoResult LegoLOD::GetTexture(LegoTextureInfo*& p_textureInfo)
 {
 	for (LegoU32 i = m_unk0x1c; i < m_numMeshes; i++) {
 		if (m_melems[i].m_unk0x04) {
-			if (LegoTextureInfo::GetGroupTexture(m_melems[i].m_tglMesh, p_textureInfo) == TRUE) {
+			if (LegoTextureInfo::GetGroupTexture(m_melems[i].m_tglMesh, p_textureInfo)) {
 				return SUCCESS;
 			}
 		}

--- a/LEGO1/lego/sources/roi/legolod.h
+++ b/LEGO1/lego/sources/roi/legolod.h
@@ -32,6 +32,7 @@ public:
 	LegoResult FUN_100aacb0(LegoFloat p_red, LegoFloat p_green, LegoFloat p_blue, LegoFloat p_alpha);
 	LegoResult FUN_100aad00(LegoTextureInfo* p_textureInfo);
 	LegoResult FUN_100aad70(LegoTextureInfo* p_textureInfo);
+	LegoResult GetTexture(LegoTextureInfo*& p_textureInfo);
 
 	static LegoBool FUN_100aae20(const LegoChar* p_name);
 

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -498,10 +498,29 @@ LegoResult LegoROI::FUN_100a9210(LegoTextureInfo* p_textureInfo)
 	return result;
 }
 
-// STUB: LEGO1 0x100a92a0
-LegoResult LegoROI::GetTexture(LegoTextureInfo*&)
+// FUNCTION: LEGO1 0x100a92a0
+// FUNCTION: BETA10 0x1018b12d
+LegoResult LegoROI::GetTexture(LegoTextureInfo*& p_textureInfo)
 {
-	// TODO
+	CompoundObject::iterator it;
+
+	int lodCount = GetLODCount();
+	for (LegoU32 i = 0; i < lodCount; i++) {
+		LegoLOD* lod = (LegoLOD*) GetLOD(i);
+
+		if (lod->GetTexture(p_textureInfo) == SUCCESS) {
+			return SUCCESS;
+		}
+	}
+
+	if (comp != NULL) {
+		for (it = comp->begin(); it != comp->end(); it++) {
+			if (((LegoROI*) *it)->GetTexture(p_textureInfo) == SUCCESS) {
+				return SUCCESS;
+			}
+		}
+	}
+
 	return FAILURE;
 }
 

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -36,7 +36,7 @@ public:
 	LegoResult SetFrame(LegoAnim* p_anim, LegoTime p_time);
 	LegoResult FUN_100a9170(LegoFloat p_red, LegoFloat p_green, LegoFloat p_blue, LegoFloat p_alpha);
 	LegoResult FUN_100a9210(LegoTextureInfo* p_textureInfo);
-	LegoResult GetTexture(LegoTextureInfo*&);
+	LegoResult GetTexture(LegoTextureInfo*& p_textureInfo);
 	LegoU32 FUN_100a9410(Vector3&, Vector3&, float, float, Vector3&, LegoBool);
 	void SetName(const LegoChar* p_name);
 


### PR DESCRIPTION
100% matches on the `GetTexture` functions (one with compiler randomness), `GetGroupTexture` isn't quite correct which is most likely due to missing inline functions required in TGL. Unfortunately anything related to `LegoTextureInfo` isn't in the beta since it was added at a later time