### PR TITLE
Implement/match LegoCharacterManager::FUN_10083c30

### DIFF
--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -42,7 +42,7 @@ struct LegoCharacter {
 
 struct LegoCharacterData;
 
-typedef map<const char*, LegoCharacter*, LegoCharacterComparator> LegoCharacterMap;
+typedef map<char*, LegoCharacter*, LegoCharacterComparator> LegoCharacterMap;
 
 // SIZE 0x08
 class LegoCharacterManager {
@@ -93,40 +93,40 @@ private:
 // _Construct
 
 // TEMPLATE: LEGO1 0x10082b90
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::~_Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::~_Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >
 
 // TEMPLATE: LEGO1 0x10082c60
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::iterator::_Inc
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::iterator::_Inc
 
 // TEMPLATE: LEGO1 0x10082ca0
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::erase
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::erase
 
 // TEMPLATE: LEGO1 0x100830f0
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Erase
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Erase
 
 // TEMPLATE: LEGO1 0x10083130
 // map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::~map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >
 
 // TEMPLATE: LEGO1 0x10083840
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::iterator::_Dec
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::iterator::_Dec
 
 // TEMPLATE: LEGO1 0x10083890
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Insert
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Insert
 
 // TEMPLATE: LEGO1 0x10085500
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::insert
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::insert
 
 // TEMPLATE: LEGO1 0x10085790
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Buynode
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Buynode
 
 // TEMPLATE: LEGO1 0x100857b0
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Lrotate
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Lrotate
 
 // TEMPLATE: LEGO1 0x10085810
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Rrotate
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Rrotate
 
 // GLOBAL: LEGO1 0x100fc508
-// _Tree<char const *,pair<char const * const,LegoCharacter *>,map<char const *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Nil
+// _Tree<char *,pair<char * const,LegoCharacter *>,map<char *,LegoCharacter *,LegoCharacterComparator,allocator<LegoCharacter *> >::_Kfn,LegoCharacterComparator,allocator<LegoCharacter *> >::_Nil
 // clang-format on
 
 #endif // LEGOCHARACTERMANAGER_H

--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -173,7 +173,7 @@ done:
 LegoROI* LegoCharacterManager::GetROI(const char* p_key, MxBool p_createEntity)
 {
 	LegoCharacter* character = NULL;
-	LegoCharacterMap::iterator it = m_characters->find(p_key);
+	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_key));
 
 	if (it != m_characters->end()) {
 		character = (*it).second;
@@ -239,11 +239,46 @@ MxU32 LegoCharacterManager::GetRefCount(LegoROI* p_roi)
 	return 0;
 }
 
-// STUB: LEGO1 0x10083c30
+// FUNCTION: LEGO1 0x10083c30
 // FUNCTION: BETA10 0x10074701
 void LegoCharacterManager::FUN_10083c30(const char* p_name)
 {
-	// TODO
+	LegoCharacter* character = NULL;
+	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_name));
+
+	if (it != m_characters->end()) {
+		character = (*it).second;
+
+		if (character->RemoveRef() == 0) {
+			LegoCharacterData* data = GetData(p_name);
+			LegoEntity* entity = character->m_roi->GetEntity();
+
+			if (entity != NULL) {
+				entity->SetROI(NULL, FALSE, FALSE);
+			}
+
+			RemoveROI(character->m_roi);
+
+			delete[] (*it).first;
+			delete (*it).second;
+
+			m_characters->erase(it);
+
+			if (data != NULL) {
+				if (data->m_actor != NULL) {
+					data->m_actor->ClearFlag(LegoEntity::c_bit2);
+					delete data->m_actor;
+				}
+				else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_bit2)) {
+					entity->ClearFlag(LegoEntity::c_bit2);
+					delete entity;
+				}
+
+				data->m_roi = NULL;
+				data->m_actor = NULL;
+			}
+		}
+	}
 }
 
 // FUNCTION: LEGO1 0x10083db0
@@ -266,7 +301,7 @@ void LegoCharacterManager::FUN_10083db0(LegoROI* p_roi)
 
 				RemoveROI(character->m_roi);
 
-				delete[] const_cast<char*>((*it).first);
+				delete[] (*it).first;
 				delete (*it).second;
 
 				m_characters->erase(it);
@@ -310,7 +345,7 @@ void LegoCharacterManager::FUN_10083f10(LegoROI* p_roi)
 
 				RemoveROI(character->m_roi);
 
-				delete[] const_cast<char*>((*it).first);
+				delete[] (*it).first;
 				delete (*it).second;
 
 				m_characters->erase(it);

--- a/LEGO1/omni/include/mxlist.h
+++ b/LEGO1/omni/include/mxlist.h
@@ -208,7 +208,6 @@ inline MxBool MxListCursor<T>::Find(T p_obj)
 {
 	for (m_match = m_list->m_first; m_match && m_list->Compare(m_match->GetValue(), p_obj);
 		 m_match = m_match->GetNext()) {
-		;
 	}
 
 	return m_match != NULL;


### PR DESCRIPTION
100% match. The key of the character map is `char*` instead of `const char*`, which enabled the match and improved matches elsewhere.