### PR TITLE
Enable some multiple-inheritance vtables

### DIFF
--- a/LEGO1/lego/legoomni/include/act2actor.h
+++ b/LEGO1/lego/legoomni/include/act2actor.h
@@ -3,16 +3,22 @@
 
 #include "legoanimactor.h"
 
-/*
-	VTABLE: LEGO1 0x100d6078 LegoPathActor
-	VTABLE: LEGO1 0x100d6148 LegoAnimActor
-*/
+// VTABLE: LEGO1 0x100d6078 LegoPathActor
+// VTABLE: LEGO1 0x100d6148 LegoAnimActor
 // SIZE 0x1a8
 class Act2Actor : public LegoAnimActor {
 public:
 	Act2Actor();
 
-	// SYNTHETIC: LEGO1 0x1001a090
+	void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2) override; // vtable+0x24
+	void SetWorldSpeed(MxFloat p_worldSpeed) override;                    // vtable+0x30
+	MxS32 VTable0x68(Vector3&, Vector3&, Vector3&) override;              // vtable+0x68
+	void VTable0x70(float p_und) override;                                // vtable+0x70
+	MxResult VTable0x94(LegoPathActor*, MxBool) override;                 // vtable+0x94
+	MxResult WaitForAnimation() override;                                 // vtable+0x9c
+	MxS32 VTable0xa0() override;                                          // vtable+0xa0
+
+	// SYNTHETIC: LEGO1 0x1001a0a0
 	// Act2Actor::`scalar deleting destructor'
 
 private:

--- a/LEGO1/lego/legoomni/include/act3actor.h
+++ b/LEGO1/lego/legoomni/include/act3actor.h
@@ -3,21 +3,25 @@
 
 #include "legoanimactor.h"
 
-/*
-	VTABLE: LEGO1 0x100d7668 LegoPathActor
-	VTABLE: LEGO1 0x100d7738 LegoAnimActor
-*/
+// VTABLE: LEGO1 0x100d7668 LegoPathActor
+// VTABLE: LEGO1 0x100d7738 LegoAnimActor
 // SIZE 0x178
 class Act3Actor : public LegoAnimActor {
 public:
 	Act3Actor();
 
-	// FUNCTION: LEGO1 0x100433b0
-	inline const char* ClassName() const override
+	// FUNCTION: LEGO1 0x100431b0
+	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03ac
 		return "Act3Actor";
 	}
+
+	MxU32 VTable0x90(float, Matrix4&) override;           // vtable+0x90
+	MxResult VTable0x94(LegoPathActor*, MxBool) override; // vtable+0x94
+
+	// SYNTHETIC: LEGO1 0x10043330
+	// Act3Actor::`scalar deleting destructor'
 
 private:
 	undefined4 m_unk0x1c; // 0x1c

--- a/LEGO1/lego/legoomni/include/act3shark.h
+++ b/LEGO1/lego/legoomni/include/act3shark.h
@@ -3,36 +3,27 @@
 
 #include "legoanimactor.h"
 
-/*
-	VTABLE: LEGO1 0x100d7920 LegoPathActor
-	VTABLE: LEGO1 0x100d79f0 LegoAnimActor
-*/
+// VTABLE: LEGO1 0x100d7920 LegoPathActor
+// VTABLE: LEGO1 0x100d79f0 LegoAnimActor
 // SIZE 0x1a8
 class Act3Shark : public LegoAnimActor {
 public:
 	Act3Shark();
 
-	// FUNCTION: LEGO1 0x100430c0
+	// FUNCTION: LEGO1 0x100430d0
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03a0
 		return "Act3Shark";
 	}
 
-	// FUNCTION: LEGO1 0x1001a130
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
-	{
-		return !strcmp(p_name, Act3Shark::ClassName()) || LegoAnimActor::IsA(p_name);
-	}
+	void ParseAction(char*) override;        // vtable+0x20
+	void VTable0x70(float p_float) override; // vtable+0x70
 
-	void ParseAction(char*) override;                  // vtable+0x20
-	void SetWorldSpeed(MxFloat p_worldSpeed) override; // vtable+0x30
-	void VTable0x70(float p_float) override;           // vtable+0x70
-	void VTable0x74(Matrix4& p_transform) override;    // vtable+0x74
+	// LegoAnimActor vtable
+	virtual MxResult FUN_10042ce0(void*); // vtable+0x10
 
-	virtual MxResult FUN_10042ce0(void*);
-
-	// SYNTHETIC: LEGO1 0x10043020
+	// SYNTHETIC: LEGO1 0x10043030
 	// Act3Shark::`scalar deleting destructor'
 
 private:
@@ -42,5 +33,10 @@ private:
 	undefined m_unk0x30[0x0c]; // 0x30
 	Mx3DPointFloat m_unk0x3c;  // 0x3c
 };
+
+// STUB: LEGO1 0x10042c90
+// List<void *>::~List<void *>
+// TODO: Update once type is known.
+// STUB to resolve diff in scalar dtor and not create a new one.
 
 #endif // ACT3SHARK_H

--- a/LEGO1/lego/legoomni/include/bumpbouy.h
+++ b/LEGO1/lego/legoomni/include/bumpbouy.h
@@ -4,24 +4,23 @@
 #include "legoanimactor.h"
 #include "mxtypes.h"
 
-/*
-	VTABLE: LEGO1 0x100d6790 LegoPathActor
-	VTABLE: LEGO1 0x100d6860 LegoAnimActor
-*/
+// VTABLE: LEGO1 0x100d6790 LegoPathActor
+// VTABLE: LEGO1 0x100d6860 LegoAnimActor
 // SIZE 0x174
 class BumpBouy : public LegoAnimActor {
 public:
 	BumpBouy();
+	~BumpBouy() override;
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
-	// FUNCTION: LEGO1 0x10027510
+	// FUNCTION: LEGO1 0x100274f0
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0394
 		return "BumpBouy";
 	}
 
-	// FUNCTION: LEGO1 0x10027500
+	// FUNCTION: LEGO1 0x10027510
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, BumpBouy::ClassName()) || LegoAnimActor::IsA(p_name);

--- a/LEGO1/lego/legoomni/src/act3/act3shark.cpp
+++ b/LEGO1/lego/legoomni/src/act3/act3shark.cpp
@@ -2,12 +2,6 @@
 
 DECOMP_SIZE_ASSERT(Act3Shark, 0x1a8)
 
-// STUB: LEGO1 0x1001a1c0
-void Act3Shark::VTable0x74(Matrix4& p_transform)
-{
-	// TODO
-}
-
 // STUB: LEGO1 0x10042ab0
 Act3Shark::Act3Shark()
 {
@@ -21,20 +15,14 @@ MxResult Act3Shark::FUN_10042ce0(void*)
 	return SUCCESS;
 }
 
-// STUB: LEGO1 0x100430e0
-void Act3Shark::ParseAction(char*)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x100430f0
-void Act3Shark::SetWorldSpeed(MxFloat p_worldSpeed)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10043100
+// STUB: LEGO1 0x10042d40
 void Act3Shark::VTable0x70(float p_float)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10042f30
+void Act3Shark::ParseAction(char*)
 {
 	// TODO
 }

--- a/LEGO1/lego/legoomni/src/actors/act2actor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act2actor.cpp
@@ -7,3 +7,49 @@ Act2Actor::Act2Actor()
 {
 	// TODO
 }
+
+// STUB: LEGO1 0x10018940
+void Act2Actor::SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x100189f0
+MxResult Act2Actor::VTable0x94(LegoPathActor*, MxBool)
+{
+	// TODO
+	return SUCCESS;
+}
+
+// STUB: LEGO1 0x10018a20
+MxResult Act2Actor::WaitForAnimation()
+{
+	// TODO
+	return SUCCESS;
+}
+
+// STUB: LEGO1 0x10018c30
+void Act2Actor::VTable0x70(float p_und)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10019280
+void Act2Actor::SetWorldSpeed(MxFloat p_worldSpeed)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x100195a0
+MxS32 Act2Actor::VTable0xa0()
+{
+	// TODO
+	return 0;
+}
+
+// STUB: LEGO1 0x1001a180
+MxS32 Act2Actor::VTable0x68(Vector3&, Vector3&, Vector3&)
+{
+	// TODO
+	return 0;
+}

--- a/LEGO1/lego/legoomni/src/actors/act3actor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actor.cpp
@@ -7,3 +7,17 @@ Act3Actor::Act3Actor()
 {
 	m_unk0x1c = 0;
 }
+
+// STUB: LEGO1 0x1003fb70
+MxU32 Act3Actor::VTable0x90(float, Matrix4&)
+{
+	// TODO
+	return FALSE;
+}
+
+// STUB: LEGO1 0x1003fd90
+MxResult Act3Actor::VTable0x94(LegoPathActor*, MxBool)
+{
+	// TODO
+	return 0;
+}

--- a/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
+++ b/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
@@ -7,6 +7,12 @@ BumpBouy::BumpBouy()
 {
 }
 
+// STUB: LEGO1 0x10027360
+BumpBouy::~BumpBouy()
+{
+	// TODO
+}
+
 // STUB: LEGO1 0x10027400
 MxLong BumpBouy::Notify(MxParam& p_param)
 {


### PR DESCRIPTION
My attempt to untangle the multiple inheritance web that connects LegoPathActor and LegoAnimActor as superclasses of:

- Act2Actor
- Act3Actor
- Act3Shark
- BumpBouy

There are some new error messages complaining about duplicate entries in the database. These are not caused by annotation address reuse because the linter would alert to that. I think it's caused by the code that unwraps the `vtordisp` thunks being called multiple times on the same address. If the address appears in multiple vtables, this is expected. We can just suppress the error in these cases.