### PR TITLE
Fix writing/reading of game state

### DIFF
--- a/LEGO1/lego/legoomni/include/act1state.h
+++ b/LEGO1/lego/legoomni/include/act1state.h
@@ -34,7 +34,7 @@ public:
 		MxResult Serialize(LegoFile* p_file)
 		{
 			if (p_file->IsWriteMode()) {
-				p_file->FUN_10006030(m_name);
+				p_file->WriteString(m_name);
 				p_file->WriteVector3(m_point1);
 				p_file->WriteVector3(m_point2);
 				p_file->WriteVector3(m_point3);
@@ -71,8 +71,8 @@ public:
 		return !strcmp(p_name, Act1State::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool SetFlag() override;                          // vtable+0x18
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxBool SetFlag() override;                         // vtable+0x18
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	void FUN_10034660();
 	void FUN_100346a0();

--- a/LEGO1/lego/legoomni/include/act3state.h
+++ b/LEGO1/lego/legoomni/include/act3state.h
@@ -22,7 +22,7 @@ public:
 		return !strcmp(p_name, Act3State::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool VTable0x14() override;
+	MxBool IsSerializable() override;
 
 	// SYNTHETIC: LEGO1 0x1000e3c0
 	// Act3State::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/ambulancemissionstate.h
+++ b/LEGO1/lego/legoomni/include/ambulancemissionstate.h
@@ -22,7 +22,7 @@ public:
 		return !strcmp(p_name, AmbulanceMissionState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	inline void SetUnknown0x08(undefined4 p_unk0x08) { m_unk0x08 = p_unk0x08; }
 

--- a/LEGO1/lego/legoomni/include/animstate.h
+++ b/LEGO1/lego/legoomni/include/animstate.h
@@ -50,8 +50,8 @@ public:
 		return !strcmp(p_name, AnimState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool SetFlag() override;                          // vtable+0x18
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxBool SetFlag() override;                         // vtable+0x18
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	void FUN_100651d0(MxU32, AnimInfo*, MxU32&);
 	void FUN_10065240(MxU32, AnimInfo*, MxU32);

--- a/LEGO1/lego/legoomni/include/gasstationstate.h
+++ b/LEGO1/lego/legoomni/include/gasstationstate.h
@@ -27,7 +27,7 @@ public:
 		return !strcmp(p_name, GasStationState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x10006290
 	// GasStationState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/helicopterstate.h
+++ b/LEGO1/lego/legoomni/include/helicopterstate.h
@@ -22,7 +22,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x1000e0b0
-	MxBool VTable0x14() override { return FALSE; } // vtable+0x14
+	MxBool IsSerializable() override { return FALSE; } // vtable+0x14
 
 	// FUNCTION: LEGO1 0x1000e0c0
 	MxBool SetFlag() override

--- a/LEGO1/lego/legoomni/include/hospitalstate.h
+++ b/LEGO1/lego/legoomni/include/hospitalstate.h
@@ -29,7 +29,7 @@ public:
 		return !strcmp(p_name, HospitalState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x100764c0
 	// HospitalState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/infocenterstate.h
+++ b/LEGO1/lego/legoomni/include/infocenterstate.h
@@ -27,7 +27,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10071830
-	MxBool VTable0x14() override { return FALSE; } // vtable+0x14
+	MxBool IsSerializable() override { return FALSE; } // vtable+0x14
 
 	inline MxS16 GetMaxNameLength() { return _countof(m_letters); }
 	inline MxStillPresenter* GetNameLetter(MxS32 p_index) { return m_letters[p_index]; }

--- a/LEGO1/lego/legoomni/include/jukeboxstate.h
+++ b/LEGO1/lego/legoomni/include/jukeboxstate.h
@@ -20,7 +20,7 @@ public:
 		return !strcmp(p_name, JukeBoxState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool VTable0x14() override; // vtable+0x14
+	MxBool IsSerializable() override; // vtable+0x14
 
 	inline MxU32 IsActive() { return m_active; }
 	inline void SetActive(MxU32 p_active) { m_active = p_active; }

--- a/LEGO1/lego/legoomni/include/legoact2state.h
+++ b/LEGO1/lego/legoomni/include/legoact2state.h
@@ -22,7 +22,7 @@ public:
 		return !strcmp(p_name, LegoAct2State::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool VTable0x14() override; // vtable+0x14
+	MxBool IsSerializable() override; // vtable+0x14
 
 	// SYNTHETIC: LEGO1 0x1000e040
 	// LegoAct2State::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legobuildingmanager.h
+++ b/LEGO1/lego/legoomni/include/legobuildingmanager.h
@@ -30,8 +30,8 @@ public:
 	void Init();
 	void FUN_1002fa00();
 	void FUN_1002fb30();
-	MxResult Save(LegoStorage* p_storage);
-	MxResult Load(LegoStorage* p_storage);
+	MxResult Write(LegoStorage* p_storage);
+	MxResult Read(LegoStorage* p_storage);
 	MxBool FUN_1002fdb0(LegoEntity* p_entity);
 	MxU32 FUN_1002ff40(LegoEntity*, MxBool);
 	void FUN_10030000(LegoEntity* p_entity);

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -27,8 +27,8 @@ public:
 	void Init();
 	void FUN_10026360(MxS32 p_scriptIndex);
 	void FUN_100263a0(undefined4 p_und);
-	void Save(LegoStorage* p_storage);
-	MxResult Load(LegoStorage* p_storage);
+	void Write(LegoStorage* p_storage);
+	MxResult Read(LegoStorage* p_storage);
 	MxBool FUN_100269e0(LegoEntity* p_entity);
 	MxU32 FUN_10026ba0(LegoEntity*, MxBool);
 	void FUN_10026c50(LegoEntity* p_entity);

--- a/LEGO1/lego/legoomni/include/legostate.h
+++ b/LEGO1/lego/legoomni/include/legostate.h
@@ -36,7 +36,7 @@ public:
 	virtual MxResult Serialize(LegoFile* p_legoFile)
 	{
 		if (p_legoFile->IsWriteMode()) {
-			p_legoFile->WriteString(this->ClassName());
+			p_legoFile->WriteString(ClassName());
 		}
 		return SUCCESS;
 	} // vtable+0x1c

--- a/LEGO1/lego/legoomni/include/legostate.h
+++ b/LEGO1/lego/legoomni/include/legostate.h
@@ -27,16 +27,16 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10005f90
-	virtual MxBool VTable0x14() { return TRUE; } // vtable+0x14
+	virtual MxBool IsSerializable() { return TRUE; } // vtable+0x14
 
 	// FUNCTION: LEGO1 0x10005fa0
 	virtual MxBool SetFlag() { return FALSE; } // vtable+0x18
 
 	// FUNCTION: LEGO1 0x10005fb0
-	virtual MxResult VTable0x1c(LegoFile* p_legoFile)
+	virtual MxResult Serialize(LegoFile* p_legoFile)
 	{
 		if (p_legoFile->IsWriteMode()) {
-			p_legoFile->FUN_10006030(this->ClassName());
+			p_legoFile->WriteString(this->ClassName());
 		}
 		return SUCCESS;
 	} // vtable+0x1c

--- a/LEGO1/lego/legoomni/include/legovehiclebuildstate.h
+++ b/LEGO1/lego/legoomni/include/legovehiclebuildstate.h
@@ -23,7 +23,7 @@ public:
 		return !strcmp(p_name, this->m_className.GetData()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x100260a0
 	// LegoVehicleBuildState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/pizzamissionstate.h
+++ b/LEGO1/lego/legoomni/include/pizzamissionstate.h
@@ -30,7 +30,7 @@ public:
 		return !strcmp(p_name, PizzaMissionState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	inline MxU16 GetColor(MxU8 p_id) { return GetState(p_id)->m_color; }
 

--- a/LEGO1/lego/legoomni/include/pizzeriastate.h
+++ b/LEGO1/lego/legoomni/include/pizzeriastate.h
@@ -31,7 +31,7 @@ public:
 		return !strcmp(p_name, PizzeriaState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x10017ce0
 	// PizzeriaState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/policestate.h
+++ b/LEGO1/lego/legoomni/include/policestate.h
@@ -26,7 +26,7 @@ public:
 		return !strcmp(p_name, PoliceState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x1005e920
 	// PoliceState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/racestate.h
+++ b/LEGO1/lego/legoomni/include/racestate.h
@@ -33,7 +33,7 @@ public:
 		return !strcmp(p_name, RaceState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	RaceStateEntry* GetState(MxU8 p_id);
 

--- a/LEGO1/lego/legoomni/include/radiostate.h
+++ b/LEGO1/lego/legoomni/include/radiostate.h
@@ -23,7 +23,7 @@ public:
 		return !strcmp(p_name, RadioState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool VTable0x14() override; // vtable+0x14
+	MxBool IsSerializable() override; // vtable+0x14
 
 	// SYNTHETIC: LEGO1 0x1002d020
 	// RadioState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/scorestate.h
+++ b/LEGO1/lego/legoomni/include/scorestate.h
@@ -20,8 +20,8 @@ public:
 		return !strcmp(p_name, ScoreState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxBool VTable0x14() override; // vtable+0x14
-	MxBool SetFlag() override;    // vtable+0x18
+	MxBool IsSerializable() override; // vtable+0x14
+	MxBool SetFlag() override;        // vtable+0x18
 
 	inline MxBool GetTutorialFlag() { return m_playCubeTutorial; }
 	inline void SetTutorialFlag(MxBool p_playCubeTutorial) { m_playCubeTutorial = p_playCubeTutorial; }

--- a/LEGO1/lego/legoomni/include/towtrackmissionstate.h
+++ b/LEGO1/lego/legoomni/include/towtrackmissionstate.h
@@ -22,7 +22,7 @@ public:
 		return !strcmp(p_name, TowTrackMissionState::ClassName()) || LegoState::IsA(p_name);
 	}
 
-	MxResult VTable0x1c(LegoFile* p_legoFile) override; // vtable+0x1c
+	MxResult Serialize(LegoFile* p_legoFile) override; // vtable+0x1c
 
 	inline MxU16 GetColor(MxU8 p_id)
 	{

--- a/LEGO1/lego/legoomni/src/act1/act1state.cpp
+++ b/LEGO1/lego/legoomni/src/act1/act1state.cpp
@@ -46,10 +46,10 @@ Act1State::Act1State() : m_unk0x00c(0), m_unk0x00e(0), m_unk0x008(NULL), m_unk0x
 }
 
 // FUNCTION: LEGO1 0x10033ac0
-MxResult Act1State::VTable0x1c(LegoFile* p_legoFile)
+MxResult Act1State::Serialize(LegoFile* p_legoFile)
 {
 	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->FUN_10006030(ClassName());
+		p_legoFile->WriteString(ClassName());
 	}
 
 	m_unk0x024.Serialize(p_legoFile);

--- a/LEGO1/lego/legoomni/src/act1/act1state.cpp
+++ b/LEGO1/lego/legoomni/src/act1/act1state.cpp
@@ -48,9 +48,7 @@ Act1State::Act1State() : m_unk0x00c(0), m_unk0x00e(0), m_unk0x008(NULL), m_unk0x
 // FUNCTION: LEGO1 0x10033ac0
 MxResult Act1State::Serialize(LegoFile* p_legoFile)
 {
-	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->WriteString(ClassName());
-	}
+	LegoState::Serialize(p_legoFile);
 
 	m_unk0x024.Serialize(p_legoFile);
 	m_unk0x070.Serialize(p_legoFile);

--- a/LEGO1/lego/legoomni/src/act2/legoact2state.cpp
+++ b/LEGO1/lego/legoomni/src/act2/legoact2state.cpp
@@ -3,7 +3,7 @@
 DECOMP_SIZE_ASSERT(LegoAct2State, 0x10)
 
 // FUNCTION: LEGO1 0x1000df70
-MxBool LegoAct2State::VTable0x14()
+MxBool LegoAct2State::IsSerializable()
 {
 	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/act3/act3state.cpp
+++ b/LEGO1/lego/legoomni/src/act3/act3state.cpp
@@ -3,7 +3,7 @@
 DECOMP_SIZE_ASSERT(Act3State, 0x0c)
 
 // FUNCTION: LEGO1 0x1000e2f0
-MxBool Act3State::VTable0x14()
+MxBool Act3State::IsSerializable()
 {
 	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/build/legobuildingmanager.cpp
@@ -45,13 +45,13 @@ void LegoBuildingManager::FUN_1002fb30()
 }
 
 // STUB: LEGO1 0x1002fb80
-MxResult LegoBuildingManager::Save(LegoStorage* p_storage)
+MxResult LegoBuildingManager::Write(LegoStorage* p_storage)
 {
 	return SUCCESS;
 }
 
 // STUB: LEGO1 0x1002fc10
-MxResult LegoBuildingManager::Load(LegoStorage* p_storage)
+MxResult LegoBuildingManager::Read(LegoStorage* p_storage)
 {
 	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
+++ b/LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
@@ -15,8 +15,8 @@ LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
 }
 
 // STUB: LEGO1 0x10026120
-MxResult LegoVehicleBuildState::VTable0x1c(LegoFile* p_legoFile)
+MxResult LegoVehicleBuildState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return SUCCESS;
+	return LegoState::Serialize(p_legoFile);
 }

--- a/LEGO1/lego/legoomni/src/common/animstate.cpp
+++ b/LEGO1/lego/legoomni/src/common/animstate.cpp
@@ -32,10 +32,10 @@ void AnimState::FUN_10065240(MxU32, AnimInfo*, MxU32)
 }
 
 // STUB: LEGO1 0x100652d0
-MxResult AnimState::VTable0x1c(LegoFile* p_legoFile)
+MxResult AnimState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return FAILURE;
+	return LegoState::Serialize(p_legoFile);
 }
 
 // STUB: LEGO1 0x100654f0

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -259,11 +259,11 @@ MxResult LegoGameState::Save(MxULong p_slot)
 
 	WriteEndOfVariables(&fileStorage);
 	CharacterManager()->Write(&fileStorage);
-	PlantManager()->Save(&fileStorage);
-	result = BuildingManager()->Save(&fileStorage);
+	PlantManager()->Write(&fileStorage);
+	result = BuildingManager()->Write(&fileStorage);
 
 	for (j = 0; j < m_stateCount; j++) {
-		if (m_stateArray[j]->VTable0x14()) {
+		if (m_stateArray[j]->IsSerializable()) {
 			count++;
 		}
 	}
@@ -271,8 +271,8 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	Write(&fileStorage, count);
 
 	for (j = 0; j < m_stateCount; j++) {
-		if (m_stateArray[j]->VTable0x14()) {
-			m_stateArray[j]->VTable0x1c(&fileStorage);
+		if (m_stateArray[j]->IsSerializable()) {
+			m_stateArray[j]->Serialize(&fileStorage);
 		}
 	}
 
@@ -295,7 +295,7 @@ MxResult LegoGameState::DeleteState()
 	m_stateArray = NULL;
 
 	for (MxS32 count = 0; count < stateCount; count++) {
-		if (!stateArray[count]->SetFlag() && stateArray[count]->VTable0x14()) {
+		if (!stateArray[count]->SetFlag() && stateArray[count]->IsSerializable()) {
 			delete stateArray[count];
 		}
 		else {
@@ -360,10 +360,10 @@ MxResult LegoGameState::Load(MxULong p_slot)
 	if (CharacterManager()->Read(&fileStorage) == FAILURE) {
 		goto done;
 	}
-	if (PlantManager()->Load(&fileStorage) == FAILURE) {
+	if (PlantManager()->Read(&fileStorage) == FAILURE) {
 		goto done;
 	}
-	if (BuildingManager()->Load(&fileStorage) == FAILURE) {
+	if (BuildingManager()->Read(&fileStorage) == FAILURE) {
 		goto done;
 	}
 	if (DeleteState() != SUCCESS) {
@@ -389,7 +389,7 @@ MxResult LegoGameState::Load(MxULong p_slot)
 				}
 			}
 
-			state->VTable0x1c(&fileStorage);
+			state->Serialize(&fileStorage);
 		}
 	}
 

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -38,13 +38,13 @@ void LegoPlantManager::FUN_100263a0(undefined4 p_und)
 }
 
 // STUB: LEGO1 0x10026720
-void LegoPlantManager::Save(LegoStorage* p_storage)
+void LegoPlantManager::Write(LegoStorage* p_storage)
 {
 	// TODO
 }
 
 // STUB: LEGO1 0x100267b0
-MxResult LegoPlantManager::Load(LegoStorage* p_storage)
+MxResult LegoPlantManager::Read(LegoStorage* p_storage)
 {
 	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -541,6 +541,6 @@ void FUN_1003f540(LegoFile* p_file, const char* p_filename)
 // FUNCTION: LEGO1 0x1003f8a0
 void WriteNamedTexture(LegoFile* p_file, LegoNamedTexture* p_texture)
 {
-	p_file->FUN_10006030(*p_texture->GetName());
+	p_file->WriteString(*p_texture->GetName());
 	p_texture->GetTexture()->Write(p_file);
 }

--- a/LEGO1/lego/legoomni/src/gasstation/gasstationstate.cpp
+++ b/LEGO1/lego/legoomni/src/gasstation/gasstationstate.cpp
@@ -18,10 +18,10 @@ GasStationState::GasStationState()
 }
 
 // STUB: LEGO1 0x10006300
-MxResult GasStationState::VTable0x1c(LegoFile* p_legoFile)
+MxResult GasStationState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return SUCCESS;
+	return LegoState::Serialize(p_legoFile);
 }
 
 // STUB: LEGO1 0x10006430

--- a/LEGO1/lego/legoomni/src/hospital/ambulancemissionstate.cpp
+++ b/LEGO1/lego/legoomni/src/hospital/ambulancemissionstate.cpp
@@ -20,8 +20,8 @@ AmbulanceMissionState::AmbulanceMissionState()
 }
 
 // STUB: LEGO1 0x10037440
-MxResult AmbulanceMissionState::VTable0x1c(LegoFile* p_legoFile)
+MxResult AmbulanceMissionState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return 0;
+	return LegoState::Serialize(p_legoFile);
 }

--- a/LEGO1/lego/legoomni/src/hospital/hospitalstate.cpp
+++ b/LEGO1/lego/legoomni/src/hospital/hospitalstate.cpp
@@ -16,9 +16,7 @@ HospitalState::HospitalState()
 // FUNCTION: LEGO1 0x10076530
 MxResult HospitalState::Serialize(LegoFile* p_legoFile)
 {
-	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->WriteString(ClassName());
-	}
+	LegoState::Serialize(p_legoFile);
 
 	if (p_legoFile->IsWriteMode()) {
 		// A write variable needs to be used here, otherwise

--- a/LEGO1/lego/legoomni/src/hospital/hospitalstate.cpp
+++ b/LEGO1/lego/legoomni/src/hospital/hospitalstate.cpp
@@ -14,10 +14,10 @@ HospitalState::HospitalState()
 }
 
 // FUNCTION: LEGO1 0x10076530
-MxResult HospitalState::VTable0x1c(LegoFile* p_legoFile)
+MxResult HospitalState::Serialize(LegoFile* p_legoFile)
 {
 	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->FUN_10006030(ClassName());
+		p_legoFile->WriteString(ClassName());
 	}
 
 	if (p_legoFile->IsWriteMode()) {

--- a/LEGO1/lego/legoomni/src/infocenter/scorestate.cpp
+++ b/LEGO1/lego/legoomni/src/infocenter/scorestate.cpp
@@ -3,7 +3,7 @@
 DECOMP_SIZE_ASSERT(ScoreState, 0x0c)
 
 // FUNCTION: LEGO1 0x1000de20
-MxBool ScoreState::VTable0x14()
+MxBool ScoreState::IsSerializable()
 {
 	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/isle/jukeboxstate.cpp
+++ b/LEGO1/lego/legoomni/src/isle/jukeboxstate.cpp
@@ -3,7 +3,7 @@
 DECOMP_SIZE_ASSERT(JukeBoxState, 0x10)
 
 // FUNCTION: LEGO1 0x1000f300
-MxBool JukeBoxState::VTable0x14()
+MxBool JukeBoxState::IsSerializable()
 {
 	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/isle/radiostate.cpp
+++ b/LEGO1/lego/legoomni/src/isle/radiostate.cpp
@@ -70,7 +70,7 @@ RadioState::RadioState()
 }
 
 // FUNCTION: LEGO1 0x1002cf50
-MxBool RadioState::VTable0x14()
+MxBool RadioState::IsSerializable()
 {
 	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/pizzeria/pizzamissionstate.cpp
+++ b/LEGO1/lego/legoomni/src/pizzeria/pizzamissionstate.cpp
@@ -4,10 +4,10 @@ DECOMP_SIZE_ASSERT(PizzaMissionStateEntry, 0x20)
 DECOMP_SIZE_ASSERT(PizzaMissionState, 0xb0)
 
 // STUB: LEGO1 0x100393c0
-MxResult PizzaMissionState::VTable0x1c(LegoFile* p_legoFile)
+MxResult PizzaMissionState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return SUCCESS;
+	return LegoState::Serialize(p_legoFile);
 }
 
 // FUNCTION: LEGO1 0x10039510

--- a/LEGO1/lego/legoomni/src/pizzeria/pizzeriastate.cpp
+++ b/LEGO1/lego/legoomni/src/pizzeria/pizzeriastate.cpp
@@ -9,8 +9,8 @@ PizzeriaState::PizzeriaState()
 }
 
 // STUB: LEGO1 0x10017da0
-MxResult PizzeriaState::VTable0x1c(LegoFile* p_legoFile)
+MxResult PizzeriaState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return SUCCESS;
+	return LegoState::Serialize(p_legoFile);
 }

--- a/LEGO1/lego/legoomni/src/police/policestate.cpp
+++ b/LEGO1/lego/legoomni/src/police/policestate.cpp
@@ -22,9 +22,7 @@ PoliceState::PoliceState()
 // FUNCTION: LEGO1 0x1005e990
 MxResult PoliceState::Serialize(LegoFile* p_legoFile)
 {
-	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->WriteString(ClassName());
-	}
+	LegoState::Serialize(p_legoFile);
 
 	if (p_legoFile->IsReadMode()) {
 		p_legoFile->Read(&m_policeScript, sizeof(m_policeScript));

--- a/LEGO1/lego/legoomni/src/police/policestate.cpp
+++ b/LEGO1/lego/legoomni/src/police/policestate.cpp
@@ -20,10 +20,10 @@ PoliceState::PoliceState()
 }
 
 // FUNCTION: LEGO1 0x1005e990
-MxResult PoliceState::VTable0x1c(LegoFile* p_legoFile)
+MxResult PoliceState::Serialize(LegoFile* p_legoFile)
 {
 	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->FUN_10006030(ClassName());
+		p_legoFile->WriteString(ClassName());
 	}
 
 	if (p_legoFile->IsReadMode()) {

--- a/LEGO1/lego/legoomni/src/race/racestate.cpp
+++ b/LEGO1/lego/legoomni/src/race/racestate.cpp
@@ -12,10 +12,10 @@ RaceState::RaceState()
 }
 
 // STUB: LEGO1 0x10016140
-MxResult RaceState::VTable0x1c(LegoFile* p_legoFile)
+MxResult RaceState::Serialize(LegoFile* p_legoFile)
 {
 	// TODO
-	return SUCCESS;
+	return LegoState::Serialize(p_legoFile);
 }
 
 // FUNCTION: LEGO1 0x10016280

--- a/LEGO1/lego/legoomni/src/towtrack/towtrackmissionstate.cpp
+++ b/LEGO1/lego/legoomni/src/towtrack/towtrackmissionstate.cpp
@@ -21,10 +21,10 @@ TowTrackMissionState::TowTrackMissionState()
 }
 
 // FUNCTION: LEGO1 0x1004dde0
-MxResult TowTrackMissionState::VTable0x1c(LegoFile* p_legoFile)
+MxResult TowTrackMissionState::Serialize(LegoFile* p_legoFile)
 {
 	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->FUN_10006030(this->ClassName());
+		p_legoFile->WriteString(this->ClassName());
 	}
 
 	if (p_legoFile->IsReadMode()) {

--- a/LEGO1/lego/legoomni/src/towtrack/towtrackmissionstate.cpp
+++ b/LEGO1/lego/legoomni/src/towtrack/towtrackmissionstate.cpp
@@ -23,9 +23,7 @@ TowTrackMissionState::TowTrackMissionState()
 // FUNCTION: LEGO1 0x1004dde0
 MxResult TowTrackMissionState::Serialize(LegoFile* p_legoFile)
 {
-	if (p_legoFile->IsWriteMode()) {
-		p_legoFile->WriteString(this->ClassName());
-	}
+	LegoState::Serialize(p_legoFile);
 
 	if (p_legoFile->IsReadMode()) {
 		p_legoFile->Read(&m_unk0x12, sizeof(m_unk0x12));

--- a/LEGO1/lego/sources/misc/legostorage.h
+++ b/LEGO1/lego/sources/misc/legostorage.h
@@ -137,7 +137,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10006030
-	LegoStorage* FUN_10006030(MxString p_str)
+	LegoStorage* WriteString(MxString p_str)
 	{
 		const char* data = p_str.GetData();
 		LegoU32 fullLength = strlen(data);


### PR DESCRIPTION
Loading of save states has been broken for a while due to overridden serialize methods not being implemented. This fixes the issue by using the parent function instead of doing nothing.

I've also renamed some functions for consistency and gave names to `Serialize`/`IsSerializable` since their purpose is pretty obvious by now.

Existing serializiation functions have been fully matched by also calling the parent `Serialize` instead of re-implementing it.