### PR TITLE
Make NotificationManager::Send take a const reference to notification

### DIFF
--- a/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
@@ -19,7 +19,7 @@ public:
 	};
 
 	// FUNCTION: LEGO1 0x10028690
-	MxNotificationParam* Clone() override
+	MxNotificationParam* Clone() const override
 	{
 		LegoEventNotificationParam* clone =
 			new LegoEventNotificationParam(m_type, m_sender, m_modifier, m_x, m_y, m_key);

--- a/LEGO1/lego/legoomni/include/legoomni.h
+++ b/LEGO1/lego/legoomni/include/legoomni.h
@@ -187,7 +187,7 @@ public:
 	void DeleteObject(MxDSAction& p_dsAction) override;                                          // vtable+24
 	MxBool DoesEntityExist(MxDSAction& p_dsAction) override;                                     // vtable+28
 	MxEntity* AddToWorld(const char* p_id, MxS32 p_entityId, MxPresenter* p_presenter) override; // vtable+30
-	void NotifyCurrentEntity(MxNotificationParam* p_param) override;                             // vtable+34
+	void NotifyCurrentEntity(const MxNotificationParam& p_param) override;                       // vtable+34
 	void StartTimer() override;                                                                  // vtable+38
 	void StopTimer() override;                                                                   // vtable+3c
 

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -124,7 +124,7 @@ void LegoAnimMMPresenter::EndAction()
 
 	MxType18NotificationParam param(c_notificationType18, NULL, m_animmanId);
 	if (m_animmanId != 0) {
-		NotificationManager()->Send(AnimationManager(), &param);
+		NotificationManager()->Send(AnimationManager(), param);
 	}
 
 	if (m_action != NULL) {

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -775,14 +775,7 @@ inline void LoadIsle()
 	LegoWorld* world = FindWorld(*g_isleScript, 0);
 	if (world != NULL) {
 		if (!world->GetUnknown0xd0().empty()) {
-#ifdef COMPAT_MODE
-			{
-				MxNotificationParam param(c_notificationType20, NULL);
-				NotificationManager()->Send(world, &param);
-			}
-#else
-			NotificationManager()->Send(world, &MxNotificationParam(c_notificationType20, NULL));
-#endif
+			NotificationManager()->Send(world, MxNotificationParam(c_notificationType20, NULL));
 		}
 	}
 	else {

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -239,14 +239,7 @@ void NotifyEntity(const char* p_filename, MxS32 p_entityId, LegoEntity* p_sender
 	}
 
 	if (entity != NULL) {
-#ifdef COMPAT_MODE
-		{
-			MxNotificationParam param(c_notificationType0, p_sender);
-			NotificationManager()->Send(entity, &param);
-		}
-#else
-		NotificationManager()->Send(entity, &MxNotificationParam(c_notificationType0, p_sender));
-#endif
+		NotificationManager()->Send(entity, MxNotificationParam(c_notificationType0, p_sender));
 	}
 }
 

--- a/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
@@ -66,14 +66,7 @@ LegoWorldPresenter::~LegoWorldPresenter()
 	}
 
 	if (m_entity) {
-#ifdef COMPAT_MODE
-		{
-			MxNotificationParam param(c_notificationNewPresenter, NULL);
-			NotificationManager()->Send(m_entity, &param);
-		}
-#else
-		NotificationManager()->Send(m_entity, &MxNotificationParam(c_notificationNewPresenter, NULL));
-#endif
+		NotificationManager()->Send(m_entity, MxNotificationParam(c_notificationNewPresenter, NULL));
 	}
 }
 

--- a/LEGO1/lego/legoomni/src/main/legoomni.cpp
+++ b/LEGO1/lego/legoomni/src/main/legoomni.cpp
@@ -678,7 +678,7 @@ MxEntity* LegoOmni::AddToWorld(const char* p_id, MxS32 p_entityId, MxPresenter* 
 }
 
 // FUNCTION: LEGO1 0x1005b3a0
-void LegoOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
+void LegoOmni::NotifyCurrentEntity(const MxNotificationParam& p_param)
 {
 	if (m_currentWorld) {
 		NotificationManager()->Send(m_currentWorld, p_param);

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -509,16 +509,7 @@ void Isle::Enable(MxBool p_enable)
 		switch (GameState()->m_currentArea) {
 		case LegoGameState::e_elevride:
 			m_destLocation = LegoGameState::e_elevride;
-
-#ifdef COMPAT_MODE
-			{
-				MxNotificationParam param(c_notificationTransitioned, NULL);
-				NotificationManager()->Send(this, &param);
-			}
-#else
-			NotificationManager()->Send(this, &MxNotificationParam(c_notificationTransitioned, NULL));
-#endif
-
+			NotificationManager()->Send(this, MxNotificationParam(c_notificationTransitioned, NULL));
 			SetIsWorldActive(FALSE);
 			break;
 		case LegoGameState::e_jetrace2:
@@ -540,30 +531,12 @@ void Isle::Enable(MxBool p_enable)
 			break;
 		case LegoGameState::e_garadoor:
 			m_destLocation = LegoGameState::e_garadoor;
-
-#ifdef COMPAT_MODE
-			{
-				MxNotificationParam param(c_notificationTransitioned, NULL);
-				NotificationManager()->Send(this, &param);
-			}
-#else
-			NotificationManager()->Send(this, &MxNotificationParam(c_notificationTransitioned, NULL));
-#endif
-
+			NotificationManager()->Send(this, MxNotificationParam(c_notificationTransitioned, NULL));
 			SetIsWorldActive(FALSE);
 			break;
 		case LegoGameState::e_polidoor:
 			m_destLocation = LegoGameState::e_polidoor;
-
-#ifdef COMPAT_MODE
-			{
-				MxNotificationParam param(c_notificationTransitioned, NULL);
-				NotificationManager()->Send(this, &param);
-			}
-#else
-			NotificationManager()->Send(this, &MxNotificationParam(c_notificationTransitioned, NULL));
-#endif
-
+			NotificationManager()->Send(this, MxNotificationParam(c_notificationTransitioned, NULL));
 			SetIsWorldActive(FALSE);
 			break;
 		case LegoGameState::e_bike:
@@ -1012,29 +985,13 @@ void Isle::FUN_10032d30(
 			m_act1state->m_unk0x01f = FALSE;
 		}
 		else {
-#ifdef COMPAT_MODE
-			{
-				MxNotificationParam param(c_notificationTransitioned, NULL);
-				NotificationManager()->Send(this, &param);
-			}
-#else
-			NotificationManager()->Send(this, &MxNotificationParam(c_notificationTransitioned, NULL));
-#endif
+			NotificationManager()->Send(this, MxNotificationParam(c_notificationTransitioned, NULL));
 		}
 	}
 	else {
 		GameState()->SwitchArea(m_destLocation);
 		GameState()->StopArea(LegoGameState::e_previousArea);
-
-#ifdef COMPAT_MODE
-		{
-			MxNotificationParam param(c_notificationTransitioned, NULL);
-			NotificationManager()->Send(this, &param);
-		}
-#else
-		NotificationManager()->Send(this, &MxNotificationParam(c_notificationTransitioned, NULL));
-#endif
-
+		NotificationManager()->Send(this, MxNotificationParam(c_notificationTransitioned, NULL));
 		m_act1state->m_unk0x01f = TRUE;
 	}
 }

--- a/LEGO1/omni/include/mxactionnotificationparam.h
+++ b/LEGO1/omni/include/mxactionnotificationparam.h
@@ -47,7 +47,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100510c0
-	MxNotificationParam* Clone() override
+	MxNotificationParam* Clone() const override
 	{
 		return new MxActionNotificationParam(this->m_type, this->m_sender, this->m_action, this->m_realloc);
 	} // vtable+0x04
@@ -73,7 +73,7 @@ public:
 	{
 	}
 
-	MxNotificationParam* Clone() override; // vtable+0x04
+	MxNotificationParam* Clone() const override; // vtable+0x04
 };
 
 // VTABLE: LEGO1 0x100d8358
@@ -91,7 +91,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10051270
-	MxNotificationParam* Clone() override
+	MxNotificationParam* Clone() const override
 	{
 		return new MxEndActionNotificationParam(
 			c_notificationEndAction,
@@ -112,7 +112,7 @@ public:
 		m_unk0x14 = p_unk0x14;
 	}
 
-	MxNotificationParam* Clone() override; // vtable+0x04
+	MxNotificationParam* Clone() const override; // vtable+0x04
 
 private:
 	MxPresenter* m_unk0x14; // 0x14

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -9,7 +9,7 @@
 
 class MxNotification {
 public:
-	MxNotification(MxCore* p_target, MxNotificationParam* p_param);
+	MxNotification(MxCore* p_target, const MxNotificationParam& p_param);
 	~MxNotification();
 
 	inline MxCore* GetTarget() { return m_target; }
@@ -43,7 +43,7 @@ public:
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x14
 	void Register(MxCore* p_listener);
 	void Unregister(MxCore* p_listener);
-	MxResult Send(MxCore* p_listener, MxNotificationParam* p_param);
+	MxResult Send(MxCore* p_listener, const MxNotificationParam& p_param);
 
 	inline MxNotificationPtrList* GetQueue() { return m_queue; }
 	inline void SetActive(MxBool p_active) { m_active = p_active; }

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -42,7 +42,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10010390
-	virtual MxNotificationParam* Clone() { return new MxNotificationParam(m_type, m_sender); } // vtable+0x04
+	virtual MxNotificationParam* Clone() const { return new MxNotificationParam(m_type, m_sender); } // vtable+0x04
 
 	inline NotificationId GetNotification() const { return m_type; }
 	inline MxCore* GetSender() const { return m_sender; }

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -48,7 +48,7 @@ public:
 	virtual MxBool DoesEntityExist(MxDSAction& p_dsAction);                                   // vtable+28
 	virtual MxResult CreatePresenter(MxStreamController* p_controller, MxDSAction& p_action); // vtable+2c
 	virtual MxEntity* AddToWorld(const char*, MxS32, MxPresenter*);                           // vtable+30
-	virtual void NotifyCurrentEntity(MxNotificationParam* p_param);                           // vtable+34
+	virtual void NotifyCurrentEntity(const MxNotificationParam& p_param);                     // vtable+34
 	virtual void StartTimer();                                                                // vtable+38
 	virtual void StopTimer();                                                                 // vtable+3c
 

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -24,7 +24,7 @@ public:
 		m_controller = p_ctrlr;
 	}
 
-	MxNotificationParam* Clone() override;
+	MxNotificationParam* Clone() const override;
 
 	MxStreamController* GetController() { return m_controller; }
 

--- a/LEGO1/omni/include/mxtype18notificationparam.h
+++ b/LEGO1/omni/include/mxtype18notificationparam.h
@@ -14,7 +14,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x1004afd0
-	MxNotificationParam* Clone() override
+	MxNotificationParam* Clone() const override
 	{
 		return new MxType18NotificationParam(m_type, m_sender, m_unk0x0c);
 	} // vtable+0x04

--- a/LEGO1/omni/src/common/mxcompositepresenter.cpp
+++ b/LEGO1/omni/src/common/mxcompositepresenter.cpp
@@ -96,17 +96,10 @@ void MxCompositePresenter::EndAction()
 	MxPresenter::EndAction();
 
 	if (action && action->GetOrigin()) {
-#ifdef COMPAT_MODE
-		{
-			MxEndActionNotificationParam param(c_notificationEndAction, this, action, FALSE);
-			NotificationManager()->Send(action->GetOrigin(), &param);
-		}
-#else
 		NotificationManager()->Send(
 			action->GetOrigin(),
-			&MxEndActionNotificationParam(c_notificationEndAction, this, action, FALSE)
+			MxEndActionNotificationParam(c_notificationEndAction, this, action, FALSE)
 		);
-#endif
 	}
 }
 
@@ -209,7 +202,7 @@ void MxCompositePresenter::VTable0x5c(MxNotificationParam& p_param)
 			}
 		}
 
-		NotificationManager()->Send(this, &p_param);
+		NotificationManager()->Send(this, p_param);
 	}
 }
 

--- a/LEGO1/omni/src/common/mxmediapresenter.cpp
+++ b/LEGO1/omni/src/common/mxmediapresenter.cpp
@@ -154,17 +154,10 @@ void MxMediaPresenter::EndAction()
 		}
 
 		if (action && action->GetOrigin()) {
-#ifdef COMPAT_MODE
-			{
-				MxEndActionNotificationParam param(c_notificationEndAction, this, action, FALSE);
-				NotificationManager()->Send(action->GetOrigin(), &param);
-			}
-#else
 			NotificationManager()->Send(
 				action->GetOrigin(),
-				&MxEndActionNotificationParam(c_notificationEndAction, this, action, FALSE)
+				MxEndActionNotificationParam(c_notificationEndAction, this, action, FALSE)
 			);
-#endif
 		}
 	}
 }

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -58,16 +58,9 @@ void MxPresenter::EndAction()
 	AUTOLOCK(m_criticalSection);
 
 	if (!this->m_compositePresenter) {
-#ifdef COMPAT_MODE
-		{
-			MxEndActionNotificationParam param(c_notificationEndAction, NULL, this->m_action, TRUE);
-			MxOmni::GetInstance()->NotifyCurrentEntity(&param);
-		}
-#else
 		MxOmni::GetInstance()->NotifyCurrentEntity(
-			&MxEndActionNotificationParam(c_notificationEndAction, NULL, this->m_action, TRUE)
+			MxEndActionNotificationParam(c_notificationEndAction, NULL, this->m_action, TRUE)
 		);
-#endif
 	}
 
 	this->m_action = NULL;

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -115,15 +115,7 @@ void MxPresenter::SendToCompositePresenter(MxOmni* p_omni)
 	if (m_compositePresenter) {
 		AUTOLOCK(m_criticalSection);
 
-#ifdef COMPAT_MODE
-		{
-			MxNotificationParam param(c_notificationPresenter, this);
-			NotificationManager()->Send(m_compositePresenter, &param);
-		}
-#else
-		NotificationManager()->Send(m_compositePresenter, &MxNotificationParam(c_notificationPresenter, this));
-#endif
-
+		NotificationManager()->Send(m_compositePresenter, MxNotificationParam(c_notificationPresenter, this));
 		m_action->SetOrigin(p_omni ? p_omni : MxOmni::GetInstance());
 		m_compositePresenter = NULL;
 	}

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -269,28 +269,14 @@ MxResult MxOmni::CreatePresenter(MxStreamController* p_controller, MxDSAction& p
 
 			if (object->StartAction(p_controller, &p_action) == SUCCESS) {
 				if (sender) {
-#ifdef COMPAT_MODE
-					{
-						MxType4NotificationParam param(this, &p_action, object);
-						NotificationManager()->Send(sender, &param);
-					}
-#else
-					NotificationManager()->Send(sender, &MxType4NotificationParam(this, &p_action, object));
-#endif
+					NotificationManager()->Send(sender, MxType4NotificationParam(this, &p_action, object));
 				}
 
 				if (p_action.GetUnknown84()) {
-#ifdef COMPAT_MODE
-					{
-						MxStartActionNotificationParam param(c_notificationStartAction, object, &p_action, FALSE);
-						NotificationManager()->Send(p_action.GetUnknown84(), &param);
-					}
-#else
 					NotificationManager()->Send(
 						p_action.GetUnknown84(),
-						&MxStartActionNotificationParam(c_notificationStartAction, object, &p_action, FALSE)
+						MxStartActionNotificationParam(c_notificationStartAction, object, &p_action, FALSE)
 					);
-#endif
 				}
 				result = SUCCESS;
 			}

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -42,7 +42,7 @@ MxEntity* MxOmni::AddToWorld(const char*, MxS32, MxPresenter*)
 }
 
 // FUNCTION: LEGO1 0x100aefc0
-void MxOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
+void MxOmni::NotifyCurrentEntity(const MxNotificationParam& p_param)
 {
 }
 

--- a/LEGO1/omni/src/notify/mxactionnotificationparam.cpp
+++ b/LEGO1/omni/src/notify/mxactionnotificationparam.cpp
@@ -4,7 +4,7 @@ DECOMP_SIZE_ASSERT(MxActionNotificationParam, 0x14)
 DECOMP_SIZE_ASSERT(MxEndActionNotificationParam, 0x14)
 
 // FUNCTION: LEGO1 0x100b0300
-MxNotificationParam* MxStartActionNotificationParam::Clone()
+MxNotificationParam* MxStartActionNotificationParam::Clone() const
 {
 	return new MxStartActionNotificationParam(
 		c_notificationStartAction,
@@ -15,7 +15,7 @@ MxNotificationParam* MxStartActionNotificationParam::Clone()
 }
 
 // FUNCTION: LEGO1 0x100b04f0
-MxNotificationParam* MxType4NotificationParam::Clone()
+MxNotificationParam* MxType4NotificationParam::Clone() const
 {
 	return new MxType4NotificationParam(this->m_sender, this->m_action, this->m_unk0x14);
 }

--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -12,10 +12,10 @@ DECOMP_SIZE_ASSERT(MxNotification, 0x08);
 DECOMP_SIZE_ASSERT(MxNotificationManager, 0x40);
 
 // FUNCTION: LEGO1 0x100ac220
-MxNotification::MxNotification(MxCore* p_target, MxNotificationParam* p_param)
+MxNotification::MxNotification(MxCore* p_target, const MxNotificationParam& p_param)
 {
 	m_target = p_target;
-	m_param = p_param->Clone();
+	m_param = p_param.Clone();
 }
 
 // FUNCTION: LEGO1 0x100ac240
@@ -61,25 +61,23 @@ MxResult MxNotificationManager::Create(MxU32 p_frequencyMS, MxBool p_createThrea
 }
 
 // FUNCTION: LEGO1 0x100ac6c0
-MxResult MxNotificationManager::Send(MxCore* p_listener, MxNotificationParam* p_param)
+MxResult MxNotificationManager::Send(MxCore* p_listener, const MxNotificationParam& p_param)
 {
 	AUTOLOCK(m_lock);
 
-	if (m_active == FALSE) {
+	if (!m_active) {
 		return FAILURE;
 	}
-	else {
-		MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
-		if (it == m_listenerIds.end()) {
-			return FAILURE;
-		}
-		else {
-			MxNotification* notif = new MxNotification(p_listener, p_param);
-			if (notif != NULL) {
-				m_queue->push_back(notif);
-				return SUCCESS;
-			}
-		}
+
+	MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
+	if (it == m_listenerIds.end()) {
+		return FAILURE;
+	}
+
+	MxNotification* notif = new MxNotification(p_listener, p_param);
+	if (notif != NULL) {
+		m_queue->push_back(notif);
+		return SUCCESS;
 	}
 
 	return FAILURE;

--- a/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
@@ -334,16 +334,9 @@ MxResult MxDiskStreamController::VTable0x24(MxDSAction* p_action)
 	AUTOLOCK(m_criticalSection);
 	if (m_unk0x54.Find(p_action, FALSE) == NULL) {
 		if (VTable0x30(p_action) == SUCCESS) {
-#ifdef COMPAT_MODE
-			{
-				MxEndActionNotificationParam param(c_notificationEndAction, NULL, p_action, TRUE);
-				MxOmni::GetInstance()->NotifyCurrentEntity(&param);
-			}
-#else
 			MxOmni::GetInstance()->NotifyCurrentEntity(
-				&MxEndActionNotificationParam(c_notificationEndAction, NULL, p_action, TRUE)
+				MxEndActionNotificationParam(c_notificationEndAction, NULL, p_action, TRUE)
 			);
-#endif
 		}
 	}
 

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -81,14 +81,7 @@ MxLong MxStreamer::Close(const char* p_name)
 				delete c;
 			}
 			else {
-#ifdef COMPAT_MODE
-				{
-					MxStreamerNotification notification(c_notificationStreamer, NULL, c);
-					NotificationManager()->Send(this, &notification);
-				}
-#else
-				NotificationManager()->Send(this, &MxStreamerNotification(c_notificationStreamer, NULL, c));
-#endif
+				NotificationManager()->Send(this, MxStreamerNotification(c_notificationStreamer, NULL, c));
 			}
 
 			return SUCCESS;
@@ -99,7 +92,7 @@ MxLong MxStreamer::Close(const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x100b9700
-MxNotificationParam* MxStreamerNotification::Clone()
+MxNotificationParam* MxStreamerNotification::Clone() const
 {
 	return new MxStreamerNotification(m_type, m_sender, m_controller);
 }
@@ -204,14 +197,7 @@ MxLong MxStreamer::Notify(MxParam& p_param)
 			delete c;
 		}
 		else {
-#ifdef COMPAT_MODE
-			{
-				MxStreamerNotification notification(c_notificationStreamer, NULL, c);
-				NotificationManager()->Send(this, &notification);
-			}
-#else
-			NotificationManager()->Send(this, &MxStreamerNotification(c_notificationStreamer, NULL, c));
-#endif
+			NotificationManager()->Send(this, MxStreamerNotification(c_notificationStreamer, NULL, c));
 		}
 	}
 


### PR DESCRIPTION
`NotificationManager::Send` eventually clones the passed notification parameter, so there was no reason not to give it a const-qualifier. This removes a number of `COMPAT_MODE` switches, matches stay the same.