### PR TITLE
Pointer substitution can use offset into variable

### DIFF
--- a/tools/isledecomp/tests/test_sanitize.py
+++ b/tools/isledecomp/tests/test_sanitize.py
@@ -113,7 +113,7 @@ name_replace_cases = [
 def test_name_replace(start, end):
     """Make sure the name lookup function is called if present"""
 
-    def substitute(_: int) -> str:
+    def substitute(_: int, __: bool) -> str:
         return "_substitute_"
 
     p = ParseAsm(name_lookup=substitute)
@@ -137,7 +137,7 @@ def test_replacement_numbering():
     """If we can use the name lookup for the first address but not the second,
     the second replacement should be <OFFSET2> not <OFFSET1>."""
 
-    def substitute_1234(addr: int) -> Optional[str]:
+    def substitute_1234(addr: int, _: bool) -> Optional[str]:
         return "_substitute_" if addr == 0x1234 else None
 
     p = ParseAsm(name_lookup=substitute_1234)
@@ -171,7 +171,7 @@ def test_jump_to_function():
     assume this is the case for all jumps. Only replace the jump with a name
     if we can find it using our lookup."""
 
-    def substitute_1234(addr: int) -> Optional[str]:
+    def substitute_1234(addr: int, _: bool) -> Optional[str]:
         return "_substitute_" if addr == 0x1234 else None
 
     p = ParseAsm(name_lookup=substitute_1234)
@@ -212,7 +212,7 @@ def test_float_variable():
     """If there is a variable at the address referenced by a float instruction,
     use the name instead of calling into the float replacement handler."""
 
-    def name_lookup(addr: int) -> Optional[str]:
+    def name_lookup(addr: int, _: bool) -> Optional[str]:
         return "g_myFloatVariable" if addr == 0x1234 else None
 
     p = ParseAsm(name_lookup=name_lookup)
@@ -234,7 +234,7 @@ def test_pointer_compare():
         return addr in (0x1234, 0x5555)
 
     # Only 0x5555 is a "known" address
-    def name_lookup(addr: int) -> Optional[str]:
+    def name_lookup(addr: int, _: bool) -> Optional[str]:
         return "hello" if addr == 0x5555 else None
 
     p = ParseAsm(relocate_lookup=relocate_lookup, name_lookup=name_lookup)
@@ -263,7 +263,7 @@ def test_absolute_indirect():
     we have it, but there are some circumstances where we want to replace
     with the pointer's name (i.e. an import function)."""
 
-    def name_lookup(addr: int) -> Optional[str]:
+    def name_lookup(addr: int, _: bool) -> Optional[str]:
         return {
             0x1234: "Hello",
             0x4321: "xyz",

--- a/tools/reccmp/reccmp.py
+++ b/tools/reccmp/reccmp.py
@@ -241,6 +241,9 @@ def main():
 
         isle_compare = IsleCompare(origfile, recompfile, args.pdb, args.decomp_dir)
 
+        if args.loglevel == logging.DEBUG:
+            isle_compare.debug = True
+
         print()
 
         ### Compare one or none.


### PR DESCRIPTION
There are a few cases where the code will refer to an address that is not the exact start of any particular variable, but an offset into a variable. (Either a struct member or an array.)

In these cases, if we detect that the nearest address in the database is a variable and our address is within the bounds _of_ that variable, we will replace it with a special offset name like this:

```diff
-0x1001a7d8: mov ecx, <OFFSET6>
+0x1001a7d8: mov ecx, g_extraPaths+56 (OFFSET)

-0x10055653: lea ebx, [edi + edi*2 + <OFFSET3>]
+0x10055653: lea ebx, [edi + edi*2 + g_cameraLocations+20 (OFFSET)]

-0x100849cb: push <OFFSET3>
+0x100849cb: push g_characterLODs+356 (OFFSET)
```

@foxtacles found that our not doing this caused a bug to go unseen in #835. We can detect diffs like that now:

```diff
-0x10084f0d: -mov eax, dword ptr [g_characterLODs+176 (OFFSET)]
+0x10084f0d: +mov eax, dword ptr [g_characterLODs+88 (OFFSET)]
```

I also added a new debug option that will dump all the sanitized asm instructions to some files. This change improved `LegoCharacterManager::CreateROI` because of a mismatch in the `<OFFSETX>` numbering, but beyond that, I wanted to make sure it was doing what it was intended to do.

This fix is a little messier than I would like, but we're running into the limits of the current design. For example: we have the type information, so we could use something better than `variable+number` for the offset name, but it would be clunky to push the dependency down to the sanitize function. I don't want to refactor this all _again_ just yet because it is working for the moment. If we break the tooling off into its own repo then that would be a good opportunity to think about a redesign.