### PR TITLE
Beta matching MxString

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,7 +542,6 @@ if (MSVC_FOR_DECOMP)
   # They ensure a recompilation that can be byte/instruction accurate to the original binaries.
   if (ISLE_BUILD_APP)
     target_link_options(isle PRIVATE "/OPT:REF")
-    target_link_options(lego1 PRIVATE "/OPT:REF")
     set_property(TARGET isle ${lego1_targets} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,7 @@ if (MSVC_FOR_DECOMP)
   # They ensure a recompilation that can be byte/instruction accurate to the original binaries.
   if (ISLE_BUILD_APP)
     target_link_options(isle PRIVATE "/OPT:REF")
+    target_link_options(lego1 PRIVATE "/OPT:REF")
     set_property(TARGET isle ${lego1_targets} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 

--- a/LEGO1/lego/legoomni/include/legophonemelist.h
+++ b/LEGO1/lego/legoomni/include/legophonemelist.h
@@ -12,12 +12,14 @@
 // class MxList<LegoPhoneme *>
 
 // VTABLE: LEGO1 0x100d9d00
+// VTABLE: BETA10 0x101bef58
 // SIZE 0x18
 class LegoPhonemeList : public MxList<LegoPhoneme*> {
 public:
 	LegoPhonemeList() { SetDestroy(Destroy); }
 
 	// FUNCTION: LEGO1 0x1007b210
+	// FUNCTION: BETA10 0x100d8340
 	MxS8 Compare(LegoPhoneme* p_a, LegoPhoneme* p_b) override
 	{
 		MxString a(p_a->GetName());

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -68,12 +68,13 @@ const char* g_nick = "Nick";
 const char* g_laura = "Laura";
 
 // FUNCTION: LEGO1 0x10037d00
+// FUNCTION: BETA10 0x100d5620
 void VisibilityVariable::SetValue(const char* p_value)
 {
 	MxVariable::SetValue(p_value);
 
 	if (p_value) {
-		char* instruction = strtok(m_value.GetDataPtr(), g_delimiter2);
+		char* instruction = strtok(m_value.GetData(), g_delimiter2);
 		char* name = strtok(NULL, g_delimiter2);
 		MxBool show;
 

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -8,19 +8,20 @@
 // SIZE 0x10
 class MxString : public MxCore {
 public:
-	MxString(const MxString& p_str);
-	~MxString() override;
-	const MxString& operator=(const char* p_data);
-
 	MxString();
-	MxString(const char*);
-	MxString(const char*, MxU16);
+	MxString(const MxString& p_str);
+	MxString(const char* p_str);
+	MxString(const char* p_str, MxU16 p_maxlen);
+	~MxString() override;
+
 	void Reverse();
 	void ToUpperCase();
 	void ToLowerCase();
+
 	MxString& operator=(const MxString& p_str);
-	MxString operator+(const MxString& p_str);
-	MxString operator+(const char* p_str);
+	const MxString& operator=(const char* p_str);
+	const MxString operator+(const MxString& p_str);
+	const MxString operator+(const char* p_str);
 	MxString& operator+=(const char* p_str);
 
 	static void CharSwap(char* p_a, char* p_b);

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -20,8 +20,8 @@ public:
 
 	MxString& operator=(const MxString& p_str);
 	const MxString& operator=(const char* p_str);
-	const MxString operator+(const MxString& p_str);
-	const MxString operator+(const char* p_str);
+	MxString operator+(const MxString& p_str) const;
+	MxString operator+(const char* p_str) const;
 	MxString& operator+=(const char* p_str);
 
 	static void CharSwap(char* p_a, char* p_b);

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -4,6 +4,7 @@
 #include "mxcore.h"
 
 // VTABLE: LEGO1 0x100dc110
+// VTABLE: BETA10 0x101c1be0
 // SIZE 0x10
 class MxString : public MxCore {
 public:
@@ -13,19 +14,31 @@ public:
 
 	MxString();
 	MxString(const char*);
+	MxString(const char*, MxU16);
+	void Reverse();
 	void ToUpperCase();
 	void ToLowerCase();
 	MxString& operator=(const MxString& p_str);
+	MxString operator+(const MxString& p_str);
 	MxString operator+(const char* p_str);
 	MxString& operator+=(const char* p_str);
 
-	inline MxS8 Compare(const MxString& p_str) const { return strcmp(m_data, p_str.m_data); }
-	inline MxBool Equal(const MxString& p_str) const { return strcmp(m_data, p_str.m_data) == 0; }
-	inline const char* GetData() const { return m_data; }
-	inline char* GetDataPtr() const { return m_data; }
+	static void CharSwap(char* p_a, char* p_b);
+
+	// FUNCTION: BETA10 0x10017c50
+	inline char* GetData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x10067630
 	inline const MxU16 GetLength() const { return m_length; }
 
+	// FUNCTION: BETA10 0x100d8a30
+	inline MxBool Equal(const MxString& p_str) const { return strcmp(m_data, p_str.m_data) == 0; }
+
+	// FUNCTION: BETA10 0x1012a810
+	inline MxS8 Compare(const MxString& p_str) const { return strcmp(m_data, p_str.m_data); }
+
 	// SYNTHETIC: LEGO1 0x100ae280
+	// SYNTHETIC: BETA10 0x1012c9d0
 	// MxString::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/src/common/mxstring.cpp
+++ b/LEGO1/omni/src/common/mxstring.cpp
@@ -128,7 +128,7 @@ const MxString& MxString::operator=(const char* p_str)
 }
 
 // FUNCTION: BETA10 0x1012c68a
-const MxString MxString::operator+(const MxString& p_str)
+MxString MxString::operator+(const MxString& p_str) const
 {
 	MxString tmp;
 	delete[] tmp.m_data;
@@ -146,7 +146,7 @@ const MxString MxString::operator+(const MxString& p_str)
 // This forces MSVC to add $ReturnUdt$ to the stack for 100% match.
 // FUNCTION: LEGO1 0x100ae580
 // FUNCTION: BETA10 0x1012c78d
-const MxString MxString::operator+(const char* p_str)
+MxString MxString::operator+(const char* p_str) const
 {
 	// MxString constructor allocates 1 byte for m_data, so free that first
 	MxString tmp;

--- a/LEGO1/omni/src/common/mxstring.cpp
+++ b/LEGO1/omni/src/common/mxstring.cpp
@@ -8,6 +8,7 @@
 DECOMP_SIZE_ASSERT(MxString, 0x10)
 
 // FUNCTION: LEGO1 0x100ae200
+// FUNCTION: BETA10 0x1012c110
 MxString::MxString()
 {
 	// Set string to one char in length and set that char to null terminator
@@ -17,6 +18,7 @@ MxString::MxString()
 }
 
 // FUNCTION: LEGO1 0x100ae2a0
+// FUNCTION: BETA10 0x1012c1a1
 MxString::MxString(const MxString& p_str)
 {
 	this->m_length = p_str.m_length;
@@ -25,6 +27,7 @@ MxString::MxString(const MxString& p_str)
 }
 
 // FUNCTION: LEGO1 0x100ae350
+// FUNCTION: BETA10 0x1012c24f
 MxString::MxString(const char* p_str)
 {
 	if (p_str) {
@@ -39,25 +42,65 @@ MxString::MxString(const char* p_str)
 	}
 }
 
+// FUNCTION: BETA10 0x1012c330
+MxString::MxString(const char* p_str, MxU16 p_maxlen)
+{
+	if (p_str) {
+		if (strlen(p_str) <= p_maxlen) {
+			this->m_length = strlen(p_str);
+		}
+		else {
+			this->m_length = p_maxlen;
+		}
+
+		// Basically strncpy
+		this->m_data = new char[this->m_length + 1];
+		memcpy(this->m_data, p_str, this->m_length);
+		this->m_data[this->m_length] = '\0';
+	}
+	else {
+		this->m_data = new char[1];
+		this->m_data[0] = 0;
+		this->m_length = 0;
+	}
+}
+
 // FUNCTION: LEGO1 0x100ae420
+// FUNCTION: BETA10 0x1012c45b
 MxString::~MxString()
 {
 	delete[] this->m_data;
 }
 
+// FUNCTION: BETA10 0x1012c4de
+void MxString::Reverse()
+{
+	char* start = this->m_data;
+	char* end = this->m_data + this->m_length - 1;
+
+	while (start < end) {
+		CharSwap(start, end);
+		start++;
+		end--;
+	}
+}
+
 // FUNCTION: LEGO1 0x100ae490
+// FUNCTION: BETA10 0x1012c537
 void MxString::ToUpperCase()
 {
 	strupr(this->m_data);
 }
 
 // FUNCTION: LEGO1 0x100ae4a0
+// FUNCTION: BETA10 0x1012c55c
 void MxString::ToLowerCase()
 {
 	strlwr(this->m_data);
 }
 
 // FUNCTION: LEGO1 0x100ae4b0
+// FUNCTION: BETA10 0x1012c581
 MxString& MxString::operator=(const MxString& p_str)
 {
 	if (this->m_data != p_str.m_data) {
@@ -71,6 +114,7 @@ MxString& MxString::operator=(const MxString& p_str)
 }
 
 // FUNCTION: LEGO1 0x100ae510
+// FUNCTION: BETA10 0x1012c606
 const MxString& MxString::operator=(const char* p_data)
 {
 	if (this->m_data != p_data) {
@@ -83,9 +127,25 @@ const MxString& MxString::operator=(const char* p_data)
 	return *this;
 }
 
+// FUNCTION: BETA10 0x1012c68a
+MxString MxString::operator+(const MxString& p_str)
+{
+	MxString tmp;
+	delete[] tmp.m_data;
+
+	tmp.m_length = p_str.m_length + this->m_length;
+	tmp.m_data = new char[tmp.m_length + 1];
+
+	strcpy(tmp.m_data, this->m_data);
+	strcpy(tmp.m_data + this->m_length, p_str.m_data);
+
+	return MxString(tmp);
+}
+
 // Return type is intentionally just MxString, not MxString&.
 // This forces MSVC to add $ReturnUdt$ to the stack for 100% match.
 // FUNCTION: LEGO1 0x100ae580
+// FUNCTION: BETA10 0x1012c78d
 MxString MxString::operator+(const char* p_str)
 {
 	// MxString constructor allocates 1 byte for m_data, so free that first
@@ -102,6 +162,7 @@ MxString MxString::operator+(const char* p_str)
 }
 
 // FUNCTION: LEGO1 0x100ae690
+// FUNCTION: BETA10 0x1012c92f
 MxString& MxString::operator+=(const char* p_str)
 {
 	int newlen = this->m_length + strlen(p_str);
@@ -111,8 +172,16 @@ MxString& MxString::operator+=(const char* p_str)
 	strcpy(tmp + this->m_length, p_str);
 
 	delete[] this->m_data;
-	this->m_length = newlen;
 	this->m_data = tmp;
+	this->m_length = newlen;
 
 	return *this;
+}
+
+// FUNCTION: BETA10 0x1012ca10
+void MxString::CharSwap(char* p_a, char* p_b)
+{
+	char t = *p_a;
+	*p_a = *p_b;
+	*p_b = t;
 }

--- a/LEGO1/omni/src/common/mxstring.cpp
+++ b/LEGO1/omni/src/common/mxstring.cpp
@@ -115,20 +115,20 @@ MxString& MxString::operator=(const MxString& p_str)
 
 // FUNCTION: LEGO1 0x100ae510
 // FUNCTION: BETA10 0x1012c606
-const MxString& MxString::operator=(const char* p_data)
+const MxString& MxString::operator=(const char* p_str)
 {
-	if (this->m_data != p_data) {
+	if (this->m_data != p_str) {
 		delete[] this->m_data;
-		this->m_length = strlen(p_data);
+		this->m_length = strlen(p_str);
 		this->m_data = new char[this->m_length + 1];
-		strcpy(this->m_data, p_data);
+		strcpy(this->m_data, p_str);
 	}
 
 	return *this;
 }
 
 // FUNCTION: BETA10 0x1012c68a
-MxString MxString::operator+(const MxString& p_str)
+const MxString MxString::operator+(const MxString& p_str)
 {
 	MxString tmp;
 	delete[] tmp.m_data;
@@ -146,7 +146,7 @@ MxString MxString::operator+(const MxString& p_str)
 // This forces MSVC to add $ReturnUdt$ to the stack for 100% match.
 // FUNCTION: LEGO1 0x100ae580
 // FUNCTION: BETA10 0x1012c78d
-MxString MxString::operator+(const char* p_str)
+const MxString MxString::operator+(const char* p_str)
 {
 	// MxString constructor allocates 1 byte for m_data, so free that first
 	MxString tmp;


### PR DESCRIPTION
How do we feel about dead code? There are a few functions in `MxString` that aren't used even in the beta, but they are there. Their presence in mxstring.h is what affects the compiler entropy.

It doesn't seem like there are separate getter functions for const `m_data` vs. non, so I consolidated those.

I will confess to not really knowing what I was doing when I implemented the `operator+` function way back at the beginning. It doesn't return `*this` which seems to be the convention, but I couldn't get that or the second (unused) one here to match any other way. Any C++ experts have any thoughts?