### PR TITLE
Beta matching MxAtom classes

### DIFF
--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -30,7 +30,6 @@ public:
 
 	// FUNCTION: BETA10 0x101236d0
 	inline MxString& GetKey() { return m_key; }
-	inline MxU16 GetValue() { return m_value; }
 
 	// SYNTHETIC: BETA10 0x10124a50
 	// MxAtom::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -68,6 +68,12 @@ public:
 	// FUNCTION: BETA10 0x100178d0
 	inline MxBool operator==(const MxAtomId& p_atomId) const { return this->m_internal == p_atomId.m_internal; }
 
+#ifdef COMPAT_MODE
+	// Required for modern compilers.
+	// MSVC 4.20 uses a synthetic function from INCLUDE/UTILITY that inverts operator==
+	inline MxBool operator!=(const MxAtomId& p_atomId) const { return this->m_internal != p_atomId.m_internal; }
+#endif
+
 	// FUNCTION: BETA10 0x10025d40
 	MxAtomId() { this->m_internal = 0; }
 

--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -15,10 +15,11 @@
 // for the combined key_value_pair, which doesn't seem possible with <map>.
 
 // SIZE 0x14
-class MxAtomIdCounter {
+class MxAtom {
 public:
 	// always inlined
-	MxAtomIdCounter(const char* p_str)
+	// FUNCTION: BETA10 0x10123720
+	MxAtom(const char* p_str)
 	{
 		m_key = p_str;
 		m_value = 0;
@@ -26,23 +27,29 @@ public:
 
 	void Inc();
 	void Dec();
-	inline MxString* GetKey() { return &m_key; }
+
+	// FUNCTION: BETA10 0x101236d0
+	inline MxString& GetKey() { return m_key; }
 	inline MxU16 GetValue() { return m_value; }
+
+	// SYNTHETIC: BETA10 0x10124a50
+	// MxAtom::`scalar deleting destructor'
 
 private:
 	MxString m_key;
 	MxU16 m_value;
 };
 
-struct MxAtomIdCounterCompare {
+struct MxAtomCompare {
 	// FUNCTION: LEGO1 0x100ad120
-	int operator()(MxAtomIdCounter* const& p_val0, MxAtomIdCounter* const& p_val1) const
+	// FUNCTION: BETA10 0x10123980
+	int operator()(MxAtom* const& p_val0, MxAtom* const& p_val1) const
 	{
-		return strcmp(p_val0->GetKey()->GetData(), p_val1->GetKey()->GetData()) > 0;
+		return strcmp(p_val0->GetKey().GetData(), p_val1->GetKey().GetData()) > 0;
 	}
 };
 
-class MxAtomIdCounterSet : public set<MxAtomIdCounter*, MxAtomIdCounterCompare> {};
+class MxAtomSet : public set<MxAtom*, MxAtomCompare> {};
 
 enum LookupMode {
 	e_exact = 0,
@@ -55,74 +62,154 @@ enum LookupMode {
 class MxAtomId {
 public:
 	MxAtomId(const char*, LookupMode);
-	MxAtomId& operator=(const MxAtomId& p_atomId);
 	~MxAtomId();
 
-	MxAtomId() { this->m_internal = 0; }
+	MxAtomId& operator=(const MxAtomId& p_atomId);
 
+	// FUNCTION: BETA10 0x100178d0
 	inline MxBool operator==(const MxAtomId& p_atomId) const { return this->m_internal == p_atomId.m_internal; }
-	inline MxBool operator!=(const MxAtomId& p_atomId) const { return this->m_internal != p_atomId.m_internal; }
+
+	// FUNCTION: BETA10 0x10025d40
+	MxAtomId() { this->m_internal = 0; }
 
 	void Clear();
 
+	// FUNCTION: BETA10 0x100735e0
 	const char* GetInternal() const { return m_internal; }
 
 private:
-	MxAtomIdCounter* GetCounter(const char*, LookupMode);
+	// FUNCTION: BETA10 0x101236f0
+	MxAtomId& operator=(const MxString& p_key)
+	{
+		m_internal = p_key.GetData();
+		return *this;
+	}
+
+	MxAtom* GetAtom(const char*, LookupMode);
 	void Destroy();
 
 	const char* m_internal; // 0x00
 };
 
+// SYNTHETIC: BETA10 0x1002b520
+// ??9@YAHABVMxAtomId@@0@Z
+// aka MxAtomId::operator!=
+
 // SYNTHETIC: LEGO1 0x100ad170
-// MxAtomIdCounter::~MxAtomIdCounter
+// MxAtom::~MxAtom
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100ad480
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::iterator::_Dec
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::iterator::_Dec
 // clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100ad780
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Lbound
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Lbound
 // clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100ad4d0
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Insert
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Insert
 // clang-format on
+
+// TEMPLATE: BETA10 0x101237a0
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *>
+// >::const_iterator::operator*
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100af6d0
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::~_Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCou
+// TEMPLATE: BETA10 0x10131170
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::~_Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >
 // clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100af7a0
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::iterator::_Inc
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::iterator::_Inc
 // clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100af7e0
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::erase
+// TEMPLATE: BETA10 0x10131210
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::erase
 // clang-format on
+
+// TEMPLATE: BETA10 0x10131460
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *>
+// >::size
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100afc40
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Erase
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Erase
 // clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100afc80
-// set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::~set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >
+// TEMPLATE: BETA10 0x10132080
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::~set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >
 // clang-format on
 
 // TEMPLATE: LEGO1 0x100afe40
-// Set<MxAtomIdCounter *,MxAtomIdCounterCompare>::~Set<MxAtomIdCounter *,MxAtomIdCounterCompare>
+// TEMPLATE: BETA10 0x101320e0
+// Set<MxAtom *,MxAtomCompare>::~Set<MxAtom *,MxAtomCompare>
+
+// TEMPLATE: BETA10 0x10132140
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::begin
 
 // clang-format off
 // GLOBAL: LEGO1 0x101013f0
-// _Tree<MxAtomIdCounter *,MxAtomIdCounter *,set<MxAtomIdCounter *,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Kfn,MxAtomIdCounterCompare,allocator<MxAtomIdCounter *> >::_Nil
+// GLOBAL: BETA10 0x10201264
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Nil
 // clang-format on
+
+// TEMPLATE: BETA10 0x10132170
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *>
+// >::begin
+
+// TEMPLATE: BETA10 0x101321d0
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::size
+
+// TEMPLATE: BETA10 0x101321f0
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::erase
+
+// TEMPLATE: BETA10 0x101237f0
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::end
+
+// TEMPLATE: BETA10 0x101238b0
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::find
+
+// clang-format off
+// TEMPLATE: BETA10 0x101238e0
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::find
+// clang-format on
+
+// SYNTHETIC: BETA10 0x10123bf0
+// MxAtom::~MxAtom
+
+// TEMPLATE: BETA10 0x10123c50
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::insert
+
+// SYNTHETIC: BETA10 0x10130fc0
+// MxAtomSet::MxAtomSet
+
+// TEMPLATE: BETA10 0x10131030
+// Set<MxAtom *,MxAtomCompare>::Set<MxAtom *,MxAtomCompare>
+
+// clang-format off
+// TEMPLATE: BETA10 0x101310a0
+// set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >
+
+// TEMPLATE: BETA10 0x10131120
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >
+
+// TEMPLATE: BETA10 0x10131f30
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Init
+// clang-format on
+
+// SYNTHETIC: BETA10 0x101322a0
+// MxAtomSet::`scalar deleting destructor'
+
+// SYNTHETIC: BETA10 0x101322e0
+// MxAtomSet::~MxAtomSet
 
 #endif // MXATOM_H

--- a/LEGO1/omni/include/mxmisc.h
+++ b/LEGO1/omni/include/mxmisc.h
@@ -3,7 +3,7 @@
 
 #include "mxtypes.h"
 
-class MxAtomIdCounterSet;
+class MxAtomSet;
 class MxDSAction;
 class MxEventManager;
 class MxMusicManager;
@@ -26,7 +26,7 @@ MxEventManager* EventManager();
 MxResult Start(MxDSAction*);
 MxNotificationManager* NotificationManager();
 MxVideoManager* MVideoManager();
-MxAtomIdCounterSet* AtomIdCounterSet();
+MxAtomSet* AtomSet();
 MxObjectFactory* ObjectFactory();
 void DeleteObject(MxDSAction& p_dsAction);
 

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -5,7 +5,7 @@
 #include "mxcriticalsection.h"
 #include "mxstring.h"
 
-class MxAtomIdCounterSet;
+class MxAtomSet;
 class MxDSAction;
 class MxEntity;
 class MxEventManager;
@@ -69,7 +69,7 @@ public:
 	MxVariableTable* GetVariableTable() const { return this->m_variableTable; }
 	MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
 	MxEventManager* GetEventManager() const { return this->m_eventManager; }
-	MxAtomIdCounterSet* GetAtomIdCounterSet() const { return this->m_atomIdCounterSet; }
+	MxAtomSet* GetAtomSet() const { return this->m_atomSet; }
 	MxLong HandleEndAction(MxParam& p_param);
 
 	// SYNTHETIC: LEGO1 0x100aefd0
@@ -90,7 +90,7 @@ protected:
 	MxEventManager* m_eventManager;               // 0x38
 	MxTimer* m_timer;                             // 0x3c
 	MxStreamer* m_streamer;                       // 0x40
-	MxAtomIdCounterSet* m_atomIdCounterSet;       // 0x44
+	MxAtomSet* m_atomSet;                         // 0x44
 	MxCriticalSection m_criticalSection;          // 0x48
 	MxBool m_timerRunning;                        // 0x64
 };

--- a/LEGO1/omni/src/common/mxatom.cpp
+++ b/LEGO1/omni/src/common/mxatom.cpp
@@ -4,33 +4,38 @@
 #include "mxmisc.h"
 #include "mxomni.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(MxAtomId, 0x04);
-DECOMP_SIZE_ASSERT(MxAtomIdCounter, 0x14);
-DECOMP_SIZE_ASSERT(MxAtomIdCounterSet, 0x10);
+DECOMP_SIZE_ASSERT(MxAtom, 0x14);
+DECOMP_SIZE_ASSERT(MxAtomSet, 0x10);
 
 // FUNCTION: LEGO1 0x100acf90
+// FUNCTION: BETA10 0x1012308b
 MxAtomId::MxAtomId(const char* p_str, LookupMode p_mode)
 {
 	if (!MxOmni::GetInstance()) {
 		return;
 	}
 
-	if (!AtomIdCounterSet()) {
+	if (!AtomSet()) {
 		return;
 	}
 
-	MxAtomIdCounter* counter = GetCounter(p_str, p_mode);
-	m_internal = counter->GetKey()->GetData();
-	counter->Inc();
+	MxAtom* atom = GetAtom(p_str, p_mode);
+	*this = atom->GetKey();
+	atom->Inc();
 }
 
 // FUNCTION: LEGO1 0x100acfd0
+// FUNCTION: BETA10 0x10123130
 MxAtomId::~MxAtomId()
 {
 	Destroy();
 }
 
 // FUNCTION: LEGO1 0x100acfe0
+// FUNCTION: BETA10 0x101231a6
 void MxAtomId::Destroy()
 {
 	if (!m_internal) {
@@ -41,34 +46,36 @@ void MxAtomId::Destroy()
 		return;
 	}
 
-	if (!AtomIdCounterSet()) {
+	if (!AtomSet()) {
 		return;
 	}
 
 #ifdef COMPAT_MODE
-	MxAtomIdCounterSet::iterator it;
+	MxAtomSet::iterator it;
 	{
-		MxAtomIdCounter idCounter(m_internal);
-		it = AtomIdCounterSet()->find(&idCounter);
+		MxAtom idAtom(m_internal);
+		it = AtomSet()->find(&idAtom);
 	}
 #else
-	MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(&MxAtomIdCounter(m_internal));
+	MxAtomSet::iterator it = AtomSet()->find(&MxAtom(m_internal));
 #endif
+	assert(it != AtomSet()->end());
 
-	MxAtomIdCounter* counter = (MxAtomIdCounter*) (*it);
-	counter->Dec();
+	MxAtom* atom = (MxAtom*) (*it);
+	atom->Dec();
 }
 
 // FUNCTION: LEGO1 0x100ad1c0
+// FUNCTION: BETA10 0x101232b9
 MxAtomId& MxAtomId::operator=(const MxAtomId& p_atomId)
 {
 	if (m_internal) {
 		Destroy();
 	}
 
-	if (p_atomId.m_internal && MxOmni::GetInstance() && AtomIdCounterSet()) {
-		MxAtomIdCounter* counter = GetCounter(p_atomId.m_internal, e_exact);
-		counter->Inc();
+	if (p_atomId.m_internal && MxOmni::GetInstance() && AtomSet()) {
+		MxAtom* atom = GetAtom(p_atomId.m_internal, e_exact);
+		atom->Inc();
 	}
 
 	m_internal = p_atomId.m_internal;
@@ -77,36 +84,41 @@ MxAtomId& MxAtomId::operator=(const MxAtomId& p_atomId)
 }
 
 // FUNCTION: LEGO1 0x100ad210
-MxAtomIdCounter* MxAtomId::GetCounter(const char* p_str, LookupMode p_mode)
+// FUNCTION: BETA10 0x10123378
+MxAtom* MxAtomId::GetAtom(const char* p_str, LookupMode p_mode)
 {
 	MxAtomId unused;
-	MxAtomIdCounter* counter = new MxAtomIdCounter(p_str);
+	MxAtom* atom = new MxAtom(p_str);
+	assert(atom);
 
 	switch (p_mode) {
-	case e_lowerCase:
-	case e_lowerCase2:
-		counter->GetKey()->ToLowerCase();
+	case e_exact:
 		break;
 	case e_upperCase:
-		counter->GetKey()->ToUpperCase();
+		atom->GetKey().ToUpperCase();
+		break;
+	case e_lowerCase:
+	case e_lowerCase2:
+		atom->GetKey().ToLowerCase();
 		break;
 	}
 
-	MxAtomIdCounterSet::iterator it = AtomIdCounterSet()->find(counter);
-	if (it != AtomIdCounterSet()->end()) {
-		// Counter already in the set. Delete temp value and return it.
-		delete counter;
-		counter = *it;
+	MxAtomSet::iterator it = AtomSet()->find(atom);
+	if (it != AtomSet()->end()) {
+		// Atom already in the set. Delete temp value and return it.
+		delete atom;
+		atom = *it;
 	}
 	else {
-		// Counter is not in the set. Add it.
-		AtomIdCounterSet()->insert(counter);
+		// Atom is not in the set. Add it.
+		AtomSet()->insert(atom);
 	}
 
-	return counter;
+	return atom;
 }
 
 // FUNCTION: LEGO1 0x100ad7e0
+// FUNCTION: BETA10 0x100553e0
 void MxAtomId::Clear()
 {
 	// Reset but do not delete MxAtomId object.
@@ -115,13 +127,15 @@ void MxAtomId::Clear()
 }
 
 // FUNCTION: LEGO1 0x100ad7f0
-void MxAtomIdCounter::Inc()
+// FUNCTION: BETA10 0x101235d5
+void MxAtom::Inc()
 {
 	m_value++;
 }
 
 // FUNCTION: LEGO1 0x100ad800
-void MxAtomIdCounter::Dec()
+// FUNCTION: BETA10 0x1012364a
+void MxAtom::Dec()
 {
 	if (m_value) {
 		m_value--;

--- a/LEGO1/omni/src/common/mxmisc.cpp
+++ b/LEGO1/omni/src/common/mxmisc.cpp
@@ -2,6 +2,8 @@
 
 #include "mxomni.h"
 
+#include <assert.h>
+
 // FUNCTION: LEGO1 0x100acea0
 MxObjectFactory* ObjectFactory()
 {
@@ -27,9 +29,11 @@ MxTimer* Timer()
 }
 
 // FUNCTION: LEGO1 0x100acee0
-MxAtomIdCounterSet* AtomIdCounterSet()
+// FUNCTION: BETA10 0x10124e4c
+MxAtomSet* AtomSet()
 {
-	return MxOmni::GetInstance()->GetAtomIdCounterSet();
+	assert(MxOmni::GetInstance());
+	return MxOmni::GetInstance()->GetAtomSet();
 }
 
 // FUNCTION: LEGO1 0x100acef0

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -66,7 +66,7 @@ void MxOmni::Init()
 	m_eventManager = NULL;
 	m_timer = NULL;
 	m_streamer = NULL;
-	m_atomIdCounterSet = NULL;
+	m_atomSet = NULL;
 	m_timerRunning = FALSE;
 }
 
@@ -82,7 +82,7 @@ MxResult MxOmni::Create(MxOmniCreateParam& p_param)
 {
 	MxResult result = FAILURE;
 
-	if (!(m_atomIdCounterSet = new MxAtomIdCounterSet())) {
+	if (!(m_atomSet = new MxAtomSet())) {
 		goto done;
 	}
 
@@ -177,6 +177,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100afe90
+// FUNCTION: BETA10 0x1012fe5b
 void MxOmni::Destroy()
 {
 	{
@@ -210,15 +211,15 @@ void MxOmni::Destroy()
 	delete m_tickleManager;
 
 	// There could be a tree/iterator function that does this inline
-	if (m_atomIdCounterSet) {
-		while (!m_atomIdCounterSet->empty()) {
+	if (m_atomSet) {
+		while (m_atomSet->size() != 0) {
 			// Pop each node and delete its value
-			MxAtomIdCounterSet::iterator begin = m_atomIdCounterSet->begin();
-			MxAtomIdCounter* value = *begin;
-			m_atomIdCounterSet->erase(begin);
+			MxAtomSet::iterator begin = m_atomSet->begin();
+			MxAtom* value = *begin;
+			m_atomSet->erase(begin);
 			delete value;
 		}
-		delete m_atomIdCounterSet;
+		delete m_atomSet;
 	}
 	Init();
 }


### PR DESCRIPTION
I took this opportunity to rename some stuff. One of the asserts refers to the item inside the `<set>` as just "atom". I take that to mean that the reference counter is the atom and the text identifier for that atom is (like the name says) `MxAtomId`.

With that, `MxAtomIdCounter` and `MxAtomIdCounterSet` are now just `MxAtom` and `MxAtomSet`. The name "AtomSet" is also referenced in an assert.

The `operator!=` function from`MxAtomId` used by MSVC 4.20 seems to be a synthetic function that flips the result from `operator==`. The cvdump output points to this as coming from `include/utility`. Modern compilers don't have this so I left the explicit function there for compatibility.

The `operator=` function with the `MxString` param used to be a setter on the `m_internal` member. The problem is that this function (in the beta) returns itself, so making it the operator is a way to make that happen. It's called only from the `MxAtomId` constructor where I have it setting `*this` to the string.

Not an exact beta match this time. The beta uses `MxAutoLock` in most of the atom functions and does not check the public getter `AtomSet()`.