### PR TITLE
Beta match MXIOINFO

### DIFF
--- a/LEGO1/omni/include/mxio.h
+++ b/LEGO1/omni/include/mxio.h
@@ -18,11 +18,13 @@ public:
 	MxU16 Open(const char*, MxULong);
 	MxU16 Close(MxLong);
 	MxLong Read(void*, MxLong);
+	MxLong Write(void*, MxLong);
 	MxLong Seek(MxLong, MxLong);
 	MxU16 SetBuffer(char*, MxLong, MxLong);
 	MxU16 Flush(MxU16);
 	MxU16 Advance(MxU16);
 	MxU16 Descend(MMCKINFO*, const MMCKINFO*, MxU16);
+	MxU16 Ascend(MMCKINFO*, MxU16);
 
 	// NOTE: In MXIOINFO, the `hmmio` member of MMIOINFO is used like
 	// an HFILE (int) instead of an HMMIO (WORD).


### PR DESCRIPTION
More dead code on this one.

The assert in `MXIOINFO::Write` points to the devs not using an intermediate `m_info` member. I remember that being a topic of debate in the early PR that added this file. Not something I feel compelled to change now unless it stands between us and byte-perfect match.