### PR TITLE
Refactor: Replace magic values by enum values

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/radio.cpp
+++ b/LEGO1/lego/legoomni/src/actors/radio.cpp
@@ -80,7 +80,7 @@ void Radio::Stop()
 	if (m_state->IsActive()) {
 		LegoWorld* world = CurrentWorld();
 
-		MxControlPresenter* presenter = (MxControlPresenter*) world->Find(world->GetAtom(), 18);
+		MxControlPresenter* presenter = (MxControlPresenter*) world->Find(world->GetAtom(), IsleScript::c_Radio_Ctl);
 
 		if (presenter) {
 			presenter->VTable0x6c(0);

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1083,28 +1083,28 @@ void LegoGameState::Init()
 	if (m_loadedAct == e_act1) {
 		Isle* isle = (Isle*) FindWorld(*g_isleScript, 0);
 
-		Helicopter* copter = (Helicopter*) isle->Find(*g_copterScript, 1);
+		Helicopter* copter = (Helicopter*) isle->Find(*g_copterScript, CopterScript::c_Helicopter_Actor);
 		if (copter) {
 			isle->FUN_1001fc80(copter);
 			isle->VTable0x6c(copter);
 			delete copter;
 		}
 
-		DuneBuggy* dunebuggy = (DuneBuggy*) isle->Find(*g_dunecarScript, 2);
+		DuneBuggy* dunebuggy = (DuneBuggy*) isle->Find(*g_dunecarScript, DunecarScript::c_DuneBugy_Actor);
 		if (dunebuggy) {
 			isle->FUN_1001fc80(dunebuggy);
 			isle->VTable0x6c(dunebuggy);
 			delete dunebuggy;
 		}
 
-		Jetski* jetski = (Jetski*) isle->Find(*g_jetskiScript, 3);
+		Jetski* jetski = (Jetski*) isle->Find(*g_jetskiScript, JetskiScript::c_Jetski_Actor);
 		if (jetski) {
 			isle->FUN_1001fc80(jetski);
 			isle->VTable0x6c(jetski);
 			delete jetski;
 		}
 
-		RaceCar* racecar = (RaceCar*) isle->Find(*g_racecarScript, 4);
+		RaceCar* racecar = (RaceCar*) isle->Find(*g_racecarScript, RacecarScript::c_RaceCar_Actor);
 		if (racecar) {
 			isle->FUN_1001fc80(racecar);
 			isle->VTable0x6c(racecar);


### PR DESCRIPTION
I found some magic values and replaced them by enums. Ideally, I wanted to have a version of `LegoWorld::Find()` that only accepts enums, but I found no elegant way to do so. The best I could come up with was
```c++
// legoworld.h
	inline MxCore* Find(const MxAtomId& p_atom, IsleScript::Script p_entityId) { return Find(p_atom, (MxS32) p_entityId); }
	inline MxCore* Find(const MxAtomId& p_atom, CopterScript::Script p_entityId) { return Find(p_atom, (MxS32) p_entityId); }
	inline MxCore* Find(const MxAtomId& p_atom, DunecarScript::Script p_entityId) { return Find(p_atom, (MxS32) p_entityId); }
	inline MxCore* Find(const MxAtomId& p_atom, JetskiScript::Script p_entityId) { return Find(p_atom, (MxS32) p_entityId); }
	inline MxCore* Find(const MxAtomId& p_atom, RacecarScript::Script p_entityId) { return Find(p_atom, (MxS32) p_entityId); }
	inline MxCore* Find(const MxAtomId& p_atom, InfomainScript::Script p_entityId) { return Find(p_atom, (MxS32) p_entityId); }

	// Only use this one when calling from other functions
	inline MxCore* FindById(const MxAtomId& p_atom, MxS32 p_entityId) { return Find(p_atom, p_entityId); }
private:
	MxCore* Find(const MxAtomId& p_atom, MxS32 p_entityId);
```
but that had a surprisingly wide range of effects (accuracy increased for 57 functions, decreased for 53 functions, overall reduction from 97.03 % to 96.97 %). For now, I think we should apply this fix and nothing else.