### PR TITLE
Rename LegoCharacterData to LegoCharacterInfo

### DIFF
--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -40,7 +40,7 @@ struct LegoCharacter {
 	MxU32 m_refCount; // 0x04
 };
 
-struct LegoCharacterData;
+struct LegoCharacterInfo;
 
 typedef map<char*, LegoCharacter*, LegoCharacterComparator> LegoCharacterMap;
 
@@ -64,8 +64,8 @@ public:
 	void FUN_10083f10(LegoROI* p_roi);
 	MxBool FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_textureInfo);
 	LegoExtraActor* GetActor(const char* p_key);
-	LegoCharacterData* GetData(const char* p_key);
-	LegoCharacterData* GetData(LegoROI* p_roi);
+	LegoCharacterInfo* GetInfo(const char* p_key);
+	LegoCharacterInfo* GetInfo(LegoROI* p_roi);
 	MxBool SwitchHat(LegoROI* p_roi);
 	MxU32 FUN_10085140(LegoROI* p_roi, MxBool p_und);
 	LegoROI* FUN_10085210(const char* p_name, const char* p_lodName, MxBool p_createEntity);

--- a/LEGO1/lego/legoomni/include/legocharacters.h
+++ b/LEGO1/lego/legoomni/include/legocharacters.h
@@ -8,7 +8,7 @@ class LegoExtraActor;
 class LegoROI;
 
 // SIZE 0x108
-struct LegoCharacterData {
+struct LegoCharacterInfo {
 	// SIZE 0x18
 	struct Part {
 		MxU8* m_unk0x00;        // 0x00
@@ -72,7 +72,7 @@ enum LegoCharacterParts {
 	c_legrtPart
 };
 
-extern LegoCharacterData g_characterDataInit[66];
+extern LegoCharacterInfo g_characterInfoInit[66];
 extern LegoCharacterLOD g_characterLODs[11];
 
 #endif // LEGOCHARACTERS_H

--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -35,7 +35,7 @@ MxU32 g_unk0x100fc4ec = 2;
 MxU32 g_unk0x100fc4f0 = 0;
 
 // GLOBAL: LEGO1 0x10104f20
-LegoCharacterData g_characterData[66];
+LegoCharacterInfo g_chracterInfo[66];
 
 // FUNCTION: LEGO1 0x10082a20
 LegoCharacterManager::LegoCharacterManager()
@@ -50,22 +50,22 @@ LegoCharacterManager::LegoCharacterManager()
 // FUNCTION: LEGO1 0x10083270
 void LegoCharacterManager::Init()
 {
-	for (MxS32 i = 0; i < _countof(g_characterData); i++) {
-		g_characterData[i] = g_characterDataInit[i];
+	for (MxS32 i = 0; i < _countof(g_chracterInfo); i++) {
+		g_chracterInfo[i] = g_characterInfoInit[i];
 	}
 }
 
 // FUNCTION: LEGO1 0x100832a0
 void LegoCharacterManager::FUN_100832a0()
 {
-	for (MxS32 i = 0; i < _countof(g_characterData); i++) {
-		LegoCharacterData* data = GetData(g_characterData[i].m_name);
+	for (MxS32 i = 0; i < _countof(g_chracterInfo); i++) {
+		LegoCharacterInfo* info = GetInfo(g_chracterInfo[i].m_name);
 
-		if (data != NULL) {
-			LegoExtraActor* actor = data->m_actor;
+		if (info != NULL) {
+			LegoExtraActor* actor = info->m_actor;
 
 			if (actor != NULL && actor->IsA("LegoExtraActor")) {
-				LegoROI* roi = g_characterData[i].m_roi;
+				LegoROI* roi = g_chracterInfo[i].m_roi;
 				MxU32 refCount = GetRefCount(roi);
 
 				while (refCount != 0) {
@@ -82,45 +82,45 @@ MxResult LegoCharacterManager::Write(LegoStorage* p_storage)
 {
 	MxResult result = FAILURE;
 
-	for (MxS32 i = 0; i < _countof(g_characterData); i++) {
-		LegoCharacterData* data = &g_characterData[i];
+	for (MxS32 i = 0; i < _countof(g_chracterInfo); i++) {
+		LegoCharacterInfo* info = &g_chracterInfo[i];
 
-		if (p_storage->Write(&data->m_unk0x0c, sizeof(data->m_unk0x0c)) != SUCCESS) {
+		if (p_storage->Write(&info->m_unk0x0c, sizeof(info->m_unk0x0c)) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_unk0x10, sizeof(data->m_unk0x10)) != SUCCESS) {
+		if (p_storage->Write(&info->m_unk0x10, sizeof(info->m_unk0x10)) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_unk0x14, sizeof(data->m_unk0x14)) != SUCCESS) {
+		if (p_storage->Write(&info->m_unk0x14, sizeof(info->m_unk0x14)) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_parts[c_infohatPart].m_unk0x08, sizeof(data->m_parts[c_infohatPart].m_unk0x08)) !=
+		if (p_storage->Write(&info->m_parts[c_infohatPart].m_unk0x08, sizeof(info->m_parts[c_infohatPart].m_unk0x08)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_parts[c_infohatPart].m_unk0x14, sizeof(data->m_parts[c_infohatPart].m_unk0x14)) !=
+		if (p_storage->Write(&info->m_parts[c_infohatPart].m_unk0x14, sizeof(info->m_parts[c_infohatPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
 		if (p_storage->Write(
-				&data->m_parts[c_infogronPart].m_unk0x14,
-				sizeof(data->m_parts[c_infogronPart].m_unk0x14)
+				&info->m_parts[c_infogronPart].m_unk0x14,
+				sizeof(info->m_parts[c_infogronPart].m_unk0x14)
 			) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_parts[c_armlftPart].m_unk0x14, sizeof(data->m_parts[c_armlftPart].m_unk0x14)) !=
+		if (p_storage->Write(&info->m_parts[c_armlftPart].m_unk0x14, sizeof(info->m_parts[c_armlftPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_parts[c_armrtPart].m_unk0x14, sizeof(data->m_parts[c_armrtPart].m_unk0x14)) !=
+		if (p_storage->Write(&info->m_parts[c_armrtPart].m_unk0x14, sizeof(info->m_parts[c_armrtPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_parts[c_leglftPart].m_unk0x14, sizeof(data->m_parts[c_leglftPart].m_unk0x14)) !=
+		if (p_storage->Write(&info->m_parts[c_leglftPart].m_unk0x14, sizeof(info->m_parts[c_leglftPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Write(&data->m_parts[c_legrtPart].m_unk0x14, sizeof(data->m_parts[c_legrtPart].m_unk0x14)) !=
+		if (p_storage->Write(&info->m_parts[c_legrtPart].m_unk0x14, sizeof(info->m_parts[c_legrtPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
@@ -137,45 +137,45 @@ MxResult LegoCharacterManager::Read(LegoStorage* p_storage)
 {
 	MxResult result = FAILURE;
 
-	for (MxS32 i = 0; i < _countof(g_characterData); i++) {
-		LegoCharacterData* data = &g_characterData[i];
+	for (MxS32 i = 0; i < _countof(g_chracterInfo); i++) {
+		LegoCharacterInfo* info = &g_chracterInfo[i];
 
-		if (p_storage->Read(&data->m_unk0x0c, sizeof(data->m_unk0x0c)) != SUCCESS) {
+		if (p_storage->Read(&info->m_unk0x0c, sizeof(info->m_unk0x0c)) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_unk0x10, sizeof(data->m_unk0x10)) != SUCCESS) {
+		if (p_storage->Read(&info->m_unk0x10, sizeof(info->m_unk0x10)) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_unk0x14, sizeof(data->m_unk0x14)) != SUCCESS) {
+		if (p_storage->Read(&info->m_unk0x14, sizeof(info->m_unk0x14)) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_parts[c_infohatPart].m_unk0x08, sizeof(data->m_parts[c_infohatPart].m_unk0x08)) !=
+		if (p_storage->Read(&info->m_parts[c_infohatPart].m_unk0x08, sizeof(info->m_parts[c_infohatPart].m_unk0x08)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_parts[c_infohatPart].m_unk0x14, sizeof(data->m_parts[c_infohatPart].m_unk0x14)) !=
+		if (p_storage->Read(&info->m_parts[c_infohatPart].m_unk0x14, sizeof(info->m_parts[c_infohatPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
 		if (p_storage->Read(
-				&data->m_parts[c_infogronPart].m_unk0x14,
-				sizeof(data->m_parts[c_infogronPart].m_unk0x14)
+				&info->m_parts[c_infogronPart].m_unk0x14,
+				sizeof(info->m_parts[c_infogronPart].m_unk0x14)
 			) != SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_parts[c_armlftPart].m_unk0x14, sizeof(data->m_parts[c_armlftPart].m_unk0x14)) !=
+		if (p_storage->Read(&info->m_parts[c_armlftPart].m_unk0x14, sizeof(info->m_parts[c_armlftPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_parts[c_armrtPart].m_unk0x14, sizeof(data->m_parts[c_armrtPart].m_unk0x14)) !=
+		if (p_storage->Read(&info->m_parts[c_armrtPart].m_unk0x14, sizeof(info->m_parts[c_armrtPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_parts[c_leglftPart].m_unk0x14, sizeof(data->m_parts[c_leglftPart].m_unk0x14)) !=
+		if (p_storage->Read(&info->m_parts[c_leglftPart].m_unk0x14, sizeof(info->m_parts[c_leglftPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
-		if (p_storage->Read(&data->m_parts[c_legrtPart].m_unk0x14, sizeof(data->m_parts[c_legrtPart].m_unk0x14)) !=
+		if (p_storage->Read(&info->m_parts[c_legrtPart].m_unk0x14, sizeof(info->m_parts[c_legrtPart].m_unk0x14)) !=
 			SUCCESS) {
 			goto done;
 		}
@@ -231,7 +231,7 @@ done:
 			actor->SetROI(character->m_roi, FALSE, FALSE);
 			actor->SetType(LegoEntity::e_character);
 			actor->SetFlag(LegoActor::c_bit2);
-			GetData(p_key)->m_actor = actor;
+			GetInfo(p_key)->m_actor = actor;
 		}
 
 		return character->m_roi;
@@ -268,7 +268,7 @@ void LegoCharacterManager::FUN_10083c30(const char* p_name)
 		character = (*it).second;
 
 		if (character->RemoveRef() == 0) {
-			LegoCharacterData* data = GetData(p_name);
+			LegoCharacterInfo* info = GetInfo(p_name);
 			LegoEntity* entity = character->m_roi->GetEntity();
 
 			if (entity != NULL) {
@@ -282,18 +282,18 @@ void LegoCharacterManager::FUN_10083c30(const char* p_name)
 
 			m_characters->erase(it);
 
-			if (data != NULL) {
-				if (data->m_actor != NULL) {
-					data->m_actor->ClearFlag(LegoEntity::c_bit2);
-					delete data->m_actor;
+			if (info != NULL) {
+				if (info->m_actor != NULL) {
+					info->m_actor->ClearFlag(LegoEntity::c_bit2);
+					delete info->m_actor;
 				}
 				else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_bit2)) {
 					entity->ClearFlag(LegoEntity::c_bit2);
 					delete entity;
 				}
 
-				data->m_roi = NULL;
-				data->m_actor = NULL;
+				info->m_roi = NULL;
+				info->m_actor = NULL;
 			}
 		}
 	}
@@ -310,7 +310,7 @@ void LegoCharacterManager::FUN_10083db0(LegoROI* p_roi)
 
 		if (character->m_roi == p_roi) {
 			if (character->RemoveRef() == 0) {
-				LegoCharacterData* data = GetData(character->m_roi->GetName());
+				LegoCharacterInfo* info = GetInfo(character->m_roi->GetName());
 				LegoEntity* entity = character->m_roi->GetEntity();
 
 				if (entity != NULL) {
@@ -324,18 +324,18 @@ void LegoCharacterManager::FUN_10083db0(LegoROI* p_roi)
 
 				m_characters->erase(it);
 
-				if (data != NULL) {
-					if (data->m_actor != NULL) {
-						data->m_actor->ClearFlag(LegoEntity::c_bit2);
-						delete data->m_actor;
+				if (info != NULL) {
+					if (info->m_actor != NULL) {
+						info->m_actor->ClearFlag(LegoEntity::c_bit2);
+						delete info->m_actor;
 					}
 					else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_bit2)) {
 						entity->ClearFlag(LegoEntity::c_bit2);
 						delete entity;
 					}
 
-					data->m_roi = NULL;
-					data->m_actor = NULL;
+					info->m_roi = NULL;
+					info->m_actor = NULL;
 				}
 			}
 
@@ -399,21 +399,21 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 	Tgl::Renderer* renderer = VideoManager()->GetRenderer();
 	ViewLODListManager* lodManager = GetViewLODListManager();
 	LegoTextureContainer* textureContainer = TextureContainer();
-	LegoCharacterData* data = GetData(p_key);
+	LegoCharacterInfo* info = GetInfo(p_key);
 
-	if (data == NULL) {
+	if (info == NULL) {
 		goto done;
 	}
 
 	if (!strcmpi(p_key, "pep")) {
-		LegoCharacterData* pepper = GetData("pepper");
+		LegoCharacterInfo* pepper = GetInfo("pepper");
 
-		data->m_unk0x0c = pepper->m_unk0x0c;
-		data->m_unk0x10 = pepper->m_unk0x10;
-		data->m_unk0x14 = pepper->m_unk0x14;
+		info->m_unk0x0c = pepper->m_unk0x0c;
+		info->m_unk0x10 = pepper->m_unk0x10;
+		info->m_unk0x14 = pepper->m_unk0x14;
 
-		for (i = 0; i < _countof(data->m_parts); i++) {
-			data->m_parts[i] = pepper->m_parts[i];
+		for (i = 0; i < _countof(info->m_parts); i++) {
+			info->m_parts[i] = pepper->m_parts[i];
 		}
 	}
 
@@ -439,7 +439,7 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 
 	for (i = 0; i < _countof(g_characterLODs) - 1; i++) {
 		char lodName[256];
-		LegoCharacterData::Part& part = data->m_parts[i];
+		LegoCharacterInfo::Part& part = info->m_parts[i];
 
 		const char* parentName;
 		if (i == 0 || i == 1) {
@@ -520,7 +520,7 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 	);
 	roi->WrappedSetLocalTransform(mat);
 
-	data->m_roi = roi;
+	info->m_roi = roi;
 	success = TRUE;
 
 done:
@@ -550,8 +550,8 @@ MxBool LegoCharacterManager::FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_tex
 		Tgl::Renderer* renderer = VideoManager()->GetRenderer();
 
 		if (p_textureInfo == NULL) {
-			LegoCharacterData* info = GetData(p_roi->GetName());
-			LegoCharacterData::Part& part = info->m_parts[c_headPart];
+			LegoCharacterInfo* info = GetInfo(p_roi->GetName());
+			LegoCharacterInfo::Part& part = info->m_parts[c_headPart];
 			p_textureInfo = TextureContainer()->Get(part.m_unk0x10[part.m_unk0x0c[part.m_unk0x14]]);
 		}
 
@@ -583,8 +583,8 @@ MxBool LegoCharacterManager::FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_tex
 // FUNCTION: LEGO1 0x10084c00
 MxBool LegoCharacterManager::Exists(const char* p_key)
 {
-	for (MxU32 i = 0; i < _countof(g_characterData); i++) {
-		if (!strcmpi(g_characterData[i].m_name, p_key)) {
+	for (MxU32 i = 0; i < _countof(g_chracterInfo); i++) {
+		if (!strcmpi(g_chracterInfo[i].m_name, p_key)) {
 			return TRUE;
 		}
 	}
@@ -595,46 +595,46 @@ MxBool LegoCharacterManager::Exists(const char* p_key)
 // FUNCTION: LEGO1 0x10084c40
 LegoExtraActor* LegoCharacterManager::GetActor(const char* p_key)
 {
-	LegoCharacterData* data = GetData(p_key);
+	LegoCharacterInfo* info = GetInfo(p_key);
 
-	if (data != NULL) {
-		return data->m_actor;
+	if (info != NULL) {
+		return info->m_actor;
 	}
 
 	return NULL;
 }
 
 // FUNCTION: LEGO1 0x10084c60
-LegoCharacterData* LegoCharacterManager::GetData(const char* p_key)
+LegoCharacterInfo* LegoCharacterManager::GetInfo(const char* p_key)
 {
 	MxU32 i;
 
-	for (i = 0; i < _countof(g_characterData); i++) {
-		if (!strcmpi(g_characterData[i].m_name, p_key)) {
+	for (i = 0; i < _countof(g_chracterInfo); i++) {
+		if (!strcmpi(g_chracterInfo[i].m_name, p_key)) {
 			break;
 		}
 	}
 
-	if (i < _countof(g_characterData)) {
-		return &g_characterData[i];
+	if (i < _countof(g_chracterInfo)) {
+		return &g_chracterInfo[i];
 	}
 
 	return NULL;
 }
 
 // FUNCTION: LEGO1 0x10084cb0
-LegoCharacterData* LegoCharacterManager::GetData(LegoROI* p_roi)
+LegoCharacterInfo* LegoCharacterManager::GetInfo(LegoROI* p_roi)
 {
 	MxU32 i;
 
-	for (i = 0; i < _countof(g_characterData); i++) {
-		if (g_characterData[i].m_roi == p_roi) {
+	for (i = 0; i < _countof(g_chracterInfo); i++) {
+		if (g_chracterInfo[i].m_roi == p_roi) {
 			break;
 		}
 	}
 
-	if (i < _countof(g_characterData)) {
-		return &g_characterData[i];
+	if (i < _countof(g_chracterInfo)) {
+		return &g_chracterInfo[i];
 	}
 
 	return NULL;
@@ -664,13 +664,13 @@ LegoROI* LegoCharacterManager::FindChildROI(LegoROI* p_roi, const char* p_name)
 // FUNCTION: LEGO1 0x10084ec0
 MxBool LegoCharacterManager::SwitchHat(LegoROI* p_roi)
 {
-	LegoCharacterData* data = GetData(p_roi->GetName());
+	LegoCharacterInfo* info = GetInfo(p_roi->GetName());
 
-	if (data == NULL) {
+	if (info == NULL) {
 		return FALSE;
 	}
 
-	LegoCharacterData::Part& part = data->m_parts[c_infohatPart];
+	LegoCharacterInfo::Part& part = info->m_parts[c_infohatPart];
 
 	part.m_unk0x08++;
 	MxU8 unk0x00 = part.m_unk0x00[part.m_unk0x08];
@@ -718,14 +718,14 @@ MxBool LegoCharacterManager::SwitchHat(LegoROI* p_roi)
 // FUNCTION: LEGO1 0x10085140
 MxU32 LegoCharacterManager::FUN_10085140(LegoROI* p_roi, MxBool p_und)
 {
-	LegoCharacterData* data = GetData(p_roi);
+	LegoCharacterInfo* info = GetInfo(p_roi);
 
 	if (p_und) {
-		return data->m_unk0x14 + g_unk0x100fc4dc;
+		return info->m_unk0x14 + g_unk0x100fc4dc;
 	}
 
-	if (data != NULL) {
-		return data->m_unk0x0c + g_unk0x100fc4d8;
+	if (info != NULL) {
+		return info->m_unk0x0c + g_unk0x100fc4d8;
 	}
 
 	return 0;

--- a/LEGO1/lego/legoomni/src/common/legocharacters.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharacters.cpp
@@ -1,7 +1,7 @@
 #include "legocharacters.h"
 
-DECOMP_SIZE_ASSERT(LegoCharacterData, 0x108)
-DECOMP_SIZE_ASSERT(LegoCharacterData::Part, 0x18)
+DECOMP_SIZE_ASSERT(LegoCharacterInfo, 0x108)
+DECOMP_SIZE_ASSERT(LegoCharacterInfo::Part, 0x18)
 DECOMP_SIZE_ASSERT(LegoCharacterLOD, 0x58)
 
 // Unclear whether g_characterLODs[0] (top) is its own global, see: LegoCharacterManager::CreateROI
@@ -172,7 +172,7 @@ const char* g_unk0x100f80a0[] =
 	{"lego white", "lego black", "lego yellow", "lego red", "lego blue", "lego brown", "lego lt grey", "lego green"};
 
 // GLOBAL: LEGO1 0x100f80c0
-LegoCharacterData g_characterDataInit[] = {
+LegoCharacterInfo g_characterInfoInit[] = {
 	{"pepper",
 	 NULL,
 	 NULL,


### PR DESCRIPTION
Based on some beta asserts the struct `LegoCharacterData` was most likely called `LegoCharacterInfo` instead. Renamed the structure and corresponding variables/functions.