### PR TITLE
Beta matching MxDSObject/MxDSAction

### DIFF
--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -8,6 +8,7 @@
 class MxOmni;
 
 // VTABLE: LEGO1 0x100dc098
+// VTABLE: BETA10 0x101c1b68
 // SIZE 0x94
 class MxDSAction : public MxDSObject {
 public:
@@ -31,6 +32,7 @@ public:
 	MxDSAction& operator=(MxDSAction& p_dsAction);
 
 	// FUNCTION: LEGO1 0x100ad980
+	// FUNCTION: BETA10 0x1012bcf0
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101013f4
@@ -38,6 +40,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100ad990
+	// FUNCTION: BETA10 0x1012bd10
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSAction::ClassName()) || MxDSObject::IsA(p_name);
@@ -57,22 +60,39 @@ public:
 
 	void AppendExtra(MxU16 p_extraLength, const char* p_extraData);
 
+	// FUNCTION: BETA10 0x1003a560
 	inline void GetExtra(MxU16& p_extraLength, char*& p_extraData)
 	{
 		p_extraLength = m_extraLength;
 		p_extraData = m_extraData;
 	}
 
+	// FUNCTION: BETA10 0x1003cf70
 	inline MxU32 GetFlags() { return m_flags; }
+
+	// FUNCTION: BETA10 0x1004daa0
 	inline void SetFlags(MxU32 p_flags) { m_flags = p_flags; }
+
 	inline char* GetExtraData() { return m_extraData; }
 	inline MxU16 GetExtraLength() const { return m_extraLength; }
+
+	// FUNCTION: BETA10 0x1005a560
 	inline MxLong GetStartTime() const { return m_startTime; }
+
+	// FUNCTION: BETA10 0x1012be80
 	inline MxS32 GetLoopCount() { return m_loopCount; }
+
 	inline void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
+
+	// FUNCTION: BETA10 0x1003db50
 	inline Mx3DPointFloat& GetLocation() { return m_location; }
+
+	// FUNCTION: BETA10 0x1003db80
 	inline Mx3DPointFloat& GetDirection() { return m_direction; }
+
+	// FUNCTION: BETA10 0x1003dbb0
 	inline Mx3DPointFloat& GetUp() { return m_up; }
+
 	inline void SetLocation(const Vector3& p_location) { m_location = p_location; }
 	inline void SetDirection(const Vector3& p_direction) { m_direction = p_direction; }
 	inline void SetUp(const Vector3& p_up) { m_up = p_up; }
@@ -85,6 +105,7 @@ public:
 	inline MxBool IsBit3() const { return m_flags & c_bit3; }
 
 	// SYNTHETIC: LEGO1 0x100ada60
+	// SYNTHETIC: BETA10 0x1012be40
 	// MxDSAction::`scalar deleting destructor'
 
 protected:

--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -28,6 +28,7 @@ public:
 	MxDSAction();
 	~MxDSAction() override;
 
+	MxDSAction(MxDSAction& p_dsAction);
 	void CopyFrom(MxDSAction& p_dsAction);
 	MxDSAction& operator=(MxDSAction& p_dsAction);
 

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -55,24 +55,25 @@ public:
 	// FUNCTION: ISLE 0x401c40
 	// FUNCTION: LEGO1 0x10005530
 	// FUNCTION: BETA10 0x100152e0
-	inline virtual void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; } // vtable+20;
+	inline virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+20;
 
-	inline Type GetType() const { return (Type) this->m_type; }
-	inline const char* GetSourceName() const { return this->m_sourceName; }
-	inline const char* GetObjectName() const { return this->m_objectName; }
-	inline MxU32 GetObjectId() { return this->m_objectId; }
-	inline const MxAtomId& GetAtomId() { return this->m_atomId; }
-	inline MxS16 GetUnknown24() { return this->m_unk0x24; }
-	inline MxPresenter* GetUnknown28() { return this->m_unk0x28; }
+	inline Type GetType() const { return (Type) m_type; }
+	inline const char* GetSourceName() const { return m_sourceName; }
+	inline const char* GetObjectName() const { return m_objectName; }
+	inline MxU32 GetObjectId() { return m_objectId; }
+	inline const MxAtomId& GetAtomId() { return m_atomId; }
+	inline MxS16 GetUnknown24() { return m_unk0x24; }
+	inline MxPresenter* GetUnknown28() { return m_unk0x28; }
 
-	inline void SetType(Type p_type) { this->m_type = p_type; }
+	inline void SetType(Type p_type) { m_type = p_type; }
 
 	// FUNCTION: BETA10 0x100152b0
-	inline void SetObjectId(MxU32 p_objectId) { this->m_objectId = p_objectId; }
+	inline void SetObjectId(MxU32 p_objectId) { m_objectId = p_objectId; }
 
 	// FUNCTION: BETA10 0x10039570
-	inline void SetUnknown24(MxS16 p_unk0x24) { this->m_unk0x24 = p_unk0x24; }
-	inline void SetUnknown28(MxPresenter* p_unk0x28) { this->m_unk0x28 = p_unk0x28; }
+	inline void SetUnknown24(MxS16 p_unk0x24) { m_unk0x24 = p_unk0x24; }
+
+	inline void SetUnknown28(MxPresenter* p_unk0x28) { m_unk0x28 = p_unk0x28; }
 
 	inline void ClearAtom() { m_atomId.Clear(); }
 

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -8,6 +8,7 @@
 class MxPresenter;
 
 // VTABLE: LEGO1 0x100dc868
+// VTABLE: BETA10 0x101c23f0
 // SIZE 0x2c
 class MxDSObject : public MxCore {
 public:
@@ -30,15 +31,18 @@ public:
 	~MxDSObject() override;
 
 	void CopyFrom(MxDSObject& p_dsObject);
+	MxDSObject(MxDSObject& p_dsObject);
 	MxDSObject& operator=(MxDSObject& p_dsObject);
 
 	void SetObjectName(const char* p_objectName);
 	void SetSourceName(const char* p_sourceName);
 
 	// FUNCTION: LEGO1 0x100bf730
+	// FUNCTION: BETA10 0x1012bdd0
 	inline const char* ClassName() const override { return "MxDSObject"; } // vtable+0c
 
 	// FUNCTION: LEGO1 0x100bf740
+	// FUNCTION: BETA10 0x1012bd70
 	inline MxBool IsA(const char* p_name) const override
 	{
 		return !strcmp(p_name, MxDSObject::ClassName()) || MxCore::IsA(p_name);
@@ -50,6 +54,7 @@ public:
 
 	// FUNCTION: ISLE 0x401c40
 	// FUNCTION: LEGO1 0x10005530
+	// FUNCTION: BETA10 0x100152e0
 	inline virtual void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; } // vtable+20;
 
 	inline Type GetType() const { return (Type) this->m_type; }
@@ -61,16 +66,21 @@ public:
 	inline MxPresenter* GetUnknown28() { return this->m_unk0x28; }
 
 	inline void SetType(Type p_type) { this->m_type = p_type; }
+
+	// FUNCTION: BETA10 0x100152b0
 	inline void SetObjectId(MxU32 p_objectId) { this->m_objectId = p_objectId; }
+
+	// FUNCTION: BETA10 0x10039570
 	inline void SetUnknown24(MxS16 p_unk0x24) { this->m_unk0x24 = p_unk0x24; }
 	inline void SetUnknown28(MxPresenter* p_unk0x28) { this->m_unk0x28 = p_unk0x28; }
 
 	inline void ClearAtom() { m_atomId.Clear(); }
 
 	// SYNTHETIC: LEGO1 0x100bf7c0
+	// SYNTHETIC: BETA10 0x10148770
 	// MxDSObject::`scalar deleting destructor'
 
-private:
+protected:
 	MxU32 m_sizeOnDisk;     // 0x08
 	MxU16 m_type;           // 0x0c
 	char* m_sourceName;     // 0x10

--- a/LEGO1/omni/src/action/mxdsaction.cpp
+++ b/LEGO1/omni/src/action/mxdsaction.cpp
@@ -112,6 +112,12 @@ void MxDSAction::CopyFrom(MxDSAction& p_dsAction)
 	this->m_unk0x90 = p_dsAction.m_unk0x90;
 }
 
+// FUNCTION: BETA10 0x1012b2b3
+MxDSAction::MxDSAction(MxDSAction& p_dsAction) : MxDSObject(p_dsAction)
+{
+	this->CopyFrom(p_dsAction);
+}
+
 // FUNCTION: LEGO1 0x100adbd0
 // FUNCTION: BETA10 0x1012b355
 undefined4 MxDSAction::VTable0x14()

--- a/LEGO1/omni/src/action/mxdsaction.cpp
+++ b/LEGO1/omni/src/action/mxdsaction.cpp
@@ -4,28 +4,47 @@
 #include "mxtimer.h"
 #include "mxutilities.h"
 
+#include <assert.h>
 #include <float.h>
 #include <limits.h>
 
 DECOMP_SIZE_ASSERT(MxDSAction, 0x94)
 
 // GLOBAL: LEGO1 0x10101410
+// GLOBAL: BETA10 0x10201f5c
 MxU16 g_sep = TWOCC(',', ' ');
 
 // FUNCTION: LEGO1 0x100ad810
+// FUNCTION: BETA10 0x1012afd0
 MxDSAction::MxDSAction()
 {
+	this->m_type = e_action;
 	this->m_flags = MxDSAction::c_enabled;
-	this->m_startTime = INT_MIN;
-	this->m_extraData = NULL;
 	this->m_extraLength = 0;
+	this->m_extraData = NULL;
+	this->m_startTime = INT_MIN;
 	this->m_duration = INT_MIN;
 	this->m_loopCount = -1;
 
-	this->SetType(e_action);
-	this->m_location.Fill(FLT_MAX);
-	this->m_direction.Fill(FLT_MAX);
-	this->m_up.Fill(FLT_MAX);
+	// TODO: No convenience function used in the beta, but maybe a macro?
+	{
+		float max = FLT_MAX;
+		float* v = &max;
+		this->m_location.EqualsScalar(v);
+	}
+
+	{
+		float max = FLT_MAX;
+		float* v = &max;
+		this->m_direction.EqualsScalar(v);
+	}
+
+	{
+		float max = FLT_MAX;
+		float* v = &max;
+		this->m_up.EqualsScalar(v);
+	}
+
 	this->m_unk0x84 = NULL;
 	this->m_unk0x88 = 0;
 	this->m_origin = NULL;
@@ -33,45 +52,52 @@ MxDSAction::MxDSAction()
 }
 
 // FUNCTION: LEGO1 0x100ad940
+// FUNCTION: BETA10 0x1012bc50
 MxLong MxDSAction::GetDuration()
 {
 	return this->m_duration;
 }
 
 // FUNCTION: LEGO1 0x100ad950
+// FUNCTION: BETA10 0x1012bc90
 void MxDSAction::SetDuration(MxLong p_duration)
 {
 	this->m_duration = p_duration;
 }
 
 // FUNCTION: LEGO1 0x100ad960
+// FUNCTION: BETA10 0x1012bcc0
 MxBool MxDSAction::HasId(MxU32 p_objectId)
 {
-	return this->GetObjectId() == p_objectId;
+	return this->m_objectId == p_objectId;
 }
 
 // FUNCTION: LEGO1 0x100ada40
+// FUNCTION: BETA10 0x1012bdf0
 void MxDSAction::SetUnknown90(MxLong p_unk0x90)
 {
 	this->m_unk0x90 = p_unk0x90;
 }
 
 // FUNCTION: LEGO1 0x100ada50
+// FUNCTION: BETA10 0x1012be20
 MxLong MxDSAction::GetUnknown90()
 {
 	return this->m_unk0x90;
 }
 
 // FUNCTION: LEGO1 0x100ada80
+// FUNCTION: BETA10 0x1012b144
 MxDSAction::~MxDSAction()
 {
 	delete[] this->m_extraData;
 }
 
 // FUNCTION: LEGO1 0x100adaf0
+// FUNCTION: BETA10 0x1012b1c7
 void MxDSAction::CopyFrom(MxDSAction& p_dsAction)
 {
-	this->SetObjectId(p_dsAction.GetObjectId());
+	this->m_objectId = p_dsAction.m_objectId;
 	this->m_flags = p_dsAction.m_flags;
 	this->m_startTime = p_dsAction.m_startTime;
 	this->m_duration = p_dsAction.m_duration;
@@ -87,23 +113,34 @@ void MxDSAction::CopyFrom(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100adbd0
+// FUNCTION: BETA10 0x1012b355
 undefined4 MxDSAction::VTable0x14()
 {
 	return MxDSObject::VTable0x14();
 }
 
 // FUNCTION: LEGO1 0x100adbe0
+// FUNCTION: BETA10 0x1012b373
 MxU32 MxDSAction::GetSizeOnDisk()
 {
-	MxU32 totalSizeOnDisk;
+	MxU32 size = MxDSObject::GetSizeOnDisk();
+	size += sizeof(m_flags);
+	size += sizeof(m_startTime);
+	size += sizeof(m_duration);
+	size += sizeof(m_loopCount);
+	size += sizeof(double) * 3; // m_location
+	size += sizeof(double) * 3; // m_direction
+	size += sizeof(double) * 3; // m_up
+	size += sizeof(m_extraLength);
+	size += this->m_extraLength;
 
-	totalSizeOnDisk = MxDSObject::GetSizeOnDisk() + 90 + this->m_extraLength;
-	this->m_sizeOnDisk = totalSizeOnDisk - MxDSObject::GetSizeOnDisk();
+	this->m_sizeOnDisk = size - MxDSObject::GetSizeOnDisk();
 
-	return totalSizeOnDisk;
+	return size;
 }
 
 // FUNCTION: LEGO1 0x100adc10
+// FUNCTION: BETA10 0x1012b3d9
 MxDSAction& MxDSAction::operator=(MxDSAction& p_dsAction)
 {
 	if (this == &p_dsAction) {
@@ -116,6 +153,7 @@ MxDSAction& MxDSAction::operator=(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100adc40
+// FUNCTION: BETA10 0x1012b420
 MxDSAction* MxDSAction::Clone()
 {
 	MxDSAction* clone = new MxDSAction();
@@ -128,54 +166,56 @@ MxDSAction* MxDSAction::Clone()
 }
 
 // FUNCTION: LEGO1 0x100adcd0
+// FUNCTION: BETA10 0x1012b4ca
 MxLong MxDSAction::GetElapsedTime()
 {
 	return Timer()->GetTime() - this->m_unk0x90;
 }
 
 // FUNCTION: LEGO1 0x100add00
+// FUNCTION: BETA10 0x1012b4f5
 void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 {
-	if (p_dsAction.m_startTime != INT_MIN) {
-		this->m_startTime = p_dsAction.m_startTime;
+	if (p_dsAction.GetStartTime() != INT_MIN) {
+		this->m_startTime = p_dsAction.GetStartTime();
 	}
 
 	if (p_dsAction.GetDuration() != INT_MIN) {
 		this->m_duration = p_dsAction.GetDuration();
 	}
 
-	if (p_dsAction.m_loopCount != -1) {
-		this->m_loopCount = p_dsAction.m_loopCount;
+	if (p_dsAction.GetLoopCount() != -1) {
+		this->m_loopCount = p_dsAction.GetLoopCount();
 	}
 
-	if (p_dsAction.m_location[0] != FLT_MAX) {
-		this->m_location[0] = p_dsAction.m_location[0];
+	if (p_dsAction.GetLocation()[0] != FLT_MAX) {
+		this->m_location[0] = p_dsAction.GetLocation()[0];
 	}
-	if (p_dsAction.m_location[1] != FLT_MAX) {
-		this->m_location[1] = p_dsAction.m_location[1];
+	if (p_dsAction.GetLocation()[1] != FLT_MAX) {
+		this->m_location[1] = p_dsAction.GetLocation()[1];
 	}
-	if (p_dsAction.m_location[2] != FLT_MAX) {
-		this->m_location[2] = p_dsAction.m_location[2];
-	}
-
-	if (p_dsAction.m_direction[0] != FLT_MAX) {
-		this->m_direction[0] = p_dsAction.m_direction[0];
-	}
-	if (p_dsAction.m_direction[1] != FLT_MAX) {
-		this->m_direction[1] = p_dsAction.m_direction[1];
-	}
-	if (p_dsAction.m_direction[2] != FLT_MAX) {
-		this->m_direction[2] = p_dsAction.m_up[2]; // This is correct
+	if (p_dsAction.GetLocation()[2] != FLT_MAX) {
+		this->m_location[2] = p_dsAction.GetLocation()[2];
 	}
 
-	if (p_dsAction.m_up[0] != FLT_MAX) {
-		this->m_up[0] = p_dsAction.m_up[0];
+	if (p_dsAction.GetDirection()[0] != FLT_MAX) {
+		this->m_direction[0] = p_dsAction.GetDirection()[0];
 	}
-	if (p_dsAction.m_up[1] != FLT_MAX) {
-		this->m_up[1] = p_dsAction.m_up[1];
+	if (p_dsAction.GetDirection()[1] != FLT_MAX) {
+		this->m_direction[1] = p_dsAction.GetDirection()[1];
 	}
-	if (p_dsAction.m_up[2] != FLT_MAX) {
-		this->m_up[2] = p_dsAction.m_up[2];
+	if (p_dsAction.GetDirection()[2] != FLT_MAX) {
+		this->m_direction[2] = p_dsAction.GetUp()[2]; // This is correct
+	}
+
+	if (p_dsAction.GetUp()[0] != FLT_MAX) {
+		this->m_up[0] = p_dsAction.GetUp()[0];
+	}
+	if (p_dsAction.GetUp()[1] != FLT_MAX) {
+		this->m_up[1] = p_dsAction.GetUp()[1];
+	}
+	if (p_dsAction.GetUp()[2] != FLT_MAX) {
+		this->m_up[2] = p_dsAction.GetUp()[2];
 	}
 
 	MxU16 extraLength;
@@ -192,55 +232,62 @@ void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100ade60
+// FUNCTION: BETA10 0x1012b8a9
 void MxDSAction::AppendExtra(MxU16 p_extraLength, const char* p_extraData)
 {
-	if (this->m_extraData == p_extraData || !p_extraData) {
+	if (this->m_extraData == p_extraData) {
 		return;
 	}
 
-	if (this->m_extraLength) {
-		char* concat = new char[p_extraLength + this->m_extraLength + sizeof(g_sep)];
-		memcpy(concat, this->m_extraData, this->m_extraLength);
+	if (p_extraData) {
+		if (this->m_extraLength) {
+			char* newExtra = new char[p_extraLength + this->m_extraLength + sizeof(g_sep)];
+			assert(newExtra);
+			memcpy(newExtra, this->m_extraData, this->m_extraLength);
+			memcpy(&newExtra[this->m_extraLength], &g_sep, sizeof(g_sep));
+			memcpy(&newExtra[this->m_extraLength + sizeof(g_sep)], p_extraData, p_extraLength);
 
-		*(MxU16*) &concat[this->m_extraLength] = g_sep;
-		memcpy(&concat[this->m_extraLength + sizeof(g_sep)], p_extraData, p_extraLength);
+			this->m_extraLength += p_extraLength + sizeof(g_sep);
+			delete[] this->m_extraData;
+			this->m_extraData = newExtra;
+		}
+		else {
+			this->m_extraData = new char[p_extraLength];
 
-		this->m_extraLength += p_extraLength + sizeof(g_sep);
-		delete[] this->m_extraData;
-		this->m_extraData = concat;
-	}
-	else {
-		char* copy = new char[p_extraLength];
-		this->m_extraData = copy;
-
-		if (copy) {
-			this->m_extraLength = p_extraLength;
-			memcpy(copy, p_extraData, p_extraLength);
+			if (this->m_extraData) {
+				this->m_extraLength = p_extraLength;
+				memcpy(this->m_extraData, p_extraData, p_extraLength);
+			}
+			else {
+				assert(0);
+			}
 		}
 	}
 }
 
 // FUNCTION: LEGO1 0x100adf70
+// FUNCTION: BETA10 0x1012ba6a
 void MxDSAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSObject::Deserialize(p_source, p_unk0x24);
 
-	GetScalar(p_source, this->m_flags);
-	GetScalar(p_source, this->m_startTime);
-	GetScalar(p_source, this->m_duration);
-	GetScalar(p_source, this->m_loopCount);
-	GetDouble(p_source, this->m_location[0]);
-	GetDouble(p_source, this->m_location[1]);
-	GetDouble(p_source, this->m_location[2]);
-	GetDouble(p_source, this->m_direction[0]);
-	GetDouble(p_source, this->m_direction[1]);
-	GetDouble(p_source, this->m_direction[2]);
-	GetDouble(p_source, this->m_up[0]);
-	GetDouble(p_source, this->m_up[1]);
-	GetDouble(p_source, this->m_up[2]);
+	// clang-format off
+	this->m_flags        = *( MxU32*) p_source;  p_source += 4;
+	this->m_startTime    = *(MxLong*) p_source;  p_source += 4;
+	this->m_duration     = *(MxLong*) p_source;  p_source += 4;
+	this->m_loopCount    = *( MxS32*) p_source;  p_source += 4;
+	this->m_location[0]  = *(double*) p_source;  p_source += 8;
+	this->m_location[1]  = *(double*) p_source;  p_source += 8;
+	this->m_location[2]  = *(double*) p_source;  p_source += 8;
+	this->m_direction[0] = *(double*) p_source;  p_source += 8;
+	this->m_direction[1] = *(double*) p_source;  p_source += 8;
+	this->m_direction[2] = *(double*) p_source;  p_source += 8;
+	this->m_up[0]        = *(double*) p_source;  p_source += 8;
+	this->m_up[1]        = *(double*) p_source;  p_source += 8;
+	this->m_up[2]        = *(double*) p_source;  p_source += 8;
 
-	MxU16 extraLength = *(MxU16*) p_source;
-	p_source += 2;
+	MxU16 extraLength    = *( MxU16*) p_source;  p_source += 2;
+	// clang-format on
 
 	if (extraLength) {
 		AppendExtra(extraLength, (char*) p_source);

--- a/LEGO1/omni/src/action/mxdsaction.cpp
+++ b/LEGO1/omni/src/action/mxdsaction.cpp
@@ -18,104 +18,87 @@ MxU16 g_sep = TWOCC(',', ' ');
 // FUNCTION: BETA10 0x1012afd0
 MxDSAction::MxDSAction()
 {
-	this->m_type = e_action;
-	this->m_flags = MxDSAction::c_enabled;
-	this->m_extraLength = 0;
-	this->m_extraData = NULL;
-	this->m_startTime = INT_MIN;
-	this->m_duration = INT_MIN;
-	this->m_loopCount = -1;
-
-	// TODO: No convenience function used in the beta, but maybe a macro?
-	{
-		float max = FLT_MAX;
-		float* v = &max;
-		this->m_location.EqualsScalar(v);
-	}
-
-	{
-		float max = FLT_MAX;
-		float* v = &max;
-		this->m_direction.EqualsScalar(v);
-	}
-
-	{
-		float max = FLT_MAX;
-		float* v = &max;
-		this->m_up.EqualsScalar(v);
-	}
-
-	this->m_unk0x84 = NULL;
-	this->m_unk0x88 = 0;
-	this->m_origin = NULL;
-	this->m_unk0x90 = INT_MIN;
+	m_type = e_action;
+	m_flags = MxDSAction::c_enabled;
+	m_extraLength = 0;
+	m_extraData = NULL;
+	m_startTime = INT_MIN;
+	m_duration = INT_MIN;
+	m_loopCount = -1;
+	m_location.Fill(FLT_MAX);
+	m_direction.Fill(FLT_MAX);
+	m_up.Fill(FLT_MAX);
+	m_unk0x84 = NULL;
+	m_unk0x88 = 0;
+	m_origin = NULL;
+	m_unk0x90 = INT_MIN;
 }
 
 // FUNCTION: LEGO1 0x100ad940
 // FUNCTION: BETA10 0x1012bc50
 MxLong MxDSAction::GetDuration()
 {
-	return this->m_duration;
+	return m_duration;
 }
 
 // FUNCTION: LEGO1 0x100ad950
 // FUNCTION: BETA10 0x1012bc90
 void MxDSAction::SetDuration(MxLong p_duration)
 {
-	this->m_duration = p_duration;
+	m_duration = p_duration;
 }
 
 // FUNCTION: LEGO1 0x100ad960
 // FUNCTION: BETA10 0x1012bcc0
 MxBool MxDSAction::HasId(MxU32 p_objectId)
 {
-	return this->m_objectId == p_objectId;
+	return m_objectId == p_objectId;
 }
 
 // FUNCTION: LEGO1 0x100ada40
 // FUNCTION: BETA10 0x1012bdf0
 void MxDSAction::SetUnknown90(MxLong p_unk0x90)
 {
-	this->m_unk0x90 = p_unk0x90;
+	m_unk0x90 = p_unk0x90;
 }
 
 // FUNCTION: LEGO1 0x100ada50
 // FUNCTION: BETA10 0x1012be20
 MxLong MxDSAction::GetUnknown90()
 {
-	return this->m_unk0x90;
+	return m_unk0x90;
 }
 
 // FUNCTION: LEGO1 0x100ada80
 // FUNCTION: BETA10 0x1012b144
 MxDSAction::~MxDSAction()
 {
-	delete[] this->m_extraData;
+	delete[] m_extraData;
 }
 
 // FUNCTION: LEGO1 0x100adaf0
 // FUNCTION: BETA10 0x1012b1c7
 void MxDSAction::CopyFrom(MxDSAction& p_dsAction)
 {
-	this->m_objectId = p_dsAction.m_objectId;
-	this->m_flags = p_dsAction.m_flags;
-	this->m_startTime = p_dsAction.m_startTime;
-	this->m_duration = p_dsAction.m_duration;
-	this->m_loopCount = p_dsAction.m_loopCount;
-	this->m_location = p_dsAction.m_location;
-	this->m_direction = p_dsAction.m_direction;
-	this->m_up = p_dsAction.m_up;
+	m_objectId = p_dsAction.m_objectId;
+	m_flags = p_dsAction.m_flags;
+	m_startTime = p_dsAction.m_startTime;
+	m_duration = p_dsAction.m_duration;
+	m_loopCount = p_dsAction.m_loopCount;
+	m_location = p_dsAction.m_location;
+	m_direction = p_dsAction.m_direction;
+	m_up = p_dsAction.m_up;
 	AppendExtra(p_dsAction.m_extraLength, p_dsAction.m_extraData);
-	this->m_unk0x84 = p_dsAction.m_unk0x84;
-	this->m_unk0x88 = p_dsAction.m_unk0x88;
-	this->m_origin = p_dsAction.m_origin;
-	this->m_unk0x90 = p_dsAction.m_unk0x90;
+	m_unk0x84 = p_dsAction.m_unk0x84;
+	m_unk0x88 = p_dsAction.m_unk0x88;
+	m_origin = p_dsAction.m_origin;
+	m_unk0x90 = p_dsAction.m_unk0x90;
 }
 
 // FUNCTION: BETA10 0x1012b2b3
 MxDSAction::MxDSAction(MxDSAction& p_dsAction) : MxDSObject(p_dsAction)
 {
-	this->CopyFrom(p_dsAction);
+	CopyFrom(p_dsAction);
 }
 
 // FUNCTION: LEGO1 0x100adbd0
@@ -138,9 +121,9 @@ MxU32 MxDSAction::GetSizeOnDisk()
 	size += sizeof(double) * 3; // m_direction
 	size += sizeof(double) * 3; // m_up
 	size += sizeof(m_extraLength);
-	size += this->m_extraLength;
+	size += m_extraLength;
 
-	this->m_sizeOnDisk = size - MxDSObject::GetSizeOnDisk();
+	m_sizeOnDisk = size - MxDSObject::GetSizeOnDisk();
 
 	return size;
 }
@@ -154,7 +137,7 @@ MxDSAction& MxDSAction::operator=(MxDSAction& p_dsAction)
 	}
 
 	MxDSObject::operator=(p_dsAction);
-	this->CopyFrom(p_dsAction);
+	CopyFrom(p_dsAction);
 	return *this;
 }
 
@@ -175,7 +158,7 @@ MxDSAction* MxDSAction::Clone()
 // FUNCTION: BETA10 0x1012b4ca
 MxLong MxDSAction::GetElapsedTime()
 {
-	return Timer()->GetTime() - this->m_unk0x90;
+	return Timer()->GetTime() - m_unk0x90;
 }
 
 // FUNCTION: LEGO1 0x100add00
@@ -183,45 +166,45 @@ MxLong MxDSAction::GetElapsedTime()
 void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 {
 	if (p_dsAction.GetStartTime() != INT_MIN) {
-		this->m_startTime = p_dsAction.GetStartTime();
+		m_startTime = p_dsAction.GetStartTime();
 	}
 
 	if (p_dsAction.GetDuration() != INT_MIN) {
-		this->m_duration = p_dsAction.GetDuration();
+		m_duration = p_dsAction.GetDuration();
 	}
 
 	if (p_dsAction.GetLoopCount() != -1) {
-		this->m_loopCount = p_dsAction.GetLoopCount();
+		m_loopCount = p_dsAction.GetLoopCount();
 	}
 
 	if (p_dsAction.GetLocation()[0] != FLT_MAX) {
-		this->m_location[0] = p_dsAction.GetLocation()[0];
+		m_location[0] = p_dsAction.GetLocation()[0];
 	}
 	if (p_dsAction.GetLocation()[1] != FLT_MAX) {
-		this->m_location[1] = p_dsAction.GetLocation()[1];
+		m_location[1] = p_dsAction.GetLocation()[1];
 	}
 	if (p_dsAction.GetLocation()[2] != FLT_MAX) {
-		this->m_location[2] = p_dsAction.GetLocation()[2];
+		m_location[2] = p_dsAction.GetLocation()[2];
 	}
 
 	if (p_dsAction.GetDirection()[0] != FLT_MAX) {
-		this->m_direction[0] = p_dsAction.GetDirection()[0];
+		m_direction[0] = p_dsAction.GetDirection()[0];
 	}
 	if (p_dsAction.GetDirection()[1] != FLT_MAX) {
-		this->m_direction[1] = p_dsAction.GetDirection()[1];
+		m_direction[1] = p_dsAction.GetDirection()[1];
 	}
 	if (p_dsAction.GetDirection()[2] != FLT_MAX) {
-		this->m_direction[2] = p_dsAction.GetUp()[2]; // This is correct
+		m_direction[2] = p_dsAction.GetUp()[2]; // This is correct
 	}
 
 	if (p_dsAction.GetUp()[0] != FLT_MAX) {
-		this->m_up[0] = p_dsAction.GetUp()[0];
+		m_up[0] = p_dsAction.GetUp()[0];
 	}
 	if (p_dsAction.GetUp()[1] != FLT_MAX) {
-		this->m_up[1] = p_dsAction.GetUp()[1];
+		m_up[1] = p_dsAction.GetUp()[1];
 	}
 	if (p_dsAction.GetUp()[2] != FLT_MAX) {
-		this->m_up[2] = p_dsAction.GetUp()[2];
+		m_up[2] = p_dsAction.GetUp()[2];
 	}
 
 	MxU16 extraLength;
@@ -229,9 +212,9 @@ void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 	p_dsAction.GetExtra(extraLength, extraData);
 
 	if (extraLength && extraData) {
-		if (!this->m_extraData || !strncmp("XXX", this->m_extraData, 3)) {
-			delete[] this->m_extraData;
-			this->m_extraLength = 0;
+		if (!m_extraData || !strncmp("XXX", m_extraData, 3)) {
+			delete[] m_extraData;
+			m_extraLength = 0;
 			AppendExtra(extraLength, extraData);
 		}
 	}
@@ -241,28 +224,28 @@ void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 // FUNCTION: BETA10 0x1012b8a9
 void MxDSAction::AppendExtra(MxU16 p_extraLength, const char* p_extraData)
 {
-	if (this->m_extraData == p_extraData) {
+	if (m_extraData == p_extraData) {
 		return;
 	}
 
 	if (p_extraData) {
-		if (this->m_extraLength) {
-			char* newExtra = new char[p_extraLength + this->m_extraLength + sizeof(g_sep)];
+		if (m_extraLength) {
+			char* newExtra = new char[p_extraLength + m_extraLength + sizeof(g_sep)];
 			assert(newExtra);
-			memcpy(newExtra, this->m_extraData, this->m_extraLength);
-			memcpy(&newExtra[this->m_extraLength], &g_sep, sizeof(g_sep));
-			memcpy(&newExtra[this->m_extraLength + sizeof(g_sep)], p_extraData, p_extraLength);
+			memcpy(newExtra, m_extraData, m_extraLength);
+			memcpy(&newExtra[m_extraLength], &g_sep, sizeof(g_sep));
+			memcpy(&newExtra[m_extraLength + sizeof(g_sep)], p_extraData, p_extraLength);
 
-			this->m_extraLength += p_extraLength + sizeof(g_sep);
-			delete[] this->m_extraData;
-			this->m_extraData = newExtra;
+			m_extraLength += p_extraLength + sizeof(g_sep);
+			delete[] m_extraData;
+			m_extraData = newExtra;
 		}
 		else {
-			this->m_extraData = new char[p_extraLength];
+			m_extraData = new char[p_extraLength];
 
-			if (this->m_extraData) {
-				this->m_extraLength = p_extraLength;
-				memcpy(this->m_extraData, p_extraData, p_extraLength);
+			if (m_extraData) {
+				m_extraLength = p_extraLength;
+				memcpy(m_extraData, p_extraData, p_extraLength);
 			}
 			else {
 				assert(0);
@@ -278,21 +261,21 @@ void MxDSAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 	MxDSObject::Deserialize(p_source, p_unk0x24);
 
 	// clang-format off
-	this->m_flags        = *( MxU32*) p_source;  p_source += 4;
-	this->m_startTime    = *(MxLong*) p_source;  p_source += 4;
-	this->m_duration     = *(MxLong*) p_source;  p_source += 4;
-	this->m_loopCount    = *( MxS32*) p_source;  p_source += 4;
-	this->m_location[0]  = *(double*) p_source;  p_source += 8;
-	this->m_location[1]  = *(double*) p_source;  p_source += 8;
-	this->m_location[2]  = *(double*) p_source;  p_source += 8;
-	this->m_direction[0] = *(double*) p_source;  p_source += 8;
-	this->m_direction[1] = *(double*) p_source;  p_source += 8;
-	this->m_direction[2] = *(double*) p_source;  p_source += 8;
-	this->m_up[0]        = *(double*) p_source;  p_source += 8;
-	this->m_up[1]        = *(double*) p_source;  p_source += 8;
-	this->m_up[2]        = *(double*) p_source;  p_source += 8;
+	m_flags           = *( MxU32*) p_source;  p_source += sizeof(m_flags);
+	m_startTime       = *(MxLong*) p_source;  p_source += sizeof(m_startTime);
+	m_duration        = *(MxLong*) p_source;  p_source += sizeof(m_duration);
+	m_loopCount       = *( MxS32*) p_source;  p_source += sizeof(m_loopCount);
+	m_location[0]     = *(double*) p_source;  p_source += sizeof(double);
+	m_location[1]     = *(double*) p_source;  p_source += sizeof(double);
+	m_location[2]     = *(double*) p_source;  p_source += sizeof(double);
+	m_direction[0]    = *(double*) p_source;  p_source += sizeof(double);
+	m_direction[1]    = *(double*) p_source;  p_source += sizeof(double);
+	m_direction[2]    = *(double*) p_source;  p_source += sizeof(double);
+	m_up[0]           = *(double*) p_source;  p_source += sizeof(double);
+	m_up[1]           = *(double*) p_source;  p_source += sizeof(double);
+	m_up[2]           = *(double*) p_source;  p_source += sizeof(double);
 
-	MxU16 extraLength    = *( MxU16*) p_source;  p_source += 2;
+	MxU16 extraLength = *( MxU16*) p_source;  p_source += sizeof(extraLength);
 	// clang-format on
 
 	if (extraLength) {

--- a/LEGO1/omni/src/action/mxdsanim.cpp
+++ b/LEGO1/omni/src/action/mxdsanim.cpp
@@ -3,6 +3,7 @@
 DECOMP_SIZE_ASSERT(MxDSAnim, 0xb8)
 
 // FUNCTION: LEGO1 0x100c8ff0
+// FUNCTION: BETA10 0x1015cd71
 MxDSAnim::MxDSAnim()
 {
 	this->SetType(e_anim);

--- a/LEGO1/omni/src/action/mxdsevent.cpp
+++ b/LEGO1/omni/src/action/mxdsevent.cpp
@@ -3,6 +3,7 @@
 DECOMP_SIZE_ASSERT(MxDSEvent, 0xb8)
 
 // FUNCTION: LEGO1 0x100c95f0
+// FUNCTION: BETA10 0x1015d2e5
 MxDSEvent::MxDSEvent()
 {
 	this->SetType(e_event);

--- a/LEGO1/omni/src/action/mxdsmediaaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmediaaction.cpp
@@ -5,6 +5,7 @@
 DECOMP_SIZE_ASSERT(MxDSMediaAction, 0xb8)
 
 // FUNCTION: LEGO1 0x100c8b40
+// FUNCTION: BETA10 0x1015c760
 MxDSMediaAction::MxDSMediaAction()
 {
 	this->m_mediaSrcPath = NULL;

--- a/LEGO1/omni/src/action/mxdsmultiaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmultiaction.cpp
@@ -5,6 +5,7 @@ DECOMP_SIZE_ASSERT(MxDSActionList, 0x1c);
 DECOMP_SIZE_ASSERT(MxDSActionListCursor, 0x10);
 
 // FUNCTION: LEGO1 0x100c9b90
+// FUNCTION: BETA10 0x10159410
 MxDSMultiAction::MxDSMultiAction()
 {
 	this->SetType(e_multiAction);

--- a/LEGO1/omni/src/action/mxdsobject.cpp
+++ b/LEGO1/omni/src/action/mxdsobject.cpp
@@ -19,18 +19,20 @@
 DECOMP_SIZE_ASSERT(MxDSObject, 0x2c);
 
 // FUNCTION: LEGO1 0x100bf6a0
+// FUNCTION: BETA10 0x101478c0
 MxDSObject::MxDSObject()
 {
-	this->SetType(e_object);
+	this->m_type = e_object;
 	this->m_sourceName = NULL;
 	this->m_unk0x14 = 0;
 	this->m_objectName = NULL;
-	this->m_unk0x24 = -1;
 	this->m_objectId = -1;
+	this->m_unk0x24 = -1;
 	this->m_unk0x28 = 0;
 }
 
 // FUNCTION: LEGO1 0x100bf7e0
+// FUNCTION: BETA10 0x1014798e
 MxDSObject::~MxDSObject()
 {
 	delete[] m_objectName;
@@ -38,6 +40,7 @@ MxDSObject::~MxDSObject()
 }
 
 // FUNCTION: LEGO1 0x100bf870
+// FUNCTION: BETA10 0x10147a45
 void MxDSObject::CopyFrom(MxDSObject& p_dsObject)
 {
 	this->SetSourceName(p_dsObject.m_sourceName);
@@ -49,7 +52,14 @@ void MxDSObject::CopyFrom(MxDSObject& p_dsObject)
 	this->m_unk0x28 = p_dsObject.m_unk0x28;
 }
 
+// FUNCTION: BETA10 0x10147abf
+MxDSObject::MxDSObject(MxDSObject& p_dsObject)
+{
+	this->CopyFrom(p_dsObject);
+}
+
 // FUNCTION: LEGO1 0x100bf8c0
+// FUNCTION: BETA10 0x10147b57
 MxDSObject& MxDSObject::operator=(MxDSObject& p_dsObject)
 {
 	if (this == &p_dsObject) {
@@ -61,62 +71,73 @@ MxDSObject& MxDSObject::operator=(MxDSObject& p_dsObject)
 }
 
 // FUNCTION: LEGO1 0x100bf8e0
+// FUNCTION: BETA10 0x10147b92
 void MxDSObject::SetObjectName(const char* p_objectName)
 {
-	if (p_objectName != this->m_objectName) {
-		delete[] this->m_objectName;
+	if (p_objectName == this->m_objectName) {
+		return;
+	}
 
-		if (p_objectName) {
-			this->m_objectName = new char[strlen(p_objectName) + 1];
+	delete[] this->m_objectName;
 
-			if (this->m_objectName) {
-				strcpy(this->m_objectName, p_objectName);
-			}
+	if (p_objectName) {
+		this->m_objectName = new char[strlen(p_objectName) + 1];
+
+		if (this->m_objectName) {
+			strcpy(this->m_objectName, p_objectName);
 		}
-		else {
-			this->m_objectName = NULL;
-		}
+	}
+	else {
+		this->m_objectName = NULL;
 	}
 }
 
 // FUNCTION: LEGO1 0x100bf950
+// FUNCTION: BETA10 0x10147c2e
 void MxDSObject::SetSourceName(const char* p_sourceName)
 {
-	if (p_sourceName != this->m_sourceName) {
-		delete[] this->m_sourceName;
+	if (p_sourceName == this->m_sourceName) {
+		return;
+	}
 
-		if (p_sourceName) {
-			this->m_sourceName = new char[strlen(p_sourceName) + 1];
+	delete[] this->m_sourceName;
 
-			if (this->m_sourceName) {
-				strcpy(this->m_sourceName, p_sourceName);
-			}
+	if (p_sourceName) {
+		this->m_sourceName = new char[strlen(p_sourceName) + 1];
+
+		if (this->m_sourceName) {
+			strcpy(this->m_sourceName, p_sourceName);
 		}
-		else {
-			this->m_sourceName = NULL;
-		}
+	}
+	else {
+		this->m_sourceName = NULL;
 	}
 }
 
 // FUNCTION: LEGO1 0x100bf9c0
+// FUNCTION: BETA10 0x10147cca
 undefined4 MxDSObject::VTable0x14()
 {
+	// DECOMP: Rendered as 8 + 2 in beta. Maybe a sizeof() call?
 	return 10;
 }
 
 // FUNCTION: LEGO1 0x100bf9d0
+// FUNCTION: BETA10 0x10147cee
 MxU32 MxDSObject::GetSizeOnDisk()
 {
-	MxU32 sizeOnDisk;
+	MxU32 sizeOnDisk = 0;
+
+	sizeOnDisk += 2;
 
 	if (this->m_sourceName) {
-		sizeOnDisk = strlen(this->m_sourceName) + 3;
+		sizeOnDisk += strlen(this->m_sourceName) + 1;
 	}
 	else {
-		sizeOnDisk = 3;
+		sizeOnDisk++;
 	}
 
-	sizeOnDisk += 4;
+	sizeOnDisk += sizeof(this->m_unk0x14);
 
 	if (this->m_objectName) {
 		sizeOnDisk += strlen(this->m_objectName) + 1;
@@ -125,33 +146,41 @@ MxU32 MxDSObject::GetSizeOnDisk()
 		sizeOnDisk++;
 	}
 
-	sizeOnDisk += 4;
+	sizeOnDisk += sizeof(this->m_objectId);
+
 	this->m_sizeOnDisk = sizeOnDisk;
 	return sizeOnDisk;
 }
 
 // FUNCTION: LEGO1 0x100bfa20
+// FUNCTION: BETA10 0x10147d73
 void MxDSObject::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
-	GetString(p_source, this->m_sourceName, this, &MxDSObject::SetSourceName);
-	GetScalar(p_source, this->m_unk0x14);
-	GetString(p_source, this->m_objectName, this, &MxDSObject::SetObjectName);
-	GetScalar(p_source, this->m_objectId);
+	this->SetSourceName((char*) p_source);
+	p_source += strlen(this->m_sourceName) + 1;
+
+	this->m_unk0x14 = *(MxU32*) p_source;
+	p_source += sizeof(this->m_unk0x14);
+
+	this->SetObjectName((char*) p_source);
+	p_source += strlen(this->m_objectName) + 1;
+
+	this->m_objectId = *(MxU32*) p_source;
+	p_source += sizeof(this->m_objectId);
 
 	this->m_unk0x24 = p_unk0x24;
 }
 
 // FUNCTION: LEGO1 0x100bfb30
+// FUNCTION: BETA10 0x10147f35
 MxDSObject* DeserializeDSObjectDispatch(MxU8*& p_source, MxS16 p_flags)
 {
+	MxDSObject* obj = NULL;
+
 	MxU16 type = *(MxU16*) p_source;
 	p_source += 2;
 
-	MxDSObject* obj = NULL;
-
 	switch (type) {
-	default:
-		return NULL;
 	case MxDSObject::e_object:
 		obj = new MxDSObject();
 		break;
@@ -167,6 +196,15 @@ MxDSObject* DeserializeDSObjectDispatch(MxU8*& p_source, MxS16 p_flags)
 	case MxDSObject::e_sound:
 		obj = new MxDSSound();
 		break;
+	case MxDSObject::e_event:
+		obj = new MxDSEvent();
+		break;
+	case MxDSObject::e_still:
+		obj = new MxDSStill();
+		break;
+	case MxDSObject::e_objectAction:
+		obj = new MxDSObjectAction();
+		break;
 	case MxDSObject::e_multiAction:
 		obj = new MxDSMultiAction();
 		break;
@@ -176,18 +214,11 @@ MxDSObject* DeserializeDSObjectDispatch(MxU8*& p_source, MxS16 p_flags)
 	case MxDSObject::e_parallelAction:
 		obj = new MxDSParallelAction();
 		break;
-	case MxDSObject::e_event:
-		obj = new MxDSEvent();
-		break;
 	case MxDSObject::e_selectAction:
 		obj = new MxDSSelectAction();
 		break;
-	case MxDSObject::e_still:
-		obj = new MxDSStill();
-		break;
-	case MxDSObject::e_objectAction:
-		obj = new MxDSObjectAction();
-		break;
+	default:
+		return NULL;
 	}
 
 	if (obj) {

--- a/LEGO1/omni/src/action/mxdsobject.cpp
+++ b/LEGO1/omni/src/action/mxdsobject.cpp
@@ -22,13 +22,13 @@ DECOMP_SIZE_ASSERT(MxDSObject, 0x2c);
 // FUNCTION: BETA10 0x101478c0
 MxDSObject::MxDSObject()
 {
-	this->m_type = e_object;
-	this->m_sourceName = NULL;
-	this->m_unk0x14 = 0;
-	this->m_objectName = NULL;
-	this->m_objectId = -1;
-	this->m_unk0x24 = -1;
-	this->m_unk0x28 = 0;
+	m_type = e_object;
+	m_sourceName = NULL;
+	m_unk0x14 = 0;
+	m_objectName = NULL;
+	m_objectId = -1;
+	m_unk0x24 = -1;
+	m_unk0x28 = NULL;
 }
 
 // FUNCTION: LEGO1 0x100bf7e0
@@ -43,19 +43,19 @@ MxDSObject::~MxDSObject()
 // FUNCTION: BETA10 0x10147a45
 void MxDSObject::CopyFrom(MxDSObject& p_dsObject)
 {
-	this->SetSourceName(p_dsObject.m_sourceName);
-	this->m_unk0x14 = p_dsObject.m_unk0x14;
-	this->SetObjectName(p_dsObject.m_objectName);
-	this->m_objectId = p_dsObject.m_objectId;
-	this->m_unk0x24 = p_dsObject.m_unk0x24;
-	this->m_atomId = p_dsObject.m_atomId;
-	this->m_unk0x28 = p_dsObject.m_unk0x28;
+	SetSourceName(p_dsObject.m_sourceName);
+	m_unk0x14 = p_dsObject.m_unk0x14;
+	SetObjectName(p_dsObject.m_objectName);
+	m_objectId = p_dsObject.m_objectId;
+	m_unk0x24 = p_dsObject.m_unk0x24;
+	m_atomId = p_dsObject.m_atomId;
+	m_unk0x28 = p_dsObject.m_unk0x28;
 }
 
 // FUNCTION: BETA10 0x10147abf
 MxDSObject::MxDSObject(MxDSObject& p_dsObject)
 {
-	this->CopyFrom(p_dsObject);
+	CopyFrom(p_dsObject);
 }
 
 // FUNCTION: LEGO1 0x100bf8c0
@@ -66,7 +66,7 @@ MxDSObject& MxDSObject::operator=(MxDSObject& p_dsObject)
 		return *this;
 	}
 
-	this->CopyFrom(p_dsObject);
+	CopyFrom(p_dsObject);
 	return *this;
 }
 
@@ -74,21 +74,21 @@ MxDSObject& MxDSObject::operator=(MxDSObject& p_dsObject)
 // FUNCTION: BETA10 0x10147b92
 void MxDSObject::SetObjectName(const char* p_objectName)
 {
-	if (p_objectName == this->m_objectName) {
+	if (p_objectName == m_objectName) {
 		return;
 	}
 
-	delete[] this->m_objectName;
+	delete[] m_objectName;
 
 	if (p_objectName) {
-		this->m_objectName = new char[strlen(p_objectName) + 1];
+		m_objectName = new char[strlen(p_objectName) + 1];
 
-		if (this->m_objectName) {
-			strcpy(this->m_objectName, p_objectName);
+		if (m_objectName) {
+			strcpy(m_objectName, p_objectName);
 		}
 	}
 	else {
-		this->m_objectName = NULL;
+		m_objectName = NULL;
 	}
 }
 
@@ -96,21 +96,21 @@ void MxDSObject::SetObjectName(const char* p_objectName)
 // FUNCTION: BETA10 0x10147c2e
 void MxDSObject::SetSourceName(const char* p_sourceName)
 {
-	if (p_sourceName == this->m_sourceName) {
+	if (p_sourceName == m_sourceName) {
 		return;
 	}
 
-	delete[] this->m_sourceName;
+	delete[] m_sourceName;
 
 	if (p_sourceName) {
-		this->m_sourceName = new char[strlen(p_sourceName) + 1];
+		m_sourceName = new char[strlen(p_sourceName) + 1];
 
-		if (this->m_sourceName) {
-			strcpy(this->m_sourceName, p_sourceName);
+		if (m_sourceName) {
+			strcpy(m_sourceName, p_sourceName);
 		}
 	}
 	else {
-		this->m_sourceName = NULL;
+		m_sourceName = NULL;
 	}
 }
 
@@ -130,25 +130,25 @@ MxU32 MxDSObject::GetSizeOnDisk()
 
 	sizeOnDisk += 2;
 
-	if (this->m_sourceName) {
-		sizeOnDisk += strlen(this->m_sourceName) + 1;
+	if (m_sourceName) {
+		sizeOnDisk += strlen(m_sourceName) + 1;
 	}
 	else {
 		sizeOnDisk++;
 	}
 
-	sizeOnDisk += sizeof(this->m_unk0x14);
+	sizeOnDisk += sizeof(m_unk0x14);
 
-	if (this->m_objectName) {
-		sizeOnDisk += strlen(this->m_objectName) + 1;
+	if (m_objectName) {
+		sizeOnDisk += strlen(m_objectName) + 1;
 	}
 	else {
 		sizeOnDisk++;
 	}
 
-	sizeOnDisk += sizeof(this->m_objectId);
+	sizeOnDisk += sizeof(m_objectId);
 
-	this->m_sizeOnDisk = sizeOnDisk;
+	m_sizeOnDisk = sizeOnDisk;
 	return sizeOnDisk;
 }
 
@@ -156,19 +156,19 @@ MxU32 MxDSObject::GetSizeOnDisk()
 // FUNCTION: BETA10 0x10147d73
 void MxDSObject::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
-	this->SetSourceName((char*) p_source);
-	p_source += strlen(this->m_sourceName) + 1;
+	SetSourceName((char*) p_source);
+	p_source += strlen(m_sourceName) + 1;
 
-	this->m_unk0x14 = *(MxU32*) p_source;
-	p_source += sizeof(this->m_unk0x14);
+	m_unk0x14 = *(undefined4*) p_source;
+	p_source += sizeof(m_unk0x14);
 
-	this->SetObjectName((char*) p_source);
-	p_source += strlen(this->m_objectName) + 1;
+	SetObjectName((char*) p_source);
+	p_source += strlen(m_objectName) + 1;
 
-	this->m_objectId = *(MxU32*) p_source;
-	p_source += sizeof(this->m_objectId);
+	m_objectId = *(MxU32*) p_source;
+	p_source += sizeof(m_objectId);
 
-	this->m_unk0x24 = p_unk0x24;
+	m_unk0x24 = p_unk0x24;
 }
 
 // FUNCTION: LEGO1 0x100bfb30

--- a/LEGO1/omni/src/action/mxdsobjectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsobjectaction.cpp
@@ -3,6 +3,7 @@
 DECOMP_SIZE_ASSERT(MxDSObjectAction, 0xb8)
 
 // FUNCTION: LEGO1 0x100c8870
+// FUNCTION: BETA10 0x1015c3b0
 MxDSObjectAction::MxDSObjectAction()
 {
 	this->SetType(e_objectAction);

--- a/LEGO1/omni/src/action/mxdsparallelaction.cpp
+++ b/LEGO1/omni/src/action/mxdsparallelaction.cpp
@@ -5,6 +5,7 @@
 DECOMP_SIZE_ASSERT(MxDSParallelAction, 0x9c)
 
 // FUNCTION: LEGO1 0x100cae80
+// FUNCTION: BETA10 0x1015a14d
 MxDSParallelAction::MxDSParallelAction()
 {
 	this->SetType(e_parallelAction);

--- a/LEGO1/omni/src/action/mxdsselectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsselectaction.cpp
@@ -10,6 +10,7 @@ DECOMP_SIZE_ASSERT(MxStringListCursor, 0x10)
 DECOMP_SIZE_ASSERT(MxListEntry<MxString>, 0x18)
 
 // FUNCTION: LEGO1 0x100cb2b0
+// FUNCTION: BETA10 0x1015a515
 MxDSSelectAction::MxDSSelectAction()
 {
 	this->SetType(e_selectAction);

--- a/LEGO1/omni/src/action/mxdsserialaction.cpp
+++ b/LEGO1/omni/src/action/mxdsserialaction.cpp
@@ -5,6 +5,7 @@
 DECOMP_SIZE_ASSERT(MxDSSerialAction, 0xa8)
 
 // FUNCTION: LEGO1 0x100ca9d0
+// FUNCTION: BETA10 0x10159cf3
 MxDSSerialAction::MxDSSerialAction()
 {
 	this->SetType(e_serialAction);

--- a/LEGO1/omni/src/action/mxdssound.cpp
+++ b/LEGO1/omni/src/action/mxdssound.cpp
@@ -5,6 +5,7 @@
 DECOMP_SIZE_ASSERT(MxDSSound, 0xc0)
 
 // FUNCTION: LEGO1 0x100c92c0
+// FUNCTION: BETA10 0x1015cfdb
 MxDSSound::MxDSSound()
 {
 	this->m_volume = 0x4f;

--- a/LEGO1/omni/src/action/mxdsstill.cpp
+++ b/LEGO1/omni/src/action/mxdsstill.cpp
@@ -3,6 +3,7 @@
 DECOMP_SIZE_ASSERT(MxDSStill, 0xb8)
 
 // FUNCTION: LEGO1 0x100c98c0
+// FUNCTION: BETA10 0x1015d54f
 MxDSStill::MxDSStill()
 {
 	this->SetType(e_still);

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -195,11 +195,11 @@ public:
 	virtual void EqualsCross(float* p_a, Vector3* p_b) { EqualsCrossImpl(p_a, p_b->m_data); } // vtable+0x78
 
 	// FUNCTION: LEGO1 0x10003bf0
-	virtual void EqualsScalar(float* p_value)
+	virtual void Fill(const float& p_value)
 	{
-		m_data[0] = *p_value;
-		m_data[1] = *p_value;
-		m_data[2] = *p_value;
+		m_data[0] = p_value;
+		m_data[1] = p_value;
+		m_data[2] = p_value;
 	} // vtable+0x84
 
 	// Vector2 overrides
@@ -269,8 +269,6 @@ public:
 	{
 		return m_data[0] * m_data[0] + m_data[1] * m_data[1] + m_data[2] * m_data[2];
 	} // vtable+0x40
-
-	inline void Fill(float p_value) { EqualsScalar(&p_value); }
 
 	friend class Mx3DPointFloat;
 };
@@ -374,12 +372,12 @@ public:
 	} // vtable+0x40
 
 	// FUNCTION: LEGO1 0x10002b40
-	void EqualsScalar(float* p_value) override
+	void Fill(const float& p_value) override
 	{
-		m_data[0] = *p_value;
-		m_data[1] = *p_value;
-		m_data[2] = *p_value;
-		m_data[3] = *p_value;
+		m_data[0] = p_value;
+		m_data[1] = p_value;
+		m_data[2] = p_value;
+		m_data[3] = p_value;
 	} // vtable+0x84
 
 	friend class Mx4DPointFloat;


### PR DESCRIPTION
Some more corrections from the beta. The secondary goal here is to get more annotations down so it's easier to parse through the file and compare/match other stuff.

It seems like they used getters more consistently than setters. I had to change `MxDSObject` from private to protected so we can set `m_type` and other members directly. The constructors for all the MxDS* child classes do this, but I only marked the address for this PR. I wanted to limit the overall changes so we wouldn't have a messy diff, and that seems to have worked out. The only degrade is `DeserializeDSObjectDispatch` which is compiler noise.

Dead code: copy constructors for `MxDSObject` and `MxDSAction`. (maybe all of them?)

In the `MxDSAction` constructor, I have the calls to `Vector3::Fill` splayed out to match the beta, but if there's a better way to do this then we should take it.

We aren't checking for this (and probably shouldn't) but `MxDSAction::~MxDSAction` breaks the function order for the `BETA10` annotations. We are still correct for `LEGO1`. Maybe a hint that some of these functions belong in the header instead?
