### PR TITLE
Beta matching MxDSMediaAction

### DIFF
--- a/LEGO1/omni/include/mxdsmediaaction.h
+++ b/LEGO1/omni/include/mxdsmediaaction.h
@@ -5,6 +5,7 @@
 #include "mxdsaction.h"
 
 // VTABLE: LEGO1 0x100dcd40
+// VTABLE: BETA10 0x101c2ad8
 // SIZE 0xb8
 class MxDSMediaAction : public MxDSAction {
 public:
@@ -12,9 +13,11 @@ public:
 	~MxDSMediaAction() override;
 
 	void CopyFrom(MxDSMediaAction& p_dsMediaAction);
+	MxDSMediaAction(MxDSMediaAction& p_dsMediaAction);
 	MxDSMediaAction& operator=(MxDSMediaAction& p_dsMediaAction);
 
 	// FUNCTION: LEGO1 0x100c8be0
+	// FUNCTION: BETA10 0x1015c700
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f7624
@@ -22,12 +25,14 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c8bf0
+	// FUNCTION: BETA10 0x1015c6a0
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSMediaAction::ClassName()) || MxDSAction::IsA(p_name);
 	}
 
 	// SYNTHETIC: LEGO1 0x100c8cd0
+	// SYNTHETIC: BETA10 0x1015d810
 	// MxDSMediaAction::`scalar deleting destructor'
 
 	undefined4 VTable0x14() override;                            // vtable+14;
@@ -37,18 +42,34 @@ public:
 
 	void CopyMediaSrcPath(const char* p_mediaSrcPath);
 
-	inline MxS32 GetFramesPerSecond() const { return this->m_framesPerSecond; }
-	inline MxS32 GetMediaFormat() const { return this->m_mediaFormat; }
-	inline MxS32 GetPaletteManagement() const { return this->m_paletteManagement; }
-	inline MxLong GetSustainTime() const { return this->m_sustainTime; }
+	// FUNCTION: BETA10 0x1013c2e0
+	inline MxS32 GetFramesPerSecond() const { return m_framesPerSecond; }
+
+	// FUNCTION: BETA10 0x1012efd0
+	inline MxS32 GetMediaFormat() const { return m_mediaFormat; }
+
+	// FUNCTION: BETA10 0x1013b860
+	inline MxS32 GetPaletteManagement() const { return m_paletteManagement; }
+
+	// FUNCTION: BETA10 0x1005ab60
+	inline MxLong GetSustainTime() const { return m_sustainTime; }
 
 private:
-	MxU32 m_sizeOnDisk;   // 0x94
-	char* m_mediaSrcPath; // 0x98
-	struct {
+	struct Unk0x9cStruct {
+		// FUNCTION: BETA10 0x1015d7c0
+		void SetUnk0x00(undefined4 p_value) { m_unk0x00 = p_value; }
+
+		// FUNCTION: BETA10 0x1015d7e0
+		void SetUnk0x04(undefined4 p_value) { m_unk0x04 = p_value; }
+
+		// intentionally public
 		undefined4 m_unk0x00;
 		undefined4 m_unk0x04;
-	} m_unk0x9c;               // 0x9c
+	};
+
+	MxU32 m_sizeOnDisk;        // 0x94
+	char* m_mediaSrcPath;      // 0x98
+	Unk0x9cStruct m_unk0x9c;   // 0x9c
 	MxS32 m_framesPerSecond;   // 0xa4
 	MxS32 m_mediaFormat;       // 0xa8
 	MxS32 m_paletteManagement; // 0xac

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -57,7 +57,10 @@ public:
 	// FUNCTION: BETA10 0x100152e0
 	inline virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+20;
 
+	// FUNCTION: BETA10 0x1012ef90
 	inline Type GetType() const { return (Type) m_type; }
+
+	// FUNCTION: BETA10 0x1012efb0
 	inline const char* GetSourceName() const { return m_sourceName; }
 	inline const char* GetObjectName() const { return m_objectName; }
 	inline MxU32 GetObjectId() { return m_objectId; }

--- a/LEGO1/omni/src/action/mxdsmediaaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmediaaction.cpp
@@ -8,36 +8,45 @@ DECOMP_SIZE_ASSERT(MxDSMediaAction, 0xb8)
 // FUNCTION: BETA10 0x1015c760
 MxDSMediaAction::MxDSMediaAction()
 {
-	this->m_mediaSrcPath = NULL;
-	this->m_unk0x9c.m_unk0x00 = 0;
-	this->m_unk0x9c.m_unk0x04 = 0;
-	this->m_framesPerSecond = 0;
-	this->m_mediaFormat = 0;
-	this->m_paletteManagement = 1;
-	this->m_unk0xb4 = -1;
-	this->m_sustainTime = 0;
-	this->SetType(e_mediaAction);
+	m_type = e_mediaAction;
+	m_mediaSrcPath = NULL;
+	m_unk0x9c.SetUnk0x00(0);
+	m_unk0x9c.SetUnk0x04(0);
+	m_framesPerSecond = 0;
+	m_mediaFormat = 0;
+	m_unk0xb4 = -1;
+	m_paletteManagement = 1;
+	m_sustainTime = 0;
 }
 
 // FUNCTION: LEGO1 0x100c8cf0
+// FUNCTION: BETA10 0x1015c846
 MxDSMediaAction::~MxDSMediaAction()
 {
-	delete[] this->m_mediaSrcPath;
+	delete[] m_mediaSrcPath;
 }
 
 // FUNCTION: LEGO1 0x100c8d60
+// FUNCTION: BETA10 0x1015c8cc
 void MxDSMediaAction::CopyFrom(MxDSMediaAction& p_dsMediaAction)
 {
 	CopyMediaSrcPath(p_dsMediaAction.m_mediaSrcPath);
 
-	this->m_unk0x9c = p_dsMediaAction.m_unk0x9c;
-	this->m_framesPerSecond = p_dsMediaAction.m_framesPerSecond;
-	this->m_mediaFormat = p_dsMediaAction.m_mediaFormat;
-	this->m_paletteManagement = p_dsMediaAction.m_paletteManagement;
-	this->m_sustainTime = p_dsMediaAction.m_sustainTime;
+	m_unk0x9c = p_dsMediaAction.m_unk0x9c;
+	m_framesPerSecond = p_dsMediaAction.m_framesPerSecond;
+	m_mediaFormat = p_dsMediaAction.m_mediaFormat;
+	m_paletteManagement = p_dsMediaAction.m_paletteManagement;
+	m_sustainTime = p_dsMediaAction.m_sustainTime;
+}
+
+// FUNCTION: BETA10 0x1015c959
+MxDSMediaAction::MxDSMediaAction(MxDSMediaAction& p_dsMediaAction) : MxDSAction(p_dsMediaAction)
+{
+	CopyFrom(p_dsMediaAction);
 }
 
 // FUNCTION: LEGO1 0x100c8dc0
+// FUNCTION: BETA10 0x1015c9da
 MxDSMediaAction& MxDSMediaAction::operator=(MxDSMediaAction& p_dsMediaAction)
 {
 	if (this == &p_dsMediaAction) {
@@ -45,11 +54,12 @@ MxDSMediaAction& MxDSMediaAction::operator=(MxDSMediaAction& p_dsMediaAction)
 	}
 
 	MxDSAction::operator=(p_dsMediaAction);
-	this->CopyFrom(p_dsMediaAction);
+	CopyFrom(p_dsMediaAction);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100c8df0
+// FUNCTION: BETA10 0x1015ca21
 MxDSAction* MxDSMediaAction::Clone()
 {
 	MxDSMediaAction* clone = new MxDSMediaAction();
@@ -62,58 +72,73 @@ MxDSAction* MxDSMediaAction::Clone()
 }
 
 // FUNCTION: LEGO1 0x100c8e80
+// FUNCTION: BETA10 0x1015cacb
 void MxDSMediaAction::CopyMediaSrcPath(const char* p_mediaSrcPath)
 {
-	if (this->m_mediaSrcPath == p_mediaSrcPath) {
+	if (m_mediaSrcPath == p_mediaSrcPath) {
 		return;
 	}
 
-	delete[] this->m_mediaSrcPath;
+	delete[] m_mediaSrcPath;
 
 	if (p_mediaSrcPath) {
-		this->m_mediaSrcPath = new char[strlen(p_mediaSrcPath) + 1];
-		if (this->m_mediaSrcPath) {
-			strcpy(this->m_mediaSrcPath, p_mediaSrcPath);
+		m_mediaSrcPath = new char[strlen(p_mediaSrcPath) + 1];
+		if (m_mediaSrcPath) {
+			strcpy(m_mediaSrcPath, p_mediaSrcPath);
 		}
 	}
 	else {
-		this->m_mediaSrcPath = NULL;
+		m_mediaSrcPath = NULL;
 	}
 }
 
 // FUNCTION: LEGO1 0x100c8f00
+// FUNCTION: BETA10 0x1015cbf5
 undefined4 MxDSMediaAction::VTable0x14()
 {
 	return MxDSAction::VTable0x14();
 }
 
 // FUNCTION: LEGO1 0x100c8f10
+// FUNCTION: BETA10 0x1015cc13
 MxU32 MxDSMediaAction::GetSizeOnDisk()
 {
 	MxU32 totalSizeOnDisk = MxDSAction::GetSizeOnDisk();
 
-	if (this->m_mediaSrcPath) {
-		totalSizeOnDisk += strlen(this->m_mediaSrcPath) + 1;
+	if (m_mediaSrcPath) {
+		totalSizeOnDisk += strlen(m_mediaSrcPath) + 1;
 	}
 	else {
 		totalSizeOnDisk++;
 	}
 
-	totalSizeOnDisk += 24;
-	this->m_sizeOnDisk = totalSizeOnDisk - MxDSAction::GetSizeOnDisk();
+	totalSizeOnDisk += sizeof(m_unk0x9c.m_unk0x00);
+	totalSizeOnDisk += sizeof(m_unk0x9c.m_unk0x04);
+	totalSizeOnDisk += sizeof(m_framesPerSecond);
+	totalSizeOnDisk += sizeof(m_mediaFormat);
+	totalSizeOnDisk += sizeof(m_paletteManagement);
+	totalSizeOnDisk += sizeof(m_sustainTime);
+
+	m_sizeOnDisk = totalSizeOnDisk - MxDSAction::GetSizeOnDisk();
 	return totalSizeOnDisk;
 }
 
 // FUNCTION: LEGO1 0x100c8f60
+// FUNCTION: BETA10 0x1015cc93
 void MxDSMediaAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSAction::Deserialize(p_source, p_unk0x24);
 
-	GetString(p_source, this->m_mediaSrcPath, this, &MxDSMediaAction::CopyMediaSrcPath);
-	GetScalar(p_source, this->m_unk0x9c.m_unk0x00);
-	GetScalar(p_source, this->m_unk0x9c.m_unk0x04);
-	GetScalar(p_source, this->m_framesPerSecond);
-	GetScalar(p_source, this->m_mediaFormat);
-	GetScalar(p_source, this->m_paletteManagement);
-	GetScalar(p_source, this->m_sustainTime);
+	CopyMediaSrcPath((char*) p_source);
+	p_source += strlen(m_mediaSrcPath) + 1;
+
+	// clang-format off
+	m_unk0x9c.SetUnk0x00(*(MxU32*) p_source);  p_source += sizeof(m_unk0x9c.m_unk0x00);
+	m_unk0x9c.SetUnk0x04(*(MxU32*) p_source);  p_source += sizeof(m_unk0x9c.m_unk0x04);
+
+	m_framesPerSecond   = *(MxS32*) p_source;  p_source += sizeof(m_framesPerSecond);
+	m_mediaFormat       = *(MxS32*) p_source;  p_source += sizeof(m_mediaFormat);
+	m_paletteManagement = *(MxS32*) p_source;  p_source += sizeof(m_paletteManagement);
+	m_sustainTime       = *(MxS32*) p_source;  p_source += sizeof(m_sustainTime);
+	// clang-format on
 }


### PR DESCRIPTION
The drop in `MxDSMediaAction::Deserialize` is compiler noise, confirmed by adding a dummy class right before the function.