### PR TITLE
Tweak MxOmni::Destroy and add more beta annotations

### DIFF
--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -118,9 +118,10 @@ private:
 // _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Insert
 // clang-format on
 
+// clang-format off
 // TEMPLATE: BETA10 0x101237a0
-// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *>
-// >::const_iterator::operator*
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::const_iterator::operator*
+// clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100af6d0

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -47,7 +47,12 @@ public:
 	MxResult Send(MxCore* p_listener, const MxNotificationParam& p_param);
 
 	inline MxNotificationPtrList* GetQueue() { return m_queue; }
+
+	// FUNCTION: BETA10 0x10132270
 	inline void SetActive(MxBool p_active) { m_active = p_active; }
+
+	// FUNCTION: BETA10 0x10132230
+	inline MxBool IsEmpty() const { return m_queue ? m_queue->empty() : TRUE; }
 
 	// SYNTHETIC: LEGO1 0x100ac390
 	// MxNotificationManager::`scalar deleting destructor'
@@ -85,5 +90,8 @@ private:
 
 // SYNTHETIC: LEGO1 0x100accd0
 // MxNotificationPtrList::~MxNotificationPtrList
+
+// TEMPLATE: BETA10 0x10129670
+// list<MxNotification *,allocator<MxNotification *> >::empty
 
 #endif // MXNOTIFICATIONMANAGER_H

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -59,17 +59,40 @@ public:
 	static MxBool ActionSourceEquals(MxDSAction* p_action, const char* p_name);
 
 	HWND GetWindowHandle() const { return this->m_windowHandle; }
+
+	// FUNCTION: BETA10 0x10125100
 	MxObjectFactory* GetObjectFactory() const { return this->m_objectFactory; }
+
+	// FUNCTION: BETA10 0x10125120
 	MxNotificationManager* GetNotificationManager() const { return this->m_notificationManager; }
+
+	// FUNCTION: BETA10 0x10125140
 	MxTickleManager* GetTickleManager() const { return this->m_tickleManager; }
+
+	// FUNCTION: BETA10 0x10125160
 	MxTimer* GetTimer() const { return this->m_timer; }
+
+	// FUNCTION: BETA10 0x101251a0
 	MxStreamer* GetStreamer() const { return this->m_streamer; }
+
+	// FUNCTION: BETA10 0x100e5250
 	MxSoundManager* GetSoundManager() const { return this->m_soundManager; }
+
+	// FUNCTION: BETA10 0x1009e860
 	MxVideoManager* GetVideoManager() const { return this->m_videoManager; }
+
+	// FUNCTION: BETA10 0x101251c0
 	MxVariableTable* GetVariableTable() const { return this->m_variableTable; }
+
+	// FUNCTION: BETA10 0x101251e0
 	MxMusicManager* GetMusicManager() const { return this->m_musicManager; }
+
+	// FUNCTION: BETA10 0x10125200
 	MxEventManager* GetEventManager() const { return this->m_eventManager; }
+
+	// FUNCTION: BETA10 0x10125180
 	MxAtomSet* GetAtomSet() const { return this->m_atomSet; }
+
 	MxLong HandleEndAction(MxParam& p_param);
 
 	// SYNTHETIC: LEGO1 0x100aefd0

--- a/LEGO1/omni/src/common/mxmisc.cpp
+++ b/LEGO1/omni/src/common/mxmisc.cpp
@@ -5,26 +5,34 @@
 #include <assert.h>
 
 // FUNCTION: LEGO1 0x100acea0
+// FUNCTION: BETA10 0x10124d30
 MxObjectFactory* ObjectFactory()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetObjectFactory();
 }
 
 // FUNCTION: LEGO1 0x100aceb0
+// FUNCTION: BETA10 0x10124d77
 MxNotificationManager* NotificationManager()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetNotificationManager();
 }
 
 // FUNCTION: LEGO1 0x100acec0
+// FUNCTION: BETA10 0x10124dbe
 MxTickleManager* TickleManager()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetTickleManager();
 }
 
 // FUNCTION: LEGO1 0x100aced0
+// FUNCTION: BETA10 0x10124e05
 MxTimer* Timer()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetTimer();
 }
 
@@ -37,49 +45,65 @@ MxAtomSet* AtomSet()
 }
 
 // FUNCTION: LEGO1 0x100acef0
+// FUNCTION: BETA10 0x10124e93
 MxStreamer* Streamer()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetStreamer();
 }
 
 // FUNCTION: LEGO1 0x100acf00
+// FUNCTION: BETA10 0x10124eda
 MxSoundManager* MSoundManager()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetSoundManager();
 }
 
 // FUNCTION: LEGO1 0x100acf10
+// FUNCTION: BETA10 0x10124f21
 MxVideoManager* MVideoManager()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetVideoManager();
 }
 
 // FUNCTION: LEGO1 0x100acf20
+// FUNCTION: BETA10 0x10124f68
 MxVariableTable* VariableTable()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetVariableTable();
 }
 
 // FUNCTION: LEGO1 0x100acf30
+// FUNCTION: BETA10 0x10124faf
 MxMusicManager* MusicManager()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetMusicManager();
 }
 
 // FUNCTION: LEGO1 0x100acf40
+// FUNCTION: BETA10 0x10124ff6
 MxEventManager* EventManager()
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->GetEventManager();
 }
 
 // FUNCTION: LEGO1 0x100acf50
+// FUNCTION: BETA10 0x1012503d
 MxResult Start(MxDSAction* p_dsAction)
 {
+	assert(MxOmni::GetInstance());
 	return MxOmni::GetInstance()->Start(p_dsAction);
 }
 
 // FUNCTION: LEGO1 0x100acf70
+// FUNCTION: BETA10 0x10125098
 void DeleteObject(MxDSAction& p_dsAction)
 {
+	assert(MxOmni::GetInstance());
 	MxOmni::GetInstance()->DeleteObject(p_dsAction);
 }

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -188,12 +188,8 @@ void MxOmni::Destroy()
 		DeleteObject(action);
 	}
 
-	// TODO: private members
 	if (m_notificationManager) {
-		while (m_notificationManager->GetQueue()) {
-			if (m_notificationManager->GetQueue()->size() == 0) {
-				break;
-			}
+		while (!m_notificationManager->IsEmpty()) {
 			m_notificationManager->Tickle();
 		}
 
@@ -211,7 +207,6 @@ void MxOmni::Destroy()
 	delete m_notificationManager;
 	delete m_tickleManager;
 
-	// There could be a tree/iterator function that does this inline
 	if (m_atomSet) {
 		while (m_atomSet->size() != 0) {
 			// Pop each node and delete its value
@@ -220,8 +215,10 @@ void MxOmni::Destroy()
 			m_atomSet->erase(begin);
 			delete value;
 		}
+
 		delete m_atomSet;
 	}
+
 	Init();
 }
 

--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -26,6 +26,7 @@ MxNotification::~MxNotification()
 }
 
 // FUNCTION: LEGO1 0x100ac250
+// FUNCTION: BETA10 0x10125805
 MxNotificationManager::MxNotificationManager() : MxCore(), m_lock(), m_listenerIds()
 {
 	m_unk0x2c = 0;


### PR DESCRIPTION
The only real change here is the addition of a utility function `IsEmpty()` on the `MxNotificationManager` list. Still 100% match on `MxOmni::Destroy`.

The function differs in the beta for these reasons:
- Used `AUTOLOCK(m_criticalSection)`. It is typical for the beta to call this more often
- No isolate scope on the `MxDSAction` object, but retail doesn't match without it
- `m_notificationManager->SetActive(FALSE)` called earlier
- Deletes on members are wrapped in if statements that get optimized away in retail
- `m_tickleManager` calls `UnregisterClient()` on `m_notificationManager` before getting deleted
- `m_notificationManager` set to null after delete

Most of these are incompatible with retail so I left them out. Adding the remaining asserts to `MxMisc` did not create any diffs.