### PR TITLE
Beta addrs for ViewLODList

### DIFF
--- a/LEGO1/realtime/lodlist.h
+++ b/LEGO1/realtime/lodlist.h
@@ -20,6 +20,7 @@ class LODObject;
 //
 
 // VTABLE: LEGO1 0x100dbdc8
+// VTABLE: BETA10 0x101c3500
 // SIZE 0x10
 class LODListBase {
 protected:
@@ -39,6 +40,7 @@ public:
 	size_t Capacity() const;
 
 	// SYNTHETIC: LEGO1 0x100a77b0
+	// SYNTHETIC: BETA10 0x1017b410
 	// LODListBase::`scalar deleting destructor'
 
 #ifdef _DEBUG
@@ -76,6 +78,7 @@ public:
 //
 // LODListBase implementation
 
+// FUNCTION: BETA10 0x1017b390
 inline LODListBase::LODListBase(size_t capacity)
 	: m_capacity(capacity), m_size(0), m_ppLODObject(new const LODObject*[capacity])
 {
@@ -88,6 +91,8 @@ inline LODListBase::LODListBase(size_t capacity)
 #endif
 }
 
+// FUNCTION: LEGO1 0x100a77e0
+// FUNCTION: BETA10 0x1017b450
 inline LODListBase::~LODListBase()
 {
 	// all LODObject* should have been popped by client
@@ -96,16 +101,19 @@ inline LODListBase::~LODListBase()
 	delete[] m_ppLODObject;
 }
 
+// FUNCTION: BETA10 0x1005c480
 inline size_t LODListBase::Size() const
 {
 	return m_size;
 }
 
+// FUNCTION: BETA10 0x10178b40
 inline size_t LODListBase::Capacity() const
 {
 	return m_capacity;
 }
 
+// FUNCTION: BETA10 0x1007b6a0
 inline const LODObject* LODListBase::operator[](int i) const
 {
 	assert((0 <= i) && (i < (int) m_size));
@@ -113,6 +121,7 @@ inline const LODObject* LODListBase::operator[](int i) const
 	return m_ppLODObject[i];
 }
 
+// FUNCTION: BETA10 0x1007bb40
 inline const LODObject* LODListBase::PushBack(const LODObject* pLOD)
 {
 	assert(m_size < m_capacity);
@@ -121,6 +130,7 @@ inline const LODObject* LODListBase::PushBack(const LODObject* pLOD)
 	return pLOD;
 }
 
+// FUNCTION: BETA10 0x10178b60
 inline const LODObject* LODListBase::PopBack()
 {
 	const LODObject* pLOD;
@@ -137,6 +147,7 @@ inline const LODObject* LODListBase::PopBack()
 }
 
 #ifdef _DEBUG
+// FUNCTION: BETA10 0x1017b4c0
 inline void LODListBase::Dump(void (*pTracer)(const char*, ...)) const
 {
 	int i;
@@ -181,10 +192,25 @@ inline const T* LODList<T>::PopBack()
 }
 
 // VTABLE: LEGO1 0x100dbdc0
+// VTABLE: BETA10 0x101c34f8
 // class LODList<ViewLOD>
 
 // SYNTHETIC: LEGO1 0x100a7740
+// SYNTHETIC: BETA10 0x1017b350
 // LODList<ViewLOD>::`scalar deleting destructor'
+
+// TEMPLATE: BETA10 0x10178b20
+// LODList<ViewLOD>::PopBack
+
+// TEMPLATE: BETA10 0x1017b2d0
+// LODList<ViewLOD>::LODList<ViewLOD>
+
+// TEMPLATE: LEGO1 0x100a8160
+// TEMPLATE: BETA10 0x1017b5d0
+// LODList<ViewLOD>::~LODList<ViewLOD>
+
+// TEMPLATE: BETA10 0x1007bae0
+// LODList<ViewLOD>::operator[]
 
 // re-enable: identifier was truncated to '255' characters in the debug information
 #pragma warning(default : 4786)

--- a/LEGO1/viewmanager/viewlodlist.cpp
+++ b/LEGO1/viewmanager/viewlodlist.cpp
@@ -125,7 +125,7 @@ ViewLODList* ViewLODListManager::Lookup(const ROIName& p_roiName) const
 
 // FUNCTION: LEGO1 0x100a7680
 // FUNCTION: BETA10 0x1017886b
-char ViewLODListManager::Destroy(ViewLODList* lodList)
+unsigned char ViewLODListManager::Destroy(ViewLODList* lodList)
 {
 	ViewLODListMap::iterator iterator;
 	char deleted = FALSE;

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -92,7 +92,7 @@ public:
 	// returned LODList's refCount is increased, i.e. caller must call Release()
 	// when it no longer holds on to the list
 	ViewLODList* Lookup(const ROIName&) const;
-	char Destroy(ViewLODList* lodList);
+	unsigned char Destroy(ViewLODList* lodList);
 
 #ifdef _DEBUG
 	void Dump(void (*pTracer)(const char*, ...)) const;

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -23,6 +23,7 @@ class ViewLODListManager;
 //
 
 // VTABLE: LEGO1 0x100dbdc4
+// VTABLE: BETA10 0x101c34f0
 // SIZE 0x18
 class ViewLODList : public LODList<ViewLOD> {
 	friend ViewLODListManager;
@@ -32,6 +33,7 @@ protected:
 	~ViewLODList() override;
 
 	// SYNTHETIC: LEGO1 0x100a80f0
+	// SYNTHETIC: BETA10 0x1017b590
 	// ViewLODList::`scalar deleting destructor'
 
 public:
@@ -53,6 +55,7 @@ private:
 // ??? for now, until we have symbol management
 typedef const char* ROIName;
 struct ROINameComparator {
+	// FUNCTION: BETA10 0x101794c0
 	unsigned char operator()(const ROIName& rName1, const ROIName& rName2) const
 	{
 		return strcmp((const char*) rName1, (const char*) rName2) > 0;
@@ -68,6 +71,7 @@ struct ROINameComparator {
 // the ViewLODList belongs.
 
 // VTABLE: LEGO1 0x100dbdbc
+// VTABLE: BETA10 0x101c34ec
 // SIZE 0x14
 class ViewLODListManager {
 
@@ -88,28 +92,30 @@ public:
 	// returned LODList's refCount is increased, i.e. caller must call Release()
 	// when it no longer holds on to the list
 	ViewLODList* Lookup(const ROIName&) const;
-	void Destroy(ViewLODList* lodList);
+	char Destroy(ViewLODList* lodList);
 
 #ifdef _DEBUG
 	void Dump(void (*pTracer)(const char*, ...)) const;
 #endif
 
 	// SYNTHETIC: LEGO1 0x100a70c0
+	// SYNTHETIC: BETA10 0x10178a80
 	// ViewLODListManager::`scalar deleting destructor'
 
 private:
+	static int g_ROINameUID;
+
 	ViewLODListMap m_map;
 };
 
 // clang-format off
 // FUNCTION: LEGO1 0x1001dde0
+// FUNCTION: BETA10 0x100223c0
 // _Lockit::~_Lockit
 
 // TEMPLATE: LEGO1 0x100a70e0
+// TEMPLATE: BETA10 0x10178ac0
 // Map<char const *,ViewLODList *,ROINameComparator>::~Map<char const *,ViewLODList *,ROINameComparator>
-
-// TEMPLATE: LEGO1 0x100a77e0
-// LODListBase::~LODListBase
 
 // TEMPLATE: LEGO1 0x100a7800
 // _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::iterator::_Dec
@@ -121,28 +127,76 @@ private:
 // _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::~_Tree<char const *,pair<char const * const,ViewLODList *>,map<char c
 
 // TEMPLATE: LEGO1 0x100a7960
+// TEMPLATE: BETA10 0x1017ab40
 // _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::erase
 
 // TEMPLATE: LEGO1 0x100a7db0
+// TEMPLATE: BETA10 0x1017aca0
 // _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::_Erase
 
 // TEMPLATE: LEGO1 0x100a7df0
+// TEMPLATE: BETA10 0x101796b0
 // _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::_Insert
 
 // TEMPLATE: LEGO1 0x100a80a0
+// TEMPLATE: BETA10 0x1017b1e0
 // map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::~map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >
 
-// TEMPLATE: LEGO1 0x100a8160
-// LODList<ViewLOD>::~LODList<ViewLOD>
-
 // GLOBAL: LEGO1 0x10101068
+// GLOBAL: BETA10 0x10205eb4
 // _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::_Nil
+
+// TEMPLATE: BETA10 0x101791f0
+// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::operator[]
+
+// TEMPLATE: BETA10 0x10178c80
+// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::iterator::operator==
+
+// TEMPLATE: BETA10 0x10178ef0
+// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::begin
+
+// TEMPLATE: BETA10 0x10179070
+// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::end
+
+// TEMPLATE: BETA10 0x10179250
+// pair<char const * const,ViewLODList *>::pair<char const * const,ViewLODList *>
+
+// TEMPLATE: BETA10 0x10179280
+// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::insert
+
+// TEMPLATE: BETA10 0x101792c0
+// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::insert
+
+// TEMPLATE: BETA10 0x10178c00
+// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::iterator::operator*
+
+// TEMPLATE: BETA10 0x1017ab10
+// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
+// Two iterators
+
+// TEMPLATE: BETA10 0x1017a040
+// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
+// One iterator
+
+// TEMPLATE: BETA10 0x10178f80
+// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::_Lmost
+
+// TEMPLATE: BETA10 0x10179e70
+// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::_Rmost
+
+// TEMPLATE: BETA10 0x10179670
+// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::_Color
+
+// TEMPLATE: BETA10 0x1017aa30
+// ?swap@@YAXAAW4_Redbl@?$_Tree@PBDU?$pair@QBDPAVViewLODList@@@@U_Kfn@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@0@Z
+
 // clang-format on
 
 //////////////////////////////////////////////////////////////////////////////
 //
 // ViewLODList implementation
 
+// FUNCTION: BETA10 0x1017b240
 inline ViewLODList::ViewLODList(size_t capacity, ViewLODListManager* owner) : LODList<ViewLOD>(capacity), m_refCount(0)
 {
 	m_owner = owner;
@@ -153,25 +207,22 @@ inline ViewLODList::~ViewLODList()
 	assert(m_refCount == 0);
 }
 
+// FUNCTION: BETA10 0x1007b5b0
 inline int ViewLODList::AddRef()
 {
 	return ++m_refCount;
 }
 
+// FUNCTION: BETA10 0x1007ad70
 inline int ViewLODList::Release()
 {
 	assert(m_refCount > 0);
 	if (!--m_refCount) {
 		m_owner->Destroy(this);
+		return 0;
 	}
+
 	return m_refCount;
 }
-
-#ifdef _DEBUG
-inline void ViewLODList::Dump(void (*pTracer)(const char*, ...)) const
-{
-	// FIXME: dump something
-}
-#endif
 
 #endif // VIEWLODLIST_H


### PR DESCRIPTION
Implemented `ViewLODListManager::Destroy`. It would return an `MxBool` if we used the Mx types here, so I have it as `char`.

I moved global `g_unk0x10101064` to a static member `ViewLODListManager::g_ROINameUID`. It is only ever incremented and only in `ViewLODListManager::Create` so it just seems to be a unique id for the ROI name.

There are a few _alpha_ addresses here along with the usual beta ones. The reason is to verify which asserts should be there.

The STL function `erase()` on the map of `ViewLODList` is called two different ways; one with a single iterator and one with two (i.e. start, end). The problem is that both functions have the name `map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase` in the PDB output. There is no mangled symbol name to use that would distinguish the two, so we just match whatever one comes first (in recomp). The first one to be matched is removed from consideration when we try to match the second one, which is why this works at all. You could argue that we don't actually need all these functions to be marked, especially for the beta.

`ViewLODList::Dump` is not the usual case of dead code because this is a virtual method. But it is implemented nonetheless. I moved it out of the header file so we would not have to import `viewlod.h` over there. The spacing of the assert line numbers does kinda support the fact that something about this size belongs in the .cpp file.