### PR TITLE
Parser bugfix: vtable namespace

### DIFF
--- a/tools/isledecomp/tests/test_parser.py
+++ b/tools/isledecomp/tests/test_parser.py
@@ -756,3 +756,18 @@ def test_virtual_inheritance(parser):
     assert parser.vtables[1].base_class == "Greetings"
     assert parser.vtables[2].base_class == "Howdy"
     assert all(v.name == "HiThere" for v in parser.vtables)
+
+
+def test_namespace_in_comment(parser):
+    parser.read_lines(
+        [
+            "// VTABLE: HELLO 0x1234",
+            "// class Tgl::Object",
+            "// VTABLE: HELLO 0x5555",
+            "// class TglImpl::RendererImpl<D3DRMImpl::D3DRM>",
+        ]
+    )
+
+    assert len(parser.vtables) == 2
+    assert parser.vtables[0].name == "Tgl::Object"
+    assert parser.vtables[1].name == "TglImpl::RendererImpl<D3DRMImpl::D3DRM>"

--- a/tools/isledecomp/tests/test_parser_util.py
+++ b/tools/isledecomp/tests/test_parser_util.py
@@ -126,6 +126,7 @@ class_name_match_cases = [
     ("// class MxList<LegoPathController* >", "MxList<LegoPathController *>"),
     # I don't know if this would ever come up, but sure, why not?
     ("// class MxList<LegoPathController**>", "MxList<LegoPathController **>"),
+    ("// class Many::Name::Spaces", "Many::Name::Spaces"),
 ]
 
 


### PR DESCRIPTION
Bug fix for the parser. We were not reading namespaces properly for vtables defined in a comment annotation. For example:

```cpp
// VTABLE: BETA10 0x101c3148
// class Tgl::Object

// VTABLE: BETA10 0x101c30d8
// class TglImpl::RendererImpl<D3DRMImpl::D3DRM>
```

These had been coming back as just `Tgl` and `TglImpl`.