### PR TITLE
Match LegoOmni::Destroy and related

### DIFF
--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -49,6 +49,7 @@ typedef map<char*, LegoCharacter*, LegoCharacterComparator> LegoCharacterMap;
 class LegoCharacterManager {
 public:
 	LegoCharacterManager();
+	~LegoCharacterManager();
 
 	MxResult Write(LegoStorage* p_storage);
 	MxResult Read(LegoStorage* p_storage);

--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -103,7 +103,9 @@ public:
 	LegoPathBoundary* GetPathBoundary(const char* p_name);
 	void Enable(MxBool p_enable);
 	void FUN_10046bb0(LegoWorld* p_world);
+
 	static MxResult Init();
+	static MxResult Reset();
 
 private:
 	void FUN_10046970();

--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -52,6 +52,26 @@ LegoCharacterManager::LegoCharacterManager()
 	VariableTable()->SetVariable(m_customizeAnimFile);
 }
 
+// FUNCTION: LEGO1 0x10083180
+// FUNCTION: BETA10 0x10073dad
+LegoCharacterManager::~LegoCharacterManager()
+{
+	LegoCharacter* character = NULL;
+	LegoCharacterMap::iterator it;
+
+	for (it = m_characters->begin(); it != m_characters->end(); it++) {
+		character = (*it).second;
+
+		RemoveROI(character->m_roi);
+
+		delete[] (*it).first;
+		delete (*it).second;
+	}
+
+	delete m_characters;
+	delete[] g_customizeAnimFile;
+}
+
 // FUNCTION: LEGO1 0x10083270
 void LegoCharacterManager::Init()
 {

--- a/LEGO1/lego/legoomni/src/main/legomain.cpp
+++ b/LEGO1/lego/legoomni/src/main/legomain.cpp
@@ -114,6 +114,7 @@ void LegoOmni::Destroy()
 	}
 
 	if (m_textureContainer) {
+		m_textureContainer->Clear();
 		delete m_textureContainer;
 		m_textureContainer = NULL;
 	}
@@ -128,16 +129,10 @@ void LegoOmni::Destroy()
 		m_inputManager = NULL;
 	}
 
-	if (m_inputManager) {
-		delete m_inputManager;
-		m_inputManager = NULL;
-	}
-
-	// todo FUN_10046de0
+	LegoPathController::Reset();
 
 	if (m_bkgAudioManager) {
 		m_bkgAudioManager->Stop();
-
 		delete m_bkgAudioManager;
 		m_bkgAudioManager = NULL;
 	}
@@ -150,7 +145,9 @@ void LegoOmni::Destroy()
 	m_action.ClearAtom();
 	DestroyScripts();
 
-	delete[] m_scripts;
+	if (m_scripts) {
+		delete[] m_scripts;
+	}
 
 	MxOmni::Destroy();
 }

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -428,6 +428,25 @@ MxResult LegoPathController::Init()
 	return SUCCESS;
 }
 
+// FUNCTION: LEGO1 0x10046de0
+// FUNCTION: BETA10 0x100b779e
+MxResult LegoPathController::Reset()
+{
+	if (g_ctrlBoundariesA == NULL || g_ctrlEdgesA == NULL) {
+		return FAILURE;
+	}
+
+	delete[] g_ctrlBoundariesA;
+	delete[] g_ctrlEdgesA;
+	delete[] g_ctrlBoundariesB;
+	delete[] g_ctrlEdgesB;
+	g_ctrlBoundariesA = NULL;
+	g_ctrlEdgesA = NULL;
+	g_ctrlBoundariesB = NULL;
+	g_ctrlEdgesB = NULL;
+	return SUCCESS;
+}
+
 // FUNCTION: LEGO1 0x10046e50
 // FUNCTION: BETA10 0x100b781f
 MxResult LegoPathController::Read(LegoStorage* p_storage)

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -45,6 +45,17 @@ public:
 		}
 	}
 
+	void Clear()
+	{
+#ifdef COMPAT_MODE
+		for (typename LegoContainerInfo<T>::iterator it = m_map.begin(); it != m_map.end(); it++) {
+#else
+		for (LegoContainerInfo<T>::iterator it = m_map.begin(); it != m_map.end(); it++) {
+#endif
+			delete (*it).second;
+		}
+	}
+
 	// FUNCTION: BETA10 0x1007bc00
 	inline T* Get(const char* p_name)
 	{

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -48,10 +48,11 @@ public:
 	void Clear()
 	{
 #ifdef COMPAT_MODE
-		for (typename LegoContainerInfo<T>::iterator it = m_map.begin(); it != m_map.end(); it++) {
+		for (typename LegoContainerInfo<T>::iterator it = m_map.begin(); it != m_map.end(); it++)
 #else
-		for (LegoContainerInfo<T>::iterator it = m_map.begin(); it != m_map.end(); it++) {
+		for (LegoContainerInfo<T>::iterator it = m_map.begin(); it != m_map.end(); it++)
 #endif
+		{
 			delete (*it).second;
 		}
 	}

--- a/tools/decomplint/decomplint.py
+++ b/tools/decomplint/decomplint.py
@@ -81,6 +81,7 @@ def process_files(files, module=None):
 def main():
     args = parse_args()
 
+    files_to_check = []
     if os.path.isdir(args.target):
         files_to_check = list(walk_source_dir(args.target))
     elif os.path.isfile(args.target) and is_file_cpp(args.target):


### PR DESCRIPTION
100% matches

@disinvite I think the decomp parser might have an issue with macros that could create situations with mismatching braces (since the macro probably isn't evaluated) which leads to some annotations not being picked up. I've fixed it like this for now by keeping the braces out of the macro:

https://github.com/isledecomp/isle/pull/917/commits/8ad98d12a8e720270722848a3236493012129c91

You can reproduce the issue by reverting that commit and you will notice that for example `0x100d86d4` is not being recognized anymore (but also a bunch of others). Maybe it's possible to get a warning/error in case braces aren't matching in a file? I think there might be other places in the code base where this can occur and we might not notice right now.