### PR TITLE
Match LegoUnknown::FUN_1009a1e0

### DIFF
--- a/LEGO1/lego/sources/misc/legounknown.cpp
+++ b/LEGO1/lego/sources/misc/legounknown.cpp
@@ -42,9 +42,9 @@ LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, L
 	}
 	else if (p_f1 >= 0.999) {
 		v1 = m_unk0x00[0];
-		((Vector3&) v2).Add(&m_unk0x00[1]);
-		((Vector3&) v3).Add(&m_unk0x00[2]);
-		((Vector3&) v4).Add(&m_unk0x00[3]);
+		((Vector3&) v1).Add(&m_unk0x00[1]);
+		((Vector3&) v1).Add(&m_unk0x00[2]);
+		((Vector3&) v1).Add(&m_unk0x00[3]);
 
 		for (LegoS32 i = 0; i < 3; i++) {
 			v4[i] = m_unk0x00[1][i] + m_unk0x00[2][i] * 2.0f + m_unk0x00[3][i] * 3.0f;


### PR DESCRIPTION
100% match but it doesn't resolve the float offset atm (@disinvite)

Autonomous navigation of extra actors now works

https://github.com/isledecomp/isle/assets/1135351/5c0e9b08-4fe0-431a-80a4-d25472122c60

