### PR TITLE
Fix missing float constants

### DIFF
--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -103,6 +103,11 @@ class Compare:
         res = CvdumpAnalysis(cv)
 
         for sym in res.nodes:
+            # Skip nodes where we have almost no information.
+            # These probably came from SECTION CONTRIBUTIONS.
+            if sym.name() is None and sym.node_type is None:
+                continue
+
             # The PDB might contain sections that do not line up with the
             # actual binary. The symbol "__except_list" is one example.
             # In these cases, just skip this symbol and move on because


### PR DESCRIPTION
Fix for the bug @foxtacles noticed in #957.

Starting with #868, we build the list of floating point constants in `.rdata` by checking floating point instructions found via the relocation table. This works fine in most cases, but the constants do not always appear in the recomp asm. When this happens, we did not add the constant to the database of recomp addresses because something was already there in its place.

That something is a dummy entry from the `SECTION CONTRIBUTIONS` output from `cvdump`. This listing is not all that useful; multiple items/symbols can be lumped together as a single "contribution", so it is not even a precise reference for where things are and how big they are. We mainly use it as a lower bound on the size of a symbol that we have found elsewhere in the pdb.

The solution (for now) is to just skip adding a cvdump reference to the db if it has no symbol name or other information. This clears the way for adding all the float constants.