### PR TITLE
Refactor MxBitmap (again)

### DIFF
--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -111,12 +111,8 @@ public:
 	inline MxBITMAPINFO* GetBitmapInfo() const { return m_info; }
 
 	// FUNCTION: BETA10 0x100982b0
-	inline MxLong GetDataSize() const
-	{
-		MxLong absHeight = GetBmiHeightAbs();
-		MxLong alignedWidth = AlignToFourByte(m_bmiHeader->biWidth);
-		return alignedWidth * absHeight;
-	}
+	inline MxLong GetDataSize() const { return AlignToFourByte(m_bmiHeader->biWidth) * GetBmiHeightAbs(); }
+
 	inline MxLong GetAdjustedStride()
 	{
 		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN || m_bmiHeader->biHeight < 0) {
@@ -157,6 +153,9 @@ public:
 	// MxBitmap::`scalar deleting destructor'
 
 private:
+	// FUNCTION: BETA10 0x1013dd10
+	inline MxLong MxBitmapInfoSize() const { return sizeof(MxBITMAPINFO); }
+
 	// FUNCTION: BETA10 0x1013dd30
 	inline MxBool IsBottomUp()
 	{

--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -87,11 +87,12 @@ public:
 	// FUNCTION: BETA10 0x1002c510
 	inline MxLong AlignToFourByte(MxLong p_value) const { return (p_value + 3) & -4; }
 
-	// Same as the one from legoutils.h, but flipped the other way
-	// TODO: While it's not outside the realm of possibility that they
-	// reimplemented Abs for only this file, that seems odd, right?
+	// DECOMP: This could be a free function. It is static here because it has no
+	// reference to "this". In the beta it is called in two places:
+	// 1. GetBmiHeightAbs
+	// 2. at 0x101523b9, in reference to BITMAPINFOHEADER.biHeight
 	// FUNCTION: BETA10 0x1002c690
-	inline MxLong AbsFlipped(MxLong p_value) const { return p_value > 0 ? p_value : -p_value; }
+	static MxLong HeightAbs(MxLong p_value) { return p_value > 0 ? p_value : -p_value; }
 
 	inline BITMAPINFOHEADER* GetBmiHeader() const { return m_bmiHeader; }
 
@@ -101,7 +102,7 @@ public:
 	inline MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
 
 	// FUNCTION: BETA10 0x1002c470
-	inline MxLong GetBmiHeightAbs() const { return AbsFlipped(m_bmiHeader->biHeight); }
+	inline MxLong GetBmiHeightAbs() const { return HeightAbs(m_bmiHeader->biHeight); }
 
 	// FUNCTION: BETA10 0x10083900
 	inline MxU8* GetImage() const { return m_data; }
@@ -156,6 +157,17 @@ public:
 	// MxBitmap::`scalar deleting destructor'
 
 private:
+	// FUNCTION: BETA10 0x1013dd30
+	inline MxBool IsBottomUp()
+	{
+		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN) {
+			return FALSE;
+		}
+		else {
+			return m_bmiHeader->biHeight > 0;
+		}
+	}
+
 	MxResult ImportColorsToPalette(RGBQUAD*, MxPalette*);
 
 	MxBITMAPINFO* m_info;          // 0x08

--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -34,6 +34,7 @@ struct MxBITMAPINFO {
 
 // SIZE 0x20
 // VTABLE: LEGO1 0x100dc7b0
+// VTABLE: BETA10 0x101c21f8
 class MxBitmap : public MxCore {
 public:
 	MxBitmap();
@@ -46,6 +47,7 @@ public:
 	virtual MxLong Read(const char* p_filename);                                           // vtable+24
 
 	// FUNCTION: LEGO1 0x1004e0d0
+	// FUNCTION: BETA10 0x10060fc0
 	virtual int VTable0x28(int) { return -1; } // vtable+28
 
 	virtual void BitBlt(
@@ -82,20 +84,32 @@ public:
 	// Bit mask trick to round up to the nearest multiple of four.
 	// Pixel data may be stored with padding.
 	// https://learn.microsoft.com/en-us/windows/win32/medfound/image-stride
+	// FUNCTION: BETA10 0x1002c510
 	inline MxLong AlignToFourByte(MxLong p_value) const { return (p_value + 3) & -4; }
 
 	// Same as the one from legoutils.h, but flipped the other way
 	// TODO: While it's not outside the realm of possibility that they
 	// reimplemented Abs for only this file, that seems odd, right?
+	// FUNCTION: BETA10 0x1002c690
 	inline MxLong AbsFlipped(MxLong p_value) const { return p_value > 0 ? p_value : -p_value; }
 
 	inline BITMAPINFOHEADER* GetBmiHeader() const { return m_bmiHeader; }
+
+	// FUNCTION: BETA10 0x1002c440
 	inline MxLong GetBmiWidth() const { return m_bmiHeader->biWidth; }
 	inline MxLong GetBmiStride() const { return ((m_bmiHeader->biWidth + 3) & -4); }
 	inline MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
+
+	// FUNCTION: BETA10 0x1002c470
 	inline MxLong GetBmiHeightAbs() const { return AbsFlipped(m_bmiHeader->biHeight); }
+
+	// FUNCTION: BETA10 0x10083900
 	inline MxU8* GetImage() const { return m_data; }
+
+	// FUNCTION: BETA10 0x100838d0
 	inline MxBITMAPINFO* GetBitmapInfo() const { return m_info; }
+
+	// FUNCTION: BETA10 0x100982b0
 	inline MxLong GetDataSize() const
 	{
 		MxLong absHeight = GetBmiHeightAbs();
@@ -138,6 +152,7 @@ public:
 	}
 
 	// SYNTHETIC: LEGO1 0x100bc9f0
+	// SYNTHETIC: BETA10 0x1013dcd0
 	// MxBitmap::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/src/video/mxbitmap.cpp
+++ b/LEGO1/omni/src/video/mxbitmap.cpp
@@ -13,24 +13,24 @@ MxU16 g_bitmapSignature = TWOCC('B', 'M');
 // FUNCTION: LEGO1 0x100bc980
 MxBitmap::MxBitmap()
 {
-	this->m_info = NULL;
-	this->m_bmiHeader = NULL;
-	this->m_paletteData = NULL;
-	this->m_data = NULL;
-	this->m_isHighColor = FALSE;
-	this->m_palette = NULL;
+	m_info = NULL;
+	m_bmiHeader = NULL;
+	m_paletteData = NULL;
+	m_data = NULL;
+	m_isHighColor = FALSE;
+	m_palette = NULL;
 }
 
 // FUNCTION: LEGO1 0x100bca10
 MxBitmap::~MxBitmap()
 {
-	if (this->m_info) {
+	if (m_info) {
 		delete m_info;
 	}
-	if (this->m_data) {
+	if (m_data) {
 		delete m_data;
 	}
-	if (this->m_palette) {
+	if (m_palette) {
 		delete m_palette;
 	}
 }
@@ -88,26 +88,26 @@ MxResult MxBitmap::ImportBitmapInfo(MxBITMAPINFO* p_info)
 	MxLong height = p_info->m_bmiHeader.biHeight;
 	MxLong size = AlignToFourByte(width) * height;
 
-	this->m_info = new MxBITMAPINFO;
-	if (this->m_info) {
-		this->m_data = new MxU8[size];
-		if (this->m_data) {
-			memcpy(this->m_info, p_info, sizeof(*this->m_info));
-			this->m_bmiHeader = &this->m_info->m_bmiHeader;
-			this->m_paletteData = this->m_info->m_bmiColors;
+	m_info = new MxBITMAPINFO;
+	if (m_info) {
+		m_data = new MxU8[size];
+		if (m_data) {
+			memcpy(m_info, p_info, sizeof(*m_info));
+			m_bmiHeader = &m_info->m_bmiHeader;
+			m_paletteData = m_info->m_bmiColors;
 			result = SUCCESS;
 		}
 	}
 
 	if (result != SUCCESS) {
-		if (this->m_info) {
-			delete this->m_info;
-			this->m_info = NULL;
+		if (m_info) {
+			delete m_info;
+			m_info = NULL;
 		}
 
-		if (this->m_data) {
-			delete[] this->m_data;
-			this->m_data = NULL;
+		if (m_data) {
+			delete[] m_data;
+			m_data = NULL;
 		}
 	}
 
@@ -119,28 +119,28 @@ MxResult MxBitmap::ImportBitmap(MxBitmap* p_bitmap)
 {
 	MxResult result = FAILURE;
 
-	this->m_info = new MxBITMAPINFO;
-	if (this->m_info) {
-		this->m_data = new MxU8[p_bitmap->GetDataSize()];
-		if (this->m_data) {
-			memcpy(this->m_info, p_bitmap->GetBitmapInfo(), MxBITMAPINFO::Size());
-			memcpy(this->m_data, p_bitmap->GetImage(), p_bitmap->GetDataSize());
+	m_info = new MxBITMAPINFO;
+	if (m_info) {
+		m_data = new MxU8[p_bitmap->GetDataSize()];
+		if (m_data) {
+			memcpy(m_info, p_bitmap->GetBitmapInfo(), MxBITMAPINFO::Size());
+			memcpy(m_data, p_bitmap->GetImage(), p_bitmap->GetDataSize());
 
-			this->m_bmiHeader = &this->m_info->m_bmiHeader;
-			this->m_paletteData = this->m_info->m_bmiColors;
+			m_bmiHeader = &m_info->m_bmiHeader;
+			m_paletteData = m_info->m_bmiColors;
 			result = SUCCESS;
 		}
 	}
 
 	if (result != SUCCESS) {
-		if (this->m_info) {
-			delete this->m_info;
-			this->m_info = NULL;
+		if (m_info) {
+			delete m_info;
+			m_info = NULL;
 		}
 
-		if (this->m_data) {
-			delete this->m_data;
-			this->m_data = NULL;
+		if (m_data) {
+			delete m_data;
+			m_data = NULL;
 		}
 	}
 
@@ -174,21 +174,20 @@ MxResult MxBitmap::LoadFile(HANDLE p_handle)
 
 	BOOL ret = ReadFile(p_handle, &hdr, sizeof(hdr), &bytesRead, NULL);
 	if (ret && (hdr.bfType == g_bitmapSignature)) {
-		this->m_info = new MxBITMAPINFO;
-		if (this->m_info) {
-			ret = ReadFile(p_handle, this->m_info, sizeof(*this->m_info), &bytesRead, NULL);
-			if (ret && (this->m_info->m_bmiHeader.biBitCount == 8)) {
+		m_info = new MxBITMAPINFO;
+		if (m_info) {
+			ret = ReadFile(p_handle, m_info, sizeof(*m_info), &bytesRead, NULL);
+			if (ret && (m_info->m_bmiHeader.biBitCount == 8)) {
 				MxLong size = hdr.bfSize - (sizeof(MxBITMAPINFO) + sizeof(BITMAPFILEHEADER));
-				this->m_data = new MxU8[size];
-				if (this->m_data) {
-					ret = ReadFile(p_handle, this->m_data, size, &bytesRead, NULL);
+				m_data = new MxU8[size];
+				if (m_data) {
+					ret = ReadFile(p_handle, m_data, size, &bytesRead, NULL);
 					if (ret) {
-						this->m_bmiHeader = &this->m_info->m_bmiHeader;
-						this->m_paletteData = this->m_info->m_bmiColors;
-						if (this->m_info->m_bmiHeader.biSizeImage == 0) {
-							MxLong height = AbsFlipped(this->m_info->m_bmiHeader.biHeight);
-							this->m_info->m_bmiHeader.biSizeImage =
-								AlignToFourByte(this->m_info->m_bmiHeader.biWidth) * height;
+						m_bmiHeader = &m_info->m_bmiHeader;
+						m_paletteData = m_info->m_bmiColors;
+						if (m_info->m_bmiHeader.biSizeImage == 0) {
+							MxLong height = AbsFlipped(m_info->m_bmiHeader.biHeight);
+							m_info->m_bmiHeader.biSizeImage = AlignToFourByte(m_info->m_bmiHeader.biWidth) * height;
 						}
 						result = SUCCESS;
 					}
@@ -198,14 +197,14 @@ MxResult MxBitmap::LoadFile(HANDLE p_handle)
 	}
 
 	if (result != SUCCESS) {
-		if (this->m_info) {
-			delete this->m_info;
-			this->m_info = NULL;
+		if (m_info) {
+			delete m_info;
+			m_info = NULL;
 		}
 
-		if (this->m_data) {
-			delete this->m_data;
-			this->m_data = NULL;
+		if (m_data) {
+			delete m_data;
+			m_data = NULL;
 		}
 	}
 
@@ -303,9 +302,9 @@ MxPalette* MxBitmap::CreatePalette()
 	MxBool success = FALSE;
 	MxPalette* palette = NULL;
 
-	switch (this->m_isHighColor) {
+	switch (m_isHighColor) {
 	case FALSE:
-		palette = new MxPalette(this->m_paletteData);
+		palette = new MxPalette(m_paletteData);
 
 		if (!palette) {
 			goto done;
@@ -313,7 +312,7 @@ MxPalette* MxBitmap::CreatePalette()
 
 		break;
 	case TRUE:
-		palette = this->m_palette->Clone();
+		palette = m_palette->Clone();
 
 		if (!palette) {
 			goto done;
@@ -339,16 +338,16 @@ done:
 void MxBitmap::ImportPalette(MxPalette* p_palette)
 {
 	// Odd to use a switch on a boolean, but it matches.
-	switch (this->m_isHighColor) {
+	switch (m_isHighColor) {
 	case FALSE:
-		ImportColorsToPalette(this->m_paletteData, p_palette);
+		ImportColorsToPalette(m_paletteData, p_palette);
 		break;
 
 	case TRUE:
-		if (this->m_palette) {
-			delete this->m_palette;
+		if (m_palette) {
+			delete m_palette;
 		}
-		this->m_palette = p_palette->Clone();
+		m_palette = p_palette->Clone();
 		break;
 	}
 }
@@ -420,8 +419,8 @@ MxResult MxBitmap::StretchBits(
 )
 {
 	// Compression fix?
-	if ((this->m_bmiHeader->biCompression != BI_RGB_TOPDOWN) && (0 < this->m_bmiHeader->biHeight)) {
-		p_ySrc = (this->m_bmiHeader->biHeight - p_destHeight) - p_ySrc;
+	if ((m_bmiHeader->biCompression != BI_RGB_TOPDOWN) && (0 < m_bmiHeader->biHeight)) {
+		p_ySrc = (m_bmiHeader->biHeight - p_destHeight) - p_ySrc;
 	}
 
 	return StretchDIBits(
@@ -434,9 +433,9 @@ MxResult MxBitmap::StretchBits(
 		p_ySrc,
 		p_destWidth,
 		p_destHeight,
-		this->m_data,
-		(BITMAPINFO*) this->m_info,
-		this->m_isHighColor,
+		m_data,
+		(BITMAPINFO*) m_info,
+		m_isHighColor,
 		SRCCOPY
 	);
 }

--- a/LEGO1/omni/src/video/mxbitmap.cpp
+++ b/LEGO1/omni/src/video/mxbitmap.cpp
@@ -194,7 +194,7 @@ MxResult MxBitmap::LoadFile(HANDLE p_handle)
 						m_bmiHeader = &m_info->m_bmiHeader;
 						m_paletteData = m_info->m_bmiColors;
 						if (m_info->m_bmiHeader.biSizeImage == 0) {
-							MxLong height = AbsFlipped(m_info->m_bmiHeader.biHeight);
+							MxLong height = HeightAbs(m_info->m_bmiHeader.biHeight);
 							m_info->m_bmiHeader.biSizeImage = AlignToFourByte(m_info->m_bmiHeader.biWidth) * height;
 						}
 						result = SUCCESS;
@@ -433,8 +433,8 @@ MxResult MxBitmap::StretchBits(
 )
 {
 	// Compression fix?
-	if ((m_bmiHeader->biCompression != BI_RGB_TOPDOWN) && (0 < m_bmiHeader->biHeight)) {
-		p_ySrc = (m_bmiHeader->biHeight - p_destHeight) - p_ySrc;
+	if (IsBottomUp()) {
+		p_ySrc = GetBmiHeightAbs() - p_ySrc - p_destHeight;
 	}
 
 	return StretchDIBits(

--- a/LEGO1/omni/src/video/mxbitmap.cpp
+++ b/LEGO1/omni/src/video/mxbitmap.cpp
@@ -8,9 +8,11 @@ DECOMP_SIZE_ASSERT(MxBitmap, 0x20);
 DECOMP_SIZE_ASSERT(MxBITMAPINFO, 0x428);
 
 // GLOBAL: LEGO1 0x10102184
+// GLOBAL: BETA10 0x10203030
 MxU16 g_bitmapSignature = TWOCC('B', 'M');
 
 // FUNCTION: LEGO1 0x100bc980
+// FUNCTION: BETA10 0x1013cab0
 MxBitmap::MxBitmap()
 {
 	m_info = NULL;
@@ -22,6 +24,7 @@ MxBitmap::MxBitmap()
 }
 
 // FUNCTION: LEGO1 0x100bca10
+// FUNCTION: BETA10 0x1013cb58
 MxBitmap::~MxBitmap()
 {
 	if (m_info) {
@@ -36,6 +39,7 @@ MxBitmap::~MxBitmap()
 }
 
 // FUNCTION: LEGO1 0x100bcaa0
+// FUNCTION: BETA10 0x1013cc47
 MxResult MxBitmap::SetSize(MxS32 p_width, MxS32 p_height, MxPalette* p_palette, MxBool p_isHighColor)
 {
 	MxResult ret = FAILURE;
@@ -81,6 +85,7 @@ MxResult MxBitmap::SetSize(MxS32 p_width, MxS32 p_height, MxPalette* p_palette, 
 }
 
 // FUNCTION: LEGO1 0x100bcba0
+// FUNCTION: BETA10 0x1013ce25
 MxResult MxBitmap::ImportBitmapInfo(MxBITMAPINFO* p_info)
 {
 	MxResult result = FAILURE;
@@ -115,6 +120,7 @@ MxResult MxBitmap::ImportBitmapInfo(MxBITMAPINFO* p_info)
 }
 
 // FUNCTION: LEGO1 0x100bcc40
+// FUNCTION: BETA10 0x1013cf6d
 MxResult MxBitmap::ImportBitmap(MxBitmap* p_bitmap)
 {
 	MxResult result = FAILURE;
@@ -148,6 +154,7 @@ MxResult MxBitmap::ImportBitmap(MxBitmap* p_bitmap)
 }
 
 // FUNCTION: LEGO1 0x100bcd10
+// FUNCTION: BETA10 0x1013d0c7
 MxLong MxBitmap::Read(const char* p_filename)
 {
 	MxResult result = FAILURE;
@@ -166,6 +173,7 @@ MxLong MxBitmap::Read(const char* p_filename)
 }
 
 // FUNCTION: LEGO1 0x100bcd60
+// FUNCTION: BETA10 0x1013d169
 MxResult MxBitmap::LoadFile(HANDLE p_handle)
 {
 	MxResult result = FAILURE;
@@ -212,6 +220,7 @@ MxResult MxBitmap::LoadFile(HANDLE p_handle)
 }
 
 // FUNCTION: LEGO1 0x100bce70
+// FUNCTION: BETA10 0x1013d399
 void MxBitmap::BitBlt(
 	MxBitmap* p_src,
 	MxS32 p_srcLeft,
@@ -251,6 +260,7 @@ void MxBitmap::BitBlt(
 }
 
 // FUNCTION: LEGO1 0x100bd020
+// FUNCTION: BETA10 0x1013d4ea
 void MxBitmap::BitBltTransparent(
 	MxBitmap* p_src,
 	MxS32 p_srcLeft,
@@ -297,6 +307,7 @@ void MxBitmap::BitBltTransparent(
 }
 
 // FUNCTION: LEGO1 0x100bd1c0
+// FUNCTION: BETA10 0x1013d684
 MxPalette* MxBitmap::CreatePalette()
 {
 	MxBool success = FALSE;
@@ -335,6 +346,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100bd280
+// FUNCTION: BETA10 0x1013d80e
 void MxBitmap::ImportPalette(MxPalette* p_palette)
 {
 	// Odd to use a switch on a boolean, but it matches.
@@ -353,6 +365,7 @@ void MxBitmap::ImportPalette(MxPalette* p_palette)
 }
 
 // FUNCTION: LEGO1 0x100bd2d0
+// FUNCTION: BETA10 0x1013d8a9
 MxResult MxBitmap::SetBitDepth(MxBool p_isHighColor)
 {
 	MxResult ret = FAILURE;
@@ -408,6 +421,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100bd3e0
+// FUNCTION: BETA10 0x1013dad2
 MxResult MxBitmap::StretchBits(
 	HDC p_hdc,
 	MxS32 p_xSrc,
@@ -441,6 +455,7 @@ MxResult MxBitmap::StretchBits(
 }
 
 // FUNCTION: LEGO1 0x100bd450
+// FUNCTION: BETA10 0x1013db55
 MxResult MxBitmap::ImportColorsToPalette(RGBQUAD* p_rgbquad, MxPalette* p_palette)
 {
 	MxResult ret = FAILURE;


### PR DESCRIPTION
Using the beta as our template for where functions should be inlined. This is a widely used class, so the minimal changes to the header created a big diff. The change to `GetDataSize` alone is responsible for a lot of that, though it is functionally equivalent.

- Removed `this->` to match other files where we've stopped using it.
- Refactored if-block "pyramids" to use `goto`. The beta supports doing this.
- We had been confused by the `Abs` function used here that does not precisely match the other `Abs` used everywhere else. The beta tells all: it is only used in combination with bitmap height, so it does appear to be a dedicated function just for this purpose.
- References to `sizeof(MxBITMAPINFO)` instead call a function that just returns the constant of 0x428 bytes. This could mean that there is _not_ a special struct for this and they just used the regular `BITMAPINFO`.

I left `BitBlt` and `BitBltTransparent` alone for now. The main reason is that we need to expand a lot of the convenience functions like `GetAdjustedStride`. I could not find a reference for this in the beta, but that doesn't mean it's definitely not there. Other files use these functions too, so we should take those on all at once and in a new PR.