### PR TITLE
Beta match MxPalette

### DIFF
--- a/LEGO1/omni/include/mxpalette.h
+++ b/LEGO1/omni/include/mxpalette.h
@@ -7,6 +7,7 @@
 #include <ddraw.h>
 
 // VTABLE: LEGO1 0x100dc848
+// VTABLE: BETA10 0x101c2300
 // SIZE 0x414
 class MxPalette : public MxCore {
 public:
@@ -26,9 +27,13 @@ public:
 	void Reset(MxBool p_ignoreSkyColor);
 	LPDIRECTDRAWPALETTE CreateNativePalette();
 
-	inline void SetOverrideSkyColor(MxBool p_value) { this->m_overrideSkyColor = p_value; }
+	void SetPalette(LPDIRECTDRAWPALETTE p_palette);
+
+	// FUNCTION: BETA10 0x100d92c0
+	inline void SetOverrideSkyColor(MxBool p_value) { m_overrideSkyColor = p_value; }
 
 	// SYNTHETIC: LEGO1 0x100beeb0
+	// SYNTHETIC: BETA10 0x10144640
 	// MxPalette::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/src/video/mxpalette.cpp
+++ b/LEGO1/omni/src/video/mxpalette.cpp
@@ -114,7 +114,8 @@ MxPalette::~MxPalette()
 LPDIRECTDRAWPALETTE MxPalette::CreateNativePalette()
 {
 	if (m_palette == NULL) {
-		for (MxS32 i = 0; i < 10; i++) {
+		MxS32 i;
+		for (i = 0; i < 10; i++) {
 			m_entries[i].peFlags = D3DPAL_RESERVED;
 		}
 
@@ -179,7 +180,8 @@ MxResult MxPalette::SetEntries(LPPALETTEENTRY p_entries)
 	MxResult status = SUCCESS;
 
 	if (m_palette) {
-		for (MxS32 i = 0; i < 10; i++) {
+		MxS32 i;
+		for (i = 0; i < 10; i++) {
 			m_entries[i].peFlags = D3DPAL_RESERVED;
 		}
 


### PR DESCRIPTION
Mostly small things.

- `CreateNativePalette` and `SetEntries` reuse the `i` variable in an odd way, but this is what matches the beta.
- Dead code in retail: `SetPalette`. Conversely, `Reset` is not called in the beta and it is slightly different.
- Removed `this->`.
- For the `peFlags` member, use macros from `d3dtypes.h` and `WINGDI.H` in place of magic numbers.
