### PR TITLE
Add static HandlerClassName function

### DIFF
--- a/LEGO1/lego/legoomni/include/jetskirace.h
+++ b/LEGO1/lego/legoomni/include/jetskirace.h
@@ -7,11 +7,18 @@
 // SIZE 0x144
 class JetskiRace : public LegoRace {
 public:
-	// FUNCTION: LEGO1 0x1000daf0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a8840
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0530
 		return "JetskiRace";
+	}
+
+	// FUNCTION: LEGO1 0x1000daf0
+	// FUNCTION: BETA10 0x100a8810
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000db00

--- a/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
+++ b/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
@@ -9,11 +9,18 @@
 // SIZE 0xa0
 class Lego3DWavePresenter : public MxWavePresenter {
 public:
-	// FUNCTION: LEGO1 0x1000d890
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a8670
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f058c
 		return "Lego3DWavePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000d890
+	// FUNCTION: BETA10 0x100a8640
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d8a0

--- a/LEGO1/lego/legoomni/include/legoactioncontrolpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoactioncontrolpresenter.h
@@ -13,11 +13,18 @@ public:
 	LegoActionControlPresenter() { m_unk0x50 = Extra::ActionType::e_none; }
 	~LegoActionControlPresenter() override { Destroy(TRUE); } // vtable+0x00
 
-	// FUNCTION: LEGO1 0x1000d0e0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a7840
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f05bc
 		return "LegoActionControlPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000d0e0
+	// FUNCTION: BETA10 0x100a7810
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d0f0

--- a/LEGO1/lego/legoomni/include/legoactorpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoactorpresenter.h
@@ -12,11 +12,18 @@ public:
 	// FUNCTION: LEGO1 0x100679c0
 	~LegoActorPresenter() override {}
 
-	// FUNCTION: LEGO1 0x1000cb10
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a6f10
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f06a4
 		return "LegoActorPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000cb10
+	// FUNCTION: BETA10 0x100a6ee0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000cb20

--- a/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
@@ -29,11 +29,18 @@ public:
 
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
-	// FUNCTION: LEGO1 0x1004a950
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1004d840
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f046c
 		return "LegoAnimMMPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1004a950
+	// FUNCTION: BETA10 0x1004d810
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1004a960

--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -41,11 +41,18 @@ public:
 	LegoAnimPresenter();
 	~LegoAnimPresenter() override;
 
-	// FUNCTION: LEGO1 0x10068530
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x10055300
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f071c
 		return "LegoAnimPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x10068530
+	// FUNCTION: BETA10 0x100552d0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10068540

--- a/LEGO1/lego/legoomni/include/legocarbuildanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildanimpresenter.h
@@ -11,11 +11,18 @@ public:
 	LegoCarBuildAnimPresenter();
 	~LegoCarBuildAnimPresenter() override; // vtable+0x00
 
-	// FUNCTION: LEGO1 0x10078510
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x10073290
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f05ec
 		return "LegoCarBuildAnimPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x10078510
+	// FUNCTION: BETA10 0x10073260
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10078520

--- a/LEGO1/lego/legoomni/include/legocontrolmanager.h
+++ b/LEGO1/lego/legoomni/include/legocontrolmanager.h
@@ -46,11 +46,18 @@ public:
 
 	MxResult Tickle() override; // vtable+0x08
 
-	// FUNCTION: LEGO1 0x10028cb0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1008af70
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f31b8
 		return "LegoControlManager";
+	}
+
+	// FUNCTION: LEGO1 0x10028cb0
+	// FUNCTION: BETA10 0x1008af40
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10028cc0

--- a/LEGO1/lego/legoomni/include/legoentitypresenter.h
+++ b/LEGO1/lego/legoomni/include/legoentitypresenter.h
@@ -13,11 +13,18 @@ public:
 	LegoEntityPresenter();
 	~LegoEntityPresenter() override; // vtable+0x00
 
-	// FUNCTION: LEGO1 0x100534b0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x10080780
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f06b8
 		return "LegoEntityPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100534b0
+	// FUNCTION: BETA10 0x10080750
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100534c0

--- a/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
@@ -10,11 +10,18 @@ class LegoFlcTexturePresenter : public MxFlcPresenter {
 public:
 	LegoFlcTexturePresenter();
 
-	// FUNCTION: LEGO1 0x1005def0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100837e0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0634
 		return "LegoFlcTexturePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1005def0
+	// FUNCTION: BETA10 0x100837b0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	void StartingTickle() override;                  // vtable+0x1c

--- a/LEGO1/lego/legoomni/include/legohideanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legohideanimpresenter.h
@@ -25,11 +25,18 @@ public:
 	LegoHideAnimPresenter();
 	~LegoHideAnimPresenter() override;
 
-	// FUNCTION: LEGO1 0x1006d880
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1005d4a0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f06cc
 		return "LegoHideAnimPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1006d880
+	// FUNCTION: BETA10 0x1005d470
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1006d890

--- a/LEGO1/lego/legoomni/include/legoloadcachesoundpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoloadcachesoundpresenter.h
@@ -13,11 +13,18 @@ public:
 	LegoLoadCacheSoundPresenter();
 	~LegoLoadCacheSoundPresenter() override;
 
-	// FUNCTION: LEGO1 0x10018450
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1008cf90
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f05a0
 		return "LegoLoadCacheSoundPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x10018450
+	// FUNCTION: BETA10 0x1008cf60
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	void ReadyTickle() override;     // vtable+0x18

--- a/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
@@ -11,11 +11,18 @@ public:
 	LegoLocomotionAnimPresenter();
 	~LegoLocomotionAnimPresenter() override;
 
-	// FUNCTION: LEGO1 0x1006ce50
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1005c4e0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f06e4
 		return "LegoLocomotionAnimPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1006ce50
+	// FUNCTION: BETA10 0x1005c4b0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1006ce60

--- a/LEGO1/lego/legoomni/include/legoloopinganimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoloopinganimpresenter.h
@@ -7,11 +7,18 @@
 // SIZE 0xc0
 class LegoLoopingAnimPresenter : public LegoAnimPresenter {
 public:
-	// FUNCTION: LEGO1 0x1000c9a0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1005c6f0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0700
 		return "LegoLoopingAnimPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000c9a0
+	// FUNCTION: BETA10 0x1005c6c0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000c9b0

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -19,11 +19,18 @@ public:
 
 	static void configureLegoModelPresenter(MxS32 p_modelPresenterConfig);
 
-	// FUNCTION: LEGO1 0x1000ccb0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a7180
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f067c
 		return "LegoModelPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000ccb0
+	// FUNCTION: BETA10 0x100a7150
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000ccc0

--- a/LEGO1/lego/legoomni/include/legopalettepresenter.h
+++ b/LEGO1/lego/legoomni/include/legopalettepresenter.h
@@ -13,11 +13,18 @@ public:
 	LegoPalettePresenter();
 	~LegoPalettePresenter() override; // vtable+0x00
 
-	// FUNCTION: LEGO1 0x10079f30
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100ab250
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f061c
 		return "LegoPalettePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x10079f30
+	// FUNCTION: BETA10 0x100ab220
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10079f40

--- a/LEGO1/lego/legoomni/include/legopartpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopartpresenter.h
@@ -13,11 +13,18 @@ public:
 	// FUNCTION: LEGO1 0x10067300
 	~LegoPartPresenter() override { Destroy(TRUE); }
 
-	// FUNCTION: LEGO1 0x1000cf70
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a75d0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f05d8
 		return "LegoPartPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000cf70
+	// FUNCTION: BETA10 0x100a75a0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000cf80

--- a/LEGO1/lego/legoomni/include/legopathpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopathpresenter.h
@@ -11,11 +11,18 @@ public:
 	LegoPathPresenter();
 	~LegoPathPresenter() override;
 
-	// FUNCTION: LEGO1 0x100449a0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100c24d0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0690
 		return "LegoPathPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100449a0
+	// FUNCTION: BETA10 0x100c24a0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100449b0

--- a/LEGO1/lego/legoomni/include/legophonemepresenter.h
+++ b/LEGO1/lego/legoomni/include/legophonemepresenter.h
@@ -15,11 +15,18 @@ public:
 	LegoPhonemePresenter();
 	~LegoPhonemePresenter() override; // vtable+0x00
 
-	// FUNCTION: LEGO1 0x1004e310
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100c4220
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f064c
 		return "LegoPhonemePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1004e310
+	// FUNCTION: BETA10 0x100c41f0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	void StartingTickle() override;                  // vtable+0x1c

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -15,11 +15,18 @@ public:
 
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
-	// FUNCTION: LEGO1 0x10015ba0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a8970
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f07c4
 		return "LegoRace";
+	}
+
+	// FUNCTION: LEGO1 0x10015ba0
+	// FUNCTION: BETA10 0x100a8940
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10015bb0

--- a/LEGO1/lego/legoomni/include/legotexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legotexturepresenter.h
@@ -11,11 +11,18 @@ public:
 	LegoTexturePresenter() : m_textures(NULL) {}
 	~LegoTexturePresenter() override;
 
-	// FUNCTION: LEGO1 0x1000ce50
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100a73c0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0664
 		return "LegoTexturePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000ce50
+	// FUNCTION: BETA10 0x100a7390
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000ce60

--- a/LEGO1/lego/legoomni/include/legoworldpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoworldpresenter.h
@@ -18,11 +18,18 @@ public:
 
 	static void configureLegoWorldPresenter(MxS32 p_legoWorldPresenterQuality);
 
-	// FUNCTION: LEGO1 0x10066630
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100e41c0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0608
 		return "LegoWorldPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x10066630
+	// FUNCTION: BETA10 0x100e4190
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10066640

--- a/LEGO1/omni/include/mxaudiopresenter.h
+++ b/LEGO1/omni/include/mxaudiopresenter.h
@@ -10,11 +10,18 @@ class MxAudioPresenter : public MxMediaPresenter {
 public:
 	MxAudioPresenter() { m_volume = 100; }
 
-	// FUNCTION: LEGO1 0x1000d280
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1008cba0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f078c
 		return "MxAudioPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000d280
+	// FUNCTION: BETA10 0x1008cb70
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d290

--- a/LEGO1/omni/include/mxcompositepresenter.h
+++ b/LEGO1/omni/include/mxcompositepresenter.h
@@ -18,11 +18,18 @@ public:
 
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
-	// FUNCTION: LEGO1 0x100b6210
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1004da30
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0774
 		return "MxCompositePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100b6210
+	// FUNCTION: BETA10 0x1004da00
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100b6220

--- a/LEGO1/omni/include/mxeventpresenter.h
+++ b/LEGO1/omni/include/mxeventpresenter.h
@@ -11,11 +11,18 @@ public:
 	MxEventPresenter();
 	~MxEventPresenter() override;
 
-	// FUNCTION: LEGO1 0x100c2c30
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1012f0d0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101dcc
 		return "MxEventPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100c2c30
+	// FUNCTION: BETA10 0x10152f10
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100c2c40

--- a/LEGO1/omni/include/mxflcpresenter.h
+++ b/LEGO1/omni/include/mxflcpresenter.h
@@ -19,11 +19,18 @@ public:
 		return !strcmp(p_name, MxFlcPresenter::ClassName()) || MxVideoPresenter::IsA(p_name);
 	}
 
-	// FUNCTION: LEGO1 0x100b33f0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x10083790
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f43c8
 		return "MxFlcPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100b33f0
+	// FUNCTION: BETA10 0x10083760
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	void LoadHeader(MxStreamChunk* p_chunk) override; // vtable+0x5c

--- a/LEGO1/omni/include/mxloopingflcpresenter.h
+++ b/LEGO1/omni/include/mxloopingflcpresenter.h
@@ -11,11 +11,18 @@ public:
 	MxLoopingFlcPresenter();
 	~MxLoopingFlcPresenter() override;
 
-	// FUNCTION: LEGO1 0x100b4380
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1012f050
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101e20
 		return "MxLoopingFlcPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100b4380
+	// FUNCTION: BETA10 0x1013c300
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	void RepeatingTickle() override;  // vtable+0x24

--- a/LEGO1/omni/include/mxloopingmidipresenter.h
+++ b/LEGO1/omni/include/mxloopingmidipresenter.h
@@ -7,11 +7,18 @@
 // SIZE 0x58
 class MxLoopingMIDIPresenter : public MxMIDIPresenter {
 public:
-	// FUNCTION: LEGO1 0x100b1830
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1012f0b0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101de0
 		return "MxLoopingMIDIPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100b1830
+	// FUNCTION: BETA10 0x10143910
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100b1840

--- a/LEGO1/omni/include/mxloopingsmkpresenter.h
+++ b/LEGO1/omni/include/mxloopingsmkpresenter.h
@@ -11,11 +11,18 @@ public:
 	MxLoopingSmkPresenter();
 	~MxLoopingSmkPresenter() override; // vtable+0x00
 
-	// FUNCTION: LEGO1 0x100b4920
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1012f070
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101e08
 		return "MxLoopingSmkPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100b4920
+	// FUNCTION: BETA10 0x1013c360
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	void RepeatingTickle() override;  // vtable+0x24

--- a/LEGO1/omni/include/mxmediapresenter.h
+++ b/LEGO1/omni/include/mxmediapresenter.h
@@ -18,11 +18,18 @@ public:
 
 	MxResult Tickle() override; // vtable+0x08
 
-	// FUNCTION: LEGO1 0x1000c5c0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x10054f50
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f074c
 		return "MxMediaPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000c5c0
+	// FUNCTION: BETA10 0x10054f20
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000c5d0

--- a/LEGO1/omni/include/mxmidipresenter.h
+++ b/LEGO1/omni/include/mxmidipresenter.h
@@ -12,11 +12,18 @@ public:
 	MxMIDIPresenter();
 	~MxMIDIPresenter() override;
 
-	// FUNCTION: LEGO1 0x100c2650
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1012f090
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101df8
 		return "MxMIDIPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100c2650
+	// FUNCTION: BETA10 0x10143a90
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100c2660

--- a/LEGO1/omni/include/mxmusicpresenter.h
+++ b/LEGO1/omni/include/mxmusicpresenter.h
@@ -10,11 +10,18 @@ public:
 	MxMusicPresenter();
 	~MxMusicPresenter() override;
 
-	// FUNCTION: LEGO1 0x100c23a0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x10143a70
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101e48
 		return "MxMusicPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100c23a0
+	// FUNCTION: BETA10 0x10143a50
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100c23b0

--- a/LEGO1/omni/include/mxpresenter.h
+++ b/LEGO1/omni/include/mxpresenter.h
@@ -33,11 +33,18 @@ public:
 
 	MxResult Tickle() override; // vtable+0x08
 
-	// FUNCTION: LEGO1 0x1000bfe0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1004d9e0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0740
 		return "MxPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000bfe0
+	// FUNCTION: BETA10 0x1004d9b0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000bff0

--- a/LEGO1/omni/include/mxsmkpresenter.h
+++ b/LEGO1/omni/include/mxsmkpresenter.h
@@ -12,11 +12,18 @@ public:
 	MxSmkPresenter();
 	~MxSmkPresenter() override;
 
-	// FUNCTION: LEGO1 0x100b3730
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1012f010
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x10101e38
 		return "MxSmkPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100b3730
+	// FUNCTION: BETA10 0x1013b8c0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100b3740

--- a/LEGO1/omni/include/mxsoundpresenter.h
+++ b/LEGO1/omni/include/mxsoundpresenter.h
@@ -10,11 +10,18 @@ public:
 	// FUNCTION: LEGO1 0x1000d430
 	~MxSoundPresenter() override { Destroy(TRUE); }
 
-	// FUNCTION: LEGO1 0x1000d4a0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1008ca70
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f07a0
 		return "MxSoundPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000d4a0
+	// FUNCTION: BETA10 0x1008ca40
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d4b0

--- a/LEGO1/omni/include/mxstillpresenter.h
+++ b/LEGO1/omni/include/mxstillpresenter.h
@@ -13,11 +13,18 @@ public:
 	// FUNCTION: LEGO1 0x10043550
 	~MxStillPresenter() override { Destroy(TRUE); } // vtable+0x00
 
-	// FUNCTION: LEGO1 0x100435c0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100980c0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0184
 		return "MxStillPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x100435c0
+	// FUNCTION: BETA10 0x10098090
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100435d0

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -17,11 +17,18 @@ public:
 	// FUNCTION: LEGO1 0x1000c740
 	~MxVideoPresenter() override { Destroy(TRUE); } // vtable+0x00
 
-	// FUNCTION: LEGO1 0x1000c820
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x100551b0
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f0760
 		return "MxVideoPresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000c820
+	// FUNCTION: BETA10 0x10055180
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000c830

--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -15,11 +15,18 @@ public:
 	// FUNCTION: LEGO1 0x1000d640
 	~MxWavePresenter() override { Destroy(TRUE); } // vtable+0x00
 
-	// FUNCTION: LEGO1 0x1000d6c0
-	inline const char* ClassName() const override // vtable+0x0c
+	// FUNCTION: BETA10 0x1008cd00
+	static const char* HandlerClassName()
 	{
 		// STRING: LEGO1 0x100f07b4
 		return "MxWavePresenter";
+	}
+
+	// FUNCTION: LEGO1 0x1000d6c0
+	// FUNCTION: BETA10 0x1008ccd0
+	inline const char* ClassName() const override // vtable+0x0c
+	{
+		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d6d0

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -8,13 +8,22 @@
 #include "mxdsanim.h"
 #include "mxdssound.h"
 #include "mxentity.h"
+#include "mxeventpresenter.h"
+#include "mxflcpresenter.h"
+#include "mxloopingflcpresenter.h"
+#include "mxloopingmidipresenter.h"
+#include "mxloopingsmkpresenter.h"
+#include "mxmidipresenter.h"
 #include "mxmisc.h"
 #include "mxnotificationmanager.h"
 #include "mxobjectfactory.h"
 #include "mxomni.h"
 #include "mxparam.h"
+#include "mxsmkpresenter.h"
+#include "mxstillpresenter.h"
 #include "mxstreamer.h"
 #include "mxutilities.h"
+#include "mxwavepresenter.h"
 
 #include <string.h>
 
@@ -175,6 +184,7 @@ void MxPresenter::Enable(MxBool p_enable)
 }
 
 // FUNCTION: LEGO1 0x100b5310
+// FUNCTION: BETA10 0x1012e8bd
 const char* PresenterNameDispatch(const MxDSAction& p_action)
 {
 	const char* name = p_action.GetSourceName();
@@ -186,10 +196,12 @@ const char* PresenterNameDispatch(const MxDSAction& p_action)
 			format = ((MxDSAnim&) p_action).GetMediaFormat();
 			switch (format) {
 			case FOURCC(' ', 'F', 'L', 'C'):
-				name = !p_action.IsLooping() ? "MxFlcPresenter" : "MxLoopingFlcPresenter";
+				name = !p_action.IsLooping() ? MxFlcPresenter::HandlerClassName()
+											 : MxLoopingFlcPresenter::HandlerClassName();
 				break;
 			case FOURCC(' ', 'S', 'M', 'K'):
-				name = !p_action.IsLooping() ? "MxSmkPresenter" : "MxLoopingSmkPresenter";
+				name = !p_action.IsLooping() ? MxSmkPresenter::HandlerClassName()
+											 : MxLoopingSmkPresenter::HandlerClassName();
 				break;
 			}
 			break;
@@ -198,10 +210,11 @@ const char* PresenterNameDispatch(const MxDSAction& p_action)
 			format = ((MxDSSound&) p_action).GetMediaFormat();
 			switch (format) {
 			case FOURCC(' ', 'M', 'I', 'D'):
-				name = !p_action.IsLooping() ? "MxMIDIPresenter" : "MxLoopingMIDIPresenter";
+				name = !p_action.IsLooping() ? MxMIDIPresenter::HandlerClassName()
+											 : MxLoopingMIDIPresenter::HandlerClassName();
 				break;
 			case FOURCC(' ', 'W', 'A', 'V'):
-				name = "MxWavePresenter";
+				name = MxWavePresenter::HandlerClassName();
 				break;
 			}
 			break;
@@ -209,15 +222,15 @@ const char* PresenterNameDispatch(const MxDSAction& p_action)
 		case MxDSObject::e_serialAction:
 		case MxDSObject::e_parallelAction:
 		case MxDSObject::e_selectAction:
-			name = "MxCompositePresenter";
+			name = MxCompositePresenter::HandlerClassName();
 			break;
 
 		case MxDSObject::e_event:
-			name = "MxEventPresenter";
+			name = MxEventPresenter::HandlerClassName();
 			break;
 
 		case MxDSObject::e_still:
-			name = "MxStillPresenter";
+			name = MxStillPresenter::HandlerClassName();
 			break;
 		}
 	}


### PR DESCRIPTION
The beta shows that some of the `ClassName` methods call another method to get the actual string value. This mainly applies to the presenter classes but also to `JetSkiRace` and `LegoRace`. There may be others, but these were all lumped together by Ghidra assuming they are all the same MSVC library function, so they were easy to find.

The name `HandlerClassName` comes from the 96 source.

Should be no effective change to retail. As expected, any change to headers creates a lot of compiler noise, but none of the `ClassName` methods are affected. The only place (in the beta) I could find where these methods are called from outside their class is `PresenterNameDispatch`, so I added them there.
