### PR TITLE
Use USHRT_MAX instead of MAXWORD

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
@@ -77,10 +77,10 @@ void LegoActionControlPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[1024];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strACTION, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -241,10 +241,10 @@ void LegoAnimMMPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[1024];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strANIMMAN_ID, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
@@ -244,10 +244,10 @@ void MxControlPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[256];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[256];
 		if (KeyValueStringParse(output, g_strSTYLE, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
@@ -40,10 +40,10 @@ void LegoMeterPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[256];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[256];
 		if (KeyValueStringParse(extraCopy, g_strTYPE, output)) {

--- a/LEGO1/lego/legoomni/src/entity/legoactorpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoactorpresenter.cpp
@@ -34,10 +34,10 @@ void LegoActorPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		m_entity->ParseAction(extraCopy);
 	}

--- a/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
@@ -96,10 +96,10 @@ void LegoEntityPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		m_entity->ParseAction(extraCopy);
 	}

--- a/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
@@ -429,10 +429,10 @@ void LegoWorldPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[1024];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strWORLD, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/paths/legopathpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathpresenter.cpp
@@ -122,10 +122,10 @@ void LegoPathPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[256], output[256];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		strupr(extraCopy);
 

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -947,18 +947,18 @@ void LegoAnimPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[256];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[256];
 		if (KeyValueStringParse(NULL, g_strFROM_PARENT, extraCopy) && m_compositePresenter != NULL) {
 			m_compositePresenter->GetAction()->GetExtra(extraLength, extraData);
 
-			if (extraLength & MAXWORD) {
-				memcpy(extraCopy, extraData, extraLength & MAXWORD);
-				extraCopy[extraLength & MAXWORD] = '\0';
+			if (extraLength & USHRT_MAX) {
+				memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+				extraCopy[extraLength & USHRT_MAX] = '\0';
 			}
 		}
 

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -296,11 +296,11 @@ void LegoModelPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[1024], output[1024];
 		output[0] = '\0';
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		if (KeyValueStringParse(output, g_strAUTO_CREATE, extraCopy) != 0) {
 			char* token = strtok(output, g_parseExtraTokens);

--- a/LEGO1/lego/sources/roi/legolod.cpp
+++ b/LEGO1/lego/sources/roi/legolod.cpp
@@ -137,14 +137,14 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 			goto done;
 		}
 
-		m_numPolys += numPolys & MAXWORD;
+		m_numPolys += numPolys & USHRT_MAX;
 
 		if (p_storage->Read(&numVertices, 2) != SUCCESS) {
 			goto done;
 		}
 
-		polyIndices = new LegoU32[numPolys & MAXWORD][sizeOfArray(*polyIndices)];
-		if (p_storage->Read(polyIndices, (numPolys & MAXWORD) * sizeof(*polyIndices)) != SUCCESS) {
+		polyIndices = new LegoU32[numPolys & USHRT_MAX][sizeOfArray(*polyIndices)];
+		if (p_storage->Read(polyIndices, (numPolys & USHRT_MAX) * sizeof(*polyIndices)) != SUCCESS) {
 			goto done;
 		}
 
@@ -153,8 +153,8 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 		}
 
 		if (numTextureIndices > 0) {
-			textureIndices = new LegoU32[numPolys & MAXWORD][sizeOfArray(*textureIndices)];
-			if (p_storage->Read(textureIndices, (numPolys & MAXWORD) * sizeof(*textureIndices)) != SUCCESS) {
+			textureIndices = new LegoU32[numPolys & USHRT_MAX][sizeOfArray(*textureIndices)];
+			if (p_storage->Read(textureIndices, (numPolys & USHRT_MAX) * sizeof(*textureIndices)) != SUCCESS) {
 				goto done;
 			}
 		}
@@ -179,7 +179,7 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 			shadingModel = Tgl::Gouraud;
 		}
 
-		m_numVertices += numVertices & MAXWORD;
+		m_numVertices += numVertices & USHRT_MAX;
 
 		textureName = mesh->GetTextureName();
 		materialName = mesh->GetMaterialName();
@@ -194,8 +194,8 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 		}
 
 		m_melems[meshIndex].m_tglMesh = m_meshBuilder->CreateMesh(
-			numPolys & MAXWORD,
-			numVertices & MAXWORD,
+			numPolys & USHRT_MAX,
+			numVertices & USHRT_MAX,
 			vertices,
 			normals,
 			textureVertices,

--- a/LEGO1/omni/src/audio/mxwavepresenter.cpp
+++ b/LEGO1/omni/src/audio/mxwavepresenter.cpp
@@ -331,10 +331,10 @@ void MxWavePresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char soundValue[512];
 		if (KeyValueStringParse(soundValue, g_strSOUND, extraCopy)) {

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -87,10 +87,10 @@ void MxPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char worldValue[512];
 		if (KeyValueStringParse(worldValue, g_strWORLD, extraCopy)) {
@@ -251,10 +251,10 @@ MxEntity* MxPresenter::CreateEntity(const char* p_defaultName)
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 		KeyValueStringParse(objectName, g_strOBJECT, extraCopy);
 	}
 

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -202,10 +202,10 @@ void MxStillPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & MAXWORD) {
+	if (extraLength & USHRT_MAX) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & MAXWORD);
-		extraCopy[extraLength & MAXWORD] = '\0';
+		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
+		extraCopy[extraLength & USHRT_MAX] = '\0';
 
 		char output[512];
 		if (KeyValueStringParse(output, g_strVISIBILITY, extraCopy)) {


### PR DESCRIPTION
`USHRT_MAX` is defined in the C standard library and available everywhere, while `MAXWORD` comes from Windows. For portability, we want to use `USHRT_MAX` instead. This was already available in MSVC4 and there is no reason to believe the developers didn't use it, so it doesn't break with authenticity.