### PR TITLE
Name/rename functions in LegoCharacterManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,11 +321,11 @@ add_library(lego1 SHARED
   LEGO1/lego/legoomni/src/build/legovehiclebuildstate.cpp
   LEGO1/lego/legoomni/src/common/animstate.cpp
   LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
+  LEGO1/lego/legoomni/src/common/legoactors.cpp
   LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
   LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
   LEGO1/lego/legoomni/src/common/legobackgroundcolor.cpp
   LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
-  LEGO1/lego/legoomni/src/common/legocharacters.cpp
   LEGO1/lego/legoomni/src/common/legofullscreenmovie.cpp
   LEGO1/lego/legoomni/src/common/legogamestate.cpp
   LEGO1/lego/legoomni/src/common/legoobjectfactory.cpp

--- a/LEGO1/lego/legoomni/include/legoactors.h
+++ b/LEGO1/lego/legoomni/include/legoactors.h
@@ -1,5 +1,5 @@
-#ifndef LEGOCHARACTERS_H
-#define LEGOCHARACTERS_H
+#ifndef LEGOACTORS_H
+#define LEGOACTORS_H
 
 #include "decomp.h"
 #include "mxtypes.h"
@@ -8,7 +8,7 @@ class LegoExtraActor;
 class LegoROI;
 
 // SIZE 0x108
-struct LegoCharacterInfo {
+struct LegoActorInfo {
 	// SIZE 0x18
 	struct Part {
 		MxU8* m_unk0x00;        // 0x00
@@ -29,7 +29,7 @@ struct LegoCharacterInfo {
 };
 
 // SIZE 0x58
-struct LegoCharacterLOD {
+struct LegoActorLOD {
 	enum {
 		c_flag1 = 0x01,
 		c_flag2 = 0x02
@@ -45,7 +45,7 @@ struct LegoCharacterLOD {
 	float m_up[3];             // 0x4c
 };
 
-enum LegoCharacterLODs {
+enum LegoActorLODs {
 	c_topLOD,
 	c_bodyLOD,
 	c_infohatLOD,
@@ -59,7 +59,7 @@ enum LegoCharacterLODs {
 	c_legrtLOD
 };
 
-enum LegoCharacterParts {
+enum LegoActorParts {
 	c_bodyPart,
 	c_infohatPart,
 	c_infogronPart,
@@ -72,7 +72,7 @@ enum LegoCharacterParts {
 	c_legrtPart
 };
 
-extern LegoCharacterInfo g_characterInfoInit[66];
-extern LegoCharacterLOD g_characterLODs[11];
+extern LegoActorInfo g_actorInfoInit[66];
+extern LegoActorLOD g_actorLODs[11];
 
-#endif // LEGOCHARACTERS_H
+#endif // LEGOACTORS_H

--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -41,7 +41,7 @@ struct LegoCharacter {
 	MxU32 m_refCount; // 0x04
 };
 
-struct LegoCharacterInfo;
+struct LegoActorInfo;
 
 typedef map<char*, LegoCharacter*, LegoCharacterComparator> LegoCharacterMap;
 
@@ -53,32 +53,32 @@ public:
 
 	MxResult Write(LegoStorage* p_storage);
 	MxResult Read(LegoStorage* p_storage);
-	LegoROI* GetROI(const char* p_key, MxBool p_createEntity);
+	LegoROI* GetActorROI(const char* p_name, MxBool p_createEntity);
 
 	void Init();
 	static void SetCustomizeAnimFile(const char* p_value);
-	static MxBool Exists(const char* p_key);
+	static MxBool IsActor(const char* p_name);
 
-	void FUN_100832a0();
-	MxBool FUN_10083b20(const char* p_key);
+	void ReleaseAllActors();
+	MxBool Exists(const char* p_name);
 	MxU32 GetRefCount(LegoROI* p_roi);
-	void FUN_10083c30(const char* p_name);
-	void FUN_10083db0(LegoROI* p_roi);
-	void FUN_10083f10(LegoROI* p_roi);
+	void ReleaseActor(const char* p_name);
+	void ReleaseActor(LegoROI* p_roi);
+	void ReleaseAutoROI(LegoROI* p_roi);
 	MxBool FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_textureInfo);
-	LegoExtraActor* GetActor(const char* p_key);
-	LegoCharacterInfo* GetInfo(const char* p_key);
-	LegoCharacterInfo* GetInfo(LegoROI* p_roi);
+	LegoExtraActor* GetExtraActor(const char* p_name);
+	LegoActorInfo* GetActorInfo(const char* p_name);
+	LegoActorInfo* GetActorInfo(LegoROI* p_roi);
 	MxBool SwitchHat(LegoROI* p_roi);
 	MxU32 FUN_10085140(LegoROI* p_roi, MxBool p_und);
 	MxU8 GetMood(LegoROI* p_roi);
-	LegoROI* FUN_10085210(const char* p_name, const char* p_lodName, MxBool p_createEntity);
+	LegoROI* CreateAutoROI(const char* p_name, const char* p_lodName, MxBool p_createEntity);
 	LegoROI* FUN_10085a80(const char* p_name, const char* p_lodName, MxBool p_createEntity);
 
 	static const char* GetCustomizeAnimFile() { return g_customizeAnimFile; }
 
 private:
-	LegoROI* CreateROI(const char* p_key);
+	LegoROI* CreateActorROI(const char* p_key);
 	void RemoveROI(LegoROI* p_roi);
 	LegoROI* FindChildROI(LegoROI* p_roi, const char* p_name);
 	MxResult FUN_10085870(LegoROI* p_roi);

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -14,11 +14,11 @@ class Vector3;
 class LegoEntity : public MxEntity {
 public:
 	enum Type {
-		e_character = 0,
+		e_actor = 0,
 		e_unk1,
 		e_plant,
 		e_building,
-		e_unk4
+		e_autoROI
 	};
 
 	enum {

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -23,7 +23,7 @@ public:
 
 	enum {
 		c_bit1 = 0x01,
-		c_bit2 = 0x02
+		c_managerOwned = 0x02
 	};
 
 	enum {

--- a/LEGO1/lego/legoomni/src/audio/lego3dsound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/lego3dsound.cpp
@@ -53,8 +53,8 @@ MxResult Lego3DSound::Create(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char
 		return SUCCESS;
 	}
 
-	if (CharacterManager()->Exists(p_name)) {
-		m_roi = CharacterManager()->GetROI(p_name, TRUE);
+	if (CharacterManager()->IsActor(p_name)) {
+		m_roi = CharacterManager()->GetActorROI(p_name, TRUE);
 		m_enabled = m_isActor = TRUE;
 	}
 	else {
@@ -62,7 +62,7 @@ MxResult Lego3DSound::Create(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char
 	}
 
 	if (m_roi == NULL) {
-		m_roi = CharacterManager()->FUN_10085210(NULL, p_name, TRUE);
+		m_roi = CharacterManager()->CreateAutoROI(NULL, p_name, TRUE);
 
 		if (m_roi != NULL) {
 			m_enabled = TRUE;
@@ -113,10 +113,10 @@ void Lego3DSound::Destroy()
 
 	if (m_enabled && m_roi && CharacterManager()) {
 		if (m_isActor) {
-			CharacterManager()->FUN_10083db0(m_roi);
+			CharacterManager()->ReleaseActor(m_roi);
 		}
 		else {
-			CharacterManager()->FUN_10083f10(m_roi);
+			CharacterManager()->ReleaseAutoROI(m_roi);
 		}
 	}
 

--- a/LEGO1/lego/legoomni/src/common/legoactors.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoactors.cpp
@@ -1,16 +1,16 @@
-#include "legocharacters.h"
+#include "legoactors.h"
 
-DECOMP_SIZE_ASSERT(LegoCharacterInfo, 0x108)
-DECOMP_SIZE_ASSERT(LegoCharacterInfo::Part, 0x18)
-DECOMP_SIZE_ASSERT(LegoCharacterLOD, 0x58)
+DECOMP_SIZE_ASSERT(LegoActorInfo, 0x108)
+DECOMP_SIZE_ASSERT(LegoActorInfo::Part, 0x18)
+DECOMP_SIZE_ASSERT(LegoActorLOD, 0x58)
 
-// Unclear whether g_characterLODs[0] (top) is its own global, see: LegoCharacterManager::CreateROI
+// Unclear whether g_actorLODs[0] (top) is its own global, see: LegoCharacterManager::CreateActorROI
 
 // GLOBAL: LEGO1 0x100da3b0
-LegoCharacterLOD g_characterLODs[] = {
+LegoActorLOD g_actorLODs[] = {
 	{"top",   "top",    0, 0.000267, 0.780808, -0.01906, 0.951612, -0.461166, -0.002794, -0.299442, 0.4617,
 	 1.56441, 0.261321, 0, 0,        0,        0,        0,        1,         0,         1,         0},
-	{"body",     "body",    LegoCharacterLOD::c_flag1,
+	{"body",     "body",    LegoActorLOD::c_flag1,
 	 0.00158332, 0.401828,  -0.00048697,
 	 0.408071,   -0.287507, 0.150419,
 	 -0.147452,  0.289219,  0.649774,
@@ -18,7 +18,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.007277,   0,         0,
 	 1,          0,         1,
 	 0},
-	{"infohat", "infohat", LegoCharacterLOD::c_flag2,
+	{"infohat", "infohat", LegoActorLOD::c_flag2,
 	 0,         -0.00938,  -0.01955,
 	 0.35,      -0.231822, -0.140237,
 	 -0.320954, 0.234149,  0.076968,
@@ -26,7 +26,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.001767,  0,         0,
 	 1,         0,         1,
 	 0},
-	{"infogron", "infogron", LegoCharacterLOD::c_flag2,
+	{"infogron", "infogron", LegoActorLOD::c_flag2,
 	 0,          0.11477,    0.00042,
 	 0.26,       -0.285558,  -0.134391,
 	 -0.142231,  0.285507,   0.152986,
@@ -34,7 +34,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.007277,   0,          0,
 	 1,          0,          1,
 	 0},
-	{"head",    "head",    LegoCharacterLOD::c_flag1,
+	{"head",    "head",    LegoActorLOD::c_flag1,
 	 0,         -0.03006,  0,
 	 0.3,       -0.189506, -0.209665,
 	 -0.189824, 0.189532,  0.228822,
@@ -42,7 +42,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.001781,  0,         0,
 	 1,         0,         1,
 	 0},
-	{"arm-lft", "arm-lft",  LegoCharacterLOD::c_flag2,
+	{"arm-lft", "arm-lft",  LegoActorLOD::c_flag2,
 	 -0.06815,  -0.0973747, 0.0154655,
 	 0.237,     -0.137931,  -0.282775,
 	 -0.105316, 0.000989,   0.100221,
@@ -50,7 +50,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.023286,  -0.003031,  -0.017187,
 	 0.999848,  0.173622,   0.984658,
 	 0.017453},
-	{"arm-rt",  "arm-rt",  LegoCharacterLOD::c_flag2,
+	{"arm-rt",  "arm-rt",  LegoActorLOD::c_flag2,
 	 0.0680946, -0.097152, 0.0152722,
 	 0.237,     0.00141,   -0.289604,
 	 -0.100831, 0.138786,  0.09291,
@@ -58,7 +58,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.018302,  0,         0,
 	 1,         -0.173648, 0.984808,
 	 0},
-	{"claw-lft",  "claw-lft", LegoCharacterLOD::c_flag2,
+	{"claw-lft",  "claw-lft", LegoActorLOD::c_flag2,
 	 0.000773381, -0.101422,  -0.0237761,
 	 0.15,        -0.089838,  -0.246208,
 	 -0.117735,   0.091275,   0.000263,
@@ -66,7 +66,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.092779,    0.000001,   0.000003,
 	 1,           0.190812,   0.981627,
 	 -0.000003},
-	{"claw-rt",   "claw-lft", LegoCharacterLOD::c_flag2,
+	{"claw-rt",   "claw-lft", LegoActorLOD::c_flag2,
 	 0.000773381, -0.101422,  -0.0237761,
 	 0.15,        -0.095016,  -0.245349,
 	 -0.117979,   0.086528,   0.00067,
@@ -74,7 +74,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.096123,    0.00606,    -0.034369,
 	 0.999391,    -0.190704,  0.981027,
 	 0.034894},
-	{"leg-lft",  "leg",     LegoCharacterLOD::c_flag2,
+	{"leg-lft",  "leg",     LegoActorLOD::c_flag2,
 	 0.00433584, -0.177404, -0.0313928,
 	 0.33,       -0.129782, -0.440428,
 	 -0.184207,  0.13817,   0.118415,
@@ -82,7 +82,7 @@ LegoCharacterLOD g_characterLODs[] = {
 	 0.006822,   0,         0,
 	 1,          0,         1,
 	 0},
-	{"leg-rt",   "leg",     LegoCharacterLOD::c_flag2,
+	{"leg-rt",   "leg",     LegoActorLOD::c_flag2,
 	 0.00433584, -0.177404, -0.0313928,
 	 0.33,       -0.132864, -0.437138,
 	 -0.183944,  0.134614,  0.12043,
@@ -172,7 +172,7 @@ const char* g_unk0x100f80a0[] =
 	{"lego white", "lego black", "lego yellow", "lego red", "lego blue", "lego brown", "lego lt grey", "lego green"};
 
 // GLOBAL: LEGO1 0x100f80c0
-LegoCharacterInfo g_characterInfoInit[] = {
+LegoActorInfo g_actorInfoInit[] = {
 	{"pepper",
 	 NULL,
 	 NULL,

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -344,14 +344,14 @@ LegoAnimationManager::~LegoAnimationManager()
 		LegoROI* roi = m_extras[i].m_roi;
 
 		if (roi != NULL) {
-			LegoPathActor* actor = CharacterManager()->GetActor(roi->GetName());
+			LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 
 			if (actor != NULL && actor->GetController() != NULL && CurrentWorld() != NULL) {
 				CurrentWorld()->RemoveActor(actor);
 				actor->SetController(NULL);
 			}
 
-			CharacterManager()->FUN_10083db0(roi);
+			CharacterManager()->ReleaseActor(roi);
 		}
 	}
 
@@ -430,14 +430,14 @@ void LegoAnimationManager::Suspend()
 			LegoROI* roi = m_extras[i].m_roi;
 
 			if (roi != NULL) {
-				LegoPathActor* actor = CharacterManager()->GetActor(roi->GetName());
+				LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 
 				if (actor != NULL && actor->GetController() != NULL) {
 					actor->GetController()->RemoveActor(actor);
 					actor->SetController(NULL);
 				}
 
-				CharacterManager()->FUN_10083db0(roi);
+				CharacterManager()->ReleaseActor(roi);
 			}
 
 			if (m_extras[i].m_unk0x14) {
@@ -1069,8 +1069,8 @@ MxResult LegoAnimationManager::StartEntityAction(MxDSAction& p_dsAction, LegoEnt
 	MxResult result = FAILURE;
 	LegoROI* roi = p_entity->GetROI();
 
-	if (p_entity->GetType() == LegoEntity::e_character) {
-		LegoPathActor* actor = CharacterManager()->GetActor(roi->GetName());
+	if (p_entity->GetType() == LegoEntity::e_actor) {
+		LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 
 		if (actor) {
 			LegoPathController* controller = actor->GetController();
@@ -1395,7 +1395,7 @@ MxLong LegoAnimationManager::Notify(MxParam& p_param)
 					LegoROI* roi = m_extras[i].m_roi;
 
 					if (roi != NULL) {
-						LegoExtraActor* actor = CharacterManager()->GetActor(roi->GetName());
+						LegoExtraActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 						if (actor != NULL) {
 							actor->Restart();
 						}
@@ -1444,14 +1444,14 @@ MxResult LegoAnimationManager::Tickle()
 			LegoROI* roi = m_extras[i].m_roi;
 
 			if (roi != NULL && m_extras[i].m_unk0x0d) {
-				LegoPathActor* actor = CharacterManager()->GetActor(roi->GetName());
+				LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 
 				if (actor != NULL && actor->GetController() != NULL) {
 					actor->GetController()->RemoveActor(actor);
 					actor->SetController(NULL);
 				}
 
-				CharacterManager()->FUN_10083db0(roi);
+				CharacterManager()->ReleaseActor(roi);
 
 				if (m_extras[i].m_unk0x14) {
 					m_extras[i].m_unk0x14 = FALSE;
@@ -1701,7 +1701,7 @@ void LegoAnimationManager::FUN_10062580(AnimInfo& p_info)
 
 	if (models != NULL && modelCount) {
 		for (MxU8 i = 0; i < modelCount; i++) {
-			LegoPathActor* actor = CharacterManager()->GetActor(models[i].m_name);
+			LegoPathActor* actor = CharacterManager()->GetExtraActor(models[i].m_name);
 
 			if (actor) {
 				LegoPathController* controller = actor->GetController();
@@ -1814,13 +1814,13 @@ void LegoAnimationManager::PurgeExtra(MxBool p_und)
 					 !viewManager->FUN_100a6150(roi->GetWorldBoundingBox()))) {
 					m_unk0x414--;
 
-					LegoPathActor* actor = CharacterManager()->GetActor(roi->GetName());
+					LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 					if (actor != NULL && actor->GetController() != NULL) {
 						actor->GetController()->RemoveActor(actor);
 						actor->SetController(NULL);
 					}
 
-					CharacterManager()->FUN_10083db0(roi);
+					CharacterManager()->ReleaseActor(roi);
 
 					if (m_extras[i].m_unk0x14) {
 						m_extras[i].m_unk0x14 = FALSE;
@@ -1930,15 +1930,15 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 									g_characters[m_lastExtraCharacterId].m_unk0x08 &&
 									!g_characters[m_lastExtraCharacterId].m_inExtras &&
 									g_characters[m_lastExtraCharacterId].m_active == active) {
-									if (!CharacterManager()->FUN_10083b20(g_characters[m_lastExtraCharacterId].m_name
-										)) {
-										m_extras[i].m_roi = CharacterManager()->GetROI(
+									if (!CharacterManager()->Exists(g_characters[m_lastExtraCharacterId].m_name)) {
+										m_extras[i].m_roi = CharacterManager()->GetActorROI(
 											g_characters[m_lastExtraCharacterId].m_name,
 											TRUE
 										);
 
-										LegoExtraActor* actor =
-											CharacterManager()->GetActor(g_characters[m_lastExtraCharacterId].m_name);
+										LegoExtraActor* actor = CharacterManager()->GetExtraActor(
+											g_characters[m_lastExtraCharacterId].m_name
+										);
 
 										switch (g_unk0x100f7504++ % 4) {
 										case 0:
@@ -2002,7 +2002,7 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 											return;
 										}
 										else {
-											CharacterManager()->FUN_10083db0(m_extras[i].m_roi);
+											CharacterManager()->ReleaseActor(m_extras[i].m_roi);
 											m_extras[i].m_roi = NULL;
 											continue;
 										}
@@ -2042,7 +2042,7 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 	MxBool inExtras = FALSE;
 	const char* name = p_roi->GetName();
 
-	LegoExtraActor* actor = CharacterManager()->GetActor(name);
+	LegoExtraActor* actor = CharacterManager()->GetExtraActor(name);
 	if (actor != NULL) {
 		MxS32 characterId = -1;
 		MxS32 i;
@@ -2104,7 +2104,7 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 				return FALSE;
 			}
 
-			CharacterManager()->FUN_10083db0(p_roi);
+			CharacterManager()->ReleaseActor(p_roi);
 		}
 		else {
 			if (inExtras) {
@@ -2216,7 +2216,7 @@ void LegoAnimationManager::FUN_10063270(LegoROIList* p_list, LegoAnimPresenter* 
 				FUN_10063950(roi);
 			}
 			else {
-				LegoExtraActor* actor = CharacterManager()->GetActor(roi->GetName());
+				LegoExtraActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 
 				if (actor != NULL) {
 					for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
@@ -2277,7 +2277,7 @@ void LegoAnimationManager::FUN_10063780(LegoROIList* p_list)
 		while (cursor.Next(roi)) {
 			const char* name = roi->GetName();
 
-			if (CharacterManager()->Exists(name)) {
+			if (CharacterManager()->IsActor(name)) {
 				m_unk0x424->Append(roi);
 				cursor.Detach();
 			}
@@ -2292,7 +2292,7 @@ void LegoAnimationManager::FUN_10063950(LegoROI* p_roi)
 		LegoROIListCursor cursor(m_unk0x424);
 
 		if (cursor.Find(p_roi)) {
-			CharacterManager()->FUN_10083db0(p_roi);
+			CharacterManager()->ReleaseActor(p_roi);
 			cursor.Detach();
 		}
 	}
@@ -2305,7 +2305,7 @@ void LegoAnimationManager::FUN_10063aa0()
 	LegoROI* roi;
 
 	while (cursor.Next(roi)) {
-		CharacterManager()->FUN_10083db0(roi);
+		CharacterManager()->ReleaseActor(roi);
 	}
 }
 
@@ -2388,7 +2388,7 @@ void LegoAnimationManager::FUN_10063d10()
 
 					m_extras[i].m_unk0x0c = FALSE;
 
-					LegoExtraActor* actor = CharacterManager()->GetActor(roi->GetName());
+					LegoExtraActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 					if (actor != NULL) {
 						float speed = m_extras[i].m_speed;
 
@@ -2405,7 +2405,7 @@ void LegoAnimationManager::FUN_10063d10()
 					}
 				}
 				else {
-					LegoExtraActor* actor = CharacterManager()->GetActor(roi->GetName());
+					LegoExtraActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
 					if (actor != NULL) {
 						actor->Restart();
 					}
@@ -2424,7 +2424,7 @@ void LegoAnimationManager::FUN_10063e40(LegoAnimPresenter* p_presenter)
 
 		while (cursor.Next(roi)) {
 			if (!FUN_10062e20(roi, p_presenter)) {
-				CharacterManager()->FUN_10083db0(roi);
+				CharacterManager()->ReleaseActor(roi);
 			}
 
 			cursor.Detach();
@@ -2594,7 +2594,7 @@ MxResult LegoAnimationManager::FUN_10064380(
 		}
 
 		if (roi != NULL && !strcmpi(roi->GetName(), p_name)) {
-			actor = CharacterManager()->GetActor(p_name);
+			actor = CharacterManager()->GetExtraActor(p_name);
 
 			if (actor != NULL && actor->GetController() != NULL) {
 				actor->GetController()->RemoveActor(actor);
@@ -2620,11 +2620,11 @@ MxResult LegoAnimationManager::FUN_10064380(
 			return FAILURE;
 		}
 
-		m_extras[extraIndex].m_roi = CharacterManager()->GetROI(p_name, TRUE);
+		m_extras[extraIndex].m_roi = CharacterManager()->GetActorROI(p_name, TRUE);
 		m_extras[extraIndex].m_characterId = characterId;
 		m_extras[extraIndex].m_speed = p_speed;
 
-		actor = CharacterManager()->GetActor(p_name);
+		actor = CharacterManager()->GetExtraActor(p_name);
 		m_unk0x414++;
 	}
 
@@ -2634,7 +2634,7 @@ MxResult LegoAnimationManager::FUN_10064380(
 		actor->SetWorldSpeed(0.0f);
 
 		if (world->PlaceActor(actor, p_boundaryName, p_src, p_srcScale, p_dest, p_destScale) != SUCCESS) {
-			CharacterManager()->FUN_10083db0(m_extras[i].m_roi);
+			CharacterManager()->ReleaseActor(m_extras[i].m_roi);
 			m_extras[i].m_roi = NULL;
 			m_unk0x414--;
 			return FAILURE;

--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -255,7 +255,7 @@ done:
 
 			actor->SetROI(character->m_roi, FALSE, FALSE);
 			actor->SetType(LegoEntity::e_actor);
-			actor->SetFlag(LegoEntity::c_bit2);
+			actor->SetFlag(LegoEntity::c_managerOwned);
 			GetActorInfo(p_name)->m_actor = actor;
 		}
 
@@ -323,11 +323,11 @@ void LegoCharacterManager::ReleaseActor(const char* p_name)
 
 			if (info != NULL) {
 				if (info->m_actor != NULL) {
-					info->m_actor->ClearFlag(LegoEntity::c_bit2);
+					info->m_actor->ClearFlag(LegoEntity::c_managerOwned);
 					delete info->m_actor;
 				}
-				else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_bit2)) {
-					entity->ClearFlag(LegoEntity::c_bit2);
+				else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_managerOwned)) {
+					entity->ClearFlag(LegoEntity::c_managerOwned);
 					delete entity;
 				}
 
@@ -365,11 +365,11 @@ void LegoCharacterManager::ReleaseActor(LegoROI* p_roi)
 
 				if (info != NULL) {
 					if (info->m_actor != NULL) {
-						info->m_actor->ClearFlag(LegoEntity::c_bit2);
+						info->m_actor->ClearFlag(LegoEntity::c_managerOwned);
 						delete info->m_actor;
 					}
-					else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_bit2)) {
-						entity->ClearFlag(LegoEntity::c_bit2);
+					else if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_managerOwned)) {
+						entity->ClearFlag(LegoEntity::c_managerOwned);
 						delete entity;
 					}
 
@@ -407,8 +407,8 @@ void LegoCharacterManager::ReleaseAutoROI(LegoROI* p_roi)
 
 				m_characters->erase(it);
 
-				if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_bit2)) {
-					entity->ClearFlag(LegoEntity::c_bit2);
+				if (entity != NULL && entity->GetFlagsIsSet(LegoEntity::c_managerOwned)) {
+					entity->ClearFlag(LegoEntity::c_managerOwned);
 					delete entity;
 				}
 			}
@@ -853,7 +853,7 @@ LegoROI* LegoCharacterManager::CreateAutoROI(const char* p_name, const char* p_l
 
 				entity->SetROI(roi, FALSE, FALSE);
 				entity->SetType(LegoEntity::e_autoROI);
-				entity->SetFlag(LegoEntity::c_bit2);
+				entity->SetFlag(LegoEntity::c_managerOwned);
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -1,8 +1,8 @@
 #include "legocharactermanager.h"
 
 #include "3dmanager/lego3dmanager.h"
+#include "legoactors.h"
 #include "legoanimactor.h"
-#include "legocharacters.h"
 #include "legoextraactor.h"
 #include "legogamestate.h"
 #include "legovariables.h"
@@ -40,7 +40,7 @@ MxU32 g_unk0x100fc4ec = 2;
 MxU32 g_unk0x100fc4f0 = 0;
 
 // GLOBAL: LEGO1 0x10104f20
-LegoCharacterInfo g_characterInfo[66];
+LegoActorInfo g_actorInfo[66];
 
 // FUNCTION: LEGO1 0x10082a20
 LegoCharacterManager::LegoCharacterManager()
@@ -75,26 +75,26 @@ LegoCharacterManager::~LegoCharacterManager()
 // FUNCTION: LEGO1 0x10083270
 void LegoCharacterManager::Init()
 {
-	for (MxS32 i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		g_characterInfo[i] = g_characterInfoInit[i];
+	for (MxS32 i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		g_actorInfo[i] = g_actorInfoInit[i];
 	}
 }
 
 // FUNCTION: LEGO1 0x100832a0
-void LegoCharacterManager::FUN_100832a0()
+void LegoCharacterManager::ReleaseAllActors()
 {
-	for (MxS32 i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		LegoCharacterInfo* info = GetInfo(g_characterInfo[i].m_name);
+	for (MxS32 i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		LegoActorInfo* info = GetActorInfo(g_actorInfo[i].m_name);
 
 		if (info != NULL) {
 			LegoExtraActor* actor = info->m_actor;
 
 			if (actor != NULL && actor->IsA("LegoExtraActor")) {
-				LegoROI* roi = g_characterInfo[i].m_roi;
+				LegoROI* roi = g_actorInfo[i].m_roi;
 				MxU32 refCount = GetRefCount(roi);
 
 				while (refCount != 0) {
-					FUN_10083db0(roi);
+					ReleaseActor(roi);
 					refCount = GetRefCount(roi);
 				}
 			}
@@ -107,8 +107,8 @@ MxResult LegoCharacterManager::Write(LegoStorage* p_storage)
 {
 	MxResult result = FAILURE;
 
-	for (MxS32 i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		LegoCharacterInfo* info = &g_characterInfo[i];
+	for (MxS32 i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		LegoActorInfo* info = &g_actorInfo[i];
 
 		if (p_storage->Write(&info->m_unk0x0c, sizeof(info->m_unk0x0c)) != SUCCESS) {
 			goto done;
@@ -162,8 +162,8 @@ MxResult LegoCharacterManager::Read(LegoStorage* p_storage)
 {
 	MxResult result = FAILURE;
 
-	for (MxS32 i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		LegoCharacterInfo* info = &g_characterInfo[i];
+	for (MxS32 i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		LegoActorInfo* info = &g_actorInfo[i];
 
 		if (p_storage->Read(&info->m_unk0x0c, sizeof(info->m_unk0x0c)) != SUCCESS) {
 			goto done;
@@ -213,10 +213,10 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10083500
-LegoROI* LegoCharacterManager::GetROI(const char* p_key, MxBool p_createEntity)
+LegoROI* LegoCharacterManager::GetActorROI(const char* p_name, MxBool p_createEntity)
 {
 	LegoCharacter* character = NULL;
-	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_key));
+	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_name));
 
 	if (it != m_characters->end()) {
 		character = (*it).second;
@@ -224,7 +224,7 @@ LegoROI* LegoCharacterManager::GetROI(const char* p_key, MxBool p_createEntity)
 	}
 
 	if (character == NULL) {
-		LegoROI* roi = CreateROI(p_key);
+		LegoROI* roi = CreateActorROI(p_name);
 
 		if (roi == NULL) {
 			goto done;
@@ -234,11 +234,11 @@ LegoROI* LegoCharacterManager::GetROI(const char* p_key, MxBool p_createEntity)
 
 		if (roi != NULL) {
 			character = new LegoCharacter(roi);
-			char* key = new char[strlen(p_key) + 1];
+			char* name = new char[strlen(p_name) + 1];
 
-			if (key != NULL) {
-				strcpy(key, p_key);
-				(*m_characters)[key] = character;
+			if (name != NULL) {
+				strcpy(name, p_name);
+				(*m_characters)[name] = character;
 				VideoManager()->Get3DManager()->Add(*roi);
 			}
 		}
@@ -254,9 +254,9 @@ done:
 			LegoExtraActor* actor = new LegoExtraActor();
 
 			actor->SetROI(character->m_roi, FALSE, FALSE);
-			actor->SetType(LegoEntity::e_character);
-			actor->SetFlag(LegoActor::c_bit2);
-			GetInfo(p_key)->m_actor = actor;
+			actor->SetType(LegoEntity::e_actor);
+			actor->SetFlag(LegoEntity::c_bit2);
+			GetActorInfo(p_name)->m_actor = actor;
 		}
 
 		return character->m_roi;
@@ -267,10 +267,10 @@ done:
 
 // FUNCTION: LEGO1 0x10083b20
 // FUNCTION: BETA10 0x10074608
-MxBool LegoCharacterManager::FUN_10083b20(const char* p_key)
+MxBool LegoCharacterManager::Exists(const char* p_name)
 {
 	LegoCharacter* character = NULL;
-	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_key));
+	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_name));
 
 	if (it != m_characters->end()) {
 		return TRUE;
@@ -298,7 +298,7 @@ MxU32 LegoCharacterManager::GetRefCount(LegoROI* p_roi)
 
 // FUNCTION: LEGO1 0x10083c30
 // FUNCTION: BETA10 0x10074701
-void LegoCharacterManager::FUN_10083c30(const char* p_name)
+void LegoCharacterManager::ReleaseActor(const char* p_name)
 {
 	LegoCharacter* character = NULL;
 	LegoCharacterMap::iterator it = m_characters->find(const_cast<char*>(p_name));
@@ -307,7 +307,7 @@ void LegoCharacterManager::FUN_10083c30(const char* p_name)
 		character = (*it).second;
 
 		if (character->RemoveRef() == 0) {
-			LegoCharacterInfo* info = GetInfo(p_name);
+			LegoActorInfo* info = GetActorInfo(p_name);
 			LegoEntity* entity = character->m_roi->GetEntity();
 
 			if (entity != NULL) {
@@ -339,7 +339,7 @@ void LegoCharacterManager::FUN_10083c30(const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x10083db0
-void LegoCharacterManager::FUN_10083db0(LegoROI* p_roi)
+void LegoCharacterManager::ReleaseActor(LegoROI* p_roi)
 {
 	LegoCharacter* character = NULL;
 	LegoCharacterMap::iterator it;
@@ -349,7 +349,7 @@ void LegoCharacterManager::FUN_10083db0(LegoROI* p_roi)
 
 		if (character->m_roi == p_roi) {
 			if (character->RemoveRef() == 0) {
-				LegoCharacterInfo* info = GetInfo(character->m_roi->GetName());
+				LegoActorInfo* info = GetActorInfo(character->m_roi->GetName());
 				LegoEntity* entity = character->m_roi->GetEntity();
 
 				if (entity != NULL) {
@@ -384,7 +384,7 @@ void LegoCharacterManager::FUN_10083db0(LegoROI* p_roi)
 }
 
 // FUNCTION: LEGO1 0x10083f10
-void LegoCharacterManager::FUN_10083f10(LegoROI* p_roi)
+void LegoCharacterManager::ReleaseAutoROI(LegoROI* p_roi)
 {
 	LegoCharacter* character = NULL;
 	LegoCharacterMap::iterator it;
@@ -425,7 +425,7 @@ void LegoCharacterManager::RemoveROI(LegoROI* p_roi)
 }
 
 // FUNCTION: LEGO1 0x10084030
-LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
+LegoROI* LegoCharacterManager::CreateActorROI(const char* p_key)
 {
 	MxBool success = FALSE;
 	LegoROI* roi = NULL;
@@ -438,14 +438,14 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 	Tgl::Renderer* renderer = VideoManager()->GetRenderer();
 	ViewLODListManager* lodManager = GetViewLODListManager();
 	LegoTextureContainer* textureContainer = TextureContainer();
-	LegoCharacterInfo* info = GetInfo(p_key);
+	LegoActorInfo* info = GetActorInfo(p_key);
 
 	if (info == NULL) {
 		goto done;
 	}
 
 	if (!strcmpi(p_key, "pep")) {
-		LegoCharacterInfo* pepper = GetInfo("pepper");
+		LegoActorInfo* pepper = GetActorInfo("pepper");
 
 		info->m_unk0x0c = pepper->m_unk0x0c;
 		info->m_unk0x10 = pepper->m_unk0x10;
@@ -459,33 +459,33 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 	roi = new LegoROI(renderer);
 	roi->SetName(p_key);
 
-	boundingSphere.Center()[0] = g_characterLODs[c_topLOD].m_boundingSphere[0];
-	boundingSphere.Center()[1] = g_characterLODs[c_topLOD].m_boundingSphere[1];
-	boundingSphere.Center()[2] = g_characterLODs[c_topLOD].m_boundingSphere[2];
-	boundingSphere.Radius() = g_characterLODs[c_topLOD].m_boundingSphere[3];
+	boundingSphere.Center()[0] = g_actorLODs[c_topLOD].m_boundingSphere[0];
+	boundingSphere.Center()[1] = g_actorLODs[c_topLOD].m_boundingSphere[1];
+	boundingSphere.Center()[2] = g_actorLODs[c_topLOD].m_boundingSphere[2];
+	boundingSphere.Radius() = g_actorLODs[c_topLOD].m_boundingSphere[3];
 	roi->SetBoundingSphere(boundingSphere);
 
-	boundingBox.Min()[0] = g_characterLODs[c_topLOD].m_boundingBox[0];
-	boundingBox.Min()[1] = g_characterLODs[c_topLOD].m_boundingBox[1];
-	boundingBox.Min()[2] = g_characterLODs[c_topLOD].m_boundingBox[2];
-	boundingBox.Max()[0] = g_characterLODs[c_topLOD].m_boundingBox[3];
-	boundingBox.Max()[1] = g_characterLODs[c_topLOD].m_boundingBox[4];
-	boundingBox.Max()[2] = g_characterLODs[c_topLOD].m_boundingBox[5];
+	boundingBox.Min()[0] = g_actorLODs[c_topLOD].m_boundingBox[0];
+	boundingBox.Min()[1] = g_actorLODs[c_topLOD].m_boundingBox[1];
+	boundingBox.Min()[2] = g_actorLODs[c_topLOD].m_boundingBox[2];
+	boundingBox.Max()[0] = g_actorLODs[c_topLOD].m_boundingBox[3];
+	boundingBox.Max()[1] = g_actorLODs[c_topLOD].m_boundingBox[4];
+	boundingBox.Max()[2] = g_actorLODs[c_topLOD].m_boundingBox[5];
 	roi->SetUnknown0x80(boundingBox);
 
 	comp = new CompoundObject();
 	roi->SetComp(comp);
 
-	for (i = 0; i < sizeOfArray(g_characterLODs) - 1; i++) {
+	for (i = 0; i < sizeOfArray(g_actorLODs) - 1; i++) {
 		char lodName[256];
-		LegoCharacterInfo::Part& part = info->m_parts[i];
+		LegoActorInfo::Part& part = info->m_parts[i];
 
 		const char* parentName;
 		if (i == 0 || i == 1) {
 			parentName = part.m_unk0x04[part.m_unk0x00[part.m_unk0x08]];
 		}
 		else {
-			parentName = g_characterLODs[i + 1].m_parentName;
+			parentName = g_actorLODs[i + 1].m_parentName;
 		}
 
 		ViewLODList* lodList = lodManager->Lookup(parentName);
@@ -505,35 +505,34 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 		LegoROI* childROI = new LegoROI(renderer, lodList);
 		lodList->Release();
 
-		childROI->SetName(g_characterLODs[i + 1].m_name);
+		childROI->SetName(g_actorLODs[i + 1].m_name);
 		childROI->SetParentROI(roi);
 
 		BoundingSphere childBoundingSphere;
-		childBoundingSphere.Center()[0] = g_characterLODs[i + 1].m_boundingSphere[0];
-		childBoundingSphere.Center()[1] = g_characterLODs[i + 1].m_boundingSphere[1];
-		childBoundingSphere.Center()[2] = g_characterLODs[i + 1].m_boundingSphere[2];
-		childBoundingSphere.Radius() = g_characterLODs[i + 1].m_boundingSphere[3];
+		childBoundingSphere.Center()[0] = g_actorLODs[i + 1].m_boundingSphere[0];
+		childBoundingSphere.Center()[1] = g_actorLODs[i + 1].m_boundingSphere[1];
+		childBoundingSphere.Center()[2] = g_actorLODs[i + 1].m_boundingSphere[2];
+		childBoundingSphere.Radius() = g_actorLODs[i + 1].m_boundingSphere[3];
 		childROI->SetBoundingSphere(childBoundingSphere);
 
 		BoundingBox childBoundingBox;
-		childBoundingBox.Min()[0] = g_characterLODs[i + 1].m_boundingBox[0];
-		childBoundingBox.Min()[1] = g_characterLODs[i + 1].m_boundingBox[1];
-		childBoundingBox.Min()[2] = g_characterLODs[i + 1].m_boundingBox[2];
-		childBoundingBox.Max()[0] = g_characterLODs[i + 1].m_boundingBox[3];
-		childBoundingBox.Max()[1] = g_characterLODs[i + 1].m_boundingBox[4];
-		childBoundingBox.Max()[2] = g_characterLODs[i + 1].m_boundingBox[5];
+		childBoundingBox.Min()[0] = g_actorLODs[i + 1].m_boundingBox[0];
+		childBoundingBox.Min()[1] = g_actorLODs[i + 1].m_boundingBox[1];
+		childBoundingBox.Min()[2] = g_actorLODs[i + 1].m_boundingBox[2];
+		childBoundingBox.Max()[0] = g_actorLODs[i + 1].m_boundingBox[3];
+		childBoundingBox.Max()[1] = g_actorLODs[i + 1].m_boundingBox[4];
+		childBoundingBox.Max()[2] = g_actorLODs[i + 1].m_boundingBox[5];
 		childROI->SetUnknown0x80(childBoundingBox);
 
 		CalcLocalTransform(
-			Mx3DPointFloat(g_characterLODs[i + 1].m_position),
-			Mx3DPointFloat(g_characterLODs[i + 1].m_direction),
-			Mx3DPointFloat(g_characterLODs[i + 1].m_up),
+			Mx3DPointFloat(g_actorLODs[i + 1].m_position),
+			Mx3DPointFloat(g_actorLODs[i + 1].m_direction),
+			Mx3DPointFloat(g_actorLODs[i + 1].m_up),
 			mat
 		);
 		childROI->WrappedSetLocalTransform(mat);
 
-		if (g_characterLODs[i + 1].m_flags & LegoCharacterLOD::c_flag1 &&
-			(i != 0 || part.m_unk0x00[part.m_unk0x08] != 0)) {
+		if (g_actorLODs[i + 1].m_flags & LegoActorLOD::c_flag1 && (i != 0 || part.m_unk0x00[part.m_unk0x08] != 0)) {
 
 			LegoTextureInfo* textureInfo = textureContainer->Get(part.m_unk0x10[part.m_unk0x0c[part.m_unk0x14]]);
 
@@ -542,7 +541,7 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 				childROI->FUN_100a9170(1.0F, 1.0F, 1.0F, 0.0F);
 			}
 		}
-		else if (g_characterLODs[i + 1].m_flags & LegoCharacterLOD::c_flag2 || (i == 0 && part.m_unk0x00[part.m_unk0x08] == 0)) {
+		else if (g_actorLODs[i + 1].m_flags & LegoActorLOD::c_flag2 || (i == 0 && part.m_unk0x00[part.m_unk0x08] == 0)) {
 			LegoFloat red, green, blue, alpha;
 			childROI->FUN_100a9bf0(part.m_unk0x10[part.m_unk0x0c[part.m_unk0x14]], red, green, blue, alpha);
 			childROI->FUN_100a9170(red, green, blue, alpha);
@@ -552,9 +551,9 @@ LegoROI* LegoCharacterManager::CreateROI(const char* p_key)
 	}
 
 	CalcLocalTransform(
-		Mx3DPointFloat(g_characterLODs[c_topLOD].m_position),
-		Mx3DPointFloat(g_characterLODs[c_topLOD].m_direction),
-		Mx3DPointFloat(g_characterLODs[c_topLOD].m_up),
+		Mx3DPointFloat(g_actorLODs[c_topLOD].m_position),
+		Mx3DPointFloat(g_actorLODs[c_topLOD].m_direction),
+		Mx3DPointFloat(g_actorLODs[c_topLOD].m_up),
 		mat
 	);
 	roi->WrappedSetLocalTransform(mat);
@@ -576,12 +575,12 @@ done:
 MxBool LegoCharacterManager::FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_textureInfo)
 {
 	LegoResult result = SUCCESS;
-	LegoROI* head = FindChildROI(p_roi, g_characterLODs[c_headLOD].m_name);
+	LegoROI* head = FindChildROI(p_roi, g_actorLODs[c_headLOD].m_name);
 
 	if (head != NULL) {
 		char lodName[256];
 
-		ViewLODList* lodList = GetViewLODListManager()->Lookup(g_characterLODs[c_headLOD].m_parentName);
+		ViewLODList* lodList = GetViewLODListManager()->Lookup(g_actorLODs[c_headLOD].m_parentName);
 		MxS32 lodSize = lodList->Size();
 		sprintf(lodName, "%s%s%d", p_roi->GetName(), "head", g_unk0x100fc4e8++);
 		ViewLODList* dupLodList = GetViewLODListManager()->Create(lodName, lodSize);
@@ -589,8 +588,8 @@ MxBool LegoCharacterManager::FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_tex
 		Tgl::Renderer* renderer = VideoManager()->GetRenderer();
 
 		if (p_textureInfo == NULL) {
-			LegoCharacterInfo* info = GetInfo(p_roi->GetName());
-			LegoCharacterInfo::Part& part = info->m_parts[c_headPart];
+			LegoActorInfo* info = GetActorInfo(p_roi->GetName());
+			LegoActorInfo::Part& part = info->m_parts[c_headPart];
 			p_textureInfo = TextureContainer()->Get(part.m_unk0x10[part.m_unk0x0c[part.m_unk0x14]]);
 		}
 
@@ -620,10 +619,10 @@ MxBool LegoCharacterManager::FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_tex
 }
 
 // FUNCTION: LEGO1 0x10084c00
-MxBool LegoCharacterManager::Exists(const char* p_key)
+MxBool LegoCharacterManager::IsActor(const char* p_name)
 {
-	for (MxU32 i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		if (!strcmpi(g_characterInfo[i].m_name, p_key)) {
+	for (MxU32 i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		if (!strcmpi(g_actorInfo[i].m_name, p_name)) {
 			return TRUE;
 		}
 	}
@@ -632,9 +631,9 @@ MxBool LegoCharacterManager::Exists(const char* p_key)
 }
 
 // FUNCTION: LEGO1 0x10084c40
-LegoExtraActor* LegoCharacterManager::GetActor(const char* p_key)
+LegoExtraActor* LegoCharacterManager::GetExtraActor(const char* p_name)
 {
-	LegoCharacterInfo* info = GetInfo(p_key);
+	LegoActorInfo* info = GetActorInfo(p_name);
 
 	if (info != NULL) {
 		return info->m_actor;
@@ -644,36 +643,36 @@ LegoExtraActor* LegoCharacterManager::GetActor(const char* p_key)
 }
 
 // FUNCTION: LEGO1 0x10084c60
-LegoCharacterInfo* LegoCharacterManager::GetInfo(const char* p_key)
+LegoActorInfo* LegoCharacterManager::GetActorInfo(const char* p_name)
 {
 	MxU32 i;
 
-	for (i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		if (!strcmpi(g_characterInfo[i].m_name, p_key)) {
+	for (i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		if (!strcmpi(g_actorInfo[i].m_name, p_name)) {
 			break;
 		}
 	}
 
-	if (i < sizeOfArray(g_characterInfo)) {
-		return &g_characterInfo[i];
+	if (i < sizeOfArray(g_actorInfo)) {
+		return &g_actorInfo[i];
 	}
 
 	return NULL;
 }
 
 // FUNCTION: LEGO1 0x10084cb0
-LegoCharacterInfo* LegoCharacterManager::GetInfo(LegoROI* p_roi)
+LegoActorInfo* LegoCharacterManager::GetActorInfo(LegoROI* p_roi)
 {
 	MxU32 i;
 
-	for (i = 0; i < sizeOfArray(g_characterInfo); i++) {
-		if (g_characterInfo[i].m_roi == p_roi) {
+	for (i = 0; i < sizeOfArray(g_actorInfo); i++) {
+		if (g_actorInfo[i].m_roi == p_roi) {
 			break;
 		}
 	}
 
-	if (i < sizeOfArray(g_characterInfo)) {
-		return &g_characterInfo[i];
+	if (i < sizeOfArray(g_actorInfo)) {
+		return &g_actorInfo[i];
 	}
 
 	return NULL;
@@ -703,13 +702,13 @@ LegoROI* LegoCharacterManager::FindChildROI(LegoROI* p_roi, const char* p_name)
 // FUNCTION: LEGO1 0x10084ec0
 MxBool LegoCharacterManager::SwitchHat(LegoROI* p_roi)
 {
-	LegoCharacterInfo* info = GetInfo(p_roi->GetName());
+	LegoActorInfo* info = GetActorInfo(p_roi->GetName());
 
 	if (info == NULL) {
 		return FALSE;
 	}
 
-	LegoCharacterInfo::Part& part = info->m_parts[c_infohatPart];
+	LegoActorInfo::Part& part = info->m_parts[c_infohatPart];
 
 	part.m_unk0x08++;
 	MxU8 unk0x00 = part.m_unk0x00[part.m_unk0x08];
@@ -719,7 +718,7 @@ MxBool LegoCharacterManager::SwitchHat(LegoROI* p_roi)
 		unk0x00 = part.m_unk0x00[part.m_unk0x08];
 	}
 
-	LegoROI* childROI = FindChildROI(p_roi, g_characterLODs[c_infohatLOD].m_name);
+	LegoROI* childROI = FindChildROI(p_roi, g_actorLODs[c_infohatLOD].m_name);
 
 	if (childROI != NULL) {
 		char lodName[256];
@@ -757,7 +756,7 @@ MxBool LegoCharacterManager::SwitchHat(LegoROI* p_roi)
 // FUNCTION: LEGO1 0x10085140
 MxU32 LegoCharacterManager::FUN_10085140(LegoROI* p_roi, MxBool p_und)
 {
-	LegoCharacterInfo* info = GetInfo(p_roi);
+	LegoActorInfo* info = GetActorInfo(p_roi);
 
 	if (p_und) {
 		return info->m_mood + g_unk0x100fc4dc;
@@ -774,7 +773,7 @@ MxU32 LegoCharacterManager::FUN_10085140(LegoROI* p_roi, MxBool p_und)
 // FUNCTION: BETA10 0x100768c5
 MxU8 LegoCharacterManager::GetMood(LegoROI* p_roi)
 {
-	LegoCharacterInfo* info = GetInfo(p_roi);
+	LegoActorInfo* info = GetActorInfo(p_roi);
 
 	if (info != NULL) {
 		return info->m_mood;
@@ -803,7 +802,7 @@ void LegoCharacterManager::SetCustomizeAnimFile(const char* p_value)
 }
 
 // FUNCTION: LEGO1 0x10085210
-LegoROI* LegoCharacterManager::FUN_10085210(const char* p_name, const char* p_lodName, MxBool p_createEntity)
+LegoROI* LegoCharacterManager::CreateAutoROI(const char* p_name, const char* p_lodName, MxBool p_createEntity)
 {
 	LegoROI* roi = NULL;
 
@@ -853,8 +852,8 @@ LegoROI* LegoCharacterManager::FUN_10085210(const char* p_name, const char* p_lo
 				LegoEntity* entity = new LegoEntity();
 
 				entity->SetROI(roi, FALSE, FALSE);
-				entity->SetType(LegoEntity::e_unk4);
-				entity->SetFlag(LegoActor::c_bit2);
+				entity->SetType(LegoEntity::e_autoROI);
+				entity->SetFlag(LegoEntity::c_bit2);
 			}
 		}
 	}
@@ -907,5 +906,5 @@ MxResult LegoCharacterManager::FUN_10085870(LegoROI* p_roi)
 // FUNCTION: LEGO1 0x10085a80
 LegoROI* LegoCharacterManager::FUN_10085a80(const char* p_name, const char* p_lodName, MxBool p_createEntity)
 {
-	return FUN_10085210(p_name, p_lodName, p_createEntity);
+	return CreateAutoROI(p_name, p_lodName, p_createEntity);
 }

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -177,7 +177,7 @@ void LegoGameState::SetActor(MxU8 p_actorId)
 
 	IslePathActor* newActor = new IslePathActor();
 	const char* actorName = LegoActor::GetActorName(m_actorId);
-	LegoROI* roi = CharacterManager()->GetROI(actorName, FALSE);
+	LegoROI* roi = CharacterManager()->GetActorROI(actorName, FALSE);
 	MxDSAction action;
 
 	action.SetAtomId(*g_isleScript);

--- a/LEGO1/lego/legoomni/src/entity/legoactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoactor.cpp
@@ -129,7 +129,7 @@ void LegoActor::SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2)
 
 		for (MxU32 i = 1; i <= sizeOfArray(g_actorNames) - 1; i++) {
 			if (!strcmpi(name, g_actorNames[i])) {
-				m_type = e_character;
+				m_type = e_actor;
 				m_actorId = i;
 				break;
 			}

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -31,7 +31,7 @@ void LegoEntity::Init()
 	m_flags = 0;
 	m_actionType = Extra::ActionType::e_unknown;
 	m_targetEntityId = -1;
-	m_type = e_unk4;
+	m_type = e_autoROI;
 }
 
 // FUNCTION: LEGO1 0x10010650
@@ -93,7 +93,7 @@ void LegoEntity::Destroy(MxBool p_fromDestructor)
 				m_roi->SetEntity(NULL);
 			}
 
-			CharacterManager()->FUN_10083db0(m_roi);
+			CharacterManager()->ReleaseActor(m_roi);
 		}
 		else {
 			VideoManager()->Get3DManager()->GetLego3DView()->Remove(*m_roi);
@@ -252,7 +252,7 @@ void LegoEntity::VTable0x34(MxBool p_und)
 		const LegoChar* roiName = m_roi->GetName();
 
 		switch (m_type) {
-		case e_character:
+		case e_actor:
 			objectId = CharacterManager()->FUN_10085140(m_roi, p_und);
 			break;
 		case e_unk1:
@@ -285,7 +285,7 @@ void LegoEntity::VTable0x38()
 void LegoEntity::VTable0x3c()
 {
 	switch (m_type) {
-	case e_character:
+	case e_actor:
 		CharacterManager()->SwitchHat(m_roi);
 		break;
 	case e_unk1:
@@ -366,7 +366,7 @@ MxLong LegoEntity::Notify(MxParam& p_param)
 			break;
 		case 6:
 			switch (m_type) {
-			case e_character:
+			case e_actor:
 			case e_unk1:
 				break;
 			case e_plant:
@@ -375,7 +375,7 @@ MxLong LegoEntity::Notify(MxParam& p_param)
 			case e_building:
 				BuildingManager()->FUN_10030000(this);
 				break;
-			case e_unk4:
+			case e_autoROI:
 				break;
 			}
 		}

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -187,7 +187,7 @@ void LegoWorld::Destroy(MxBool p_fromDestructor)
 		while (cursor.First(entity)) {
 			cursor.Detach();
 
-			if (!(entity->GetFlags() & LegoEntity::c_bit2)) {
+			if (!(entity->GetFlags() & LegoEntity::c_managerOwned)) {
 				delete entity;
 			}
 		}

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -188,7 +188,7 @@ LegoChar* LegoAnimPresenter::FUN_10069150(const LegoChar* p_und1)
 {
 	LegoChar* str;
 
-	if (LegoCharacterManager::Exists(p_und1 + 1)) {
+	if (LegoCharacterManager::IsActor(p_und1 + 1)) {
 		str = new LegoChar[strlen(p_und1)];
 
 		if (str != NULL) {
@@ -232,7 +232,7 @@ void LegoAnimPresenter::FUN_100692b0()
 					src = str;
 				}
 
-				roi = CharacterManager()->GetROI(src, TRUE);
+				roi = CharacterManager()->GetActorROI(src, TRUE);
 
 				if (roi != NULL && str[0] == '*') {
 					roi->SetVisibility(FALSE);
@@ -268,7 +268,7 @@ void LegoAnimPresenter::FUN_100692b0()
 				strlwr(lodName);
 
 				LegoChar* und = FUN_10069150(str);
-				roi = CharacterManager()->FUN_10085210(und, lodName, TRUE);
+				roi = CharacterManager()->CreateAutoROI(und, lodName, TRUE);
 
 				if (roi != NULL) {
 					roi->SetVisibility(FALSE);
@@ -313,7 +313,7 @@ void LegoAnimPresenter::FUN_100695c0()
 
 					strlwr(lodName);
 
-					CharacterManager()->FUN_10085210(actorName, lodName, FALSE);
+					CharacterManager()->CreateAutoROI(actorName, lodName, FALSE);
 					FUN_100698b0(rois, actorName);
 				}
 			}
@@ -530,8 +530,8 @@ void LegoAnimPresenter::FUN_1006aa60()
 	while (cursor.Next(roi)) {
 		const char* name = roi->GetName();
 
-		if (m_unk0x96 || !CharacterManager()->Exists(name)) {
-			CharacterManager()->FUN_10083c30(name);
+		if (m_unk0x96 || !CharacterManager()->IsActor(name)) {
+			CharacterManager()->ReleaseActor(name);
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -224,7 +224,7 @@ MxResult LegoModelPresenter::FUN_1007ff70(
 
 	if (p_entity != NULL) {
 		p_entity->SetROI(m_roi, TRUE, TRUE);
-		p_entity->ClearFlag(LegoEntity::c_bit2);
+		p_entity->ClearFlag(LegoEntity::c_managerOwned);
 	}
 	else {
 		p_world->GetROIList().push_back(m_roi);
@@ -249,7 +249,8 @@ void LegoModelPresenter::ReadyTickle()
 			((LegoEntityPresenter*) m_compositePresenter)
 				->GetInternalEntity()
 				->SetFlags(
-					((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->GetFlags() & ~LegoEntity::c_bit2
+					((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->GetFlags() &
+					~LegoEntity::c_managerOwned
 				);
 			((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->SetType(LegoEntity::e_actor);
 		}
@@ -276,7 +277,7 @@ void LegoModelPresenter::ReadyTickle()
 						->GetInternalEntity()
 						->SetFlags(
 							((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->GetFlags() &
-							~LegoEntity::c_bit2
+							~LegoEntity::c_managerOwned
 						);
 				}
 

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -251,7 +251,7 @@ void LegoModelPresenter::ReadyTickle()
 				->SetFlags(
 					((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->GetFlags() & ~LegoEntity::c_bit2
 				);
-			((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->SetType(LegoEntity::e_character);
+			((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->SetType(LegoEntity::e_actor);
 		}
 
 		ParseExtra();
@@ -306,7 +306,7 @@ void LegoModelPresenter::ParseExtra()
 			char* token = strtok(output, g_parseExtraTokens);
 
 			if (m_roi == NULL) {
-				m_roi = CharacterManager()->GetROI(token, FALSE);
+				m_roi = CharacterManager()->GetActorROI(token, FALSE);
 				m_addedToView = FALSE;
 			}
 		}

--- a/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
@@ -52,7 +52,7 @@ void LegoPhonemePresenter::StartingTickle()
 				m_unk0x84 = TRUE;
 			}
 			else {
-				entityROI = CharacterManager()->GetROI(m_roiName.GetData(), TRUE);
+				entityROI = CharacterManager()->GetActorROI(m_roiName.GetData(), TRUE);
 			}
 
 			head = entityROI->FindChildROI("head", entityROI);
@@ -143,7 +143,7 @@ void LegoPhonemePresenter::EndAction()
 					roi = FindROI(m_roiName.GetData());
 				}
 				else {
-					roi = CharacterManager()->GetROI(m_roiName.GetData(), TRUE);
+					roi = CharacterManager()->GetActorROI(m_roiName.GetData(), TRUE);
 				}
 
 				if (roi != NULL) {
@@ -151,7 +151,7 @@ void LegoPhonemePresenter::EndAction()
 				}
 
 				if (!m_unk0x84) {
-					CharacterManager()->FUN_10083c30(m_roiName.GetData());
+					CharacterManager()->ReleaseActor(m_roiName.GetData());
 				}
 
 				TextureContainer()->EraseCached(phoneme->VTable0x10());
@@ -164,7 +164,7 @@ void LegoPhonemePresenter::EndAction()
 			}
 
 			if (!m_unk0x84) {
-				CharacterManager()->FUN_10083c30(m_roiName.GetData());
+				CharacterManager()->ReleaseActor(m_roiName.GetData());
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -1308,7 +1308,7 @@ void Infocenter::Reset()
 	PlantManager()->FUN_10027120();
 	BuildingManager()->FUN_10030590();
 	AnimationManager()->Reset(FALSE);
-	CharacterManager()->FUN_100832a0();
+	CharacterManager()->ReleaseAllActors();
 	GameState()->SetCurrentAct(LegoGameState::e_act1);
 	GameState()->SetPreviousArea(LegoGameState::e_undefined);
 	GameState()->SetUnknown0x42c(LegoGameState::e_undefined);


### PR DESCRIPTION
Based on recent decompilation work, I've renamed a number of functions/variables in `LegoCharacterManager`.

The key insight is that there are essentially two types of "characters" that are being managed by this class: actors, which are the Lego characters found in the game (66 of them), and "auto ROIs", which are dynamically created (animated) entities (for example a parrot).

Actors are treated as a superset of auto ROIs for the purposes of this class.