### PR TITLE
Streamline MxVideoParamFlags

### DIFF
--- a/LEGO1/omni/include/mxomnicreateflags.h
+++ b/LEGO1/omni/include/mxomnicreateflags.h
@@ -9,46 +9,46 @@ public:
 	MxOmniCreateFlags();
 
 	// FUNCTION: BETA10 0x10092b50
-	inline void CreateObjectFactory(MxBool p_enable) { this->m_flags1.m_bit0 = p_enable; }
+	inline void CreateObjectFactory(MxBool p_enable) { m_flags1.m_bit0 = p_enable; }
 
 	// FUNCTION: BETA10 0x10092b90
-	inline void CreateTickleManager(MxBool p_enable) { this->m_flags1.m_bit2 = p_enable; }
+	inline void CreateTickleManager(MxBool p_enable) { m_flags1.m_bit2 = p_enable; }
 
 	// FUNCTION: BETA10 0x10092bd0
-	inline void CreateVideoManager(MxBool p_enable) { this->m_flags1.m_bit4 = p_enable; }
+	inline void CreateVideoManager(MxBool p_enable) { m_flags1.m_bit4 = p_enable; }
 
 	// FUNCTION: BETA10 0x10092c10
-	inline void CreateSoundManager(MxBool p_enable) { this->m_flags1.m_bit5 = p_enable; }
+	inline void CreateSoundManager(MxBool p_enable) { m_flags1.m_bit5 = p_enable; }
 
 	// FUNCTION: BETA10 0x10130cd0
-	inline const MxBool CreateObjectFactory() const { return this->m_flags1.m_bit0; }
+	inline const MxBool CreateObjectFactory() const { return m_flags1.m_bit0; }
 
 	// FUNCTION: BETA10 0x10130cf0
-	inline const MxBool CreateVariableTable() const { return this->m_flags1.m_bit1; }
+	inline const MxBool CreateVariableTable() const { return m_flags1.m_bit1; }
 
 	// FUNCTION: BETA10 0x10130d10
-	inline const MxBool CreateTickleManager() const { return this->m_flags1.m_bit2; }
+	inline const MxBool CreateTickleManager() const { return m_flags1.m_bit2; }
 
 	// FUNCTION: BETA10 0x10130d30
-	inline const MxBool CreateNotificationManager() const { return this->m_flags1.m_bit3; }
+	inline const MxBool CreateNotificationManager() const { return m_flags1.m_bit3; }
 
 	// FUNCTION: BETA10 0x10130d50
-	inline const MxBool CreateVideoManager() const { return this->m_flags1.m_bit4; }
+	inline const MxBool CreateVideoManager() const { return m_flags1.m_bit4; }
 
 	// FUNCTION: BETA10 0x10130d70
-	inline const MxBool CreateSoundManager() const { return this->m_flags1.m_bit5; }
+	inline const MxBool CreateSoundManager() const { return m_flags1.m_bit5; }
 
 	// FUNCTION: BETA10 0x10130d90
-	inline const MxBool CreateMusicManager() const { return this->m_flags1.m_bit6; }
+	inline const MxBool CreateMusicManager() const { return m_flags1.m_bit6; }
 
 	// FUNCTION: BETA10 0x10130db0
-	inline const MxBool CreateEventManager() const { return this->m_flags1.m_bit7; }
+	inline const MxBool CreateEventManager() const { return m_flags1.m_bit7; }
 
 	// FUNCTION: BETA10 0x10130dd0
-	inline const MxBool CreateTimer() const { return this->m_flags2.m_bit1; }
+	inline const MxBool CreateTimer() const { return m_flags2.m_bit1; }
 
 	// FUNCTION: BETA10 0x10130e00
-	inline const MxBool CreateStreamer() const { return this->m_flags2.m_bit2; }
+	inline const MxBool CreateStreamer() const { return m_flags2.m_bit2; }
 
 private:
 	FlagBitfield m_flags1;

--- a/LEGO1/omni/include/mxvideoparam.h
+++ b/LEGO1/omni/include/mxvideoparam.h
@@ -14,22 +14,33 @@ class MxPalette;
 class MxVideoParam {
 public:
 	MxVideoParam();
-	MxVideoParam(MxVideoParam& p_videoParam);
 	__declspec(dllexport)
 		MxVideoParam(MxRect32& p_rect, MxPalette* p_palette, MxULong p_backBuffers, MxVideoParamFlags& p_flags);
-	MxVideoParam& operator=(const MxVideoParam& p_videoParam);
+	MxVideoParam(MxVideoParam& p_videoParam);
 	~MxVideoParam();
 	void SetDeviceName(char* p_deviceId);
+	MxVideoParam& operator=(const MxVideoParam& p_videoParam);
 
+	// FUNCTION: BETA10 0x100886e0
 	inline MxVideoParamFlags& Flags() { return m_flags; }
 
-	inline void SetPalette(MxPalette* p_palette) { this->m_palette = p_palette; }
-	inline void SetBackBuffers(MxU32 p_backBuffers) { this->m_backBuffers = p_backBuffers; }
+	// FUNCTION: BETA10 0x100d81f0
+	inline MxRect32& GetRect() { return m_rect; }
 
-	inline MxRect32& GetRect() { return this->m_rect; }
-	inline MxPalette* GetPalette() { return this->m_palette; }
-	inline MxU32 GetBackBuffers() { return this->m_backBuffers; }
-	inline char* GetDeviceName() { return this->m_deviceId; }
+	// FUNCTION: BETA10 0x100d8210
+	inline MxPalette* GetPalette() { return m_palette; }
+
+	// FUNCTION: BETA10 0x100d8240
+	inline void SetPalette(MxPalette* p_palette) { m_palette = p_palette; }
+
+	// FUNCTION: BETA10 0x100d8270
+	inline char* GetDeviceName() { return m_deviceId; }
+
+	// FUNCTION: BETA10 0x10141f60
+	inline MxU32 GetBackBuffers() { return m_backBuffers; }
+
+	// FUNCTION: BETA10 0x10141fe0
+	inline void SetBackBuffers(MxU32 p_backBuffers) { m_backBuffers = p_backBuffers; }
 
 private:
 	MxRect32 m_rect;           // 0x00

--- a/LEGO1/omni/include/mxvideoparamflags.h
+++ b/LEGO1/omni/include/mxvideoparamflags.h
@@ -9,39 +9,56 @@ class MxVideoParamFlags {
 public:
 	MxVideoParamFlags();
 
-	inline void SetFullScreen(BOOL p_e) { m_flags1.m_bit0 = p_e; }
-	inline void SetFlipSurfaces(BOOL p_e) { m_flags1.m_bit1 = p_e; }
-	inline void SetBackBuffers(BOOL p_e) { m_flags1.m_bit2 = p_e; }
-	inline void SetF1bit3(BOOL p_e) { m_flags1.m_bit3 = p_e; }
-	inline void SetF1bit4(BOOL p_e) { m_flags1.m_bit4 = p_e; }
-	inline void Set16Bit(BYTE p_e) { m_flags1.m_bit5 = p_e; }
-	inline void SetWideViewAngle(BOOL p_e) { m_flags1.m_bit6 = p_e; }
-	inline void SetF1bit7(BOOL p_e) { m_flags1.m_bit7 = p_e; }
-	inline void SetF2bit0(BOOL p_e) { m_flags2.m_bit0 = p_e; }
-	inline void SetF2bit1(BOOL p_e) { m_flags2.m_bit1 = p_e; }
-	inline void SetF2bit2(BOOL p_e) { m_flags2.m_bit2 = p_e; }
-	inline void SetF2bit3(BOOL p_e) { m_flags2.m_bit3 = p_e; }
-	inline void SetF2bit4(BOOL p_e) { m_flags2.m_bit4 = p_e; }
-	inline void SetF2bit5(BOOL p_e) { m_flags2.m_bit5 = p_e; }
-	inline void SetF2bit6(BOOL p_e) { m_flags2.m_bit6 = p_e; }
-	inline void SetF2bit7(BOOL p_e) { m_flags2.m_bit7 = p_e; }
+	// inlined in ISLE
+	inline void SetFullScreen(MxBool p_e) { m_flags1.m_bit0 = p_e; }
 
-	inline BYTE GetFullScreen() { return m_flags1.m_bit0; }
-	inline BYTE GetFlipSurfaces() { return m_flags1.m_bit1; }
-	inline BYTE GetBackBuffers() { return m_flags1.m_bit2; }
-	inline BYTE GetF1bit3() { return m_flags1.m_bit3; }
-	inline BYTE GetF1bit4() { return m_flags1.m_bit4; }
-	inline BYTE Get16Bit() { return m_flags1.m_bit5; }
-	inline BYTE GetWideViewAngle() { return m_flags1.m_bit6; }
-	inline BYTE GetF1bit7() { return m_flags1.m_bit7; }
-	inline BYTE GetF2bit0() { return m_flags2.m_bit0; }
-	inline BYTE GetF2bit1() { return m_flags2.m_bit1; }
-	inline BYTE GetF2bit2() { return m_flags2.m_bit2; }
-	inline BYTE GetF2bit3() { return m_flags2.m_bit3; }
-	inline BYTE GetF2bit4() { return m_flags2.m_bit4; }
-	inline BYTE GetF2bit5() { return m_flags2.m_bit5; }
-	inline BYTE GetF2bit6() { return m_flags2.m_bit6; }
-	inline BYTE GetF2bit7() { return m_flags2.m_bit7; }
+	// FUNCTION: BETA10 0x10141f80
+	inline void SetFlipSurfaces(MxBool p_e) { m_flags1.m_bit1 = p_e; }
+
+	// FUNCTION: BETA10 0x10141fb0
+	inline void SetBackBuffers(MxBool p_e) { m_flags1.m_bit2 = p_e; }
+
+	// FUNCTION: BETA10 0x100d9250
+	inline void SetF1bit3(MxBool p_e) { m_flags1.m_bit3 = p_e; }
+
+	// inlined in ISLE
+	inline void Set16Bit(MxBool p_e) { m_flags1.m_bit5 = p_e; }
+
+	// inlined in ISLE
+	inline void SetWideViewAngle(MxBool p_e) { m_flags1.m_bit6 = p_e; }
+
+	// inlined in ISLE
+	inline void SetF1bit7(MxBool p_e) { m_flags1.m_bit7 = p_e; }
+
+	// FUNCTION: BETA10 0x100d81b0
+	inline void SetF2bit0(MxBool p_e) { m_flags2.m_bit0 = p_e; }
+
+	// inlined in ISLE
+	inline void SetF2bit1(MxBool p_e) { m_flags2.m_bit1 = p_e; }
+
+	// FUNCTION: BETA10 0x1009e770
+	inline MxBool GetFullScreen() { return m_flags1.m_bit0; }
+
+	// FUNCTION: BETA10 0x100d80f0
+	inline MxBool GetFlipSurfaces() { return m_flags1.m_bit1; }
+
+	// FUNCTION: BETA10 0x100d8120
+	inline MxBool GetBackBuffers() { return m_flags1.m_bit2; }
+
+	// FUNCTION: BETA10 0x10142010
+	inline MxBool GetF1bit3() { return m_flags1.m_bit3; }
+
+	// FUNCTION: BETA10 0x100d8150
+	inline MxBool Get16Bit() { return m_flags1.m_bit5; }
+
+	// FUNCTION: BETA10 0x100d8180
+	inline MxBool GetWideViewAngle() { return m_flags1.m_bit6; }
+
+	// FUNCTION: BETA10 0x100886b0
+	inline MxBool GetF2bit0() { return m_flags2.m_bit0; }
+
+	// FUNCTION: BETA10 0x10142050
+	inline MxBool GetF2bit1() { return m_flags2.m_bit1; }
 
 private:
 	FlagBitfield m_flags1;

--- a/LEGO1/omni/src/main/mxomnicreateflags.cpp
+++ b/LEGO1/omni/src/main/mxomnicreateflags.cpp
@@ -8,15 +8,15 @@ DECOMP_SIZE_ASSERT(MxOmniCreateFlags, 0x02)
 // FUNCTION: BETA10 0x10130a1c
 MxOmniCreateFlags::MxOmniCreateFlags()
 {
-	this->m_flags1.m_bit0 = TRUE; // CreateObjectFactory
-	this->m_flags1.m_bit1 = TRUE; // CreateVariableTable
-	this->m_flags1.m_bit2 = TRUE; // CreateTickleManager
-	this->m_flags1.m_bit3 = TRUE; // CreateNotificationManager
-	this->m_flags1.m_bit4 = TRUE; // CreateVideoManager
-	this->m_flags1.m_bit5 = TRUE; // CreateSoundManager
-	this->m_flags1.m_bit6 = TRUE; // CreateMusicManager
-	this->m_flags1.m_bit7 = TRUE; // CreateEventManager
+	m_flags1.m_bit0 = TRUE; // CreateObjectFactory
+	m_flags1.m_bit1 = TRUE; // CreateVariableTable
+	m_flags1.m_bit2 = TRUE; // CreateTickleManager
+	m_flags1.m_bit3 = TRUE; // CreateNotificationManager
+	m_flags1.m_bit4 = TRUE; // CreateVideoManager
+	m_flags1.m_bit5 = TRUE; // CreateSoundManager
+	m_flags1.m_bit6 = TRUE; // CreateMusicManager
+	m_flags1.m_bit7 = TRUE; // CreateEventManager
 
-	this->m_flags2.m_bit1 = TRUE; // CreateTimer
-	this->m_flags2.m_bit2 = TRUE; // CreateStreamer
+	m_flags2.m_bit1 = TRUE; // CreateTimer
+	m_flags2.m_bit2 = TRUE; // CreateStreamer
 }

--- a/LEGO1/omni/src/video/mxvideoparam.cpp
+++ b/LEGO1/omni/src/video/mxvideoparam.cpp
@@ -5,79 +5,82 @@
 #include <stdlib.h>
 #include <string.h>
 
-DECOMP_SIZE_ASSERT(MxVideoParam, 0x24);
+DECOMP_SIZE_ASSERT(MxVideoParam, 0x24)
 
 // FUNCTION: LEGO1 0x100bec70
+// FUNCTION: BETA10 0x1012db3e
 MxVideoParam::MxVideoParam()
 {
-	this->m_rect.SetRight(640);
-	this->m_rect.SetBottom(480);
-	this->m_rect.SetLeft(0);
-	this->m_rect.SetTop(0);
-	this->m_palette = NULL;
-	this->m_backBuffers = 0;
-	this->m_unk0x1c = 0;
-	this->m_deviceId = NULL;
+	m_rect = MxRect32(0, 0, 640, 480);
+	m_palette = NULL;
+	m_backBuffers = 0;
+	m_unk0x1c = 0;
+	m_deviceId = NULL;
 }
 
 // FUNCTION: LEGO1 0x100beca0
+// FUNCTION: BETA10 0x1012dbb1
 MxVideoParam::MxVideoParam(MxRect32& p_rect, MxPalette* p_palette, MxULong p_backBuffers, MxVideoParamFlags& p_flags)
 {
-	this->m_rect = p_rect;
-	this->m_palette = p_palette;
-	this->m_backBuffers = p_backBuffers;
-	this->m_flags = p_flags;
-	this->m_unk0x1c = 0;
-	this->m_deviceId = NULL;
+	m_rect = p_rect;
+	m_palette = p_palette;
+	m_backBuffers = p_backBuffers;
+	m_flags = p_flags;
+	m_unk0x1c = 0;
+	m_deviceId = NULL;
 }
 
 // FUNCTION: LEGO1 0x100becf0
+// FUNCTION: BETA10 0x1012dc1e
 MxVideoParam::MxVideoParam(MxVideoParam& p_videoParam)
 {
-	this->m_rect = p_videoParam.m_rect;
-	this->m_palette = p_videoParam.m_palette;
-	this->m_backBuffers = p_videoParam.m_backBuffers;
-	this->m_flags = p_videoParam.m_flags;
-	this->m_unk0x1c = p_videoParam.m_unk0x1c;
-	this->m_deviceId = NULL;
+	m_rect = p_videoParam.m_rect;
+	m_palette = p_videoParam.m_palette;
+	m_backBuffers = p_videoParam.m_backBuffers;
+	m_flags = p_videoParam.m_flags;
+	m_unk0x1c = p_videoParam.m_unk0x1c;
+	m_deviceId = NULL;
 	SetDeviceName(p_videoParam.m_deviceId);
 }
 
 // FUNCTION: LEGO1 0x100bed50
+// FUNCTION: BETA10 0x1012dca3
 MxVideoParam::~MxVideoParam()
 {
-	if (this->m_deviceId != NULL) {
-		delete[] this->m_deviceId;
+	if (m_deviceId != NULL) {
+		delete[] m_deviceId;
 	}
 }
 
 // FUNCTION: LEGO1 0x100bed70
+// FUNCTION: BETA10 0x1012dce1
 void MxVideoParam::SetDeviceName(char* p_deviceId)
 {
-	if (this->m_deviceId != NULL) {
-		delete[] this->m_deviceId;
+	if (m_deviceId != NULL) {
+		delete[] m_deviceId;
 	}
 
 	if (p_deviceId != NULL) {
-		this->m_deviceId = new char[strlen(p_deviceId) + 1];
+		m_deviceId = new char[strlen(p_deviceId) + 1];
 
-		if (this->m_deviceId != NULL) {
-			strcpy(this->m_deviceId, p_deviceId);
+		if (m_deviceId != NULL) {
+			strcpy(m_deviceId, p_deviceId);
 		}
 	}
 	else {
-		this->m_deviceId = NULL;
+		m_deviceId = NULL;
 	}
 }
 
 // FUNCTION: LEGO1 0x100bede0
+// FUNCTION: BETA10 0x1012dd76
 MxVideoParam& MxVideoParam::operator=(const MxVideoParam& p_videoParam)
 {
-	this->m_rect = p_videoParam.m_rect;
-	this->m_palette = p_videoParam.m_palette;
-	this->m_backBuffers = p_videoParam.m_backBuffers;
-	this->m_flags = p_videoParam.m_flags;
-	this->m_unk0x1c = p_videoParam.m_unk0x1c;
+	m_rect = p_videoParam.m_rect;
+	m_palette = p_videoParam.m_palette;
+	m_backBuffers = p_videoParam.m_backBuffers;
+	m_flags = p_videoParam.m_flags;
+	m_unk0x1c = p_videoParam.m_unk0x1c;
 	SetDeviceName(p_videoParam.m_deviceId);
 
 	return *this;

--- a/LEGO1/omni/src/video/mxvideoparamflags.cpp
+++ b/LEGO1/omni/src/video/mxvideoparamflags.cpp
@@ -1,15 +1,21 @@
 #include "mxvideoparamflags.h"
 
+#include "decomp.h"
+
+DECOMP_SIZE_ASSERT(MxVideoParamFlags, 0x02)
+
 // FUNCTION: LEGO1 0x100bec40
+// FUNCTION: BETA10 0x1012dadb
 MxVideoParamFlags::MxVideoParamFlags()
 {
-	this->SetFullScreen(0);
-	this->SetFlipSurfaces(0);
-	this->SetBackBuffers(0);
-	this->SetF1bit3(0);
-	this->SetF1bit4(0);
-	this->Set16Bit(0);
-	this->SetWideViewAngle(1);
-	this->SetF1bit7(1);
-	this->SetF2bit1(1);
+	m_flags1.m_bit0 = FALSE; // FullScreen
+	m_flags1.m_bit1 = FALSE; // FlipSurfaces
+	m_flags1.m_bit2 = FALSE; // BackBuffers
+	m_flags1.m_bit3 = FALSE;
+	m_flags1.m_bit4 = FALSE;
+	m_flags1.m_bit5 = FALSE; // 16Bit
+	m_flags1.m_bit6 = TRUE;  // WideViewAngle
+	m_flags1.m_bit7 = TRUE;
+
+	m_flags2.m_bit1 = TRUE;
 }


### PR DESCRIPTION
Removes the unused bit functions from `MxVideoParamFlags`. We get the expected compiler noise for header changes, but I don't see any change to the functions that actually touch the flags.

I couldn't find a beta address for the sets used only by ISLE (in `IsleApp::SetupVideoFlags`) so those don't get one.

Beta match and addresses for `MxVideoParam` too. I took the opportunity to remove `this->` from both of those classes and `MxOmniCreateFlags` which is similar to `MxVideoParamFlags`.