### PR TITLE
Disable autojunk for python difflib

### DIFF
--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -565,7 +565,7 @@ class Compare:
         orig_asm = [x[1] for x in orig_combined]
         recomp_asm = [x[1] for x in recomp_combined]
 
-        diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm)
+        diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm, autojunk=False)
         ratio = diff.ratio()
 
         if ratio != 1.0:


### PR DESCRIPTION
A small change but one that should help keep the diffs more stable.

The python [difflib](https://docs.python.org/3/library/difflib.html) library provides the `SequenceMatcher` class that we use to compare assembly. For sequences over 200 elements, the code will identify common elements and not use these as the anchor for a match. If, for example, your sequence contains a list of words, a match on common words like "the" should not be considered significant inside a larger diff. The name of the general algorithm is Longest Common Subsequence: providing that is the general goal, but with the added approach of having a straightforward diff without the "zebra" effect. As the python doc page puts it:

> This does not yield minimal edit sequences, but does tend to yield matches that "look right" to people.

Our goals with comparing assembly are a little different. If we ignore "popular" elements that appear more than once, this includes things like `add esp, 4` or references to `this` on the stack. Longer functions will create longer diffs and it becomes tougher to see what's actually wrong. We do consider a match on these instructions significant because they usually mark the start and end of a function call.

Here's a small example to show the effect of disabling the `autojunk` option.

Before:
```diff
@@ 0x1006074b @@
-mov ecx, dword ptr [ebp - 0x18]
-mov eax, dword ptr [ebp - 0x14]
-mov edx, dword ptr [ebp - 0x10]
+mov eax, dword ptr [ebp - 0x14]
+mov edx, dword ptr [ebp - 0x10]
+mov byte ptr [ebp - 4], 0
+mov ecx, dword ptr [ebp - 0x18]
mov dword ptr [eax], ecx
-mov byte ptr [ebp - 4], 0
```

After:
```diff
@@ 0x1006074b @@
-mov ecx, dword ptr [ebp - 0x18]
mov eax, dword ptr [ebp - 0x14]
mov edx, dword ptr [ebp - 0x10]
+mov byte ptr [ebp - 4], 0
+mov ecx, dword ptr [ebp - 0x18]
mov dword ptr [eax], ecx
-mov byte ptr [ebp - 4], 0
```