### PR TITLE
TowTrack and LegoAct2 destructors

### DIFF
--- a/LEGO1/lego/legoomni/include/legoact2.h
+++ b/LEGO1/lego/legoomni/include/legoact2.h
@@ -43,6 +43,8 @@ public:
 // SIZE 0x1154
 class LegoAct2 : public LegoWorld {
 public:
+	~LegoAct2();
+
 	MxLong Notify(MxParam& p_param) override;         // vtable+0x04
 	MxResult Tickle() override;                       // vtable+0x08
 	MxResult Create(MxDSAction& p_dsAction) override; // vtable+0x18
@@ -58,6 +60,8 @@ public:
 	// LegoAct2::`scalar deleting destructor'
 
 private:
+	void FUN_10051900();
+
 	Act2Brick m_bricks[10];      // 0x00f8
 	undefined m_unk0x10c0;       // 0x10c0
 	undefined m_unk0x10c1;       // 0x10c1

--- a/LEGO1/lego/legoomni/include/legoact2.h
+++ b/LEGO1/lego/legoomni/include/legoact2.h
@@ -43,7 +43,7 @@ public:
 // SIZE 0x1154
 class LegoAct2 : public LegoWorld {
 public:
-	~LegoAct2();
+	~LegoAct2() override;
 
 	MxLong Notify(MxParam& p_param) override;         // vtable+0x04
 	MxResult Tickle() override;                       // vtable+0x08

--- a/LEGO1/lego/legoomni/include/towtrack.h
+++ b/LEGO1/lego/legoomni/include/towtrack.h
@@ -67,7 +67,7 @@ public:
 class TowTrack : public IslePathActor {
 public:
 	TowTrack();
-	~TowTrack();
+	~TowTrack() override;
 
 	// FUNCTION: LEGO1 0x1004c7c0
 	inline const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/include/towtrack.h
+++ b/LEGO1/lego/legoomni/include/towtrack.h
@@ -67,6 +67,7 @@ public:
 class TowTrack : public IslePathActor {
 public:
 	TowTrack();
+	~TowTrack();
 
 	// FUNCTION: LEGO1 0x1004c7c0
 	inline const char* ClassName() const override // vtable+0x0c

--- a/LEGO1/lego/legoomni/src/actors/towtrack.cpp
+++ b/LEGO1/lego/legoomni/src/actors/towtrack.cpp
@@ -1,5 +1,6 @@
 #include "towtrack.h"
 
+#include "legocontrolmanager.h"
 #include "legogamestate.h"
 #include "legovariables.h"
 #include "legoworld.h"
@@ -23,6 +24,12 @@ TowTrack::TowTrack()
 	m_unk0x174 = -1;
 	m_maxLinearVel = 40.0;
 	m_unk0x178 = 1.0;
+}
+
+// FUNCTION: LEGO1 0x1004c970
+TowTrack::~TowTrack()
+{
+	ControlManager()->Unregister(this);
 }
 
 // FUNCTION: LEGO1 0x1004c9e0

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -477,6 +477,7 @@ void LegoWorld::Add(MxCore* p_object)
 }
 
 // FUNCTION: LEGO1 0x10020f10
+// FUNCTION: BETA10 0x100dad2a
 void LegoWorld::Remove(MxCore* p_object)
 {
 	if (p_object) {

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -1,5 +1,12 @@
 #include "legoact2.h"
 
+#include "legoanimationmanager.h"
+#include "legoinputmanager.h"
+#include "misc.h"
+#include "mxmisc.h"
+#include "mxnotificationmanager.h"
+#include "mxticklemanager.h"
+
 DECOMP_SIZE_ASSERT(LegoAct2, 0x1154)
 DECOMP_SIZE_ASSERT(LegoAct2State, 0x10)
 
@@ -7,6 +14,23 @@ DECOMP_SIZE_ASSERT(LegoAct2State, 0x10)
 MxBool LegoAct2::VTable0x5c()
 {
 	return TRUE;
+}
+
+// FUNCTION: LEGO1 0x1004fe40
+// FUNCTION: BETA10 0x1003a6f0
+LegoAct2::~LegoAct2()
+{
+	if (m_unk0x10c2) {
+		TickleManager()->UnregisterClient(this);
+	}
+
+	FUN_10051900();
+	InputManager()->UnRegister(this);
+	if (CurrentActor()) {
+		Remove(CurrentActor());
+	}
+
+	NotificationManager()->Unregister(this);
 }
 
 // STUB: LEGO1 0x1004ff20
@@ -40,6 +64,20 @@ void LegoAct2::ReadyWorld()
 void LegoAct2::Enable(MxBool p_enable)
 {
 	// TODO
+}
+
+// FUNCTION: LEGO1 0x10051900
+// FUNCTION: BETA10 0x1003bed1
+void LegoAct2::FUN_10051900()
+{
+	if (AnimationManager()) {
+		AnimationManager()->Suspend();
+		AnimationManager()->Resume();
+		AnimationManager()->FUN_10060540(FALSE);
+		AnimationManager()->FUN_100604d0(FALSE);
+		AnimationManager()->EnableCamAnims(FALSE);
+		AnimationManager()->FUN_1005f6d0(FALSE);
+	}
 }
 
 // STUB: LEGO1 0x100519c0


### PR DESCRIPTION
Adds missing destructor functions for TowTrack and LegoAct2. These bring the scalar dtor functions to 100%. I noticed these were off when checking #1004.

Also: beta addrs for LegoAct2, but the functions are slightly different there.