### PR TITLE
Fix remaining vtordisp issues

### DIFF
--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -3,25 +3,23 @@
 
 #include "legoraceactor.h"
 
-/*
-	VTABLE: LEGO1 0x100da0c0 LegoRaceActor
-	VTABLE: LEGO1 0x100da0c8 LegoAnimActor
-	VTABLE: LEGO1 0x100da0d8 LegoPathActor
-	VTABLE: LEGO1 0x100da1a8 LegoCarRaceActor
-*/
+// VTABLE: LEGO1 0x100da0c0 LegoRaceActor
+// VTABLE: LEGO1 0x100da0c8 LegoAnimActor
+// VTABLE: LEGO1 0x100da0d8 LegoPathActor
+// VTABLE: LEGO1 0x100da1a8 LegoCarRaceActor
 // SIZE 0x1a0
 class LegoCarRaceActor : public virtual LegoRaceActor {
 public:
 	LegoCarRaceActor();
 
-	// FUNCTION: LEGO1 0x10081650
+	// FUNCTION: LEGO1 0x10081660
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0568
 		return "LegoCarRaceActor";
 	}
 
-	// FUNCTION: LEGO1 0x10081670
+	// FUNCTION: LEGO1 0x10081680
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(p_name);
@@ -62,7 +60,7 @@ public:
 
 	virtual void VTable0x1c(); // vtable+0x1c
 
-	// SYNTHETIC: LEGO1 0x10081610
+	// SYNTHETIC: LEGO1 0x10081620
 	// LegoCarRaceActor::`scalar deleting destructor'
 
 protected:

--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -34,10 +34,8 @@ public:
 		float p_f1,
 		float p_f2,
 		Vector3& p_v3
-	) override;                                                          // vtable+0x6c
-	void VTable0x70(float p_float) override;                             // vtable+0x70
-	MxU32 VTable0x90(float, Matrix4&) override;                          // vtable+0x90
-	MxResult VTable0x94(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94
+	) override;                              // vtable+0x6c
+	void VTable0x70(float p_float) override; // vtable+0x70
 	void SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 		override;                   // vtable+0x98
 	MxResult VTable0x9c() override; // vtable+0x9c

--- a/LEGO1/lego/legoomni/include/legojetski.h
+++ b/LEGO1/lego/legoomni/include/legojetski.h
@@ -4,28 +4,27 @@
 #include "legojetskiraceactor.h"
 #include "legoracemap.h"
 
-/*
-	VTABLE: LEGO1 0x100d5a08 LegoJetskiRaceActor
-	VTABLE: LEGO1 0x100d5a28 LegoRaceActor
-	VTABLE: LEGO1 0x100d5a30 LegoAnimActor
-	VTABLE: LEGO1 0x100d5a40 LegoPathActor
-	VTABLE: LEGO1 0x100d5b10 LegoRaceMap
-*/
+// VTABLE: LEGO1 0x100d5a08 LegoJetskiRaceActor
+// VTABLE: LEGO1 0x100d5a28 LegoRaceActor
+// VTABLE: LEGO1 0x100d5a30 LegoAnimActor
+// VTABLE: LEGO1 0x100d5a40 LegoPathActor
+// VTABLE: LEGO1 0x100d5b10 LegoRaceMap
 // SIZE 0x1dc
 class LegoJetski : public LegoJetskiRaceActor, public LegoRaceMap {
 public:
 	LegoJetski();
+	~LegoJetski() override;
 
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
-	// FUNCTION: LEGO1 0x10013e80
+	// FUNCTION: LEGO1 0x10013e90
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f053c
 		return "LegoJetski";
 	}
 
-	// FUNCTION: LEGO1 0x10013ea0
+	// FUNCTION: LEGO1 0x10013eb0
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoJetski::ClassName()) || LegoJetskiRaceActor::IsA(p_name);
@@ -49,7 +48,7 @@ public:
 
 	virtual void FUN_100136f0(float p_worldSpeed);
 
-	// SYNTHETIC: LEGO1 0x10013e20
+	// SYNTHETIC: LEGO1 0x10013e30
 	// LegoJetski::`scalar deleting destructor'
 };
 

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -3,25 +3,23 @@
 
 #include "legocarraceactor.h"
 
-/*
-	VTABLE: LEGO1 0x100da208 LegoCarRaceActor
-	VTABLE: LEGO1 0x100da228 LegoRaceActor
-	VTABLE: LEGO1 0x100da230 LegoAnimActor
-	VTABLE: LEGO1 0x100da240 LegoPathActor
-*/
+// VTABLE: LEGO1 0x100da208 LegoCarRaceActor
+// VTABLE: LEGO1 0x100da228 LegoRaceActor
+// VTABLE: LEGO1 0x100da230 LegoAnimActor
+// VTABLE: LEGO1 0x100da240 LegoPathActor
 // SIZE 0x1a8
 class LegoJetskiRaceActor : public virtual LegoCarRaceActor {
 public:
 	LegoJetskiRaceActor();
 
-	// FUNCTION: LEGO1 0x10081d80
+	// FUNCTION: LEGO1 0x10081d90
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0554
 		return "LegoJetskiRaceActor";
 	}
 
-	// FUNCTION: LEGO1 0x10081da0
+	// FUNCTION: LEGO1 0x10081db0
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoJetskiRaceActor::ClassName()) || LegoCarRaceActor::IsA(p_name);
@@ -36,12 +34,9 @@ public:
 		Vector3& p_v3
 	) override;                              // vtable+0x6c
 	void VTable0x70(float p_float) override; // vtable+0x70
-	void SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
-		override;                   // vtable+0x98
-	MxResult VTable0x9c() override; // vtable+0x9c
-	void VTable0x1c() override;     // vtable+0x1c
+	void VTable0x1c() override;              // vtable+0x1c
 
-	// SYNTHETIC: LEGO1 0x10081d40
+	// SYNTHETIC: LEGO1 0x10081d50
 	// LegoJetskiRaceActor::`scalar deleting destructor'
 };
 

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -5,40 +5,35 @@
 
 class Matrix4;
 
-/*
-	VTABLE: LEGO1 0x100d5b78 LegoAnimActor
-	VTABLE: LEGO1 0x100d5b88 LegoPathActor
-	VTABLE: LEGO1 0x100d5c54 LegoRaceActor
-*/
+// VTABLE: LEGO1 0x100d5b78 LegoAnimActor
+// VTABLE: LEGO1 0x100d5b88 LegoPathActor
+// VTABLE: LEGO1 0x100d5c54 LegoRaceActor
 // SIZE 0x180
 class LegoRaceActor : public virtual LegoAnimActor {
 public:
 	LegoRaceActor();
 
-	// FUNCTION: LEGO1 0x10014af0
+	// FUNCTION: LEGO1 0x10014b00
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0bf4
 		return "LegoRaceActor";
 	}
 
-	// FUNCTION: LEGO1 0x10014b10
+	// FUNCTION: LEGO1 0x10014b20
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoRaceActor::ClassName()) || LegoAnimActor::IsA(p_name);
 	}
 
-	void SetWorldSpeed(MxFloat p_worldSpeed) override;                   // vtable+0x30
 	MxS32 VTable0x68(Vector3&, Vector3&, Vector3&) override;             // vtable+0x68
-	void VTable0x70(float p_float) override;                             // vtable+0x70
-	void VTable0x74(Matrix4& p_transform) override;                      // vtable+0x74
 	MxU32 VTable0x90(float, Matrix4&) override;                          // vtable+0x90
 	MxResult VTable0x94(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94
 
 	// FUNCTION: LEGO1 0x10014aa0
 	virtual MxResult FUN_10014aa0() { return SUCCESS; }
 
-	// SYNTHETIC: LEGO1 0x10014ab0
+	// SYNTHETIC: LEGO1 0x10014ac0
 	// LegoRaceActor::`scalar deleting destructor'
 
 private:

--- a/LEGO1/lego/legoomni/include/legoracecar.h
+++ b/LEGO1/lego/legoomni/include/legoracecar.h
@@ -4,30 +4,30 @@
 #include "legocarraceactor.h"
 #include "legoracemap.h"
 
-/*
-	VTABLE: LEGO1 0x100d58a0 LegoRaceActor
-	VTABLE: LEGO1 0x100d58a8 LegoAnimActor
-	VTABLE: LEGO1 0x100d58b8 LegoPathActor
-	VTABLE: LEGO1 0x100d5894 LegoRaceMap
-	VTABLE: LEGO1 0x100d5898 LegoCarRaceActor
-*/
+// VTABLE: LEGO1 0x100d58a0 LegoRaceActor
+// VTABLE: LEGO1 0x100d58a8 LegoAnimActor
+// VTABLE: LEGO1 0x100d58b8 LegoPathActor
+// VTABLE: LEGO1 0x100d5984 LegoRaceMap
+// VTABLE: LEGO1 0x100d5988 LegoCarRaceActor
 // SIZE 0x200
 class LegoRaceCar : public LegoCarRaceActor, public LegoRaceMap {
 public:
 	LegoRaceCar();
+	~LegoRaceCar() override;
+
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
-	// FUNCTION: LEGO1 0x10014290
+	// FUNCTION: LEGO1 0x100142a0
 	inline const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0548
 		return "LegoRaceCar";
 	}
 
-	// FUNCTION: LEGO1 0x100142b0
+	// FUNCTION: LEGO1 0x100142c0
 	inline MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
-		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoCarRaceActor::IsA(p_name);
+		return !strcmp(p_name, LegoRaceCar::ClassName()) || LegoCarRaceActor::IsA(p_name);
 	}
 
 	void ParseAction(char*) override;                  // vtable+0x20
@@ -50,7 +50,7 @@ public:
 	virtual void FUN_10012ff0(float);
 	virtual MxBool FUN_10013130(float);
 
-	// SYNTHETIC: LEGO1 0x10014230
+	// SYNTHETIC: LEGO1 0x10014240
 	// LegoRaceCar::`scalar deleting destructor'
 
 private:

--- a/LEGO1/lego/legoomni/include/legoracemap.h
+++ b/LEGO1/lego/legoomni/include/legoracemap.h
@@ -3,20 +3,25 @@
 
 #include "legoraceactor.h"
 
-/*
-	VTABLE: LEGO1 0x100d8858 LegoRaceActor
-	VTABLE: LEGO1 0x100d8860 LegoAnimActor
-	VTABLE: LEGO1 0x100d8870 LegoPathActor
-	VTABLE: LEGO1 0x100d893c LegoRaceMap
-*/
+// VTABLE: LEGO1 0x100d8858 LegoRaceActor
+// VTABLE: LEGO1 0x100d8860 LegoAnimActor
+// VTABLE: LEGO1 0x100d8870 LegoPathActor
+// VTABLE: LEGO1 0x100d893c LegoRaceMap
 // SIZE 0x1b4
 class LegoRaceMap : public virtual LegoRaceActor {
 public:
 	LegoRaceMap();
+	~LegoRaceMap() override;
 
-	virtual void FUN_1005d4b0();
+	// LegoPathActor vtable
+	MxLong Notify(MxParam& p_param) override;  // vtable+0x04
+	void ParseAction(char* p_extra) override;  // vtable+0x20
+	void VTable0x70(float p_und) override = 0; // vtable+0x70
 
-	// SYNTHETIC: LEGO1 0x1005d5c0
+	// LegoRaceMap vtable
+	virtual void FUN_1005d4b0(); // vtable+0x00
+
+	// SYNTHETIC: LEGO1 0x1005d5d0
 	// LegoRaceMap::`scalar deleting destructor'
 
 private:

--- a/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
@@ -9,20 +9,6 @@ DECOMP_SIZE_ASSERT(LegoCarRaceActor, 0x1a0)
 // STRING: LEGO1 0x100f7ae4
 const char* g_fuel = "FUEL";
 
-// STUB: LEGO1 0x100141a0
-MxU32 LegoCarRaceActor::VTable0x90(float, Matrix4&)
-{
-	// TODO
-	return 0;
-}
-
-// STUB: LEGO1 0x1005d650
-MxResult LegoCarRaceActor::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
-{
-	// TODO
-	return 0;
-}
-
 // FUNCTION: LEGO1 0x10080350
 LegoCarRaceActor::LegoCarRaceActor()
 {

--- a/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
@@ -37,7 +37,26 @@ void LegoCarRaceActor::VTable0x1c()
 {
 }
 
-// STUB: LEGO1 0x10081830
+// STUB: LEGO1 0x10080b40
+void LegoCarRaceActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10080b70
+void LegoCarRaceActor::VTable0x70(float p_float)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10080be0
+MxResult LegoCarRaceActor::VTable0x9c()
+{
+	// TODO
+	return SUCCESS;
+}
+
+// STUB: LEGO1 0x10081840
 MxU32 LegoCarRaceActor::VTable0x6c(
 	LegoPathBoundary* p_boundary,
 	Vector3& p_v1,
@@ -49,23 +68,4 @@ MxU32 LegoCarRaceActor::VTable0x6c(
 {
 	// TODO
 	return 0;
-}
-
-// STUB: LEGO1 0x10081d10
-void LegoCarRaceActor::VTable0x70(float p_float)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10081d20
-void LegoCarRaceActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10081d30
-MxResult LegoCarRaceActor::VTable0x9c()
-{
-	// TODO
-	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/entity/legojetski.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legojetski.cpp
@@ -5,6 +5,12 @@
 
 DECOMP_SIZE_ASSERT(LegoJetski, 0x1dc)
 
+// STUB: LEGO1 0x100136a0
+void LegoJetski::SetWorldSpeed(MxFloat p_worldSpeed)
+{
+	// TODO
+}
+
 // FUNCTION: LEGO1 0x100136f0
 void LegoJetski::FUN_100136f0(float p_worldSpeed)
 {
@@ -18,32 +24,45 @@ void LegoJetski::FUN_100136f0(float p_worldSpeed)
 	}
 }
 
+// STUB: LEGO1 0x10013740
+void LegoJetski::VTable0x70(float p_float)
+{
+	// TODO
+}
+
 // FUNCTION: LEGO1 0x10013820
 LegoJetski::LegoJetski()
 {
 	NotificationManager()->Register(this);
 }
 
-// STUB: LEGO1 0x10013e70
+// STUB: LEGO1 0x10013aa0
+LegoJetski::~LegoJetski()
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10013bb0
+void LegoJetski::ParseAction(char*)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10013c30
 MxLong LegoJetski::Notify(MxParam& p_param)
 {
 	// TODO
 	return 0;
 }
 
-// STUB: LEGO1 0x10014110
-void LegoJetski::ParseAction(char*)
+// STUB: LEGO1 0x10013c40
+MxResult LegoJetski::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 {
 	// TODO
+	return 0;
 }
 
-// STUB: LEGO1 0x10014120
-void LegoJetski::SetWorldSpeed(MxFloat p_worldSpeed)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10014140
+// STUB: LEGO1 0x10014150
 MxU32 LegoJetski::VTable0x6c(
 	LegoPathBoundary* p_boundary,
 	Vector3& p_v1,
@@ -57,26 +76,13 @@ MxU32 LegoJetski::VTable0x6c(
 	return 0;
 }
 
-// STUB: LEGO1 0x10014180
-void LegoJetski::VTable0x70(float p_float)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x100141b0
-MxResult LegoJetski::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
-{
-	// TODO
-	return 0;
-}
-
-// STUB: LEGO1 0x100141c0
+// STUB: LEGO1 0x100141d0
 void LegoJetski::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 {
 	// TODO
 }
 
-// STUB: LEGO1 0x10014200
+// STUB: LEGO1 0x10014210
 MxResult LegoJetski::VTable0x9c()
 {
 	// TODO

--- a/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
@@ -2,12 +2,6 @@
 
 DECOMP_SIZE_ASSERT(LegoJetskiRaceActor, 0x1a8)
 
-// STUB: LEGO1 0x10014220
-void LegoJetskiRaceActor::VTable0x1c()
-{
-	// TODO
-}
-
 // FUNCTION: LEGO1 0x10080ef0
 LegoJetskiRaceActor::LegoJetskiRaceActor()
 {
@@ -17,7 +11,19 @@ LegoJetskiRaceActor::LegoJetskiRaceActor()
 	m_unk0x150 = 1.5f;
 }
 
-// STUB: LEGO1 0x10081fc0
+// STUB: LEGO1 0x10081120
+void LegoJetskiRaceActor::VTable0x1c()
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10081550
+void LegoJetskiRaceActor::VTable0x70(float p_float)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10081fd0
 MxU32 LegoJetskiRaceActor::VTable0x6c(
 	LegoPathBoundary* p_boundary,
 	Vector3& p_v1,
@@ -29,23 +35,4 @@ MxU32 LegoJetskiRaceActor::VTable0x6c(
 {
 	// TODO
 	return 0;
-}
-
-// STUB: LEGO1 0x100822c0
-void LegoJetskiRaceActor::VTable0x70(float p_float)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x100822d0
-void LegoJetskiRaceActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x100822e0
-MxResult LegoJetskiRaceActor::VTable0x9c()
-{
-	// TODO
-	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -2,12 +2,6 @@
 
 DECOMP_SIZE_ASSERT(LegoRaceActor, 0x180)
 
-// STUB: LEGO1 0x10014190
-void LegoRaceActor::VTable0x74(Matrix4& p_transform)
-{
-	// TODO
-}
-
 // FUNCTION: LEGO1 0x100145d0
 LegoRaceActor::LegoRaceActor()
 {
@@ -15,33 +9,21 @@ LegoRaceActor::LegoRaceActor()
 	m_unk0x08 = 0;
 }
 
-// STUB: LEGO1 0x10014cb0
-void LegoRaceActor::SetWorldSpeed(MxFloat p_worldSpeed)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10014cc0
+// STUB: LEGO1 0x10014750
 MxS32 LegoRaceActor::VTable0x68(Vector3&, Vector3&, Vector3&)
 {
 	// TODO
 	return 0;
 }
 
-// STUB: LEGO1 0x10014cd0
-void LegoRaceActor::VTable0x70(float p_float)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10014ce0
+// STUB: LEGO1 0x100147f0
 MxU32 LegoRaceActor::VTable0x90(float, Matrix4&)
 {
 	// TODO
 	return 0;
 }
 
-// STUB: LEGO1 0x10014cf0
+// STUB: LEGO1 0x10014a00
 MxResult LegoRaceActor::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 {
 	// TODO

--- a/LEGO1/lego/legoomni/src/race/legoracecar.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracecar.cpp
@@ -18,6 +18,25 @@ LegoRaceCar::LegoRaceCar()
 	NotificationManager()->Register(this);
 }
 
+// STUB: LEGO1 0x10012c80
+LegoRaceCar::~LegoRaceCar()
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x10012d90
+MxLong LegoRaceCar::Notify(MxParam& p_param)
+{
+	// TODO
+	return 0;
+}
+
+// STUB: LEGO1 0x10012e60
+void LegoRaceCar::SetWorldSpeed(MxFloat p_worldSpeed)
+{
+	// TODO
+}
+
 // FUNCTION: LEGO1 0x10012ea0
 void LegoRaceCar::FUN_10012ea0(float p_worldSpeed)
 {
@@ -29,6 +48,12 @@ void LegoRaceCar::FUN_10012ea0(float p_worldSpeed)
 	else {
 		m_maxLinearVel = p_worldSpeed;
 	}
+}
+
+// STUB: LEGO1 0x10012ef0
+void LegoRaceCar::ParseAction(char*)
+{
+	// TODO
 }
 
 // STUB: LEGO1 0x10012ff0
@@ -44,26 +69,27 @@ MxBool LegoRaceCar::FUN_10013130(float)
 	return TRUE;
 }
 
-// STUB: LEGO1 0x10014280
-MxLong LegoRaceCar::Notify(MxParam& p_param)
+// STUB: LEGO1 0x100131f0
+void LegoRaceCar::VTable0x70(float p_float)
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x100133c0
+MxResult LegoRaceCar::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 {
 	// TODO
 	return 0;
 }
 
-// STUB: LEGO1 0x100144d0
-void LegoRaceCar::ParseAction(char*)
+// STUB: LEGO1 0x10013600
+MxResult LegoRaceCar::VTable0x9c()
 {
 	// TODO
+	return SUCCESS;
 }
 
-// STUB: LEGO1 0x100144e0
-void LegoRaceCar::SetWorldSpeed(MxFloat p_worldSpeed)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x100144f0
+// STUB: LEGO1 0x10014500
 MxU32 LegoRaceCar::VTable0x6c(
 	LegoPathBoundary* p_boundary,
 	Vector3& p_v1,
@@ -77,28 +103,8 @@ MxU32 LegoRaceCar::VTable0x6c(
 	return 0;
 }
 
-// STUB: LEGO1 0x10014530
-void LegoRaceCar::VTable0x70(float p_float)
-{
-	// TODO
-}
-
-// STUB: LEGO1 0x10014540
-MxResult LegoRaceCar::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
-{
-	// TODO
-	return 0;
-}
-
-// STUB: LEGO1 0x10014550
+// STUB: LEGO1 0x10014560
 void LegoRaceCar::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 {
 	// TODO
-}
-
-// STUB: LEGO1 0x10014580
-MxResult LegoRaceCar::VTable0x9c()
-{
-	// TODO
-	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/race/legoracemap.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracemap.cpp
@@ -14,8 +14,27 @@ LegoRaceMap::LegoRaceMap()
 	ControlManager()->Register(this);
 }
 
+// STUB: LEGO1 0x1005d2b0
+LegoRaceMap::~LegoRaceMap()
+{
+	// TODO
+}
+
+// STUB: LEGO1 0x1005d310
+void LegoRaceMap::ParseAction(char* p_extra)
+{
+	// TODO
+}
+
 // FUNCTION: LEGO1 0x1005d4b0
 void LegoRaceMap::FUN_1005d4b0()
 {
 	// TODO
+}
+
+// STUB: LEGO1 0x1005d550
+MxLong LegoRaceMap::Notify(MxParam& p_param)
+{
+	// TODO
+	return 0;
 }

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -233,7 +233,7 @@ class CompareDb:
         self, orig: int, recomp: int, compare_type: Optional[SymbolType] = None
     ) -> bool:
         if self._orig_used(orig):
-            logger.error("Original address %s not unique!", hex(orig))
+            logger.debug("Original address %s not unique!", hex(orig))
             return False
 
         compare_value = compare_type.value if compare_type is not None else None


### PR DESCRIPTION
Enabled the `// VTABLE` annotations for these classes that use virtual inheritance:
- LegoRaceActor
- LegoRaceMap
- LegoCarRaceActor
- LegoJetskiRaceActor
- LegoJetski
- LegoRaceCar

I moved some of the override functions around to get the tables up to 100%.

The code in `isledecomp` that autodetects the vtordisp thunks alerted to the original address being reused. With this change we now have far more of those alerts than before. They are not indicative of a problem with the annotations so I have set these to appear only in debug mode for now.