### PR TITLE
Bugfix for LegoMeterPresenter::DrawMeter

### DIFF
--- a/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
@@ -145,7 +145,7 @@ void LegoMeterPresenter::DrawMeter()
 		case e_bottomToTop:
 			bottomTopEnd = m_meterRect.GetBottom() - (MxS16) (m_meterRect.GetHeight() * m_curPercent);
 
-			for (row = m_meterRect.GetBottom(); row < bottomTopEnd; row--) {
+			for (row = m_meterRect.GetBottom(); row > bottomTopEnd; row--) {
 				MxU8* line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), row);
 
 				for (bottomTopCol = 0; bottomTopCol < m_meterRect.GetWidth(); bottomTopCol++, line++) {


### PR DESCRIPTION
Vertical meters were not displayed properly. The main one we have available now is the fuel gauge in the ambulance:

![fuel gauge](https://github.com/isledecomp/isle/assets/6954746/0effbeaa-323c-4767-b61b-72c6072433a3)

We never entered the for-loop to start drawing pixels because the less-than/greater-than was swapped. This slipped by because it blended in with compiler noise: the `si` and `di` registers are swapped, so this means that `cmp si, di` should flip `jle` to `jge`. I had it matched on the jump instruction, hence the bug.