### PR TITLE
Small update to datacmp and roadmap

### DIFF
--- a/ISLE/library_smartheap.h
+++ b/ISLE/library_smartheap.h
@@ -297,7 +297,7 @@
 // GLOBAL: ISLE 0x4105b0
 // __shi_TaskRecord
 
-// ~GLOBAL: ISLE 0x4125f8
+// GLOBAL: ISLE 0x4125f8
 // ?_pnhHeap@@3P6AHI@ZA
 
 // GLOBAL: ISLE 0x412830

--- a/tools/roadmap/roadmap.py
+++ b/tools/roadmap/roadmap.py
@@ -415,7 +415,9 @@ def main():
             displacement = None
             module_name = None
 
-            if match.recomp_addr is not None and recomp_bin.is_valid_vaddr(match.recomp_addr):
+            if match.recomp_addr is not None and recomp_bin.is_valid_vaddr(
+                match.recomp_addr
+            ):
                 if (module_ref := module_map.get_module(match.recomp_addr)) is not None:
                     (_, module_name) = module_ref
 

--- a/tools/roadmap/roadmap.py
+++ b/tools/roadmap/roadmap.py
@@ -415,7 +415,7 @@ def main():
             displacement = None
             module_name = None
 
-            if match.recomp_addr is not None:
+            if match.recomp_addr is not None and recomp_bin.is_valid_vaddr(match.recomp_addr):
                 if (module_ref := module_map.get_module(match.recomp_addr)) is not None:
                     (_, module_name) = module_ref
 


### PR DESCRIPTION
In `datacmp` we had some problems matching variables that should be initialized to zero. The linker might put these in the uninitialized zone of the data section and this gets reported as a diff. In the actual program, these virtual addrs are set to zero by Windows, so for practical purposes, such a variable would behave the same in both situations. This might still be wrong enough to care about (i.e. if the variables are not in the same order in each binary) so we will flag it as a warning for the user to review.

With this fix, I re-enabled the `_pnhHeap` variable from smartheap in the files for `ISLE`. We disabled it back in #990.

There was also a bug with the `roadmap` script that I noticed while checking out the `CONFIG` app. We are using a dummy value for the address of each ordinal import, and so we should ignore this when it would cause a problem.