### PR TITLE
Improve several functions in `vector.h`

### DIFF
--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -43,6 +43,7 @@ private:
 };
 
 // VTABLE: LEGO1 0x100d41e8
+// VTABLE: BETA10 0x101bab78
 // SIZE 0x18
 class Mx4DPointFloat : public Vector4 {
 public:

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -385,8 +385,8 @@ public:
 	friend class Mx4DPointFloat;
 };
 
-// FUNCTION: BETA10 0x10048ad0
 // FUNCTION: LEGO1 0x10002b70
+// FUNCTION: BETA10 0x10048ad0
 inline int Vector4::NormalizeQuaternion()
 {
 	float* v = m_data;
@@ -408,8 +408,8 @@ inline static float QuaternionProductScalarPart(float* bDat, float* aDat)
 	return aDat[3] * bDat[3] - (aDat[0] * bDat[0] + aDat[2] * bDat[2] + aDat[1] * bDat[1]);
 }
 
-// FUNCTION: BETA10 0x10048c20
 // FUNCTION: LEGO1 0x10002bf0
+// FUNCTION: BETA10 0x10048c20
 inline int Vector4::EqualsHamiltonProduct(Vector4* p_a, Vector4* p_b)
 {
 	m_data[3] = QuaternionProductScalarPart(p_a->m_data, p_b->m_data);

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -385,7 +385,7 @@ public:
 	friend class Mx4DPointFloat;
 };
 
-// FUNCTION: BETA10 0x10048c20
+// FUNCTION: BETA10 0x10048ad0
 // FUNCTION: LEGO1 0x10002b70
 inline int Vector4::NormalizeQuaternion()
 {


### PR DESCRIPTION
There is some progress here, but I'd also appreciate some ideas for further improvements.

- Add BETA10 references
- Turn some functions into inline functions based on BETA10
- Identify and improve `Vector4::EqualsHamiltonProduct()`, partly based on BETA10
- Match `Vector4::NormalizeQuaternion()` to 100 %, partly based on BETA10

The remaining issue with `Vector4::EqualsHamiltonProduct()` is the same as `Vector3::EqualsCrossImpl()` due to an `inline`. I was unable to improve the match on that one.