### PR TITLE
Add MxTrace function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(omni STATIC
   LEGO1/omni/src/common/mxatom.cpp
   LEGO1/omni/src/common/mxcompositepresenter.cpp
   LEGO1/omni/src/common/mxcore.cpp
+  LEGO1/omni/src/common/mxdebug.cpp
   LEGO1/omni/src/common/mxmediamanager.cpp
   LEGO1/omni/src/common/mxmediapresenter.cpp
   LEGO1/omni/src/common/mxmisc.cpp

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -8,6 +8,7 @@
 #include "legoworld.h"
 #include "misc.h"
 #include "mxautolock.h"
+#include "mxdebug.h"
 #include "roi/legoroi.h"
 
 DECOMP_SIZE_ASSERT(LegoInputManager, 0x338)
@@ -111,17 +112,19 @@ void LegoInputManager::Destroy()
 }
 
 // FUNCTION: LEGO1 0x1005c030
+// FUNCTION: BETA10 0x10088f6e
 void LegoInputManager::CreateAndAcquireKeyboard(HWND p_hwnd)
 {
 	HINSTANCE hinstance = (HINSTANCE) GetWindowLong(p_hwnd, GWL_HINSTANCE);
-	HRESULT hresult = DirectInputCreate(hinstance, 0x500, &m_directInput, NULL); // 0x500 for DX5
 
-	if (hresult == DI_OK) {
-		HRESULT createdeviceresult = m_directInput->CreateDevice(GUID_SysKeyboard, &m_directInputDevice, NULL);
-		if (createdeviceresult == DI_OK) {
+	// 0x500 for DX5
+	if (DirectInputCreate(hinstance, 0x500, &m_directInput, NULL) == DI_OK) {
+		if (m_directInput->CreateDevice(GUID_SysKeyboard, &m_directInputDevice, NULL) == DI_OK) {
 			m_directInputDevice->SetCooperativeLevel(p_hwnd, DISCL_NONEXCLUSIVE | DISCL_FOREGROUND);
 			m_directInputDevice->SetDataFormat(&c_dfDIKeyboard);
-			m_directInputDevice->Acquire();
+			if (m_directInputDevice->Acquire()) {
+				MxTrace("Can't acquire the keyboard!\n");
+			}
 		}
 	}
 }

--- a/LEGO1/omni/include/mxdebug.h
+++ b/LEGO1/omni/include/mxdebug.h
@@ -1,0 +1,32 @@
+#ifndef MXDEBUG_H
+#define MXDEBUG_H
+
+#include "compat.h"
+
+#ifdef _DEBUG
+
+// In debug mode, replace the macro with the function call.
+#define MxTrace _MxTrace
+
+void _MxTrace(const char* format, ...);
+int DebugHeapState();
+
+#else
+
+// If not debug, MxTrace is a no-op.
+
+#ifdef COMPAT_MODE
+
+// Use variadic args for macro (C99)
+#define MxTrace(...)
+
+#else
+
+// MSVC 4.20 does not have variadic args for macros
+#define MxTrace(args)
+
+#endif // COMPAT_MODE
+
+#endif // _DEBUG
+
+#endif // MXDEBUG_H

--- a/LEGO1/omni/include/mxdssubscriber.h
+++ b/LEGO1/omni/include/mxdssubscriber.h
@@ -34,7 +34,10 @@ public:
 	MxStreamChunk* PeekData();
 	void FreeDataChunk(MxStreamChunk* p_chunk);
 
+	// FUNCTION: BETA10 0x101354f0
 	inline MxU32 GetObjectId() { return m_objectId; }
+
+	// FUNCTION: BETA10 0x10135510
 	inline MxS16 GetUnknown48() { return m_unk0x48; }
 
 private:

--- a/LEGO1/omni/include/mxmemorypool.h
+++ b/LEGO1/omni/include/mxmemorypool.h
@@ -3,6 +3,7 @@
 
 #include "decomp.h"
 #include "mxbitset.h"
+#include "mxdebug.h"
 #include "mxtypes.h"
 
 #include <assert.h>
@@ -49,11 +50,7 @@ MxU8* MxMemoryPool<BS, NB>::Get()
 		if (!m_blockRef[i]) {
 			m_blockRef[i].Flip();
 
-#ifdef _DEBUG
-			// TODO: This is actually some debug print function, but
-			// we just need any func with variatic args to eliminate diff noise.
-			printf("Get> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
-#endif
+			MxTrace("Get> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
 
 			return &m_pool[i * m_blockSize * 1024];
 		}
@@ -78,9 +75,7 @@ void MxMemoryPool<BS, NB>::Release(MxU8* p_buf)
 		m_blockRef[i].Flip();
 	}
 
-#ifdef _DEBUG
-	printf("Release> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
-#endif
+	MxTrace("Release> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
 }
 
 #endif // MXMEMORYPOOL_H

--- a/LEGO1/omni/include/mxstreamcontroller.h
+++ b/LEGO1/omni/include/mxstreamcontroller.h
@@ -47,7 +47,7 @@ public:
 	MxResult FUN_100c1a00(MxDSAction* p_action, MxU32 p_offset);
 	MxPresenter* FUN_100c1e70(MxDSAction& p_action);
 	MxResult FUN_100c1f00(MxDSAction* p_action);
-	MxBool FUN_100c20d0(MxDSObject& p_obj);
+	MxBool IsStoped(MxDSObject* p_obj);
 	MxResult InsertActionToList54(MxDSAction* p_action);
 	MxNextActionDataStart* FindNextActionDataStartFromStreamingAction(MxDSStreamingAction* p_action);
 

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -35,6 +35,7 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dc710
+// VTABLE: BETA10 0x101c2378
 // SIZE 0x2c
 class MxStreamer : public MxCore {
 public:
@@ -115,6 +116,7 @@ private:
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100b9090
+// TEMPLATE: BETA10 0x10146720
 // list<MxStreamController *,allocator<MxStreamController *> >::~list<MxStreamController *,allocator<MxStreamController *> >
 // clang-format on
 

--- a/LEGO1/omni/src/action/mxdsmediaaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmediaaction.cpp
@@ -1,5 +1,6 @@
 #include "mxdsmediaaction.h"
 
+#include "mxdebug.h"
 #include "mxutilities.h"
 
 DECOMP_SIZE_ASSERT(MxDSMediaAction, 0xb8)
@@ -86,6 +87,8 @@ void MxDSMediaAction::CopyMediaSrcPath(const char* p_mediaSrcPath)
 		if (m_mediaSrcPath) {
 			strcpy(m_mediaSrcPath, p_mediaSrcPath);
 		}
+
+		MxTrace("MxDSMediaAction: name allocation failed: %s.\n", p_mediaSrcPath);
 	}
 	else {
 		m_mediaSrcPath = NULL;

--- a/LEGO1/omni/src/common/mxdebug.cpp
+++ b/LEGO1/omni/src/common/mxdebug.cpp
@@ -1,0 +1,30 @@
+#include "mxdebug.h"
+
+#ifdef _DEBUG
+
+// Debug-only wrapper for OutputDebugString to support variadic arguments.
+// Identical functions at BETA10 0x100ec9fe and 0x101741b5 are more limited in scope.
+// This is the most widely used version.
+
+#include <stdio.h>
+#include <windows.h>
+
+// FUNCTION: BETA10 0x10124cb9
+int DebugHeapState()
+{
+	return 0;
+}
+
+// FUNCTION: BETA10 0x10124cdd
+void _MxTrace(const char* format, ...)
+{
+	va_list args;
+	char buffer[256];
+
+	va_start(args, format);
+	_vsnprintf(buffer, 256, format, args);
+	OutputDebugString(buffer);
+	va_end(args);
+}
+
+#endif


### PR DESCRIPTION
This adds the `MxTrace` function, a wrapper around the Windows API call `OutputDebugString`. The beta/debug builds use this (along with asserts) and this provides some extra information about what the real code looked like. There are three versions of almost the exact same function in the beta. I added the most commonly used one at `// FUNCTION BETA10 0x10124cdd`. The ifdefs and macro in mxdebug.h should stop this from appearing in retail builds.

- I had `printf` in place of `MxTrace` in mxmemorypool.h; this is now fixed.
- Reshuffled code in `LegoInputManager::CreateAndAcquireKeyboard` to demonstrate `MxTrace`.
- Added `MxTrace` to `MxDSMediaAction::CopyMediaSrcPath` because its beta addr was already marked.
- The most significant changes are to `MxStreamer` and `MxStreamController`. An assert in `MxStreamer::~MxStreamer` provides the name for the `IsStoped` function and shows how it is called. I changed the parameter from a reference to a pointer so that it matches. This function has its own `MxTrace` call to give additional context.
