### PR TITLE
Refactor surrounding `MxBitmap::GetAdjustedStride`

### DIFF
--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -94,6 +94,7 @@ public:
 	// FUNCTION: BETA10 0x1002c690
 	static MxLong HeightAbs(MxLong p_value) { return p_value > 0 ? p_value : -p_value; }
 
+	// FUNCTION: BETA10 0x10142030
 	inline BITMAPINFOHEADER* GetBmiHeader() const { return m_bmiHeader; }
 
 	// FUNCTION: BETA10 0x1002c440
@@ -124,15 +125,9 @@ public:
 		}
 	}
 
-	inline MxLong GetAdjustedStride()
-	{
-		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN || m_bmiHeader->biHeight < 0) {
-			return GetBmiStride();
-		}
-		else {
-			return -GetBmiStride();
-		}
-	}
+#define GetAdjustedStride(p_bitmap)                                                                                    \
+	(p_bitmap->IsTopDown() ? p_bitmap->AlignToFourByte(p_bitmap->GetBmiWidth())                                        \
+						   : -p_bitmap->AlignToFourByte(p_bitmap->GetBmiWidth()))
 
 	// FUNCTION: BETA10 0x1002c320
 	inline MxU8* GetStart(MxS32 p_left, MxS32 p_top)

--- a/LEGO1/omni/include/mxdisplaysurface.h
+++ b/LEGO1/omni/include/mxdisplaysurface.h
@@ -99,7 +99,7 @@ public:
 	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }
 	inline MxVideoParam& GetVideoParam() { return this->m_videoParam; }
 
-	static void FUN_100bb500(
+	void FUN_100bb500(
 		MxU8** p_bitmapData,
 		MxU8** p_surfaceData,
 		MxU32 p_bitmapSize,

--- a/LEGO1/omni/include/mxdisplaysurface.h
+++ b/LEGO1/omni/include/mxdisplaysurface.h
@@ -95,9 +95,9 @@ public:
 	static LPDIRECTDRAWSURFACE CreateCursorSurface();
 	static LPDIRECTDRAWSURFACE CopySurface(LPDIRECTDRAWSURFACE p_src);
 
-	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return this->m_ddSurface1; }
-	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return this->m_ddSurface2; }
-	inline MxVideoParam& GetVideoParam() { return this->m_videoParam; }
+	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return m_ddSurface1; }
+	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return m_ddSurface2; }
+	inline MxVideoParam& GetVideoParam() { return m_videoParam; }
 
 	void FUN_100bb500(
 		MxU8** p_bitmapData,

--- a/LEGO1/omni/src/video/mxbitmap.cpp
+++ b/LEGO1/omni/src/video/mxbitmap.cpp
@@ -274,14 +274,11 @@ void MxBitmap::BitBlt(
 	MxS32 p_height
 )
 {
-	MxLong dstHeight = GetBmiHeightAbs();
-	MxLong srcHeight = p_src->GetBmiHeightAbs();
-
-	if (GetRectIntersection(
+	if (!GetRectIntersection(
 			p_src->GetBmiWidth(),
-			srcHeight,
+			p_src->GetBmiHeightAbs(),
 			GetBmiWidth(),
-			dstHeight,
+			GetBmiHeightAbs(),
 			&p_srcLeft,
 			&p_srcTop,
 			&p_dstLeft,
@@ -289,16 +286,18 @@ void MxBitmap::BitBlt(
 			&p_width,
 			&p_height
 		)) {
-		MxU8* srcStart = p_src->GetStart(p_srcLeft, p_srcTop);
-		MxU8* dstStart = GetStart(p_dstLeft, p_dstTop);
-		MxLong srcStride = p_src->GetAdjustedStride();
-		MxLong dstStride = GetAdjustedStride();
+		return;
+	}
 
-		while (p_height--) {
-			memcpy(dstStart, srcStart, p_width);
-			dstStart += dstStride;
-			srcStart += srcStride;
-		}
+	MxU8* srcStart = p_src->GetStart(p_srcLeft, p_srcTop);
+	MxU8* dstStart = GetStart(p_dstLeft, p_dstTop);
+	MxLong srcStride = GetAdjustedStride(p_src);
+	MxLong dstStride = GetAdjustedStride(this);
+
+	while (p_height--) {
+		memcpy(dstStart, srcStart, p_width);
+		dstStart += dstStride;
+		srcStart += srcStride;
 	}
 }
 
@@ -314,14 +313,11 @@ void MxBitmap::BitBltTransparent(
 	MxS32 p_height
 )
 {
-	MxLong dstHeight = GetBmiHeightAbs();
-	MxLong srcHeight = p_src->GetBmiHeightAbs();
-
-	if (GetRectIntersection(
+	if (!GetRectIntersection(
 			p_src->GetBmiWidth(),
-			srcHeight,
+			p_src->GetBmiHeightAbs(),
 			GetBmiWidth(),
-			dstHeight,
+			GetBmiHeightAbs(),
 			&p_srcLeft,
 			&p_srcTop,
 			&p_dstLeft,
@@ -329,23 +325,25 @@ void MxBitmap::BitBltTransparent(
 			&p_width,
 			&p_height
 		)) {
-		MxU8* srcStart = p_src->GetStart(p_srcLeft, p_srcTop);
-		MxU8* dstStart = GetStart(p_dstLeft, p_dstTop);
-		MxLong srcStride = p_src->GetAdjustedStride() - p_width;
-		MxLong dstStride = GetAdjustedStride() - p_width;
+		return;
+	}
 
-		for (MxS32 h = 0; h < p_height; h++) {
-			for (MxS32 w = 0; w < p_width; w++) {
-				if (*srcStart) {
-					*dstStart = *srcStart;
-				}
-				srcStart++;
-				dstStart++;
+	MxU8* srcStart = p_src->GetStart(p_srcLeft, p_srcTop);
+	MxU8* dstStart = GetStart(p_dstLeft, p_dstTop);
+	MxLong srcStride = -p_width + GetAdjustedStride(p_src);
+	MxLong dstStride = -p_width + GetAdjustedStride(this);
+
+	for (MxS32 h = 0; h < p_height; h++) {
+		for (MxS32 w = 0; w < p_width; w++) {
+			if (*srcStart) {
+				*dstStart = *srcStart;
 			}
-
-			srcStart += srcStride;
-			dstStart += dstStride;
+			srcStart++;
+			dstStart++;
 		}
+
+		srcStart += srcStride;
+		dstStart += dstStride;
 	}
 }
 

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -18,24 +18,24 @@ MxU32 g_unk0x1010215c = 0;
 // FUNCTION: LEGO1 0x100ba500
 MxDisplaySurface::MxDisplaySurface()
 {
-	this->Init();
+	Init();
 }
 
 // FUNCTION: LEGO1 0x100ba5a0
 MxDisplaySurface::~MxDisplaySurface()
 {
-	this->Destroy();
+	Destroy();
 }
 
 // FUNCTION: LEGO1 0x100ba610
 void MxDisplaySurface::Init()
 {
-	this->m_ddSurface1 = NULL;
-	this->m_ddSurface2 = NULL;
-	this->m_ddClipper = NULL;
-	this->m_16bitPal = NULL;
-	this->m_initialized = FALSE;
-	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
+	m_ddSurface1 = NULL;
+	m_ddSurface2 = NULL;
+	m_ddClipper = NULL;
+	m_16bitPal = NULL;
+	m_initialized = FALSE;
+	memset(&m_surfaceDesc, 0, sizeof(m_surfaceDesc));
 }
 
 // FUNCTION: LEGO1 0x100ba640
@@ -115,16 +115,16 @@ MxResult MxDisplaySurface::Init(
 {
 	MxResult result = SUCCESS;
 
-	this->m_videoParam = p_videoParam;
-	this->m_ddSurface1 = p_ddSurface1;
-	this->m_ddSurface2 = p_ddSurface2;
-	this->m_ddClipper = p_ddClipper;
-	this->m_initialized = FALSE;
+	m_videoParam = p_videoParam;
+	m_ddSurface1 = p_ddSurface1;
+	m_ddSurface2 = p_ddSurface2;
+	m_ddClipper = p_ddClipper;
+	m_initialized = FALSE;
 
-	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
-	this->m_surfaceDesc.dwSize = sizeof(this->m_surfaceDesc);
+	memset(&m_surfaceDesc, 0, sizeof(m_surfaceDesc));
+	m_surfaceDesc.dwSize = sizeof(m_surfaceDesc);
 
-	if (this->m_ddSurface2->GetSurfaceDesc(&this->m_surfaceDesc)) {
+	if (m_ddSurface2->GetSurfaceDesc(&m_surfaceDesc)) {
 		result = FAILURE;
 	}
 
@@ -139,32 +139,32 @@ MxResult MxDisplaySurface::Create(MxVideoParam& p_videoParam)
 	LPDIRECTDRAW lpDirectDraw = MVideoManager()->GetDirectDraw();
 	HWND hWnd = MxOmni::GetInstance()->GetWindowHandle();
 
-	this->m_initialized = TRUE;
-	this->m_videoParam = p_videoParam;
+	m_initialized = TRUE;
+	m_videoParam = p_videoParam;
 
-	if (!this->m_videoParam.Flags().GetFullScreen()) {
-		this->m_videoParam.Flags().SetFlipSurfaces(FALSE);
+	if (!m_videoParam.Flags().GetFullScreen()) {
+		m_videoParam.Flags().SetFlipSurfaces(FALSE);
 	}
 
-	if (!this->m_videoParam.Flags().GetFlipSurfaces()) {
-		this->m_videoParam.SetBackBuffers(1);
+	if (!m_videoParam.Flags().GetFlipSurfaces()) {
+		m_videoParam.SetBackBuffers(1);
 	}
 	else {
-		MxU32 backBuffers = this->m_videoParam.GetBackBuffers();
+		MxU32 backBuffers = m_videoParam.GetBackBuffers();
 
 		if (backBuffers < 1) {
-			this->m_videoParam.SetBackBuffers(1);
+			m_videoParam.SetBackBuffers(1);
 		}
 		else if (backBuffers > 2) {
-			this->m_videoParam.SetBackBuffers(2);
+			m_videoParam.SetBackBuffers(2);
 		}
 
-		this->m_videoParam.Flags().SetBackBuffers(TRUE);
+		m_videoParam.Flags().SetBackBuffers(TRUE);
 	}
 
-	if (this->m_videoParam.Flags().GetFullScreen()) {
-		MxS32 width = this->m_videoParam.GetRect().GetWidth();
-		MxS32 height = this->m_videoParam.GetRect().GetHeight();
+	if (m_videoParam.Flags().GetFullScreen()) {
+		MxS32 width = m_videoParam.GetRect().GetWidth();
+		MxS32 height = m_videoParam.GetRect().GetHeight();
 
 		if (lpDirectDraw->SetCooperativeLevel(hWnd, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN)) {
 			goto done;
@@ -177,7 +177,7 @@ MxResult MxDisplaySurface::Create(MxVideoParam& p_videoParam)
 			goto done;
 		}
 
-		MxS32 bitdepth = !this->m_videoParam.Flags().Get16Bit() ? 8 : 16;
+		MxS32 bitdepth = !m_videoParam.Flags().Get16Bit() ? 8 : 16;
 
 		if (ddsd.dwWidth != width || ddsd.dwHeight != height || ddsd.ddpfPixelFormat.dwRGBBitCount != bitdepth) {
 			if (lpDirectDraw->SetDisplayMode(width, height, bitdepth)) {
@@ -186,20 +186,20 @@ MxResult MxDisplaySurface::Create(MxVideoParam& p_videoParam)
 		}
 	}
 
-	if (this->m_videoParam.Flags().GetFlipSurfaces()) {
+	if (m_videoParam.Flags().GetFlipSurfaces()) {
 		memset(&ddsd, 0, sizeof(ddsd));
 		ddsd.dwSize = sizeof(ddsd);
-		ddsd.dwBackBufferCount = this->m_videoParam.GetBackBuffers();
+		ddsd.dwBackBufferCount = m_videoParam.GetBackBuffers();
 		ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
 		ddsd.ddsCaps.dwCaps = DDSCAPS_3DDEVICE | DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_COMPLEX;
 
-		if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface1, NULL)) {
+		if (lpDirectDraw->CreateSurface(&ddsd, &m_ddSurface1, NULL)) {
 			goto done;
 		}
 
 		ddsd.ddsCaps.dwCaps = DDSCAPS_BACKBUFFER;
 
-		if (this->m_ddSurface1->GetAttachedSurface(&ddsd.ddsCaps, &this->m_ddSurface2)) {
+		if (m_ddSurface1->GetAttachedSurface(&ddsd.ddsCaps, &m_ddSurface2)) {
 			goto done;
 		}
 	}
@@ -209,32 +209,32 @@ MxResult MxDisplaySurface::Create(MxVideoParam& p_videoParam)
 		ddsd.dwFlags = DDSD_CAPS;
 		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
 
-		if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface1, NULL)) {
+		if (lpDirectDraw->CreateSurface(&ddsd, &m_ddSurface1, NULL)) {
 			goto done;
 		}
 
 		memset(&ddsd, 0, sizeof(ddsd));
 		ddsd.dwSize = sizeof(ddsd);
 		ddsd.dwFlags = DDSD_HEIGHT | DDSD_WIDTH | DDSD_CAPS;
-		ddsd.dwWidth = this->m_videoParam.GetRect().GetWidth();
-		ddsd.dwHeight = this->m_videoParam.GetRect().GetHeight();
+		ddsd.dwWidth = m_videoParam.GetRect().GetWidth();
+		ddsd.dwHeight = m_videoParam.GetRect().GetHeight();
 		ddsd.ddsCaps.dwCaps = DDSCAPS_VIDEOMEMORY | DDSCAPS_3DDEVICE | DDSCAPS_OFFSCREENPLAIN;
 
-		if (!this->m_videoParam.Flags().GetBackBuffers()) {
+		if (!m_videoParam.Flags().GetBackBuffers()) {
 			ddsd.ddsCaps.dwCaps = DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
 		}
 
-		if (lpDirectDraw->CreateSurface(&ddsd, &this->m_ddSurface2, NULL)) {
+		if (lpDirectDraw->CreateSurface(&ddsd, &m_ddSurface2, NULL)) {
 			goto done;
 		}
 	}
 
-	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
-	this->m_surfaceDesc.dwSize = sizeof(this->m_surfaceDesc);
+	memset(&m_surfaceDesc, 0, sizeof(m_surfaceDesc));
+	m_surfaceDesc.dwSize = sizeof(m_surfaceDesc);
 
-	if (!this->m_ddSurface2->GetSurfaceDesc(&this->m_surfaceDesc)) {
-		if (!lpDirectDraw->CreateClipper(0, &this->m_ddClipper, NULL) && !this->m_ddClipper->SetHWnd(0, hWnd) &&
-			!this->m_ddSurface1->SetClipper(this->m_ddClipper)) {
+	if (!m_ddSurface2->GetSurfaceDesc(&m_surfaceDesc)) {
+		if (!lpDirectDraw->CreateClipper(0, &m_ddClipper, NULL) && !m_ddClipper->SetHWnd(0, hWnd) &&
+			!m_ddSurface1->SetClipper(m_ddClipper)) {
 			result = SUCCESS;
 		}
 	}
@@ -246,25 +246,25 @@ done:
 // FUNCTION: LEGO1 0x100baa90
 void MxDisplaySurface::Destroy()
 {
-	if (this->m_initialized) {
-		if (this->m_ddSurface2) {
-			this->m_ddSurface2->Release();
+	if (m_initialized) {
+		if (m_ddSurface2) {
+			m_ddSurface2->Release();
 		}
 
-		if (this->m_ddSurface1) {
-			this->m_ddSurface1->Release();
+		if (m_ddSurface1) {
+			m_ddSurface1->Release();
 		}
 
-		if (this->m_ddClipper) {
-			this->m_ddClipper->Release();
+		if (m_ddClipper) {
+			m_ddClipper->Release();
 		}
 	}
 
-	if (this->m_16bitPal) {
-		delete[] this->m_16bitPal;
+	if (m_16bitPal) {
+		delete[] m_16bitPal;
 	}
 
-	this->Init();
+	Init();
 }
 
 // FUNCTION: LEGO1 0x100baae0
@@ -659,7 +659,7 @@ void MxDisplaySurface::Display(MxS32 p_left, MxS32 p_top, MxS32 p_left2, MxS32 p
 // FUNCTION: LEGO1 0x100bbc10
 void MxDisplaySurface::GetDC(HDC* p_hdc)
 {
-	if (this->m_ddSurface2 && !this->m_ddSurface2->GetDC(p_hdc)) {
+	if (m_ddSurface2 && !m_ddSurface2->GetDC(p_hdc)) {
 		return;
 	}
 
@@ -669,8 +669,8 @@ void MxDisplaySurface::GetDC(HDC* p_hdc)
 // FUNCTION: LEGO1 0x100bbc40
 void MxDisplaySurface::ReleaseDC(HDC p_hdc)
 {
-	if (this->m_ddSurface2 && p_hdc) {
-		this->m_ddSurface2->ReleaseDC(p_hdc);
+	if (m_ddSurface2 && p_hdc) {
+		m_ddSurface2->ReleaseDC(p_hdc);
 	}
 }
 


### PR DESCRIPTION
The stride of a bitmap is the number of bytes to seek ahead to get to the next row of pixels. Each row of the bitmap is dword-aligned, so there are between 0 and 3 padding bytes added to the visible image width on each row.

The `MxBitmap::GetAdjustedStride` function takes into account that the image can be stored with its rows in reverse order:

>There are two varieties of [Device-Independent Bitmaps]:
>
>A bottom-up DIB, in which the origin lies at the lower-left corner.
>A top-down DIB, in which the origin lies at the upper-left corner.
>If the height of a DIB, as indicated by the Height member of the bitmap information header structure, is a positive value, it is a bottom-up DIB; if the height is a negative value, it is a top-down DIB. Top-down DIBs cannot be compressed.
>
> https://learn.microsoft.com/en-us/windows/win32/gdi/device-independent-bitmaps

Until now we have been using an inline function for `GetAdjustedStride`, but there is no match for this in the beta. The calculation always refers to the `IsTopDown` function that gets used 13 times: 6 in `MxBitmap` and 7 in `MxDisplaySurface`. Of these, only one has a slightly different order of the functions, so it made sense to use a `GetAdjustedStride` macro in place of the function call.

The affected functions are:
- `MxBitmap::BitBlt`
- `MxBitmap::BitBltTransparent`
- `MxDisplaySurface::FUN_100bb500` (changed to non-static)
- `MxDisplaySurface::VTable0x28`
- `MxDisplaySurface::VTable0x30`
- `MxDisplaySurface::VTable0x44`

The main refactoring was in the `MxDisplaySurface` functions. These are stubborn to match even in the beta, but as best I can tell we are doing the same work in each. I'm not sure what exactly to test in the game to verify this, but I had problems with both the opening lego movie and the Pepper "dude with the food" movie while working on this. Both are playing fine now.