### PR TITLE
User clang-format InsertBraces instead of clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,7 @@ EmptyLineBeforeAccessModifier: Always
 IncludeBlocks: Regroup
 IndentAccessModifiers: false
 IndentWidth: 4
+InsertBraces: true
 InsertNewlineAtEOF: true
 PointerAlignment: Left
 QualifierAlignment: Custom

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,5 @@
 Checks: >
   -*,
-  readability-braces-around-statements,
   modernize-use-override
-WarningsAsErrors: '-*,readability-braces-around-statements,modernize-use-override'
+WarningsAsErrors: '-*,modernize-use-override'
 HeaderFilterRegex: ".*"


### PR DESCRIPTION
As previously suggested in Matrix, clang-format supports `InsertBraces` since version 15 which is essentially the same as `readability-braces-around-statements` in clang-tidy. Generally a clang-format option is preferable since it doesn't require a compilation pass.