### PR TITLE
Add clang-tidy readability-redundant-inline-specifier

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: >
   -*,
+  readability-redundant-inline-specifier,
   modernize-use-override
-WarningsAsErrors: '-*,modernize-use-override'
+WarningsAsErrors: '-*,readability-redundant-inline-specifier,modernize-use-override'
 HeaderFilterRegex: ".*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ In general, we're not exhaustively strict about coding style, but there are some
 
 ### Formatting
 
-We are currently using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) with configuration files that aim to replicate the code formatting employed by the original developers. There are [integrations](https://clang.llvm.org/docs/ClangFormat.html#vim-integration) available for most editors and IDEs. The required `clang-format` version is `17.x`.
+We are currently using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) with configuration files that aim to replicate the code formatting employed by the original developers. There are [integrations](https://clang.llvm.org/docs/ClangFormat.html#vim-integration) available for most editors and IDEs. The required `clang` toolchain version is `18.x`.
 
 ### Naming conventions
 

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -36,15 +36,15 @@ public:
 	void Tick(BOOL sleepIfNotNextFrame);
 	void SetupCursor(WPARAM wParam);
 
-	inline HWND GetWindowHandle() { return m_windowHandle; }
-	inline MxLong GetFrameDelta() { return m_frameDelta; }
-	inline BOOL GetFullScreen() { return m_fullScreen; }
-	inline HCURSOR GetCursorCurrent() { return m_cursorCurrent; }
-	inline HCURSOR GetCursorBusy() { return m_cursorBusy; }
-	inline HCURSOR GetCursorNo() { return m_cursorNo; }
-	inline BOOL GetDrawCursor() { return m_drawCursor; }
+	HWND GetWindowHandle() { return m_windowHandle; }
+	MxLong GetFrameDelta() { return m_frameDelta; }
+	BOOL GetFullScreen() { return m_fullScreen; }
+	HCURSOR GetCursorCurrent() { return m_cursorCurrent; }
+	HCURSOR GetCursorBusy() { return m_cursorBusy; }
+	HCURSOR GetCursorNo() { return m_cursorNo; }
+	BOOL GetDrawCursor() { return m_drawCursor; }
 
-	inline void SetWindowActive(BOOL p_windowActive) { m_windowActive = p_windowActive; }
+	void SetWindowActive(BOOL p_windowActive) { m_windowActive = p_windowActive; }
 
 private:
 	LPSTR m_hdPath;            // 0x00

--- a/LEGO1/lego/legoomni/include/act2brick.h
+++ b/LEGO1/lego/legoomni/include/act2brick.h
@@ -14,14 +14,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1007a360
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0438
 		return "Act2Brick";
 	}
 
 	// FUNCTION: LEGO1 0x1007a370
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Act2Brick::ClassName()) || LegoEntity::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/act2policestation.h
+++ b/LEGO1/lego/legoomni/include/act2policestation.h
@@ -10,14 +10,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1000e200
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03fc
 		return "Act2PoliceStation";
 	}
 
 	// FUNCTION: LEGO1 0x1000e210
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Act2PoliceStation::ClassName()) || LegoEntity::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/act3.h
+++ b/LEGO1/lego/legoomni/include/act3.h
@@ -8,17 +8,17 @@
 // SIZE 0x0c
 class Act3State : public LegoState {
 public:
-	inline Act3State() { m_unk0x08 = 0; }
+	Act3State() { m_unk0x08 = 0; }
 
 	// FUNCTION: LEGO1 0x1000e300
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03f0
 		return "Act3State";
 	}
 
 	// FUNCTION: LEGO1 0x1000e310
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Act3State::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -29,7 +29,7 @@ public:
 	// SYNTHETIC: LEGO1 0x1000e3c0
 	// Act3State::`scalar deleting destructor'
 
-	inline undefined4 GetUnknown0x08() { return m_unk0x08; }
+	undefined4 GetUnknown0x08() { return m_unk0x08; }
 
 	// TODO: Most likely getters/setters are not used according to BETA.
 
@@ -48,14 +48,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10072510
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f013c
 		return "Act3";
 	}
 
 	// FUNCTION: LEGO1 0x10072520
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Act3::ClassName()) || LegoWorld::IsA(p_name);
 	}
@@ -68,8 +68,8 @@ public:
 	MxBool Escape() override;                         // vtable+0x64
 	void Enable(MxBool p_enable) override;            // vtable+0x68
 
-	inline void SetUnknown420c(MxEntity* p_entity) { m_unk0x420c = p_entity; }
-	inline void SetUnknown4270(MxU32 p_unk0x4270) { m_unk0x4270 = p_unk0x4270; }
+	void SetUnknown420c(MxEntity* p_entity) { m_unk0x420c = p_entity; }
+	void SetUnknown4270(MxU32 p_unk0x4270) { m_unk0x4270 = p_unk0x4270; }
 
 	// SYNTHETIC: LEGO1 0x10072630
 	// Act3::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/act3actor.h
+++ b/LEGO1/lego/legoomni/include/act3actor.h
@@ -11,7 +11,7 @@ public:
 	Act3Actor();
 
 	// FUNCTION: LEGO1 0x100431b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03ac
 		return "Act3Actor";

--- a/LEGO1/lego/legoomni/include/act3shark.h
+++ b/LEGO1/lego/legoomni/include/act3shark.h
@@ -11,7 +11,7 @@ public:
 	Act3Shark();
 
 	// FUNCTION: LEGO1 0x100430d0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03a0
 		return "Act3Shark";

--- a/LEGO1/lego/legoomni/include/ambulance.h
+++ b/LEGO1/lego/legoomni/include/ambulance.h
@@ -13,21 +13,21 @@ public:
 	AmbulanceMissionState();
 
 	// FUNCTION: LEGO1 0x10037600
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f00e8
 		return "AmbulanceMissionState";
 	}
 
 	// FUNCTION: LEGO1 0x10037610
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, AmbulanceMissionState::ClassName()) || LegoState::IsA(p_name);
 	}
 
 	MxResult Serialize(LegoFile* p_file) override; // vtable+0x1c
 
-	inline MxS16 GetHighScore(MxU8 p_actorId)
+	MxS16 GetHighScore(MxU8 p_actorId)
 	{
 		switch (p_actorId) {
 		case LegoActor::c_pepper:
@@ -46,7 +46,7 @@ public:
 	}
 
 	// FUNCTION: BETA10 0x100242d0
-	inline void UpdateScore(ScoreColor p_score, MxS16 p_actorId)
+	void UpdateScore(ScoreColor p_score, MxS16 p_actorId)
 	{
 		switch (p_actorId) {
 		case LegoActor::c_pepper:
@@ -110,14 +110,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10035fa0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03c4
 		return "Ambulance";
 	}
 
 	// FUNCTION: LEGO1 0x10035fb0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Ambulance::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/bike.h
+++ b/LEGO1/lego/legoomni/include/bike.h
@@ -11,14 +11,14 @@ public:
 	Bike();
 
 	// FUNCTION: LEGO1 0x100766f0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03d0
 		return "Bike";
 	}
 
 	// FUNCTION: LEGO1 0x10076700
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Bike::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/buildingentity.h
+++ b/LEGO1/lego/legoomni/include/buildingentity.h
@@ -15,14 +15,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10014f20
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f07e8
 		return "BuildingEntity";
 	}
 
 	// FUNCTION: LEGO1 0x10014f30
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, BuildingEntity::ClassName()) || LegoEntity::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/buildings.h
+++ b/LEGO1/lego/legoomni/include/buildings.h
@@ -9,14 +9,14 @@ class LegoEventNotificationParam;
 // SIZE 0x68
 class RaceStandsEntity : public BuildingEntity {
 	// FUNCTION: LEGO1 0x1000efa0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0300
 		return "RaceStandsEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000efb0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, RaceStandsEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -32,14 +32,14 @@ class RaceStandsEntity : public BuildingEntity {
 class BeachHouseEntity : public BuildingEntity {
 public:
 	// FUNCTION: LEGO1 0x1000ee80
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0314
 		return "BeachHouseEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000ee90
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, BeachHouseEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -55,14 +55,14 @@ public:
 class PoliceEntity : public BuildingEntity {
 public:
 	// FUNCTION: LEGO1 0x1000ed60
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0328
 		return "PoliceEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000ed70
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, PoliceEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -78,14 +78,14 @@ public:
 class InfoCenterEntity : public BuildingEntity {
 public:
 	// FUNCTION: LEGO1 0x1000ea00
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f035c
 		return "InfoCenterEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000ea10
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, InfoCenterEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -101,14 +101,14 @@ public:
 class HospitalEntity : public BuildingEntity {
 public:
 	// FUNCTION: LEGO1 0x1000ec40
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0338
 		return "HospitalEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000ec50
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, HospitalEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -123,14 +123,14 @@ public:
 // SIZE 0x68
 class CaveEntity : public BuildingEntity {
 	// FUNCTION: LEGO1 0x1000f1e0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0300
 		return "RaceStandsEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000f1f0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, CaveEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -145,14 +145,14 @@ class CaveEntity : public BuildingEntity {
 // SIZE 0x68
 class JailEntity : public BuildingEntity {
 	// FUNCTION: LEGO1 0x1000f0c0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0300
 		return "RaceStandsEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000f0d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, JailEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}
@@ -168,14 +168,14 @@ class JailEntity : public BuildingEntity {
 class GasStationEntity : public BuildingEntity {
 public:
 	// FUNCTION: LEGO1 0x1000eb20
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0348
 		return "GasStationEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000eb30
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, GasStationEntity::ClassName()) || BuildingEntity::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/bumpbouy.h
+++ b/LEGO1/lego/legoomni/include/bumpbouy.h
@@ -14,14 +14,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100274f0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0394
 		return "BumpBouy";
 	}
 
 	// FUNCTION: LEGO1 0x10027510
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, BumpBouy::ClassName()) || LegoAnimActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/carrace.h
+++ b/LEGO1/lego/legoomni/include/carrace.h
@@ -9,14 +9,14 @@
 class CarRaceState : public RaceState {
 public:
 	// FUNCTION: LEGO1 0x1000dd30
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f009c
 		return "CarRaceState";
 	}
 
 	// FUNCTION: LEGO1 0x1000dd40
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, CarRaceState::ClassName()) || RaceState::IsA(p_name);
 	}
@@ -32,14 +32,14 @@ public:
 	CarRace();
 
 	// FUNCTION: LEGO1 0x10016b20
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0528
 		return "CarRace";
 	}
 
 	// FUNCTION: LEGO1 0x10016b30
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, CarRace::ClassName()) || LegoRace::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/doors.h
+++ b/LEGO1/lego/legoomni/include/doors.h
@@ -10,14 +10,14 @@ public:
 	Doors() : m_unk0x154(0), m_unk0x15c(0), m_unk0x160(0), m_unk0x1f4(0) {}
 
 	// FUNCTION: LEGO1 0x1000e430
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03e8
 		return "Doors";
 	}
 
 	// FUNCTION: LEGO1 0x1000e440
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Doors::ClassName()) || LegoPathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/dunebuggy.h
+++ b/LEGO1/lego/legoomni/include/dunebuggy.h
@@ -11,14 +11,14 @@ public:
 	DuneBuggy();
 
 	// FUNCTION: LEGO1 0x10067c30
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0410
 		return "DuneBuggy";
 	}
 
 	// FUNCTION: LEGO1 0x10067c40
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, DuneBuggy::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/elevatorbottom.h
+++ b/LEGO1/lego/legoomni/include/elevatorbottom.h
@@ -17,14 +17,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10017f20
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f04ac
 		return "ElevatorBottom";
 	}
 
 	// FUNCTION: LEGO1 0x10017f30
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ElevatorBottom::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/gasstation.h
+++ b/LEGO1/lego/legoomni/include/gasstation.h
@@ -21,14 +21,14 @@ public:
 	GasStationState();
 
 	// FUNCTION: LEGO1 0x100061d0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0174
 		return "GasStationState";
 	}
 
 	// FUNCTION: LEGO1 0x100061e0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, GasStationState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -64,14 +64,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10004780
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0168
 		return "GasStation";
 	}
 
 	// FUNCTION: LEGO1 0x10004790
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, GasStation::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/helicopter.h
+++ b/LEGO1/lego/legoomni/include/helicopter.h
@@ -12,14 +12,14 @@ public:
 	HelicopterState() : m_unk0x08(0) {}
 
 	// FUNCTION: LEGO1 0x1000e0d0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0144
 		return "HelicopterState";
 	}
 
 	// FUNCTION: LEGO1 0x1000e0e0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, HelicopterState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -34,8 +34,8 @@ public:
 		return TRUE;
 	} // vtable+0x18
 
-	inline void SetUnknown8(MxU32 p_unk0x08) { m_unk0x08 = p_unk0x08; }
-	inline MxU32 GetUnkown8() { return m_unk0x08; }
+	void SetUnknown8(MxU32 p_unk0x08) { m_unk0x08 = p_unk0x08; }
+	MxU32 GetUnkown8() { return m_unk0x08; }
 
 	// SYNTHETIC: LEGO1 0x1000e190
 	// HelicopterState::`scalar deleting destructor'
@@ -53,14 +53,14 @@ public:
 	~Helicopter() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10003070
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0130
 		return "Helicopter";
 	}
 
 	// FUNCTION: LEGO1 0x10003080
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Helicopter::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/historybook.h
+++ b/LEGO1/lego/legoomni/include/historybook.h
@@ -17,14 +17,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10082390
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f04bc
 		return "HistoryBook";
 	}
 
 	// FUNCTION: LEGO1 0x100823a0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, HistoryBook::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -24,14 +24,14 @@ public:
 	~HospitalState() override {}
 
 	// FUNCTION: LEGO1 0x10076400
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0480
 		return "HospitalState";
 	}
 
 	// FUNCTION: LEGO1 0x10076410
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, HospitalState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -63,14 +63,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x100746b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0490
 		return "Hospital";
 	}
 
 	// FUNCTION: LEGO1 0x100746c0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Hospital::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -20,14 +20,14 @@ public:
 	~InfocenterState() override;
 
 	// FUNCTION: LEGO1 0x10071840
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f04dc
 		return "InfocenterState";
 	}
 
 	// FUNCTION: LEGO1 0x10071850
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, InfocenterState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -35,18 +35,18 @@ public:
 	// FUNCTION: LEGO1 0x10071830
 	MxBool IsSerializable() override { return FALSE; } // vtable+0x14
 
-	inline MxS16 GetMaxNameLength() { return sizeOfArray(m_letters); }
-	inline MxStillPresenter* GetNameLetter(MxS32 p_index) { return m_letters[p_index]; }
-	inline void SetNameLetter(MxS32 p_index, MxStillPresenter* p_letter) { m_letters[p_index] = p_letter; }
-	inline MxBool HasRegistered() { return m_letters[0] != NULL; }
-	inline Playlist& GetExitDialogueAct1() { return m_exitDialogueAct1; }
-	inline Playlist& GetExitDialogueAct23() { return m_exitDialogueAct23; }
-	inline Playlist& GetReturnDialogue(LegoGameState::Act p_act) { return m_returnDialogue[p_act]; }
-	inline Playlist& GetLeaveDialogue(LegoGameState::Act p_act) { return m_leaveDialogue[p_act]; }
-	inline Playlist& GetBricksterDialogue() { return m_bricksterDialogue; }
-	inline MxU32 GetUnknown0x74() { return m_unk0x74; }
+	MxS16 GetMaxNameLength() { return sizeOfArray(m_letters); }
+	MxStillPresenter* GetNameLetter(MxS32 p_index) { return m_letters[p_index]; }
+	void SetNameLetter(MxS32 p_index, MxStillPresenter* p_letter) { m_letters[p_index] = p_letter; }
+	MxBool HasRegistered() { return m_letters[0] != NULL; }
+	Playlist& GetExitDialogueAct1() { return m_exitDialogueAct1; }
+	Playlist& GetExitDialogueAct23() { return m_exitDialogueAct23; }
+	Playlist& GetReturnDialogue(LegoGameState::Act p_act) { return m_returnDialogue[p_act]; }
+	Playlist& GetLeaveDialogue(LegoGameState::Act p_act) { return m_leaveDialogue[p_act]; }
+	Playlist& GetBricksterDialogue() { return m_bricksterDialogue; }
+	MxU32 GetUnknown0x74() { return m_unk0x74; }
 
-	inline void SetUnknown0x74(MxU32 p_unk0x74) { m_unk0x74 = p_unk0x74; }
+	void SetUnknown0x74(MxU32 p_unk0x74) { m_unk0x74 = p_unk0x74; }
 
 	// SYNTHETIC: LEGO1 0x10071900
 	// InfocenterState::`scalar deleting destructor'
@@ -102,14 +102,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1006eb40
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f04ec
 		return "Infocenter";
 	}
 
 	// FUNCTION: LEGO1 0x1006eb50
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Infocenter::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/infocenterdoor.h
+++ b/LEGO1/lego/legoomni/include/infocenterdoor.h
@@ -16,14 +16,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100377b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f049c
 		return "InfocenterDoor";
 	}
 
 	// FUNCTION: LEGO1 0x100377c0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, InfocenterDoor::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/isle.h
+++ b/LEGO1/lego/legoomni/include/isle.h
@@ -44,8 +44,8 @@ public:
 		// FUNCTION: LEGO1 0x10033800
 		NamedPlane() {}
 
-		inline void SetName(const char* p_name) { m_name = p_name; }
-		inline const MxString* GetName() const { return &m_name; }
+		void SetName(const char* p_name) { m_name = p_name; }
+		const MxString* GetName() const { return &m_name; }
 
 		// FUNCTION: LEGO1 0x100344d0
 		MxResult Serialize(LegoFile* p_file)
@@ -76,14 +76,14 @@ public:
 	Act1State();
 
 	// FUNCTION: LEGO1 0x100338a0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0154
 		return "Act1State";
 	}
 
 	// FUNCTION: LEGO1 0x100338b0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Act1State::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -96,13 +96,13 @@ public:
 	void FUN_10034b60();
 	void FUN_10034d00();
 
-	inline MxU32 GetUnknown18() { return m_unk0x018; }
-	inline ElevatorFloor GetElevatorFloor() { return (ElevatorFloor) m_elevFloor; }
-	inline MxU8 GetUnknown21() { return m_unk0x021; }
+	MxU32 GetUnknown18() { return m_unk0x018; }
+	ElevatorFloor GetElevatorFloor() { return (ElevatorFloor) m_elevFloor; }
+	MxU8 GetUnknown21() { return m_unk0x021; }
 
-	inline void SetUnknown18(MxU32 p_unk0x18) { m_unk0x018 = p_unk0x18; }
-	inline void SetElevatorFloor(ElevatorFloor p_elevFloor) { m_elevFloor = p_elevFloor; }
-	inline void SetUnknown21(MxU8 p_unk0x21) { m_unk0x021 = p_unk0x21; }
+	void SetUnknown18(MxU32 p_unk0x18) { m_unk0x018 = p_unk0x18; }
+	void SetElevatorFloor(ElevatorFloor p_elevFloor) { m_elevFloor = p_elevFloor; }
+	void SetUnknown21(MxU8 p_unk0x21) { m_unk0x021 = p_unk0x21; }
 
 	// SYNTHETIC: LEGO1 0x10033960
 	// Act1State::`scalar deleting destructor'
@@ -163,14 +163,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10030910
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0458
 		return "Isle";
 	}
 
 	// FUNCTION: LEGO1 0x10030920
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Isle::ClassName()) || LegoWorld::IsA(p_name);
 	}
@@ -189,7 +189,7 @@ public:
 	void Enable(MxBool p_enable) override;           // vtable+68
 	virtual void VTable0x6c(LegoPathActor* p_actor); // vtable+6c
 
-	inline void SetDestLocation(LegoGameState::Area p_destLocation) { m_destLocation = p_destLocation; }
+	void SetDestLocation(LegoGameState::Area p_destLocation) { m_destLocation = p_destLocation; }
 
 	void FUN_10033350();
 

--- a/LEGO1/lego/legoomni/include/isleactor.h
+++ b/LEGO1/lego/legoomni/include/isleactor.h
@@ -16,14 +16,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1000e660
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f07dc
 		return "IsleActor";
 	}
 
 	// FUNCTION: LEGO1 0x1000e670
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, IsleActor::ClassName()) || LegoActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/islepathactor.h
+++ b/LEGO1/lego/legoomni/include/islepathactor.h
@@ -86,19 +86,19 @@ public:
 	IslePathActor();
 
 	// FUNCTION: LEGO1 0x10002e10
-	inline ~IslePathActor() override { IslePathActor::Destroy(TRUE); }
+	~IslePathActor() override { IslePathActor::Destroy(TRUE); }
 
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10002ea0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0104
 		return "IslePathActor";
 	}
 
 	// FUNCTION: LEGO1 0x10002eb0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, IslePathActor::ClassName()) || LegoPathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/jetski.h
+++ b/LEGO1/lego/legoomni/include/jetski.h
@@ -13,14 +13,14 @@ public:
 	Jetski();
 
 	// FUNCTION: LEGO1 0x1007e430
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03d8
 		return "Jetski";
 	}
 
 	// FUNCTION: LEGO1 0x1007e440
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Jetski::ClassName()) || IslePathActor::IsA(p_name);
 	}
@@ -33,7 +33,7 @@ public:
 
 	void FUN_1007e990();
 
-	inline MxS16 GetUnknown0x160() { return m_unk0x160; }
+	MxS16 GetUnknown0x160() { return m_unk0x160; }
 
 	// SYNTHETIC: LEGO1 0x1007e5c0
 	// Jetski::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/jetskirace.h
+++ b/LEGO1/lego/legoomni/include/jetskirace.h
@@ -8,14 +8,14 @@
 class JetskiRaceState : public RaceState {
 public:
 	// FUNCTION: LEGO1 0x1000dc40
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f00ac
 		return "JetskiRaceState";
 	}
 
 	// FUNCTION: LEGO1 0x1000dc50
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, JetskiRaceState::ClassName()) || RaceState::IsA(p_name);
 	}
@@ -37,13 +37,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000daf0
 	// FUNCTION: BETA10 0x100a8810
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000db00
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, JetskiRace::ClassName()) || LegoRace::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/jukebox.h
+++ b/LEGO1/lego/legoomni/include/jukebox.h
@@ -24,14 +24,14 @@ public:
 	JukeBoxState() : m_music(e_pasquell), m_active(FALSE) {}
 
 	// FUNCTION: LEGO1 0x1000f310
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f02bc
 		return "JukeBoxState";
 	}
 
 	// FUNCTION: LEGO1 0x1000f320
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, JukeBoxState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -57,14 +57,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1005d6f0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f02cc
 		return "JukeBox";
 	}
 
 	// FUNCTION: LEGO1 0x1005d700
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, JukeBox::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/jukeboxentity.h
+++ b/LEGO1/lego/legoomni/include/jukeboxentity.h
@@ -14,14 +14,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10085cc0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f02f0
 		return "JukeBoxEntity";
 	}
 
 	// FUNCTION: LEGO1 0x10085cd0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, JukeBoxEntity::ClassName()) || LegoEntity::IsA(p_name);
 	}
@@ -29,7 +29,7 @@ public:
 	void StartAction();
 	void StopAction(JukeboxScript::Script p_script);
 
-	inline MxBool IsBackgroundAudioEnabled() { return m_audioEnabled; }
+	MxBool IsBackgroundAudioEnabled() { return m_audioEnabled; }
 
 	// SYNTHETIC: LEGO1 0x10085db0
 	// JukeBoxEntity::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
+++ b/LEGO1/lego/legoomni/include/lego3dwavepresenter.h
@@ -18,13 +18,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000d890
 	// FUNCTION: BETA10 0x100a8640
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d8a0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Lego3DWavePresenter::ClassName()) || MxWavePresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoact2.h
+++ b/LEGO1/lego/legoomni/include/legoact2.h
@@ -19,14 +19,14 @@ public:
 	~LegoAct2State() override {}
 
 	// FUNCTION: LEGO1 0x1000df80
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0428
 		return "LegoAct2State";
 	}
 
 	// FUNCTION: LEGO1 0x1000df90
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoAct2State::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -37,8 +37,8 @@ public:
 	// SYNTHETIC: LEGO1 0x1000e040
 	// LegoAct2State::`scalar deleting destructor'
 
-	inline undefined4 GetUnknown0x08() { return m_unk0x08; }
-	inline void SetUnknown0x0c(undefined p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
+	undefined4 GetUnknown0x08() { return m_unk0x08; }
+	void SetUnknown0x0c(undefined p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
 
 	// TODO: Most likely getters/setters are not used according to BETA.
 
@@ -62,8 +62,8 @@ public:
 	MxBool Escape() override;                         // vtable+0x64
 	void Enable(MxBool p_enable) override;            // vtable+0x68
 
-	inline void SetUnknown0x1138(Act2Actor* p_unk0x1138) { m_unk0x1138 = p_unk0x1138; }
-	inline void SetUnknown0x1150(undefined4 p_unk0x1150) { m_unk0x1150 = p_unk0x1150; }
+	void SetUnknown0x1138(Act2Actor* p_unk0x1138) { m_unk0x1138 = p_unk0x1138; }
+	void SetUnknown0x1150(undefined4 p_unk0x1150) { m_unk0x1150 = p_unk0x1150; }
 
 	// SYNTHETIC: LEGO1 0x1004fe20
 	// LegoAct2::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoactioncontrolpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoactioncontrolpresenter.h
@@ -22,13 +22,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000d0e0
 	// FUNCTION: BETA10 0x100a7810
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d0f0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoActionControlPresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoactor.h
+++ b/LEGO1/lego/legoomni/include/legoactor.h
@@ -24,14 +24,14 @@ public:
 	~LegoActor() override;
 
 	// FUNCTION: LEGO1 0x1002d210
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0124
 		return "LegoActor";
 	}
 
 	// FUNCTION: LEGO1 0x1002d220
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoActor::ClassName()) || LegoEntity::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoactorpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoactorpresenter.h
@@ -21,13 +21,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000cb10
 	// FUNCTION: BETA10 0x100a6ee0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000cb20
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoActorPresenter::ClassName()) || LegoEntityPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoanimactor.h
+++ b/LEGO1/lego/legoomni/include/legoanimactor.h
@@ -13,7 +13,7 @@ struct LegoAnimActorStruct {
 
 	float GetDuration();
 
-	inline float GetUnknown0x00() { return m_unk0x00; }
+	float GetUnknown0x00() { return m_unk0x00; }
 
 	float m_unk0x00;              // 0x00
 	LegoAnim* m_AnimTreePtr;      // 0x04
@@ -31,14 +31,14 @@ public:
 	~LegoAnimActor() override;
 
 	// FUNCTION: LEGO1 0x1000fba0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f057c
 		return "LegoAnimActor";
 	}
 
 	// FUNCTION: LEGO1 0x1000fbc0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoAnimActor::ClassName()) || LegoPathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -56,14 +56,14 @@ public:
 	~AnimState() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10065070
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0460
 		return "AnimState";
 	}
 
 	// FUNCTION: LEGO1 0x10065080
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, AnimState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -135,14 +135,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1005ec80
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f7508
 		return "LegoAnimationManager";
 	}
 
 	// FUNCTION: LEGO1 0x1005ec90
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
@@ -38,13 +38,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1004a950
 	// FUNCTION: BETA10 0x1004d810
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1004a960
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoAnimMMPresenter::ClassName()) || MxCompositePresenter::IsA(p_name);
 	}
@@ -66,7 +66,7 @@ public:
 	MxBool FUN_1004b8b0();
 	void FUN_1004b8c0();
 
-	inline LegoAnimPresenter* GetPresenter() { return m_presenter; }
+	LegoAnimPresenter* GetPresenter() { return m_presenter; }
 
 private:
 	MxBool FUN_1004b450();

--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -50,13 +50,13 @@ public:
 
 	// FUNCTION: LEGO1 0x10068530
 	// FUNCTION: BETA10 0x100552d0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10068540
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoAnimPresenter::ClassName()) || MxVideoPresenter::IsA(p_name);
 	}
@@ -91,11 +91,11 @@ public:
 	void FUN_1006c7a0();
 	const char* GetActionObjectName();
 
-	inline void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
-	inline void SetUnknown0x0cTo1() { m_unk0x9c = 1; }
-	inline void SetUnknown0xa0(MxMatrix* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
+	void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
+	void SetUnknown0x0cTo1() { m_unk0x9c = 1; }
+	void SetUnknown0xa0(MxMatrix* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
 
-	inline LegoAnim* GetAnimation() { return m_anim; }
+	LegoAnim* GetAnimation() { return m_anim; }
 
 protected:
 	void Init();

--- a/LEGO1/lego/legoomni/include/legobuildingmanager.h
+++ b/LEGO1/lego/legoomni/include/legobuildingmanager.h
@@ -56,7 +56,7 @@ public:
 	MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1002f930
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f37d0
 		return "LegoBuildingManager";

--- a/LEGO1/lego/legoomni/include/legocachesoundmanager.h
+++ b/LEGO1/lego/legoomni/include/legocachesoundmanager.h
@@ -25,8 +25,8 @@ struct LegoCacheSoundEntry {
 	bool operator==(LegoCacheSoundEntry) const { return 0; }
 	bool operator<(LegoCacheSoundEntry) const { return 0; }
 
-	inline LegoCacheSound* GetSound() const { return m_sound; }
-	inline const char* GetName() const { return m_name; }
+	LegoCacheSound* GetSound() const { return m_sound; }
+	const char* GetName() const { return m_name; }
 
 	friend struct Set100d6b4cComparator;
 

--- a/LEGO1/lego/legoomni/include/legocachsound.h
+++ b/LEGO1/lego/legoomni/include/legocachsound.h
@@ -14,14 +14,14 @@ public:
 	~LegoCacheSound() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10006580
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f01c4
 		return "LegoCacheSound";
 	}
 
 	// FUNCTION: LEGO1 0x10006590
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoCacheSound::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -36,8 +36,8 @@ public:
 	virtual void Destroy();                            // vtable+0x18
 	virtual void FUN_10006cd0(undefined4, undefined4); // vtable+0x1c
 
-	inline const MxString& GetUnknown0x48() const { return m_unk0x48; }
-	inline const MxBool GetUnknown0x58() const { return m_unk0x58; }
+	const MxString& GetUnknown0x48() const { return m_unk0x48; }
+	const MxBool GetUnknown0x58() const { return m_unk0x58; }
 
 	LegoCacheSound* Clone();
 	MxResult Play(const char* p_name, MxBool p_looping);

--- a/LEGO1/lego/legoomni/include/legocameracontroller.h
+++ b/LEGO1/lego/legoomni/include/legocameracontroller.h
@@ -16,14 +16,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+04
 
 	// FUNCTION: LEGO1 0x10011ec0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0850
 		return "LegoCameraController";
 	}
 
 	// FUNCTION: LEGO1 0x10011ed0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legocarbuild.h
+++ b/LEGO1/lego/legoomni/include/legocarbuild.h
@@ -11,13 +11,13 @@ public:
 	LegoVehicleBuildState(const char* p_classType);
 
 	// FUNCTION: LEGO1 0x10025ff0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return this->m_className.GetData();
 	}
 
 	// FUNCTION: LEGO1 0x10026000
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, this->m_className.GetData()) || LegoState::IsA(p_name);
 	}
@@ -65,14 +65,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10022940
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0504
 		return "LegoCarBuild";
 	}
 
 	// FUNCTION: LEGO1 0x10022950
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoCarBuild::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
@@ -20,13 +20,13 @@ public:
 
 	// FUNCTION: LEGO1 0x10078510
 	// FUNCTION: BETA10 0x10073260
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10078520
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoCarBuildAnimPresenter::ClassName()) || LegoAnimPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -13,14 +13,14 @@ public:
 	LegoCarRaceActor();
 
 	// FUNCTION: LEGO1 0x10081660
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0568
 		return "LegoCarRaceActor";
 	}
 
 	// FUNCTION: LEGO1 0x10081680
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoCarRaceActor::ClassName()) || LegoRaceActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -27,8 +27,8 @@ struct LegoCharacter {
 	}
 	~LegoCharacter() { delete m_roi; }
 
-	inline void AddRef() { m_refCount++; }
-	inline MxU32 RemoveRef()
+	void AddRef() { m_refCount++; }
+	MxU32 RemoveRef()
 	{
 		if (m_refCount != 0) {
 			m_refCount--;

--- a/LEGO1/lego/legoomni/include/legocontrolmanager.h
+++ b/LEGO1/lego/legoomni/include/legocontrolmanager.h
@@ -12,7 +12,7 @@ class MxControlPresenter;
 // SIZE 0x2c
 class LegoControlManagerNotificationParam : public LegoEventNotificationParam {
 public:
-	inline LegoControlManagerNotificationParam() : LegoEventNotificationParam()
+	LegoControlManagerNotificationParam() : LegoEventNotificationParam()
 	{
 		m_clickedObjectId = -1;
 		m_clickedAtom = NULL;
@@ -20,13 +20,13 @@ public:
 
 	// TODO: Most likely getters/setters are not used according to BETA.
 
-	inline MxS32 GetClickedObjectId() const { return m_clickedObjectId; }
-	inline const char* GetClickedAtom() const { return m_clickedAtom; }
-	inline MxS16 GetUnknown0x28() const { return m_unk0x28; }
+	MxS32 GetClickedObjectId() const { return m_clickedObjectId; }
+	const char* GetClickedAtom() const { return m_clickedAtom; }
+	MxS16 GetUnknown0x28() const { return m_unk0x28; }
 
-	inline void SetClickedObjectId(MxS32 p_clickedObjectId) { m_clickedObjectId = p_clickedObjectId; }
-	inline void SetClickedAtom(const char* p_clickedAtom) { m_clickedAtom = p_clickedAtom; }
-	inline void SetUnknown0x28(MxS16 p_unk0x28) { m_unk0x28 = p_unk0x28; }
+	void SetClickedObjectId(MxS32 p_clickedObjectId) { m_clickedObjectId = p_clickedObjectId; }
+	void SetClickedAtom(const char* p_clickedAtom) { m_clickedAtom = p_clickedAtom; }
+	void SetUnknown0x28(MxS16 p_unk0x28) { m_unk0x28 = p_unk0x28; }
 
 	MxS32 m_clickedObjectId;   // 0x20
 	const char* m_clickedAtom; // 0x24
@@ -56,13 +56,13 @@ public:
 
 	// FUNCTION: LEGO1 0x10028cb0
 	// FUNCTION: BETA10 0x1008af40
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10028cc0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoControlManager::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -77,8 +77,8 @@ public:
 	MxBool FUN_10029750();
 	void FUN_100292e0();
 
-	inline undefined4 GetUnknown0x0c() { return m_unk0x0c; }
-	inline undefined GetUnknown0x10() { return m_unk0x10; }
+	undefined4 GetUnknown0x0c() { return m_unk0x0c; }
+	undefined GetUnknown0x10() { return m_unk0x10; }
 
 	// SYNTHETIC: LEGO1 0x10028d40
 	// LegoControlManager::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoendanimnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoendanimnotificationparam.h
@@ -19,7 +19,7 @@ public:
 		return new LegoEndAnimNotificationParam(m_type, m_sender, m_index);
 	} // vtable+0x04
 
-	inline MxU32 GetIndex() { return m_index; }
+	MxU32 GetIndex() { return m_index; }
 
 protected:
 	MxU32 m_index; // 0x0c

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -30,7 +30,7 @@ public:
 		c_altBit1 = 0x01
 	};
 
-	inline LegoEntity() { Init(); }
+	LegoEntity() { Init(); }
 
 	// FUNCTION: LEGO1 0x1000c290
 	~LegoEntity() override { Destroy(TRUE); }
@@ -38,14 +38,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1000c2f0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0064
 		return "LegoEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000c300
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoEntity::ClassName()) || MxEntity::IsA(p_name);
 	}
@@ -79,19 +79,19 @@ public:
 	Mx3DPointFloat GetWorldUp();
 	Mx3DPointFloat GetWorldPosition();
 
-	inline MxBool GetUnknown0x10IsSet(MxU8 p_flag) { return m_unk0x10 & p_flag; }
-	inline MxBool GetFlagsIsSet(MxU8 p_flag) { return m_flags & p_flag; }
-	inline MxU8 GetFlags() { return m_flags; }
-	inline MxFloat GetWorldSpeed() { return m_worldSpeed; }
-	inline LegoROI* GetROI() { return m_roi; }
-	inline MxU8 GetType() { return m_type; }
-	inline MxBool GetCameraFlag() { return m_cameraFlag; }
+	MxBool GetUnknown0x10IsSet(MxU8 p_flag) { return m_unk0x10 & p_flag; }
+	MxBool GetFlagsIsSet(MxU8 p_flag) { return m_flags & p_flag; }
+	MxU8 GetFlags() { return m_flags; }
+	MxFloat GetWorldSpeed() { return m_worldSpeed; }
+	LegoROI* GetROI() { return m_roi; }
+	MxU8 GetType() { return m_type; }
+	MxBool GetCameraFlag() { return m_cameraFlag; }
 
-	inline void SetFlags(MxU8 p_flags) { m_flags = p_flags; }
-	inline void SetFlag(MxU8 p_flag) { m_flags |= p_flag; }
-	inline void ClearFlag(MxU8 p_flag) { m_flags &= ~p_flag; }
-	inline void SetUnknown0x10Flag(MxU8 p_flag) { m_unk0x10 |= p_flag; }
-	inline void ClearUnknown0x10Flag(MxU8 p_flag) { m_unk0x10 &= ~p_flag; }
+	void SetFlags(MxU8 p_flags) { m_flags = p_flags; }
+	void SetFlag(MxU8 p_flag) { m_flags |= p_flag; }
+	void ClearFlag(MxU8 p_flag) { m_flags &= ~p_flag; }
+	void SetUnknown0x10Flag(MxU8 p_flag) { m_unk0x10 |= p_flag; }
+	void ClearUnknown0x10Flag(MxU8 p_flag) { m_unk0x10 &= ~p_flag; }
 
 protected:
 	void Init();

--- a/LEGO1/lego/legoomni/include/legoentitypresenter.h
+++ b/LEGO1/lego/legoomni/include/legoentitypresenter.h
@@ -22,13 +22,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100534b0
 	// FUNCTION: BETA10 0x10080750
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100534c0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoEntityPresenter::ClassName()) || MxCompositePresenter::IsA(p_name);
 	}
@@ -43,8 +43,8 @@ public:
 
 	void SetEntityLocation(const Vector3& p_location, const Vector3& p_direction, const Vector3& p_up);
 
-	inline LegoEntity* GetInternalEntity() { return m_entity; }
-	inline void SetInternalEntity(LegoEntity* p_entity) { m_entity = p_entity; }
+	LegoEntity* GetInternalEntity() { return m_entity; }
+	void SetInternalEntity(LegoEntity* p_entity) { m_entity = p_entity; }
 
 	// SYNTHETIC: LEGO1 0x100535a0
 	// LegoEntityPresenter::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
@@ -28,8 +28,8 @@ public:
 		return clone;
 	} // vtable+0x04
 
-	inline LegoEventNotificationParam() : MxNotificationParam(c_notificationType0, NULL) {}
-	inline LegoEventNotificationParam(
+	LegoEventNotificationParam() : MxNotificationParam(c_notificationType0, NULL) {}
+	LegoEventNotificationParam(
 		NotificationId p_type,
 		MxCore* p_sender,
 		MxU8 p_modifier,
@@ -41,21 +41,21 @@ public:
 	{
 	}
 
-	inline LegoROI* GetROI() { return m_roi; }
-	inline MxU8 GetModifier() { return m_modifier; }
-	inline MxU8 GetKey() const { return m_key; }
+	LegoROI* GetROI() { return m_roi; }
+	MxU8 GetModifier() { return m_modifier; }
+	MxU8 GetKey() const { return m_key; }
 
 	// FUNCTION: LEGO1 0x10012190
-	inline MxS32 GetX() const { return m_x; }
+	MxS32 GetX() const { return m_x; }
 
 	// FUNCTION: LEGO1 0x100121a0
-	inline MxS32 GetY() const { return m_y; }
+	MxS32 GetY() const { return m_y; }
 
-	inline void SetROI(LegoROI* p_roi) { m_roi = p_roi; }
-	inline void SetModifier(MxU8 p_modifier) { m_modifier = p_modifier; }
-	inline void SetKey(MxU8 p_key) { m_key = p_key; }
-	inline void SetX(MxS32 p_x) { m_x = p_x; }
-	inline void SetY(MxS32 p_y) { m_y = p_y; }
+	void SetROI(LegoROI* p_roi) { m_roi = p_roi; }
+	void SetModifier(MxU8 p_modifier) { m_modifier = p_modifier; }
+	void SetKey(MxU8 p_key) { m_key = p_key; }
+	void SetX(MxS32 p_x) { m_x = p_x; }
+	void SetY(MxS32 p_y) { m_y = p_y; }
 
 protected:
 	MxU8 m_modifier; // 0x0c

--- a/LEGO1/lego/legoomni/include/legoextraactor.h
+++ b/LEGO1/lego/legoomni/include/legoextraactor.h
@@ -20,14 +20,14 @@ public:
 	~LegoExtraActor() override;
 
 	// FUNCTION: LEGO1 0x1002b7b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f3204
 		return "LegoExtraActor";
 	}
 
 	// FUNCTION: LEGO1 0x1002b7d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoExtraActor::ClassName()) || LegoAnimActor::IsA(p_name);
 	}
@@ -55,7 +55,7 @@ public:
 	void Restart();
 	inline void FUN_1002ad8a();
 
-	inline void SetUnknown0x0c(undefined p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
+	void SetUnknown0x0c(undefined p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
 
 	// SYNTHETIC: LEGO1 0x1002b760
 	// LegoExtraActor::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legoflctexturepresenter.h
@@ -21,7 +21,7 @@ public:
 
 	// FUNCTION: LEGO1 0x1005def0
 	// FUNCTION: BETA10 0x100837b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -108,8 +108,8 @@ public:
 	// SIZE 0x0e
 	struct Username {
 		Username();
-		inline Username(Username& p_other) { Set(p_other); }
-		inline void Set(Username& p_other) { memcpy(m_letters, p_other.m_letters, sizeof(m_letters)); }
+		Username(Username& p_other) { Set(p_other); }
+		void Set(Username& p_other) { memcpy(m_letters, p_other.m_letters, sizeof(m_letters)); }
 
 		MxResult ReadWrite(LegoStorage* p_storage);
 		Username& operator=(const Username& p_other);
@@ -131,7 +131,7 @@ public:
 		void WriteScoreHistory();
 		void FUN_1003ccf0(LegoFile&);
 
-		inline ScoreItem* GetScore(MxS16 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
+		ScoreItem* GetScore(MxS16 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
 
 		MxS16 m_count;          // 0x00
 		ScoreItem m_scores[20]; // 0x02
@@ -165,26 +165,26 @@ public:
 	void SwitchArea(Area p_area);
 	void Init();
 
-	inline MxU8 GetActorId() { return m_actorId; }
+	MxU8 GetActorId() { return m_actorId; }
 
 	// FUNCTION: BETA10 0x1004a2d0
-	inline const char* GetActorName() { return g_actorNames[GetActorId()]; }
+	const char* GetActorName() { return g_actorNames[GetActorId()]; }
 
-	inline Act GetCurrentAct() { return m_currentAct; }
-	inline Act GetLoadedAct() { return m_loadedAct; }
-	inline Area GetCurrentArea() { return m_currentArea; }
-	inline Area GetPreviousArea() { return m_previousArea; }
-	inline Area GetUnknown0x42c() { return m_unk0x42c; }
-	inline History* GetHistory() { return &m_history; }
+	Act GetCurrentAct() { return m_currentAct; }
+	Act GetLoadedAct() { return m_loadedAct; }
+	Area GetCurrentArea() { return m_currentArea; }
+	Area GetPreviousArea() { return m_previousArea; }
+	Area GetUnknown0x42c() { return m_unk0x42c; }
+	History* GetHistory() { return &m_history; }
 
-	inline void SetDirty(MxBool p_isDirty) { m_isDirty = p_isDirty; }
-	inline void SetCurrentArea(Area p_currentArea) { m_currentArea = p_currentArea; }
-	inline void SetPreviousArea(Area p_previousArea) { m_previousArea = p_previousArea; }
-	inline void SetActorId(MxU8 p_actorId) { m_actorId = p_actorId; }
-	inline void SetUnknown0x42c(Area p_unk0x42c) { m_unk0x42c = p_unk0x42c; }
-	inline Username* GetPlayersIndex(MxS32 p_index) { return &m_players[p_index]; }
-	inline MxS16 GetPlayerCount() { return m_playerCount; }
-	inline LegoBackgroundColor* GetBackgroundColor() { return m_backgroundColor; }
+	void SetDirty(MxBool p_isDirty) { m_isDirty = p_isDirty; }
+	void SetCurrentArea(Area p_currentArea) { m_currentArea = p_currentArea; }
+	void SetPreviousArea(Area p_previousArea) { m_previousArea = p_previousArea; }
+	void SetActorId(MxU8 p_actorId) { m_actorId = p_actorId; }
+	void SetUnknown0x42c(Area p_unk0x42c) { m_unk0x42c = p_unk0x42c; }
+	Username* GetPlayersIndex(MxS32 p_index) { return &m_players[p_index]; }
+	MxS16 GetPlayerCount() { return m_playerCount; }
+	LegoBackgroundColor* GetBackgroundColor() { return m_backgroundColor; }
 
 	void SetCurrentAct(Act p_currentAct);
 	void FindLoadedAct();

--- a/LEGO1/lego/legoomni/include/legohideanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legohideanimpresenter.h
@@ -34,13 +34,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1006d880
 	// FUNCTION: BETA10 0x1005d470
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1006d890
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || LegoAnimPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -106,21 +106,21 @@ public:
 	void SetWorld(LegoWorld* p_world);
 	void ClearWorld();
 
-	inline void SetUnknown88(MxBool p_unk0x88) { m_unk0x88 = p_unk0x88; }
-	inline void SetUnknown335(MxBool p_unk0x335) { m_unk0x335 = p_unk0x335; }
-	inline void SetUnknown336(MxBool p_unk0x336) { m_unk0x336 = p_unk0x336; }
-	inline void SetUseJoystick(MxBool p_useJoystick) { m_useJoystick = p_useJoystick; }
-	inline void SetJoystickIndex(MxS32 p_joystickIndex) { m_joystickIndex = p_joystickIndex; }
+	void SetUnknown88(MxBool p_unk0x88) { m_unk0x88 = p_unk0x88; }
+	void SetUnknown335(MxBool p_unk0x335) { m_unk0x335 = p_unk0x335; }
+	void SetUnknown336(MxBool p_unk0x336) { m_unk0x336 = p_unk0x336; }
+	void SetUseJoystick(MxBool p_useJoystick) { m_useJoystick = p_useJoystick; }
+	void SetJoystickIndex(MxS32 p_joystickIndex) { m_joystickIndex = p_joystickIndex; }
 
-	inline void DisableInputProcessing()
+	void DisableInputProcessing()
 	{
 		m_unk0x88 = TRUE;
 		m_unk0x336 = FALSE;
 	}
 
-	inline LegoControlManager* GetControlManager() { return m_controlManager; }
-	inline LegoWorld* GetWorld() { return m_world; }
-	inline LegoCameraController* GetCamera() { return m_camera; }
+	LegoControlManager* GetControlManager() { return m_controlManager; }
+	LegoWorld* GetWorld() { return m_world; }
+	LegoCameraController* GetCamera() { return m_camera; }
 
 	void ProcessEvents();
 	MxBool ProcessOneEvent(LegoEventNotificationParam& p_param);

--- a/LEGO1/lego/legoomni/include/legojetski.h
+++ b/LEGO1/lego/legoomni/include/legojetski.h
@@ -18,14 +18,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10013e90
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f053c
 		return "LegoJetski";
 	}
 
 	// FUNCTION: LEGO1 0x10013eb0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoJetski::ClassName()) || LegoJetskiRaceActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -13,14 +13,14 @@ public:
 	LegoJetskiRaceActor();
 
 	// FUNCTION: LEGO1 0x10081d90
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0554
 		return "LegoJetskiRaceActor";
 	}
 
 	// FUNCTION: LEGO1 0x10081db0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoJetskiRaceActor::ClassName()) || LegoCarRaceActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoloadcachesoundpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoloadcachesoundpresenter.h
@@ -22,7 +22,7 @@ public:
 
 	// FUNCTION: LEGO1 0x10018450
 	// FUNCTION: BETA10 0x1008cf60
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}

--- a/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legolocomotionanimpresenter.h
@@ -20,13 +20,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1006ce50
 	// FUNCTION: BETA10 0x1005c4b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1006ce60
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || LegoLoopingAnimPresenter::IsA(p_name);
 	}
@@ -45,14 +45,14 @@ public:
 
 	void FUN_1006d680(LegoAnimActor* p_actor, MxFloat p_value);
 
-	inline void DecrementUnknown0xd4()
+	void DecrementUnknown0xd4()
 	{
 		if (m_unk0xd4) {
 			--m_unk0xd4;
 		}
 	}
 
-	inline undefined2 GetUnknown0xd4() { return m_unk0xd4; }
+	undefined2 GetUnknown0xd4() { return m_unk0xd4; }
 
 private:
 	void Init();

--- a/LEGO1/lego/legoomni/include/legoloopinganimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoloopinganimpresenter.h
@@ -16,13 +16,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000c9a0
 	// FUNCTION: BETA10 0x1005c6c0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000c9b0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || LegoAnimPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legomain.h
+++ b/LEGO1/lego/legoomni/include/legomain.h
@@ -66,8 +66,8 @@ public:
 			return *this;
 		}
 
-		inline MxS32 GetId() { return m_id; }
-		inline const char* GetKey() { return m_key; }
+		MxS32 GetId() { return m_id; }
+		const char* GetKey() { return m_key; }
 
 		MxS32 m_id;         // 0x00
 		char m_key[20];     // 0x04
@@ -80,14 +80,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10058aa0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f671c
 		return "LegoOmni";
 	}
 
 	// FUNCTION: LEGO1 0x10058ab0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoOmni::ClassName()) || MxOmni::IsA(p_name);
 	}
@@ -138,17 +138,17 @@ public:
 	LegoCharacterManager* GetCharacterManager() { return m_characterManager; }
 	LegoWorldList* GetWorldList() { return m_worldList; }
 
-	inline void SetNavController(LegoNavController* p_navController) { m_navController = p_navController; }
-	inline void SetUserActor(LegoPathActor* p_userActor) { m_userActor = p_userActor; }
-	inline void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
-	inline void SetExit(MxBool p_exit) { m_exit = p_exit; }
-	inline MxResult StartActionIfUnknown0x13c(MxDSAction& p_dsAction)
+	void SetNavController(LegoNavController* p_navController) { m_navController = p_navController; }
+	void SetUserActor(LegoPathActor* p_userActor) { m_userActor = p_userActor; }
+	void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
+	void SetExit(MxBool p_exit) { m_exit = p_exit; }
+	MxResult StartActionIfUnknown0x13c(MxDSAction& p_dsAction)
 	{
 		return m_unk0x13c ? Start(&p_dsAction) : SUCCESS;
 	}
-	inline void SetUnknown13c(MxBool p_unk0x13c) { m_unk0x13c = p_unk0x13c; }
+	void SetUnknown13c(MxBool p_unk0x13c) { m_unk0x13c = p_unk0x13c; }
 
-	inline void CloseMainWindow() { PostMessageA(m_windowHandle, WM_CLOSE, 0, 0); }
+	void CloseMainWindow() { PostMessageA(m_windowHandle, WM_CLOSE, 0, 0); }
 
 	// SYNTHETIC: LEGO1 0x10058b30
 	// LegoOmni::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legomain.h
+++ b/LEGO1/lego/legoomni/include/legomain.h
@@ -142,10 +142,7 @@ public:
 	void SetUserActor(LegoPathActor* p_userActor) { m_userActor = p_userActor; }
 	void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
 	void SetExit(MxBool p_exit) { m_exit = p_exit; }
-	MxResult StartActionIfUnknown0x13c(MxDSAction& p_dsAction)
-	{
-		return m_unk0x13c ? Start(&p_dsAction) : SUCCESS;
-	}
+	MxResult StartActionIfUnknown0x13c(MxDSAction& p_dsAction) { return m_unk0x13c ? Start(&p_dsAction) : SUCCESS; }
 	void SetUnknown13c(MxBool p_unk0x13c) { m_unk0x13c = p_unk0x13c; }
 
 	void CloseMainWindow() { PostMessageA(m_windowHandle, WM_CLOSE, 0, 0); }

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -28,13 +28,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000ccb0
 	// FUNCTION: BETA10 0x100a7150
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000ccc0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || MxVideoPresenter::IsA(p_name);
 	}
@@ -45,7 +45,7 @@ public:
 
 	MxResult FUN_1007ff70(MxDSChunk& p_chunk, LegoEntity* p_entity, MxBool p_roiVisible, LegoWorld* p_world);
 
-	inline void Reset()
+	void Reset()
 	{
 		m_roi = NULL;
 		m_addedToView = FALSE;

--- a/LEGO1/lego/legoomni/include/legonavcontroller.h
+++ b/LEGO1/lego/legoomni/include/legonavcontroller.h
@@ -22,14 +22,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10054b80
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f66d8
 		return "LegoNavController";
 	}
 
 	// FUNCTION: LEGO1 0x10054b90
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || MxCore::IsA(p_name);
 	}
@@ -77,11 +77,11 @@ public:
 	static MxS32 GetNumLocations();
 	static LegoLocation* GetLocation(MxU32 p_location);
 
-	inline void SetLinearVel(MxFloat p_linearVel) { m_linearVel = p_linearVel; }
-	inline MxFloat GetLinearVel() { return m_linearVel; }
-	inline MxFloat GetRotationalVel() { return m_rotationalVel; }
-	inline MxFloat GetMaxLinearVel() { return m_maxLinearVel; }
-	inline void ResetMaxLinearVel(MxFloat p_maxLinearVel)
+	void SetLinearVel(MxFloat p_linearVel) { m_linearVel = p_linearVel; }
+	MxFloat GetLinearVel() { return m_linearVel; }
+	MxFloat GetRotationalVel() { return m_rotationalVel; }
+	MxFloat GetMaxLinearVel() { return m_maxLinearVel; }
+	void ResetMaxLinearVel(MxFloat p_maxLinearVel)
 	{
 		m_maxLinearVel = p_maxLinearVel;
 		m_trackDefault = 0;

--- a/LEGO1/lego/legoomni/include/legopalettepresenter.h
+++ b/LEGO1/lego/legoomni/include/legopalettepresenter.h
@@ -22,13 +22,13 @@ public:
 
 	// FUNCTION: LEGO1 0x10079f30
 	// FUNCTION: BETA10 0x100ab220
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10079f40
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ClassName()) || MxVideoPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legopartpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopartpresenter.h
@@ -22,13 +22,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000cf70
 	// FUNCTION: BETA10 0x100a75a0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000cf80
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoPartPresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}
@@ -42,7 +42,7 @@ public:
 	// SYNTHETIC: LEGO1 0x1000d060
 	// LegoPartPresenter::`scalar deleting destructor'
 
-	inline void Reset() { m_parts = NULL; }
+	void Reset() { m_parts = NULL; }
 
 	MxResult Read(MxDSChunk& p_chunk);
 	void Store();

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -25,14 +25,14 @@ public:
 	~LegoPathActor() override;
 
 	// FUNCTION: LEGO1 0x1000c430
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0114
 		return "LegoPathActor";
 	}
 
 	// FUNCTION: LEGO1 0x1000c440
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoPathActor::ClassName()) || LegoActor::IsA(p_name);
 	}
@@ -123,14 +123,14 @@ public:
 	// FUNCTION: LEGO1 0x10002de0
 	virtual void VTable0xc8(MxU8 p_unk0x148) { m_unk0x148 = p_unk0x148; } // vtable+0xc8
 
-	inline LegoPathBoundary* GetBoundary() { return m_boundary; }
-	inline MxU32 GetState() { return m_state; }
-	inline LegoPathController* GetController() { return m_controller; }
-	inline MxBool GetCollideBox() { return m_collideBox; }
+	LegoPathBoundary* GetBoundary() { return m_boundary; }
+	MxU32 GetState() { return m_state; }
+	LegoPathController* GetController() { return m_controller; }
+	MxBool GetCollideBox() { return m_collideBox; }
 
-	inline void SetBoundary(LegoPathBoundary* p_boundary) { m_boundary = p_boundary; }
-	inline void SetState(MxU32 p_state) { m_state = p_state; }
-	inline void SetController(LegoPathController* p_controller) { m_controller = p_controller; }
+	void SetBoundary(LegoPathBoundary* p_boundary) { m_boundary = p_boundary; }
+	void SetState(MxU32 p_state) { m_state = p_state; }
+	void SetController(LegoPathController* p_controller) { m_controller = p_controller; }
 
 	// SYNTHETIC: LEGO1 0x1002d800
 	// LegoPathActor::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -56,8 +56,8 @@ public:
 	MxU32 FUN_10057fe0(LegoAnimPresenter* p_presenter);
 	MxU32 FUN_100586e0(LegoAnimPresenter* p_presenter);
 
-	inline LegoPathActorSet& GetActors() { return m_actors; }
-	inline LegoAnimPresenterSet& GetPresenters() { return m_presenters; }
+	LegoPathActorSet& GetActors() { return m_actors; }
+	LegoAnimPresenterSet& GetPresenters() { return m_presenters; }
 
 	// SYNTHETIC: LEGO1 0x10047a80
 	// LegoPathBoundary::`vector deleting destructor'

--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -69,14 +69,14 @@ public:
 	MxResult Tickle() override; // vtable+08
 
 	// FUNCTION: LEGO1 0x10045110
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f11b8
 		return "LegoPathController";
 	}
 
 	// FUNCTION: LEGO1 0x10045120
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoPathController::ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legopathpresenter.h
+++ b/LEGO1/lego/legoomni/include/legopathpresenter.h
@@ -20,13 +20,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100449a0
 	// FUNCTION: BETA10 0x100c24a0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100449b0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoPathPresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legopathstruct.h
+++ b/LEGO1/lego/legoomni/include/legopathstruct.h
@@ -28,8 +28,8 @@ public:
 		return new LegoPathStructNotificationParam(m_type, m_sender, m_trigger, m_data);
 	} // vtable+0x04
 
-	inline MxU8 GetTrigger() { return m_trigger; }
-	inline MxS16 GetData() { return m_data; }
+	MxU8 GetTrigger() { return m_trigger; }
+	MxS16 GetData() { return m_data; }
 
 protected:
 	MxS16 m_data;   // 0x0c
@@ -87,8 +87,8 @@ public:
 
 	virtual void HandleTrigger(LegoPathActor* p_actor, MxBool p_direction, MxU32 p_data); // vtable+0x04
 
-	inline void SetWorld(LegoWorld* p_world) { m_world = p_world; }
-	inline void SetAtomId(const MxAtomId& p_atomId) { m_atomId = p_atomId; }
+	void SetWorld(LegoWorld* p_world) { m_world = p_world; }
+	void SetAtomId(const MxAtomId& p_atomId) { m_atomId = p_atomId; }
 
 private:
 	MxBool HandleTrigger(LegoPathActor* p_actor, MxBool p_direction, MxU32 p_data, MxBool p_bool);

--- a/LEGO1/lego/legoomni/include/legophoneme.h
+++ b/LEGO1/lego/legoomni/include/legophoneme.h
@@ -29,7 +29,7 @@ public:
 	virtual void Init();                                 // vtable+0x1c
 	virtual void VTable0x20(undefined4);                 // vtable+0x20
 
-	inline MxString& GetName() { return m_name; }
+	MxString& GetName() { return m_name; }
 
 private:
 	MxString m_name;            // 0x04

--- a/LEGO1/lego/legoomni/include/legophonemepresenter.h
+++ b/LEGO1/lego/legoomni/include/legophonemepresenter.h
@@ -24,7 +24,7 @@ public:
 
 	// FUNCTION: LEGO1 0x1004e310
 	// FUNCTION: BETA10 0x100c41f0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -28,7 +28,7 @@ public:
 	MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10026290
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f318c
 		return "LegoPlantManager";

--- a/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
@@ -89,8 +89,8 @@ public:
 	MxResult Create(Lego3DView* p_lego3DView);
 	void OnViewSize(int p_width, int p_height);
 
-	inline LegoEntity* GetEntity() { return m_entity; }
-	inline LegoNavController* GetNavController() { return m_nav; }
+	LegoEntity* GetEntity() { return m_entity; }
+	LegoNavController* GetNavController() { return m_nav; }
 
 protected:
 	void AffectPointOfView();

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -23,10 +23,10 @@ public:
 	// SIZE 0x06
 	struct Entry {
 	public:
-		inline MxS16 GetUnknown0x02() { return m_unk0x02; }
-		inline MxS16 GetHighScore() { return m_score; }
+		MxS16 GetUnknown0x02() { return m_unk0x02; }
+		MxS16 GetHighScore() { return m_score; }
 
-		inline MxResult Serialize(LegoFile* p_file)
+		MxResult Serialize(LegoFile* p_file)
 		{
 			if (p_file->IsReadMode()) {
 				Read(p_file, &m_id);
@@ -51,14 +51,14 @@ public:
 	RaceState();
 
 	// FUNCTION: LEGO1 0x10016010
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f07d0
 		return "RaceState";
 	}
 
 	// FUNCTION: LEGO1 0x10016020
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, RaceState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -67,7 +67,7 @@ public:
 
 	Entry* GetState(MxU8 p_id);
 
-	inline undefined4 GetUnknown0x28() { return m_unk0x28; }
+	undefined4 GetUnknown0x28() { return m_unk0x28; }
 
 	// SYNTHETIC: LEGO1 0x1000f6f0
 	// RaceState::~RaceState
@@ -99,13 +99,13 @@ public:
 
 	// FUNCTION: LEGO1 0x10015ba0
 	// FUNCTION: BETA10 0x100a8940
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10015bb0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoRace::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -14,14 +14,14 @@ public:
 	LegoRaceActor();
 
 	// FUNCTION: LEGO1 0x10014b00
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0bf4
 		return "LegoRaceActor";
 	}
 
 	// FUNCTION: LEGO1 0x10014b20
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoRaceActor::ClassName()) || LegoAnimActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legoracecar.h
+++ b/LEGO1/lego/legoomni/include/legoracecar.h
@@ -24,14 +24,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100142a0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0548
 		return "LegoRaceCar";
 	}
 
 	// FUNCTION: LEGO1 0x100142c0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoRaceCar::ClassName()) || LegoCarRaceActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legosoundmanager.h
+++ b/LEGO1/lego/legoomni/include/legosoundmanager.h
@@ -21,7 +21,7 @@ public:
 
 	void UpdateListener(const float* p_position, const float* p_direction, const float* p_up, const float* p_velocity);
 
-	inline LegoCacheSoundManager* GetCacheSoundManager() { return m_cacheSoundManager; }
+	LegoCacheSoundManager* GetCacheSoundManager() { return m_cacheSoundManager; }
 
 private:
 	void Init();

--- a/LEGO1/lego/legoomni/include/legostate.h
+++ b/LEGO1/lego/legoomni/include/legostate.h
@@ -56,15 +56,15 @@ public:
 		MxU32 Next();
 		MxBool Contains(MxU32 p_objectId);
 
-		inline void SetUnknown0x08(MxS16 p_unk0x08) { m_nextIndex = p_unk0x08; }
+		void SetUnknown0x08(MxS16 p_unk0x08) { m_nextIndex = p_unk0x08; }
 
-		inline MxResult ReadFromFile(LegoFile* p_file)
+		MxResult ReadFromFile(LegoFile* p_file)
 		{
 			Read(p_file, &m_nextIndex);
 			return SUCCESS;
 		}
 
-		inline MxResult WriteToFile(LegoFile* p_file)
+		MxResult WriteToFile(LegoFile* p_file)
 		{
 			Write(p_file, m_nextIndex);
 			return SUCCESS;
@@ -81,14 +81,14 @@ public:
 	~LegoState() override {}
 
 	// FUNCTION: LEGO1 0x100060d0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f01b8
 		return "LegoState";
 	}
 
 	// FUNCTION: LEGO1 0x100060e0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoState::ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legotexturepresenter.h
+++ b/LEGO1/lego/legoomni/include/legotexturepresenter.h
@@ -20,13 +20,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000ce50
 	// FUNCTION: BETA10 0x100a7390
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000ce60
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoTexturePresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/legovideomanager.h
+++ b/LEGO1/lego/legoomni/include/legovideomanager.h
@@ -47,15 +47,15 @@ public:
 
 	void FUN_1007c520();
 
-	inline Tgl::Renderer* GetRenderer() { return m_renderer; }
-	inline Lego3DManager* Get3DManager() { return m_3dManager; }
-	inline LegoROI* GetViewROI() { return m_viewROI; }
-	inline MxDirect3D* GetDirect3D() { return m_direct3d; }
-	inline MxBool GetRender3D() { return m_render3d; }
-	inline double GetElapsedSeconds() { return m_elapsedSeconds; }
+	Tgl::Renderer* GetRenderer() { return m_renderer; }
+	Lego3DManager* Get3DManager() { return m_3dManager; }
+	LegoROI* GetViewROI() { return m_viewROI; }
+	MxDirect3D* GetDirect3D() { return m_direct3d; }
+	MxBool GetRender3D() { return m_render3d; }
+	double GetElapsedSeconds() { return m_elapsedSeconds; }
 
-	inline void SetRender3D(MxBool p_render3d) { m_render3d = p_render3d; }
-	inline void SetUnk0x554(MxBool p_unk0x554) { m_unk0x554 = p_unk0x554; }
+	void SetRender3D(MxBool p_render3d) { m_render3d = p_render3d; }
+	void SetUnk0x554(MxBool p_unk0x554) { m_unk0x554 = p_unk0x554; }
 
 private:
 	MxResult CreateDirect3D();

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -46,14 +46,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1001d690
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0058
 		return "LegoWorld";
 	}
 
 	// FUNCTION: LEGO1 0x1001d6a0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoWorld::ClassName()) || LegoEntity::IsA(p_name);
 	}
@@ -97,14 +97,14 @@ public:
 	MxCore* Find(const char* p_class, const char* p_name);
 	MxCore* Find(const MxAtomId& p_atom, MxS32 p_entityId);
 
-	inline LegoCameraController* GetCamera() { return m_cameraController; }
-	inline LegoEntityList* GetEntityList() { return m_entityList; }
-	inline MxS32 GetWorldId() { return m_worldId; }
-	inline MxBool GetUnknown0xd0Empty() { return m_set0xd0.empty(); }
-	inline list<LegoROI*>& GetROIList() { return m_roiList; }
-	inline LegoHideAnimPresenter* GetHideAnimPresenter() { return m_hideAnimPresenter; }
+	LegoCameraController* GetCamera() { return m_cameraController; }
+	LegoEntityList* GetEntityList() { return m_entityList; }
+	MxS32 GetWorldId() { return m_worldId; }
+	MxBool GetUnknown0xd0Empty() { return m_set0xd0.empty(); }
+	list<LegoROI*>& GetROIList() { return m_roiList; }
+	LegoHideAnimPresenter* GetHideAnimPresenter() { return m_hideAnimPresenter; }
 
-	inline void SetWorldId(MxS32 p_worldId) { m_worldId = p_worldId; }
+	void SetWorldId(MxS32 p_worldId) { m_worldId = p_worldId; }
 
 	// SYNTHETIC: LEGO1 0x1001dee0
 	// LegoWorld::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoworldpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoworldpresenter.h
@@ -27,13 +27,13 @@ public:
 
 	// FUNCTION: LEGO1 0x10066630
 	// FUNCTION: BETA10 0x100e4190
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x10066640
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoWorldPresenter::ClassName()) || LegoEntityPresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/motorcycle.h
+++ b/LEGO1/lego/legoomni/include/motorcycle.h
@@ -11,14 +11,14 @@ public:
 	Motocycle();
 
 	// FUNCTION: LEGO1 0x10035840
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f38e8
 		return "Motorcycle";
 	}
 
 	// FUNCTION: LEGO1 0x10035850
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Motocycle::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
+++ b/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
@@ -18,19 +18,19 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1007eb70
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f7ac4
 		return "MxBackgroundAudioManager";
 	}
 
 	// FUNCTION: LEGO1 0x1007eb80
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxBackgroundAudioManager::ClassName()) || MxCore::IsA(p_name);
 	}
 
-	inline MxBool GetEnabled() { return m_enabled; }
+	MxBool GetEnabled() { return m_enabled; }
 
 	void StartAction(MxParam& p_param);
 	void StopAction(MxParam& p_param);

--- a/LEGO1/lego/legoomni/include/mxcompositemediapresenter.h
+++ b/LEGO1/lego/legoomni/include/mxcompositemediapresenter.h
@@ -13,14 +13,14 @@ public:
 	MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10073f10
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f02d4
 		return "MxCompositeMediaPresenter";
 	}
 
 	// FUNCTION: LEGO1 0x10073f20
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxCompositeMediaPresenter::ClassName()) || MxCompositePresenter::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/mxcontrolpresenter.h
+++ b/LEGO1/lego/legoomni/include/mxcontrolpresenter.h
@@ -15,14 +15,14 @@ public:
 	~MxControlPresenter() override;
 
 	// FUNCTION: LEGO1 0x10044000
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0514
 		return "MxControlPresenter";
 	}
 
 	// FUNCTION: LEGO1 0x10044010
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxControlPresenter::ClassName()) || MxCompositePresenter::IsA(p_name);
 	}
@@ -42,7 +42,7 @@ public:
 	MxBool FUN_10044480(LegoControlManagerNotificationParam* p_param, MxPresenter* p_presenter);
 	MxBool FUN_10044270(MxS32 p_x, MxS32 p_y, MxVideoPresenter* p_presenter);
 
-	inline MxS16 GetUnknown0x4e() { return m_unk0x4e; }
+	MxS16 GetUnknown0x4e() { return m_unk0x4e; }
 
 private:
 	undefined2 m_unk0x4c; // 0x4c

--- a/LEGO1/lego/legoomni/include/mxtransitionmanager.h
+++ b/LEGO1/lego/legoomni/include/mxtransitionmanager.h
@@ -20,13 +20,13 @@ public:
 	MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x1004b950
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return "MxTransitionManager";
 	}
 
 	// FUNCTION: LEGO1 0x1004b960
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxTransitionManager::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -45,7 +45,7 @@ public:
 
 	MxResult StartTransition(TransitionType p_animationType, MxS32 p_speed, MxBool p_doCopy, MxBool p_playMusicInAnim);
 
-	inline TransitionType GetTransitionType() { return m_transitionType; }
+	TransitionType GetTransitionType() { return m_transitionType; }
 
 	// SYNTHETIC: LEGO1 0x1004b9e0
 	// MxTransitionManager::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/pizza.h
+++ b/LEGO1/lego/legoomni/include/pizza.h
@@ -15,7 +15,7 @@ public:
 	// SIZE 0x20
 	struct Entry {
 	public:
-		inline MxResult WriteToFile(LegoFile* p_file)
+		MxResult WriteToFile(LegoFile* p_file)
 		{
 			Write(p_file, m_unk0x06);
 			Write(p_file, m_unk0x14);
@@ -24,7 +24,7 @@ public:
 			return SUCCESS;
 		}
 
-		inline MxResult ReadFromFile(LegoFile* p_file)
+		MxResult ReadFromFile(LegoFile* p_file)
 		{
 			Read(p_file, &m_unk0x06);
 			Read(p_file, &m_unk0x14);
@@ -49,21 +49,21 @@ public:
 	PizzaMissionState();
 
 	// FUNCTION: LEGO1 0x10039290
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f00d4
 		return "PizzaMissionState";
 	}
 
 	// FUNCTION: LEGO1 0x100392a0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, PizzaMissionState::ClassName()) || LegoState::IsA(p_name);
 	}
 
 	MxResult Serialize(LegoFile* p_file) override; // vtable+0x1c
 
-	inline MxS16 GetHighScore(MxU8 p_id) { return GetState(p_id)->m_score; }
+	MxS16 GetHighScore(MxU8 p_id) { return GetState(p_id)->m_score; }
 
 	// SYNTHETIC: LEGO1 0x10039350
 	// PizzaMissionState::`scalar deleting destructor'
@@ -86,14 +86,14 @@ public:
 	MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10037f90
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f038c
 		return "Pizza";
 	}
 
 	// FUNCTION: LEGO1 0x10037fa0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Pizza::ClassName()) || IsleActor::IsA(p_name);
 	}
@@ -108,7 +108,7 @@ public:
 	void FUN_100382b0();
 	void FUN_10038380();
 
-	inline void SetSkateboard(SkateBoard* p_skateboard) { m_skateboard = p_skateboard; }
+	void SetSkateboard(SkateBoard* p_skateboard) { m_skateboard = p_skateboard; }
 
 	// SYNTHETIC: LEGO1 0x100380e0
 	// Pizza::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/pizzeria.h
+++ b/LEGO1/lego/legoomni/include/pizzeria.h
@@ -23,14 +23,14 @@ public:
 	PizzeriaState();
 
 	// FUNCTION: LEGO1 0x10017c20
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0370
 		return "PizzeriaState";
 	}
 
 	// FUNCTION: LEGO1 0x10017c30
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, PizzeriaState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -55,14 +55,14 @@ public:
 	Pizzeria() : m_pizzeriaState(NULL) {}
 
 	// FUNCTION: LEGO1 0x1000e780
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0380
 		return "Pizzeria";
 	}
 
 	// FUNCTION: LEGO1 0x1000e790
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Pizzeria::ClassName()) || IsleActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/police.h
+++ b/LEGO1/lego/legoomni/include/police.h
@@ -19,14 +19,14 @@ public:
 	~PoliceState() override {}
 
 	// FUNCTION: LEGO1 0x1005e860
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0444
 		return "PoliceState";
 	}
 
 	// FUNCTION: LEGO1 0x1005e870
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, PoliceState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -36,8 +36,8 @@ public:
 	// SYNTHETIC: LEGO1 0x1005e920
 	// PoliceState::`scalar deleting destructor'
 
-	inline undefined4 GetUnknown0x0c() { return m_unk0x0c; }
-	inline void SetUnknown0x0c(undefined4 p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
+	undefined4 GetUnknown0x0c() { return m_unk0x0c; }
+	void SetUnknown0x0c(undefined4 p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
 
 	void FUN_1005ea40();
 
@@ -57,14 +57,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1005e1e0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0450
 		return "Police";
 	}
 
 	// FUNCTION: LEGO1 0x1005e1f0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Police::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/racecar.h
+++ b/LEGO1/lego/legoomni/include/racecar.h
@@ -12,14 +12,14 @@ public:
 	~RaceCar() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10028270
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03e0
 		return "RaceCar";
 	}
 
 	// FUNCTION: LEGO1 0x10028280
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, RaceCar::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/radio.h
+++ b/LEGO1/lego/legoomni/include/radio.h
@@ -15,14 +15,14 @@ public:
 	RadioState();
 
 	// FUNCTION: LEGO1 0x1002cf60
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f04f8
 		return "RadioState";
 	}
 
 	// FUNCTION: LEGO1 0x1002cf70
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, RadioState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -32,9 +32,9 @@ public:
 	// SYNTHETIC: LEGO1 0x1002d020
 	// RadioState::`scalar deleting destructor'
 
-	inline MxBool IsActive() { return m_active; }
+	MxBool IsActive() { return m_active; }
 
-	inline void SetActive(MxBool p_active) { m_active = p_active; }
+	void SetActive(MxBool p_active) { m_active = p_active; }
 
 	undefined4 FUN_1002d090();
 	MxBool FUN_1002d0c0(const MxAtomId& p_atom, MxU32 p_objectId);
@@ -56,14 +56,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x1002c8e0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f328c
 		return "Radio";
 	}
 
 	// FUNCTION: LEGO1 0x1002c8f0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Radio::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -73,7 +73,7 @@ public:
 	void Play();
 	void Stop();
 
-	inline RadioState* GetState() { return m_state; }
+	RadioState* GetState() { return m_state; }
 
 	// SYNTHETIC: LEGO1 0x1002c970
 	// Radio::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/registrationbook.h
+++ b/LEGO1/lego/legoomni/include/registrationbook.h
@@ -20,14 +20,14 @@ public:
 	MxResult Tickle() override;               // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10076e10
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f04c8
 		return "RegistrationBook";
 	}
 
 	// FUNCTION: LEGO1 0x10076e20
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, RegistrationBook::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/score.h
+++ b/LEGO1/lego/legoomni/include/score.h
@@ -15,14 +15,14 @@ public:
 	ScoreState() : m_playCubeTutorial(TRUE) {}
 
 	// FUNCTION: LEGO1 0x1000de40
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0084
 		return "ScoreState";
 	}
 
 	// FUNCTION: LEGO1 0x1000de50
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, ScoreState::ClassName()) || LegoState::IsA(p_name);
 	}
@@ -37,8 +37,8 @@ public:
 		return TRUE;
 	} // vtable+0x18
 
-	inline MxBool GetTutorialFlag() { return m_playCubeTutorial; }
-	inline void SetTutorialFlag(MxBool p_playCubeTutorial) { m_playCubeTutorial = p_playCubeTutorial; }
+	MxBool GetTutorialFlag() { return m_playCubeTutorial; }
+	void SetTutorialFlag(MxBool p_playCubeTutorial) { m_playCubeTutorial = p_playCubeTutorial; }
 
 	// SYNTHETIC: LEGO1 0x1000df00
 	// ScoreState::`scalar deleting destructor'
@@ -57,14 +57,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100010c0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0050
 		return "Score";
 	}
 
 	// FUNCTION: LEGO1 0x100010d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, Score::ClassName()) || LegoWorld::IsA(p_name);
 	}

--- a/LEGO1/lego/legoomni/include/skateboard.h
+++ b/LEGO1/lego/legoomni/include/skateboard.h
@@ -14,14 +14,14 @@ public:
 	~SkateBoard() override;
 
 	// FUNCTION: LEGO1 0x1000fdd0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f041c
 		return "SkateBoard";
 	}
 
 	// FUNCTION: LEGO1 0x1000fde0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, SkateBoard::ClassName()) || IslePathActor::IsA(p_name);
 	}
@@ -32,7 +32,7 @@ public:
 	MxLong HandleControl(LegoControlManagerNotificationParam& p_param) override; // vtable+0xd4
 	void Exit() override;                                                        // vtable+0xe4
 
-	inline void SetUnknown0x160(MxBool p_unk0x160) { m_unk0x160 = p_unk0x160; }
+	void SetUnknown0x160(MxBool p_unk0x160) { m_unk0x160 = p_unk0x160; }
 
 	void ActivateSceneActions();
 

--- a/LEGO1/lego/legoomni/include/towtrack.h
+++ b/LEGO1/lego/legoomni/include/towtrack.h
@@ -12,21 +12,21 @@ public:
 	TowTrackMissionState();
 
 	// FUNCTION: LEGO1 0x1004dfa0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f00bc
 		return "TowTrackMissionState";
 	}
 
 	// FUNCTION: LEGO1 0x1004dfb0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, TowTrackMissionState::ClassName()) || LegoState::IsA(p_name);
 	}
 
 	MxResult Serialize(LegoFile* p_file) override; // vtable+0x1c
 
-	inline MxS16 GetHighScore(MxU8 p_id)
+	MxS16 GetHighScore(MxU8 p_id)
 	{
 		switch (p_id) {
 		case 1:
@@ -70,14 +70,14 @@ public:
 	~TowTrack() override;
 
 	// FUNCTION: LEGO1 0x1004c7c0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f03b8
 		return "TowTrack";
 	}
 
 	// FUNCTION: LEGO1 0x1004c7d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, TowTrack::ClassName()) || IslePathActor::IsA(p_name);
 	}

--- a/LEGO1/lego/sources/anim/legoanim.h
+++ b/LEGO1/lego/sources/anim/legoanim.h
@@ -103,7 +103,7 @@ public:
 	LegoUnknownKey();
 	LegoResult Read(LegoStorage* p_storage);
 
-	inline LegoFloat GetZ() { return m_z; }
+	LegoFloat GetZ() { return m_z; }
 
 protected:
 	LegoFloat m_z; // 0x08
@@ -216,13 +216,13 @@ public:
 	LegoResult Read(LegoStorage* p_storage);
 	LegoResult FUN_1009f490(LegoFloat p_time, Matrix4& p_matrix);
 
-	inline LegoU32 GetUnknown0x18() { return m_unk0x18; }
-	inline LegoU32 GetUnknown0x1c() { return m_unk0x1c; }
-	inline LegoU32 GetUnknown0x20() { return m_unk0x20; }
+	LegoU32 GetUnknown0x18() { return m_unk0x18; }
+	LegoU32 GetUnknown0x1c() { return m_unk0x1c; }
+	LegoU32 GetUnknown0x20() { return m_unk0x20; }
 
-	inline void SetUnknown0x18(LegoU32 p_unk0x18) { m_unk0x18 = p_unk0x18; }
-	inline void SetUnknown0x1c(LegoU32 p_unk0x1c) { m_unk0x1c = p_unk0x1c; }
-	inline void SetUnknown0x20(LegoU32 p_unk0x20) { m_unk0x20 = p_unk0x20; }
+	void SetUnknown0x18(LegoU32 p_unk0x18) { m_unk0x18 = p_unk0x18; }
+	void SetUnknown0x1c(LegoU32 p_unk0x1c) { m_unk0x1c = p_unk0x1c; }
+	void SetUnknown0x20(LegoU32 p_unk0x20) { m_unk0x20 = p_unk0x20; }
 
 private:
 	LegoU16 m_unk0x00;             // 0x00
@@ -250,7 +250,7 @@ public:
 	const LegoChar* GetActorName(LegoU32 p_index);
 	undefined4 GetActorUnknown0x04(LegoU32 p_index);
 
-	inline LegoAnimScene* GetScene() { return m_scene; }
+	LegoAnimScene* GetScene() { return m_scene; }
 
 	// SYNTHETIC: LEGO1 0x100a0ba0
 	// LegoAnim::`scalar deleting destructor'

--- a/LEGO1/lego/sources/geom/legoweedge.h
+++ b/LEGO1/lego/sources/geom/legoweedge.h
@@ -15,11 +15,11 @@ public:
 
 	virtual LegoResult VTable0x04(); // vtable+0x04
 
-	inline LegoU8 GetNumEdges() { return m_numEdges; }
-	inline LegoEdge** GetEdges() { return m_edges; }
-	inline LegoU32 IsEqual(LegoWEEdge& p_other) { return this == &p_other; }
+	LegoU8 GetNumEdges() { return m_numEdges; }
+	LegoEdge** GetEdges() { return m_edges; }
+	LegoU32 IsEqual(LegoWEEdge& p_other) { return this == &p_other; }
 
-	inline void SetEdges(LegoEdge** p_edges, LegoU8 p_numEdges)
+	void SetEdges(LegoEdge** p_edges, LegoU8 p_numEdges)
 	{
 		m_edges = p_edges;
 		m_numEdges = p_numEdges;

--- a/LEGO1/lego/sources/geom/legowegedge.h
+++ b/LEGO1/lego/sources/geom/legowegedge.h
@@ -40,12 +40,12 @@ public:
 
 	LegoResult VTable0x04() override; // vtable+0x04
 
-	inline LegoU32 GetFlag0x10() { return m_flags & c_bit5 ? FALSE : TRUE; }
-	inline Mx4DPointFloat* GetUnknown0x14() { return &m_unk0x14; }
-	inline Mx4DPointFloat* GetEdgeNormal(int index) { return &m_edgeNormals[index]; }
-	inline LegoChar* GetName() { return m_name; }
+	LegoU32 GetFlag0x10() { return m_flags & c_bit5 ? FALSE : TRUE; }
+	Mx4DPointFloat* GetUnknown0x14() { return &m_unk0x14; }
+	Mx4DPointFloat* GetEdgeNormal(int index) { return &m_edgeNormals[index]; }
+	LegoChar* GetName() { return m_name; }
 
-	inline void SetFlag0x10(LegoU32 p_disable)
+	void SetFlag0x10(LegoU32 p_disable)
 	{
 		if (p_disable) {
 			m_flags &= ~c_bit5;
@@ -55,7 +55,7 @@ public:
 		}
 	}
 
-	inline LegoU8 GetMask0x03() { return m_flags & (c_bit1 | c_bit2); }
+	LegoU8 GetMask0x03() { return m_flags & (c_bit1 | c_bit2); }
 
 	// SYNTHETIC: LEGO1 0x1009a7e0
 	// LegoWEGEdge::`scalar deleting destructor'

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -58,7 +58,7 @@ public:
 	}
 
 	// FUNCTION: BETA10 0x1007bc00
-	inline T* Get(const char* p_name)
+	T* Get(const char* p_name)
 	{
 		T* value = NULL;
 
@@ -75,7 +75,7 @@ public:
 		return value;
 	}
 
-	inline void Add(const char* p_name, T* p_value)
+	void Add(const char* p_name, T* p_value)
 	{
 #ifdef COMPAT_MODE
 		typename LegoContainerInfo<T>::iterator it = m_map.find(p_name);
@@ -99,7 +99,7 @@ public:
 		m_map[name] = p_value;
 	}
 
-	inline void SetOwnership(LegoBool p_ownership) { m_ownership = p_ownership; }
+	void SetOwnership(LegoBool p_ownership) { m_ownership = p_ownership; }
 
 protected:
 	LegoBool m_ownership;       // 0x04

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -60,13 +60,13 @@ public:
 	);
 	static LegoBool FUN_100a9cf0(const LegoChar* p_param, unsigned char* paletteEntries, LegoU32 p_numEntries);
 
-	inline const LegoChar* GetName() const { return m_name; }
-	inline LegoEntity* GetEntity() { return m_entity; }
+	const LegoChar* GetName() const { return m_name; }
+	LegoEntity* GetEntity() { return m_entity; }
 
-	inline void SetEntity(LegoEntity* p_entity) { m_entity = p_entity; }
-	inline void SetComp(CompoundObject* p_comp) { comp = p_comp; }
-	inline void SetBoundingSphere(const BoundingSphere& p_sphere) { m_sphere = m_world_bounding_sphere = p_sphere; }
-	inline void SetUnknown0x80(const BoundingBox& p_unk0x80) { m_unk0x80 = p_unk0x80; }
+	void SetEntity(LegoEntity* p_entity) { m_entity = p_entity; }
+	void SetComp(CompoundObject* p_comp) { comp = p_comp; }
+	void SetBoundingSphere(const BoundingSphere& p_sphere) { m_sphere = m_world_bounding_sphere = p_sphere; }
+	void SetUnknown0x80(const BoundingBox& p_unk0x80) { m_unk0x80 = p_unk0x80; }
 
 	// SYNTHETIC: LEGO1 0x100a82b0
 	// LegoROI::`scalar deleting destructor'

--- a/LEGO1/mxdirectx/mxdirect3d.h
+++ b/LEGO1/mxdirectx/mxdirect3d.h
@@ -29,9 +29,9 @@ public:
 	void Destroy() override;                 // vtable+0x08
 	void DestroyButNotDirectDraw() override; // vtable+0x0c
 
-	inline MxAssignedDevice* AssignedDevice() { return this->m_assignedDevice; }
-	inline IDirect3D2* Direct3D() { return this->m_pDirect3d; }
-	inline IDirect3DDevice2* Direct3DDevice() { return this->m_pDirect3dDevice; }
+	MxAssignedDevice* AssignedDevice() { return this->m_assignedDevice; }
+	IDirect3D2* Direct3D() { return this->m_pDirect3d; }
+	IDirect3DDevice2* Direct3DDevice() { return this->m_pDirect3dDevice; }
 
 	BOOL SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_driver, Direct3DDeviceInfo* p_device);
 

--- a/LEGO1/mxdirectx/mxdirectdraw.h
+++ b/LEGO1/mxdirectx/mxdirectdraw.h
@@ -31,10 +31,10 @@ public:
 	virtual void Destroy();                 // vtable+0x08
 	virtual void DestroyButNotDirectDraw(); // vtable+0x0c
 
-	inline IDirectDraw* DirectDraw() { return m_pDirectDraw; }
-	inline IDirectDrawSurface* FrontBuffer() { return m_pFrontBuffer; }
-	inline IDirectDrawSurface* BackBuffer() { return m_pBackBuffer; }
-	inline IDirectDrawClipper* Clipper() { return m_pClipper; }
+	IDirectDraw* DirectDraw() { return m_pDirectDraw; }
+	IDirectDrawSurface* FrontBuffer() { return m_pFrontBuffer; }
+	IDirectDrawSurface* BackBuffer() { return m_pBackBuffer; }
+	IDirectDrawClipper* Clipper() { return m_pClipper; }
 
 	BOOL IsFullScreen() { return m_bFullScreen; }
 

--- a/LEGO1/mxdirectx/mxdirectxinfo.h
+++ b/LEGO1/mxdirectx/mxdirectxinfo.h
@@ -44,9 +44,9 @@ public:
 	MxAssignedDevice();
 	~MxAssignedDevice();
 
-	inline unsigned int GetFlags() { return m_flags; }
-	inline BOOL GetHardwareMode() { return ((int) m_flags << 31) >> 31; }
-	inline D3DDEVICEDESC& GetDesc() { return m_desc; }
+	unsigned int GetFlags() { return m_flags; }
+	BOOL GetHardwareMode() { return ((int) m_flags << 31) >> 31; }
+	D3DDEVICEDESC& GetDesc() { return m_desc; }
 
 	friend class MxDirect3D;
 

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -9,8 +9,8 @@
 // SIZE 0x14
 class Mx3DPointFloat : public Vector3 {
 public:
-	inline Mx3DPointFloat() : Vector3(m_elements) {}
-	inline Mx3DPointFloat(float p_x, float p_y, float p_z) : Vector3(m_elements)
+	Mx3DPointFloat() : Vector3(m_elements) {}
+	Mx3DPointFloat(float p_x, float p_y, float p_z) : Vector3(m_elements)
 	{
 		m_elements[0] = p_x;
 		m_elements[1] = p_y;
@@ -18,9 +18,9 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100343a0
-	inline Mx3DPointFloat(const Mx3DPointFloat& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
+	Mx3DPointFloat(const Mx3DPointFloat& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
 
-	inline Mx3DPointFloat(const Vector3& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
+	Mx3DPointFloat(const Vector3& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
 
 	// SYNTHETIC: LEGO1 0x1001d170
 	// Mx3DPointFloat::Mx3DPointFloat
@@ -28,12 +28,12 @@ public:
 	// FUNCTION: LEGO1 0x10003c10
 	virtual void operator=(const Vector3& p_impl) { EqualsImpl(p_impl.m_data); } // vtable+0x88
 
-	inline float GetX() { return m_data[0]; }
-	inline float GetY() { return m_data[1]; }
-	inline float GetZ() { return m_data[2]; }
+	float GetX() { return m_data[0]; }
+	float GetY() { return m_data[1]; }
+	float GetZ() { return m_data[2]; }
 
-	inline float& operator[](int idx) { return m_data[idx]; }
-	inline const float& operator[](int idx) const { return m_data[idx]; }
+	float& operator[](int idx) { return m_data[idx]; }
+	const float& operator[](int idx) const { return m_data[idx]; }
 
 	// SYNTHETIC: LEGO1 0x10010c00
 	// Mx3DPointFloat::operator=
@@ -48,9 +48,9 @@ private:
 class Mx4DPointFloat : public Vector4 {
 public:
 	// FUNCTION: LEGO1 0x10048290
-	inline Mx4DPointFloat() : Vector4(m_elements) {}
+	Mx4DPointFloat() : Vector4(m_elements) {}
 
-	inline Mx4DPointFloat(float p_x, float p_y, float p_z, float p_a) : Vector4(m_elements)
+	Mx4DPointFloat(float p_x, float p_y, float p_z, float p_a) : Vector4(m_elements)
 	{
 		m_elements[0] = p_x;
 		m_elements[1] = p_y;
@@ -58,13 +58,13 @@ public:
 		m_elements[3] = p_a;
 	}
 
-	inline Mx4DPointFloat(const Mx4DPointFloat& p_other) : Vector4(m_elements) { EqualsImpl(p_other.m_data); }
+	Mx4DPointFloat(const Mx4DPointFloat& p_other) : Vector4(m_elements) { EqualsImpl(p_other.m_data); }
 
 	// FUNCTION: LEGO1 0x10003200
 	virtual void operator=(const Vector4& p_impl) { EqualsImpl(p_impl.m_data); } // vtable+0x98
 
-	inline float& operator[](int idx) { return m_data[idx]; }
-	inline const float& operator[](int idx) const { return m_data[idx]; }
+	float& operator[](int idx) { return m_data[idx]; }
+	const float& operator[](int idx) const { return m_data[idx]; }
 
 	// SYNTHETIC: LEGO1 0x10064b20
 	// Mx4DPointFloat::operator=
@@ -84,35 +84,35 @@ public:
 	UnknownMx4DPointFloat() : m_unk0x30(0) {}
 
 	// FUNCTION: BETA10 0x1004a9b0
-	inline void Unknown1(Matrix4& p_m1, Matrix4& p_m2)
+	void Unknown1(Matrix4& p_m1, Matrix4& p_m2)
 	{
 		Unknown2(p_m1);
 		Unknown3(p_m2);
 	}
 
 	// FUNCTION: BETA10 0x1004a9f0
-	inline void Unknown2(Matrix4& p_m)
+	void Unknown2(Matrix4& p_m)
 	{
 		p_m.ToQuaternion(m_unk0x00);
 		m_unk0x30 |= c_bit1;
 	}
 
 	// FUNCTION: BETA10 0x1004aa30
-	inline void Unknown3(Matrix4& p_m)
+	void Unknown3(Matrix4& p_m)
 	{
 		p_m.ToQuaternion(m_unk0x18);
 		m_unk0x30 |= c_bit2;
 	}
 
 	// FUNCTION: BETA10 0x10180b80
-	inline void Unknown4(Vector4& p_v)
+	void Unknown4(Vector4& p_v)
 	{
 		m_unk0x00 = p_v;
 		m_unk0x30 |= c_bit1;
 	}
 
 	// FUNCTION: BETA10 0x10180bc0
-	inline void Unknown5(Vector4& p_v)
+	void Unknown5(Vector4& p_v)
 	{
 		m_unk0x18 = p_v;
 		m_unk0x30 |= c_bit2;

--- a/LEGO1/mxgeometry/mxmatrix.h
+++ b/LEGO1/mxgeometry/mxmatrix.h
@@ -8,12 +8,12 @@
 class MxMatrix : public Matrix4 {
 public:
 	// FUNCTION: LEGO1 0x1006b120
-	inline MxMatrix() : Matrix4(m_elements) {}
+	MxMatrix() : Matrix4(m_elements) {}
 
 	// FUNCTION: LEGO1 0x10032770
-	inline MxMatrix(const MxMatrix& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
+	MxMatrix(const MxMatrix& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
 
-	inline MxMatrix(const Matrix4& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
+	MxMatrix(const Matrix4& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
 
 	float* operator[](int idx) { return m_data[idx]; }
 	const float* operator[](int idx) const { return m_data[idx]; }

--- a/LEGO1/omni/include/mxactionnotificationparam.h
+++ b/LEGO1/omni/include/mxactionnotificationparam.h
@@ -10,12 +10,7 @@ class MxPresenter;
 // SIZE 0x14
 class MxActionNotificationParam : public MxNotificationParam {
 public:
-	MxActionNotificationParam(
-		NotificationId p_type,
-		MxCore* p_sender,
-		MxDSAction* p_action,
-		MxBool p_reallocAction
-	)
+	MxActionNotificationParam(NotificationId p_type, MxCore* p_sender, MxDSAction* p_action, MxBool p_reallocAction)
 		: MxNotificationParam(p_type, p_sender)
 	{
 		MxDSAction* oldAction = p_action;
@@ -80,12 +75,7 @@ public:
 // SIZE 0x14
 class MxEndActionNotificationParam : public MxActionNotificationParam {
 public:
-	MxEndActionNotificationParam(
-		NotificationId p_type,
-		MxCore* p_sender,
-		MxDSAction* p_action,
-		MxBool p_reallocAction
-	)
+	MxEndActionNotificationParam(NotificationId p_type, MxCore* p_sender, MxDSAction* p_action, MxBool p_reallocAction)
 		: MxActionNotificationParam(p_type, p_sender, p_action, p_reallocAction)
 	{
 	}

--- a/LEGO1/omni/include/mxactionnotificationparam.h
+++ b/LEGO1/omni/include/mxactionnotificationparam.h
@@ -10,7 +10,7 @@ class MxPresenter;
 // SIZE 0x14
 class MxActionNotificationParam : public MxNotificationParam {
 public:
-	inline MxActionNotificationParam(
+	MxActionNotificationParam(
 		NotificationId p_type,
 		MxCore* p_sender,
 		MxDSAction* p_action,
@@ -35,7 +35,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10051050
-	inline ~MxActionNotificationParam() override
+	~MxActionNotificationParam() override
 	{
 		if (!m_realloc) {
 			return;
@@ -52,7 +52,7 @@ public:
 		return new MxActionNotificationParam(m_type, m_sender, m_action, m_realloc);
 	} // vtable+0x04
 
-	inline MxDSAction* GetAction() { return m_action; }
+	MxDSAction* GetAction() { return m_action; }
 
 protected:
 	MxDSAction* m_action; // 0x0c
@@ -63,7 +63,7 @@ protected:
 // SIZE 0x14
 class MxStartActionNotificationParam : public MxActionNotificationParam {
 public:
-	inline MxStartActionNotificationParam(
+	MxStartActionNotificationParam(
 		NotificationId p_type,
 		MxCore* p_sender,
 		MxDSAction* p_action,
@@ -80,7 +80,7 @@ public:
 // SIZE 0x14
 class MxEndActionNotificationParam : public MxActionNotificationParam {
 public:
-	inline MxEndActionNotificationParam(
+	MxEndActionNotificationParam(
 		NotificationId p_type,
 		MxCore* p_sender,
 		MxDSAction* p_action,
@@ -101,7 +101,7 @@ public:
 // SIZE 0x18
 class MxType4NotificationParam : public MxActionNotificationParam {
 public:
-	inline MxType4NotificationParam(MxCore* p_sender, MxDSAction* p_action, MxPresenter* p_unk0x14)
+	MxType4NotificationParam(MxCore* p_sender, MxDSAction* p_action, MxPresenter* p_unk0x14)
 		: MxActionNotificationParam(c_notificationType4, p_sender, p_action, FALSE)
 	{
 		m_unk0x14 = p_unk0x14;

--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -29,7 +29,7 @@ public:
 	void Dec();
 
 	// FUNCTION: BETA10 0x101236d0
-	inline MxString& GetKey() { return m_key; }
+	MxString& GetKey() { return m_key; }
 
 	// SYNTHETIC: BETA10 0x10124a50
 	// MxAtom::`scalar deleting destructor'
@@ -66,12 +66,12 @@ public:
 	MxAtomId& operator=(const MxAtomId& p_atomId);
 
 	// FUNCTION: BETA10 0x100178d0
-	inline MxBool operator==(const MxAtomId& p_atomId) const { return this->m_internal == p_atomId.m_internal; }
+	MxBool operator==(const MxAtomId& p_atomId) const { return this->m_internal == p_atomId.m_internal; }
 
 #ifdef COMPAT_MODE
 	// Required for modern compilers.
 	// MSVC 4.20 uses a synthetic function from INCLUDE/UTILITY that inverts operator==
-	inline MxBool operator!=(const MxAtomId& p_atomId) const { return this->m_internal != p_atomId.m_internal; }
+	MxBool operator!=(const MxAtomId& p_atomId) const { return this->m_internal != p_atomId.m_internal; }
 #endif
 
 	// FUNCTION: BETA10 0x10025d40

--- a/LEGO1/omni/include/mxaudiopresenter.h
+++ b/LEGO1/omni/include/mxaudiopresenter.h
@@ -19,13 +19,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000d280
 	// FUNCTION: BETA10 0x1008cb70
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d290
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxAudioPresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -85,7 +85,7 @@ public:
 	// Pixel data may be stored with padding.
 	// https://learn.microsoft.com/en-us/windows/win32/medfound/image-stride
 	// FUNCTION: BETA10 0x1002c510
-	inline MxLong AlignToFourByte(MxLong p_value) const { return (p_value + 3) & -4; }
+	MxLong AlignToFourByte(MxLong p_value) const { return (p_value + 3) & -4; }
 
 	// DECOMP: This could be a free function. It is static here because it has no
 	// reference to "this". In the beta it is called in two places:
@@ -95,27 +95,27 @@ public:
 	static MxLong HeightAbs(MxLong p_value) { return p_value > 0 ? p_value : -p_value; }
 
 	// FUNCTION: BETA10 0x10142030
-	inline BITMAPINFOHEADER* GetBmiHeader() const { return m_bmiHeader; }
+	BITMAPINFOHEADER* GetBmiHeader() const { return m_bmiHeader; }
 
 	// FUNCTION: BETA10 0x1002c440
-	inline MxLong GetBmiWidth() const { return m_bmiHeader->biWidth; }
-	inline MxLong GetBmiStride() const { return ((m_bmiHeader->biWidth + 3) & -4); }
-	inline MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
+	MxLong GetBmiWidth() const { return m_bmiHeader->biWidth; }
+	MxLong GetBmiStride() const { return ((m_bmiHeader->biWidth + 3) & -4); }
+	MxLong GetBmiHeight() const { return m_bmiHeader->biHeight; }
 
 	// FUNCTION: BETA10 0x1002c470
-	inline MxLong GetBmiHeightAbs() const { return HeightAbs(m_bmiHeader->biHeight); }
+	MxLong GetBmiHeightAbs() const { return HeightAbs(m_bmiHeader->biHeight); }
 
 	// FUNCTION: BETA10 0x10083900
-	inline MxU8* GetImage() const { return m_data; }
+	MxU8* GetImage() const { return m_data; }
 
 	// FUNCTION: BETA10 0x100838d0
-	inline MxBITMAPINFO* GetBitmapInfo() const { return m_info; }
+	MxBITMAPINFO* GetBitmapInfo() const { return m_info; }
 
 	// FUNCTION: BETA10 0x100982b0
-	inline MxLong GetDataSize() const { return AlignToFourByte(m_bmiHeader->biWidth) * GetBmiHeightAbs(); }
+	MxLong GetDataSize() const { return AlignToFourByte(m_bmiHeader->biWidth) * GetBmiHeightAbs(); }
 
 	// FUNCTION: BETA10 0x1002c4b0
-	inline MxBool IsTopDown()
+	MxBool IsTopDown()
 	{
 		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN) {
 			return TRUE;
@@ -130,7 +130,7 @@ public:
 						   : -p_bitmap->AlignToFourByte(p_bitmap->GetBmiWidth()))
 
 	// FUNCTION: BETA10 0x1002c320
-	inline MxU8* GetStart(MxS32 p_left, MxS32 p_top)
+	MxU8* GetStart(MxS32 p_left, MxS32 p_top)
 	{
 		if (m_bmiHeader->biCompression == BI_RGB) {
 			return m_data + p_left +
@@ -150,10 +150,10 @@ public:
 
 private:
 	// FUNCTION: BETA10 0x1013dd10
-	inline MxLong MxBitmapInfoSize() const { return sizeof(MxBITMAPINFO); }
+	MxLong MxBitmapInfoSize() const { return sizeof(MxBITMAPINFO); }
 
 	// FUNCTION: BETA10 0x1013dd30
-	inline MxBool IsBottomUp()
+	MxBool IsBottomUp()
 	{
 		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN) {
 			return FALSE;

--- a/LEGO1/omni/include/mxcompositepresenter.h
+++ b/LEGO1/omni/include/mxcompositepresenter.h
@@ -27,13 +27,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100b6210
 	// FUNCTION: BETA10 0x1004da00
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100b6220
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxCompositePresenter::ClassName()) || MxPresenter::IsA(p_name);
 	}
@@ -56,7 +56,7 @@ public:
 		return TRUE;
 	} // vtable+0x64
 
-	inline MxCompositePresenterList* GetList() { return &m_list; }
+	MxCompositePresenterList* GetList() { return &m_list; }
 
 protected:
 	MxCompositePresenterList m_list; // 0x40

--- a/LEGO1/omni/include/mxcore.h
+++ b/LEGO1/omni/include/mxcore.h
@@ -23,7 +23,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100144c0
 	// FUNCTION: BETA10 0x100126d0
-	inline virtual const char* ClassName() const // vtable+0c
+	virtual const char* ClassName() const // vtable+0c
 	{
 		// STRING: LEGO1 0x100f007c
 		return "MxCore";
@@ -31,12 +31,12 @@ public:
 
 	// FUNCTION: LEGO1 0x100140d0
 	// FUNCTION: BETA10 0x10012680
-	inline virtual MxBool IsA(const char* p_name) const // vtable+10
+	virtual MxBool IsA(const char* p_name) const // vtable+10
 	{
 		return !strcmp(p_name, MxCore::ClassName());
 	}
 
-	inline MxU32 GetId() { return m_id; }
+	MxU32 GetId() { return m_id; }
 
 	// SYNTHETIC: LEGO1 0x100ae1c0
 	// SYNTHETIC: BETA10 0x1012c0d0

--- a/LEGO1/omni/include/mxdiskstreamcontroller.h
+++ b/LEGO1/omni/include/mxdiskstreamcontroller.h
@@ -21,14 +21,14 @@ public:
 	MxResult Tickle() override; // vtable+0x08
 
 	// FUNCTION: LEGO1 0x100c7360
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102144
 		return "MxDiskStreamController";
 	}
 
 	// FUNCTION: LEGO1 0x100c7370
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDiskStreamController::ClassName()) || MxStreamController::IsA(p_name);
 	}
@@ -41,7 +41,7 @@ public:
 	MxResult VTable0x30(MxDSAction* p_action) override;   // vtable+0x30
 	virtual MxResult VTable0x34(undefined4);              // vtable+0x34
 
-	inline MxBool GetUnk0xc4() const { return m_unk0xc4; }
+	MxBool GetUnk0xc4() const { return m_unk0xc4; }
 
 	MxResult FUN_100c7890(MxDSStreamingAction* p_action);
 	void FUN_100c7cb0(MxDSStreamingAction* p_action);

--- a/LEGO1/omni/include/mxdiskstreamprovider.h
+++ b/LEGO1/omni/include/mxdiskstreamprovider.h
@@ -16,7 +16,7 @@ class MxDSStreamingAction;
 // SIZE 0x1c
 class MxDiskStreamProviderThread : public MxThread {
 public:
-	inline MxDiskStreamProviderThread() : MxThread() { m_target = NULL; }
+	MxDiskStreamProviderThread() : MxThread() { m_target = NULL; }
 
 	MxResult Run() override;
 	MxResult StartWithTarget(MxDiskStreamProvider* p_target);
@@ -30,14 +30,14 @@ public:
 	~MxDiskStreamProvider() override;
 
 	// FUNCTION: LEGO1 0x100d1160
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x1010287c
 		return "MxDiskStreamProvider";
 	}
 
 	// FUNCTION: LEGO1 0x100d1170
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDiskStreamProvider::ClassName()) || MxStreamProvider::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdisplaysurface.h
+++ b/LEGO1/omni/include/mxdisplaysurface.h
@@ -95,9 +95,9 @@ public:
 	static LPDIRECTDRAWSURFACE CreateCursorSurface();
 	static LPDIRECTDRAWSURFACE CopySurface(LPDIRECTDRAWSURFACE p_src);
 
-	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return m_ddSurface1; }
-	inline LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return m_ddSurface2; }
-	inline MxVideoParam& GetVideoParam() { return m_videoParam; }
+	LPDIRECTDRAWSURFACE GetDirectDrawSurface1() { return m_ddSurface1; }
+	LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return m_ddSurface2; }
+	MxVideoParam& GetVideoParam() { return m_videoParam; }
 
 	void FUN_100bb500(
 		MxU8** p_bitmapData,

--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -34,7 +34,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100ad980
 	// FUNCTION: BETA10 0x1012bcf0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101013f4
 		return "MxDSAction";
@@ -42,7 +42,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100ad990
 	// FUNCTION: BETA10 0x1012bd10
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSAction::ClassName()) || MxDSObject::IsA(p_name);
 	}
@@ -62,48 +62,48 @@ public:
 	void AppendExtra(MxU16 p_extraLength, const char* p_extraData);
 
 	// FUNCTION: BETA10 0x1003a560
-	inline void GetExtra(MxU16& p_extraLength, char*& p_extraData)
+	void GetExtra(MxU16& p_extraLength, char*& p_extraData)
 	{
 		p_extraLength = m_extraLength;
 		p_extraData = m_extraData;
 	}
 
 	// FUNCTION: BETA10 0x1003cf70
-	inline MxU32 GetFlags() { return m_flags; }
+	MxU32 GetFlags() { return m_flags; }
 
 	// FUNCTION: BETA10 0x1004daa0
-	inline void SetFlags(MxU32 p_flags) { m_flags = p_flags; }
+	void SetFlags(MxU32 p_flags) { m_flags = p_flags; }
 
-	inline char* GetExtraData() { return m_extraData; }
-	inline MxU16 GetExtraLength() const { return m_extraLength; }
+	char* GetExtraData() { return m_extraData; }
+	MxU16 GetExtraLength() const { return m_extraLength; }
 
 	// FUNCTION: BETA10 0x1005a560
-	inline MxLong GetStartTime() const { return m_startTime; }
+	MxLong GetStartTime() const { return m_startTime; }
 
 	// FUNCTION: BETA10 0x1012be80
-	inline MxS32 GetLoopCount() { return m_loopCount; }
+	MxS32 GetLoopCount() { return m_loopCount; }
 
-	inline void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
+	void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
 
 	// FUNCTION: BETA10 0x1003db50
-	inline Mx3DPointFloat& GetLocation() { return m_location; }
+	Mx3DPointFloat& GetLocation() { return m_location; }
 
 	// FUNCTION: BETA10 0x1003db80
-	inline Mx3DPointFloat& GetDirection() { return m_direction; }
+	Mx3DPointFloat& GetDirection() { return m_direction; }
 
 	// FUNCTION: BETA10 0x1003dbb0
-	inline Mx3DPointFloat& GetUp() { return m_up; }
+	Mx3DPointFloat& GetUp() { return m_up; }
 
-	inline void SetLocation(const Vector3& p_location) { m_location = p_location; }
-	inline void SetDirection(const Vector3& p_direction) { m_direction = p_direction; }
-	inline void SetUp(const Vector3& p_up) { m_up = p_up; }
-	inline MxCore* GetUnknown84() { return m_unk0x84; }
-	inline void SetUnknown84(MxCore* p_unk0x84) { m_unk0x84 = p_unk0x84; }
-	inline MxCore* GetOrigin() { return m_origin; }
-	inline void SetOrigin(MxCore* p_origin) { m_origin = p_origin; }
+	void SetLocation(const Vector3& p_location) { m_location = p_location; }
+	void SetDirection(const Vector3& p_direction) { m_direction = p_direction; }
+	void SetUp(const Vector3& p_up) { m_up = p_up; }
+	MxCore* GetUnknown84() { return m_unk0x84; }
+	void SetUnknown84(MxCore* p_unk0x84) { m_unk0x84 = p_unk0x84; }
+	MxCore* GetOrigin() { return m_origin; }
+	void SetOrigin(MxCore* p_origin) { m_origin = p_origin; }
 
-	inline MxBool IsLooping() const { return m_flags & c_looping; }
-	inline MxBool IsBit3() const { return m_flags & c_bit3; }
+	MxBool IsLooping() const { return m_flags & c_looping; }
+	MxBool IsBit3() const { return m_flags & c_bit3; }
 
 	// SYNTHETIC: LEGO1 0x100ada60
 	// SYNTHETIC: BETA10 0x1012be40

--- a/LEGO1/omni/include/mxdsanim.h
+++ b/LEGO1/omni/include/mxdsanim.h
@@ -14,14 +14,14 @@ public:
 	MxDSAnim& operator=(MxDSAnim& p_dsAnim);
 
 	// FUNCTION: LEGO1 0x100c9060
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025d8
 		return "MxDSAnim";
 	}
 
 	// FUNCTION: LEGO1 0x100c9070
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSAnim::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdsbuffer.h
+++ b/LEGO1/omni/include/mxdsbuffer.h
@@ -25,7 +25,7 @@ public:
 	~MxDSBuffer() override;
 
 	// FUNCTION: LEGO1 0x100c6500
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025b8
 		return "MxDSBuffer";
@@ -63,17 +63,17 @@ public:
 	static MxCore* ReadChunk(MxDSBuffer* p_buffer, MxU32* p_chunkData, MxU16 p_flags);
 	static MxResult Append(MxU8* p_buffer1, MxU8* p_buffer2);
 
-	inline MxU8* GetBuffer() { return m_pBuffer; }
-	inline MxU8** GetBufferRef() { return &m_pBuffer; }
-	inline undefined4 GetUnknown14() { return m_unk0x14; }
-	inline MxU16 GetRefCount() { return m_referenceCount; }
-	inline Type GetMode() { return m_mode; }
-	inline MxU32 GetWriteOffset() { return m_writeOffset; }
-	inline MxU32 GetBytesRemaining() { return m_bytesRemaining; }
-	inline void SetUnknown14(undefined4 p_unk0x14) { m_unk0x14 = p_unk0x14; }
-	inline void SetUnknown1c(undefined4 p_unk0x1c) { m_unk0x1c = p_unk0x1c; }
-	inline void SetMode(Type p_mode) { m_mode = p_mode; }
-	inline void SetUnk30(MxDSStreamingAction* p_unk0x30) { m_unk0x30 = p_unk0x30; }
+	MxU8* GetBuffer() { return m_pBuffer; }
+	MxU8** GetBufferRef() { return &m_pBuffer; }
+	undefined4 GetUnknown14() { return m_unk0x14; }
+	MxU16 GetRefCount() { return m_referenceCount; }
+	Type GetMode() { return m_mode; }
+	MxU32 GetWriteOffset() { return m_writeOffset; }
+	MxU32 GetBytesRemaining() { return m_bytesRemaining; }
+	void SetUnknown14(undefined4 p_unk0x14) { m_unk0x14 = p_unk0x14; }
+	void SetUnknown1c(undefined4 p_unk0x1c) { m_unk0x1c = p_unk0x1c; }
+	void SetMode(Type p_mode) { m_mode = p_mode; }
+	void SetUnk30(MxDSStreamingAction* p_unk0x30) { m_unk0x30 = p_unk0x30; }
 
 	// SYNTHETIC: LEGO1 0x100c6510
 	// MxDSBuffer::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxdschunk.h
+++ b/LEGO1/omni/include/mxdschunk.h
@@ -19,37 +19,37 @@ public:
 	~MxDSChunk() override;
 
 	// FUNCTION: LEGO1 0x100be0c0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e6c
 		return "MxDSChunk";
 	}
 
 	// FUNCTION: LEGO1 0x100be0d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSChunk::ClassName()) || MxCore::IsA(p_name);
 	}
 
 	static MxU32 GetHeaderSize();
-	inline static MxU32* IntoType(MxU8* p_buffer) { return (MxU32*) p_buffer; }
-	inline static MxU32* IntoLength(MxU8* p_buffer) { return (MxU32*) (p_buffer + 4); }
-	inline static MxU32 Size(MxU32 p_dataSize) { return (p_dataSize & 1) + p_dataSize + 8; }
-	inline static MxU8* End(MxU8* p_buffer) { return p_buffer + Size(*IntoLength(p_buffer)); }
+	static MxU32* IntoType(MxU8* p_buffer) { return (MxU32*) p_buffer; }
+	static MxU32* IntoLength(MxU8* p_buffer) { return (MxU32*) (p_buffer + 4); }
+	static MxU32 Size(MxU32 p_dataSize) { return (p_dataSize & 1) + p_dataSize + 8; }
+	static MxU8* End(MxU8* p_buffer) { return p_buffer + Size(*IntoLength(p_buffer)); }
 
-	inline void SetChunkFlags(MxU16 p_flags) { m_flags = p_flags; }
-	inline void SetObjectId(undefined4 p_objectid) { m_objectId = p_objectid; }
-	inline void SetTime(MxLong p_time) { m_time = p_time; }
-	inline void SetLength(MxU32 p_length) { m_length = p_length; }
-	inline void SetData(MxU8* p_data) { m_data = p_data; }
+	void SetChunkFlags(MxU16 p_flags) { m_flags = p_flags; }
+	void SetObjectId(undefined4 p_objectid) { m_objectId = p_objectid; }
+	void SetTime(MxLong p_time) { m_time = p_time; }
+	void SetLength(MxU32 p_length) { m_length = p_length; }
+	void SetData(MxU8* p_data) { m_data = p_data; }
 
-	inline MxU16 GetChunkFlags() { return m_flags; }
-	inline undefined4 GetObjectId() { return m_objectId; }
-	inline MxLong GetTime() { return m_time; }
-	inline MxU32 GetLength() { return m_length; }
-	inline MxU8* GetData() { return m_data; }
+	MxU16 GetChunkFlags() { return m_flags; }
+	undefined4 GetObjectId() { return m_objectId; }
+	MxLong GetTime() { return m_time; }
+	MxU32 GetLength() { return m_length; }
+	MxU8* GetData() { return m_data; }
 
-	inline void Release()
+	void Release()
 	{
 		if (m_data) {
 			delete[] m_data;

--- a/LEGO1/omni/include/mxdsevent.h
+++ b/LEGO1/omni/include/mxdsevent.h
@@ -13,14 +13,14 @@ public:
 	MxDSEvent& operator=(MxDSEvent& p_dsEvent);
 
 	// FUNCTION: LEGO1 0x100c9660
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025f0
 		return "MxDSEvent";
 	}
 
 	// FUNCTION: LEGO1 0x100c9670
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSEvent::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdsfile.h
+++ b/LEGO1/omni/include/mxdsfile.h
@@ -24,14 +24,14 @@ public:
 #endif
 
 	// FUNCTION: LEGO1 0x100c0120
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102594
 		return "MxDSFile";
 	}
 
 	// FUNCTION: LEGO1 0x100c0130
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSFile::ClassName()) || MxDSSource::IsA(p_name);
 	}
@@ -43,9 +43,9 @@ public:
 	MxULong GetBufferSize() override;                // vtable+0x28
 	MxULong GetStreamBuffersNum() override;          // vtable+0x2c
 
-	inline void SetFileName(const char* p_filename) { m_filename = p_filename; }
+	void SetFileName(const char* p_filename) { m_filename = p_filename; }
 
-	inline MxS32 CalcFileSize() { return GetFileSize(m_io.m_info.hmmio, NULL); }
+	MxS32 CalcFileSize() { return GetFileSize(m_io.m_info.hmmio, NULL); }
 
 	// SYNTHETIC: LEGO1 0x100c01e0
 	// MxDSFile::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxdsmediaaction.h
+++ b/LEGO1/omni/include/mxdsmediaaction.h
@@ -18,7 +18,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100c8be0
 	// FUNCTION: BETA10 0x1015c700
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f7624
 		return "MxDSMediaAction";
@@ -26,7 +26,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100c8bf0
 	// FUNCTION: BETA10 0x1015c6a0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSMediaAction::ClassName()) || MxDSAction::IsA(p_name);
 	}
@@ -43,19 +43,19 @@ public:
 	void CopyMediaSrcPath(const char* p_mediaSrcPath);
 
 	// FUNCTION: LEGO1 0x100186e0
-	inline const char* GetMediaSrcPath() { return m_mediaSrcPath; }
+	const char* GetMediaSrcPath() { return m_mediaSrcPath; }
 
 	// FUNCTION: BETA10 0x1013c2e0
-	inline MxS32 GetFramesPerSecond() const { return m_framesPerSecond; }
+	MxS32 GetFramesPerSecond() const { return m_framesPerSecond; }
 
 	// FUNCTION: BETA10 0x1012efd0
-	inline MxS32 GetMediaFormat() const { return m_mediaFormat; }
+	MxS32 GetMediaFormat() const { return m_mediaFormat; }
 
 	// FUNCTION: BETA10 0x1013b860
-	inline MxS32 GetPaletteManagement() const { return m_paletteManagement; }
+	MxS32 GetPaletteManagement() const { return m_paletteManagement; }
 
 	// FUNCTION: BETA10 0x1005ab60
-	inline MxLong GetSustainTime() const { return m_sustainTime; }
+	MxLong GetSustainTime() const { return m_sustainTime; }
 
 private:
 	struct Unk0x9cStruct {

--- a/LEGO1/omni/include/mxdsmultiaction.h
+++ b/LEGO1/omni/include/mxdsmultiaction.h
@@ -15,14 +15,14 @@ public:
 	MxDSMultiAction& operator=(MxDSMultiAction& p_dsMultiAction);
 
 	// FUNCTION: LEGO1 0x100c9f50
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101dbc
 		return "MxDSMultiAction";
 	}
 
 	// FUNCTION: LEGO1 0x100c9f60
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSMultiAction::ClassName()) || MxDSAction::IsA(p_name);
 	}
@@ -36,7 +36,7 @@ public:
 	MxBool HasId(MxU32 p_objectId) override;                     // vtable+34;
 	void SetUnknown90(MxLong p_unk0x90) override;                // vtable+38;
 
-	inline MxDSActionList* GetActionList() const { return m_actions; }
+	MxDSActionList* GetActionList() const { return m_actions; }
 
 	// SYNTHETIC: LEGO1 0x100ca040
 	// MxDSMultiAction::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -39,11 +39,11 @@ public:
 
 	// FUNCTION: LEGO1 0x100bf730
 	// FUNCTION: BETA10 0x1012bdd0
-	inline const char* ClassName() const override { return "MxDSObject"; } // vtable+0c
+	const char* ClassName() const override { return "MxDSObject"; } // vtable+0c
 
 	// FUNCTION: LEGO1 0x100bf740
 	// FUNCTION: BETA10 0x1012bd70
-	inline MxBool IsA(const char* p_name) const override
+	MxBool IsA(const char* p_name) const override
 	{
 		return !strcmp(p_name, MxDSObject::ClassName()) || MxCore::IsA(p_name);
 	} // vtable+10;
@@ -55,31 +55,31 @@ public:
 	// FUNCTION: ISLE 0x401c40
 	// FUNCTION: LEGO1 0x10005530
 	// FUNCTION: BETA10 0x100152e0
-	inline virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+20;
+	virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+20;
 
 	// FUNCTION: BETA10 0x1012ef90
-	inline Type GetType() const { return (Type) m_type; }
+	Type GetType() const { return (Type) m_type; }
 
 	// FUNCTION: BETA10 0x1012efb0
-	inline const char* GetSourceName() const { return m_sourceName; }
+	const char* GetSourceName() const { return m_sourceName; }
 
-	inline const char* GetObjectName() const { return m_objectName; }
-	inline MxU32 GetObjectId() { return m_objectId; }
-	inline const MxAtomId& GetAtomId() { return m_atomId; }
-	inline MxS16 GetUnknown24() { return m_unk0x24; }
-	inline MxPresenter* GetUnknown28() { return m_unk0x28; }
+	const char* GetObjectName() const { return m_objectName; }
+	MxU32 GetObjectId() { return m_objectId; }
+	const MxAtomId& GetAtomId() { return m_atomId; }
+	MxS16 GetUnknown24() { return m_unk0x24; }
+	MxPresenter* GetUnknown28() { return m_unk0x28; }
 
-	inline void SetType(Type p_type) { m_type = p_type; }
+	void SetType(Type p_type) { m_type = p_type; }
 
 	// FUNCTION: BETA10 0x100152b0
-	inline void SetObjectId(MxU32 p_objectId) { m_objectId = p_objectId; }
+	void SetObjectId(MxU32 p_objectId) { m_objectId = p_objectId; }
 
 	// FUNCTION: BETA10 0x10039570
-	inline void SetUnknown24(MxS16 p_unk0x24) { m_unk0x24 = p_unk0x24; }
+	void SetUnknown24(MxS16 p_unk0x24) { m_unk0x24 = p_unk0x24; }
 
-	inline void SetUnknown28(MxPresenter* p_unk0x28) { m_unk0x28 = p_unk0x28; }
+	void SetUnknown28(MxPresenter* p_unk0x28) { m_unk0x28 = p_unk0x28; }
 
-	inline void ClearAtom() { m_atomId.Clear(); }
+	void ClearAtom() { m_atomId.Clear(); }
 
 	// SYNTHETIC: LEGO1 0x100bf7c0
 	// SYNTHETIC: BETA10 0x10148770

--- a/LEGO1/omni/include/mxdsobjectaction.h
+++ b/LEGO1/omni/include/mxdsobjectaction.h
@@ -13,14 +13,14 @@ public:
 	MxDSObjectAction& operator=(MxDSObjectAction& p_dsObjectAction);
 
 	// FUNCTION: LEGO1 0x100c88e0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025c4
 		return "MxDSObjectAction";
 	}
 
 	// FUNCTION: LEGO1 0x100c88f0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSObjectAction::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdsparallelaction.h
+++ b/LEGO1/omni/include/mxdsparallelaction.h
@@ -14,14 +14,14 @@ public:
 	MxDSParallelAction& operator=(MxDSParallelAction& p_dsParallelAction);
 
 	// FUNCTION: LEGO1 0x100caf00
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102608
 		return "MxDSParallelAction";
 	}
 
 	// FUNCTION: LEGO1 0x100caf10
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSParallelAction::ClassName()) || MxDSMultiAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdsselectaction.h
+++ b/LEGO1/omni/include/mxdsselectaction.h
@@ -16,14 +16,14 @@ public:
 	MxDSSelectAction& operator=(MxDSSelectAction& p_dsSelectAction);
 
 	// FUNCTION: LEGO1 0x100cb6f0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x1010261c
 		return "MxDSSelectAction";
 	}
 
 	// FUNCTION: LEGO1 0x100cb700
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdsserialaction.h
+++ b/LEGO1/omni/include/mxdsserialaction.h
@@ -15,14 +15,14 @@ public:
 	MxDSSerialAction& operator=(MxDSSerialAction& p_dsSerialAction);
 
 	// FUNCTION: LEGO1 0x100caad0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f75dc
 		return "MxDSSerialAction";
 	}
 
 	// FUNCTION: LEGO1 0x100caae0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSerialAction::ClassName()) || MxDSMultiAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdssound.h
+++ b/LEGO1/omni/include/mxdssound.h
@@ -14,14 +14,14 @@ public:
 	MxDSSound& operator=(MxDSSound& p_dsSound);
 
 	// FUNCTION: LEGO1 0x100c9330
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025e4
 		return "MxDSSound";
 	}
 
 	// FUNCTION: LEGO1 0x100c9340
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSound::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
@@ -30,7 +30,7 @@ public:
 	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
 	MxDSAction* Clone() override;                                // vtable+2c;
 
-	inline MxS32 GetVolume() const { return m_volume; }
+	MxS32 GetVolume() const { return m_volume; }
 
 	// SYNTHETIC: LEGO1 0x100c9450
 	// MxDSSound::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxdssource.h
+++ b/LEGO1/omni/include/mxdssource.h
@@ -15,14 +15,14 @@ public:
 	~MxDSSource() override { delete[] m_pBuffer; }
 
 	// FUNCTION: LEGO1 0x100c0010
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102588
 		return "MxDSSource";
 	}
 
 	// FUNCTION: LEGO1 0x100c0020
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSource::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -36,7 +36,7 @@ public:
 	virtual MxULong GetStreamBuffersNum() = 0;           // vtable+0x2c
 	virtual MxLong GetLengthInDWords();                  // vtable+0x30
 	virtual MxU32* GetBuffer();                          // vtable+0x34
-	inline MxLong GetPosition() const { return m_position; }
+	MxLong GetPosition() const { return m_position; }
 
 protected:
 	MxULong m_lengthInDWords; // 0x08

--- a/LEGO1/omni/include/mxdsstill.h
+++ b/LEGO1/omni/include/mxdsstill.h
@@ -14,14 +14,14 @@ public:
 	MxDSStill& operator=(MxDSStill& p_dsStill);
 
 	// FUNCTION: LEGO1 0x100c9930
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025fc
 		return "MxDSStill";
 	}
 
 	// FUNCTION: LEGO1 0x100c9940
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSStill::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxdsstreamingaction.h
+++ b/LEGO1/omni/include/mxdsstreamingaction.h
@@ -31,18 +31,18 @@ public:
 	void SetInternalAction(MxDSAction* p_dsAction);
 	void FUN_100cd2d0();
 
-	inline MxU32 GetUnknown94() { return m_unk0x94; }
-	inline MxS32 GetUnknown9c() { return m_unk0x9c; }
-	inline MxDSBuffer* GetUnknowna0() { return m_unk0xa0; }
-	inline MxDSBuffer* GetUnknowna4() { return m_unk0xa4; }
-	inline MxLong GetUnknowna8() { return m_unk0xa8; }
-	inline MxDSAction* GetInternalAction() { return m_internalAction; }
-	inline MxU32 GetBufferOffset() { return m_bufferOffset; }
-	inline void SetUnknown94(MxU32 p_unk0x94) { m_unk0x94 = p_unk0x94; }
-	inline void SetUnknown9c(MxS32 p_unk0x9c) { m_unk0x9c = p_unk0x9c; }
-	inline void SetUnknowna0(MxDSBuffer* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
-	inline void SetUnknowna4(MxDSBuffer* p_unk0xa4) { m_unk0xa4 = p_unk0xa4; }
-	inline void SetBufferOffset(MxU32 p_bufferOffset) { m_bufferOffset = p_bufferOffset; }
+	MxU32 GetUnknown94() { return m_unk0x94; }
+	MxS32 GetUnknown9c() { return m_unk0x9c; }
+	MxDSBuffer* GetUnknowna0() { return m_unk0xa0; }
+	MxDSBuffer* GetUnknowna4() { return m_unk0xa4; }
+	MxLong GetUnknowna8() { return m_unk0xa8; }
+	MxDSAction* GetInternalAction() { return m_internalAction; }
+	MxU32 GetBufferOffset() { return m_bufferOffset; }
+	void SetUnknown94(MxU32 p_unk0x94) { m_unk0x94 = p_unk0x94; }
+	void SetUnknown9c(MxS32 p_unk0x9c) { m_unk0x9c = p_unk0x9c; }
+	void SetUnknowna0(MxDSBuffer* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
+	void SetUnknowna4(MxDSBuffer* p_unk0xa4) { m_unk0xa4 = p_unk0xa4; }
+	void SetBufferOffset(MxU32 p_bufferOffset) { m_bufferOffset = p_bufferOffset; }
 
 	// SYNTHETIC: LEGO1 0x100cd0b0
 	// MxDSStreamingAction::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxdssubscriber.h
+++ b/LEGO1/omni/include/mxdssubscriber.h
@@ -15,14 +15,14 @@ public:
 	~MxDSSubscriber() override;
 
 	// FUNCTION: LEGO1 0x100b7d50
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101020f8
 		return "MxDSSubscriber";
 	}
 
 	// FUNCTION: LEGO1 0x100b7d60
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSubscriber::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -35,10 +35,10 @@ public:
 	void FreeDataChunk(MxStreamChunk* p_chunk);
 
 	// FUNCTION: BETA10 0x101354f0
-	inline MxU32 GetObjectId() { return m_objectId; }
+	MxU32 GetObjectId() { return m_objectId; }
 
 	// FUNCTION: BETA10 0x10135510
-	inline MxS16 GetUnknown48() { return m_unk0x48; }
+	MxS16 GetUnknown48() { return m_unk0x48; }
 
 private:
 	MxStreamChunkList m_pendingChunks;              // 0x08

--- a/LEGO1/omni/include/mxentity.h
+++ b/LEGO1/omni/include/mxentity.h
@@ -18,14 +18,14 @@ public:
 	~MxEntity() override {}
 
 	// FUNCTION: LEGO1 0x1000c180
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0070
 		return "MxEntity";
 	}
 
 	// FUNCTION: LEGO1 0x1000c190
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxEntity::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -38,15 +38,15 @@ public:
 		return SUCCESS;
 	} // vtable+0x14
 
-	inline MxResult Create(MxDSAction& p_dsAction)
+	MxResult Create(MxDSAction& p_dsAction)
 	{
 		m_mxEntityId = p_dsAction.GetObjectId();
 		m_atom = p_dsAction.GetAtomId();
 		return SUCCESS;
 	}
 
-	inline MxS32 GetEntityId() { return m_mxEntityId; }
-	inline MxAtomId& GetAtom() { return m_atom; }
+	MxS32 GetEntityId() { return m_mxEntityId; }
+	MxAtomId& GetAtom() { return m_atom; }
 
 	// SYNTHETIC: LEGO1 0x1000c210
 	// MxEntity::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxeventpresenter.h
+++ b/LEGO1/omni/include/mxeventpresenter.h
@@ -20,13 +20,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100c2c30
 	// FUNCTION: BETA10 0x10152f10
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100c2c40
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxEventPresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxflcpresenter.h
+++ b/LEGO1/omni/include/mxflcpresenter.h
@@ -14,7 +14,7 @@ public:
 	~MxFlcPresenter() override;
 
 	// FUNCTION: LEGO1 0x1004e200
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxFlcPresenter::ClassName()) || MxVideoPresenter::IsA(p_name);
 	}
@@ -28,7 +28,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100b33f0
 	// FUNCTION: BETA10 0x10083760
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}

--- a/LEGO1/omni/include/mxloopingflcpresenter.h
+++ b/LEGO1/omni/include/mxloopingflcpresenter.h
@@ -20,7 +20,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100b4380
 	// FUNCTION: BETA10 0x1013c300
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}

--- a/LEGO1/omni/include/mxloopingmidipresenter.h
+++ b/LEGO1/omni/include/mxloopingmidipresenter.h
@@ -16,13 +16,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100b1830
 	// FUNCTION: BETA10 0x10143910
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100b1840
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxLoopingMIDIPresenter::ClassName()) || MxMIDIPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxloopingsmkpresenter.h
+++ b/LEGO1/omni/include/mxloopingsmkpresenter.h
@@ -20,7 +20,7 @@ public:
 
 	// FUNCTION: LEGO1 0x100b4920
 	// FUNCTION: BETA10 0x1013c360
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}

--- a/LEGO1/omni/include/mxmediapresenter.h
+++ b/LEGO1/omni/include/mxmediapresenter.h
@@ -11,7 +11,7 @@ class MxDSSubscriber;
 // SIZE 0x50
 class MxMediaPresenter : public MxPresenter {
 public:
-	inline MxMediaPresenter() { Init(); }
+	MxMediaPresenter() { Init(); }
 
 	// FUNCTION: LEGO1 0x1000c550
 	~MxMediaPresenter() override { Destroy(TRUE); }
@@ -27,13 +27,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000c5c0
 	// FUNCTION: BETA10 0x10054f20
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000c5d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxMediaPresenter::ClassName()) || MxPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxmidipresenter.h
+++ b/LEGO1/omni/include/mxmidipresenter.h
@@ -21,13 +21,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100c2650
 	// FUNCTION: BETA10 0x10143a90
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100c2660
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxMIDIPresenter::ClassName()) || MxMusicPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxmusicmanager.h
+++ b/LEGO1/omni/include/mxmusicmanager.h
@@ -17,8 +17,8 @@ public:
 	void SetVolume(MxS32 p_volume) override;                             // vtable+2c
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+30
 
-	inline MxBool GetMIDIInitialized() { return m_midiInitialized; }
-	inline void GetMIDIVolume(DWORD& p_volume)
+	MxBool GetMIDIInitialized() { return m_midiInitialized; }
+	void GetMIDIVolume(DWORD& p_volume)
 	{
 		if (midiOutGetVolume((HMIDIOUT) m_midiStreamH, &p_volume)) {
 			p_volume = CalculateVolume(100);

--- a/LEGO1/omni/include/mxmusicpresenter.h
+++ b/LEGO1/omni/include/mxmusicpresenter.h
@@ -19,13 +19,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100c23a0
 	// FUNCTION: BETA10 0x10143a50
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100c23b0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxMusicPresenter::ClassName()) || MxAudioPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxnextactiondatastart.h
+++ b/LEGO1/omni/include/mxnextactiondatastart.h
@@ -8,7 +8,7 @@
 class MxNextActionDataStart : public MxCore {
 public:
 	// inlined constructor at 0x100c1847
-	inline MxNextActionDataStart(MxU32 p_objectId, MxS16 p_unk0x24, MxU32 p_data)
+	MxNextActionDataStart(MxU32 p_objectId, MxS16 p_unk0x24, MxU32 p_data)
 	{
 		m_objectId = p_objectId;
 		m_unk0x24 = p_unk0x24;
@@ -16,22 +16,22 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c1900
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025a0
 		return "MxNextActionDataStart";
 	}
 
 	// FUNCTION: LEGO1 0x100c1910
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxNextActionDataStart::ClassName()) || MxCore::IsA(p_name);
 	}
 
-	inline MxU32 GetObjectId() const { return m_objectId; }
-	inline MxS16 GetUnknown24() const { return m_unk0x24; }
-	inline MxU32 GetData() const { return m_data; }
-	inline void SetData(MxU32 p_data) { m_data = p_data; }
+	MxU32 GetObjectId() const { return m_objectId; }
+	MxS16 GetUnknown24() const { return m_unk0x24; }
+	MxU32 GetData() const { return m_data; }
+	void SetData(MxU32 p_data) { m_data = p_data; }
 
 	// SYNTHETIC: LEGO1 0x100c1990
 	// MxNextActionDataStart::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -13,8 +13,8 @@ public:
 	MxNotification(MxCore* p_target, const MxNotificationParam& p_param);
 	~MxNotification();
 
-	inline MxCore* GetTarget() { return m_target; }
-	inline MxNotificationParam* GetParam() { return m_param; }
+	MxCore* GetTarget() { return m_target; }
+	MxNotificationParam* GetParam() { return m_param; }
 
 private:
 	MxCore* m_target;             // 0x00
@@ -46,13 +46,13 @@ public:
 	void Unregister(MxCore* p_listener);
 	MxResult Send(MxCore* p_listener, const MxNotificationParam& p_param);
 
-	inline MxNotificationPtrList* GetQueue() { return m_queue; }
+	MxNotificationPtrList* GetQueue() { return m_queue; }
 
 	// FUNCTION: BETA10 0x10132270
-	inline void SetActive(MxBool p_active) { m_active = p_active; }
+	void SetActive(MxBool p_active) { m_active = p_active; }
 
 	// FUNCTION: BETA10 0x10132230
-	inline MxBool IsEmpty() const { return m_queue ? m_queue->empty() : TRUE; }
+	MxBool IsEmpty() const { return m_queue ? m_queue->empty() : TRUE; }
 
 	// SYNTHETIC: LEGO1 0x100ac390
 	// MxNotificationManager::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -39,9 +39,7 @@ enum NotificationId {
 class MxNotificationParam : public MxParam {
 public:
 	MxNotificationParam() : m_type(c_notificationType0), m_sender(NULL) {}
-	MxNotificationParam(NotificationId p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender)
-	{
-	}
+	MxNotificationParam(NotificationId p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender) {}
 
 	// FUNCTION: LEGO1 0x10010390
 	virtual MxNotificationParam* Clone() const { return new MxNotificationParam(m_type, m_sender); } // vtable+0x04

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -38,19 +38,19 @@ enum NotificationId {
 // SIZE 0x0c
 class MxNotificationParam : public MxParam {
 public:
-	inline MxNotificationParam() : m_type(c_notificationType0), m_sender(NULL) {}
-	inline MxNotificationParam(NotificationId p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender)
+	MxNotificationParam() : m_type(c_notificationType0), m_sender(NULL) {}
+	MxNotificationParam(NotificationId p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender)
 	{
 	}
 
 	// FUNCTION: LEGO1 0x10010390
 	virtual MxNotificationParam* Clone() const { return new MxNotificationParam(m_type, m_sender); } // vtable+0x04
 
-	inline NotificationId GetNotification() const { return m_type; }
-	inline MxCore* GetSender() const { return m_sender; }
+	NotificationId GetNotification() const { return m_type; }
+	MxCore* GetSender() const { return m_sender; }
 
-	inline void SetNotification(NotificationId p_type) { m_type = p_type; }
-	inline void SetSender(MxCore* p_sender) { m_sender = p_sender; }
+	void SetNotification(NotificationId p_type) { m_type = p_type; }
+	void SetSender(MxCore* p_sender) { m_sender = p_sender; }
 
 protected:
 	NotificationId m_type; // 0x04

--- a/LEGO1/omni/include/mxobjectfactory.h
+++ b/LEGO1/omni/include/mxobjectfactory.h
@@ -24,14 +24,14 @@ public:
 	MxObjectFactory();
 
 	// FUNCTION: LEGO1 0x10008f70
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0730
 		return "MxObjectFactory";
 	}
 
 	// FUNCTION: LEGO1 0x10008f80
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxObjectFactory::ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxomnicreateflags.h
+++ b/LEGO1/omni/include/mxomnicreateflags.h
@@ -9,46 +9,46 @@ public:
 	MxOmniCreateFlags();
 
 	// FUNCTION: BETA10 0x10092b50
-	inline void CreateObjectFactory(MxBool p_enable) { m_flags1.m_bit0 = p_enable; }
+	void CreateObjectFactory(MxBool p_enable) { m_flags1.m_bit0 = p_enable; }
 
 	// FUNCTION: BETA10 0x10092b90
-	inline void CreateTickleManager(MxBool p_enable) { m_flags1.m_bit2 = p_enable; }
+	void CreateTickleManager(MxBool p_enable) { m_flags1.m_bit2 = p_enable; }
 
 	// FUNCTION: BETA10 0x10092bd0
-	inline void CreateVideoManager(MxBool p_enable) { m_flags1.m_bit4 = p_enable; }
+	void CreateVideoManager(MxBool p_enable) { m_flags1.m_bit4 = p_enable; }
 
 	// FUNCTION: BETA10 0x10092c10
-	inline void CreateSoundManager(MxBool p_enable) { m_flags1.m_bit5 = p_enable; }
+	void CreateSoundManager(MxBool p_enable) { m_flags1.m_bit5 = p_enable; }
 
 	// FUNCTION: BETA10 0x10130cd0
-	inline const MxBool CreateObjectFactory() const { return m_flags1.m_bit0; }
+	const MxBool CreateObjectFactory() const { return m_flags1.m_bit0; }
 
 	// FUNCTION: BETA10 0x10130cf0
-	inline const MxBool CreateVariableTable() const { return m_flags1.m_bit1; }
+	const MxBool CreateVariableTable() const { return m_flags1.m_bit1; }
 
 	// FUNCTION: BETA10 0x10130d10
-	inline const MxBool CreateTickleManager() const { return m_flags1.m_bit2; }
+	const MxBool CreateTickleManager() const { return m_flags1.m_bit2; }
 
 	// FUNCTION: BETA10 0x10130d30
-	inline const MxBool CreateNotificationManager() const { return m_flags1.m_bit3; }
+	const MxBool CreateNotificationManager() const { return m_flags1.m_bit3; }
 
 	// FUNCTION: BETA10 0x10130d50
-	inline const MxBool CreateVideoManager() const { return m_flags1.m_bit4; }
+	const MxBool CreateVideoManager() const { return m_flags1.m_bit4; }
 
 	// FUNCTION: BETA10 0x10130d70
-	inline const MxBool CreateSoundManager() const { return m_flags1.m_bit5; }
+	const MxBool CreateSoundManager() const { return m_flags1.m_bit5; }
 
 	// FUNCTION: BETA10 0x10130d90
-	inline const MxBool CreateMusicManager() const { return m_flags1.m_bit6; }
+	const MxBool CreateMusicManager() const { return m_flags1.m_bit6; }
 
 	// FUNCTION: BETA10 0x10130db0
-	inline const MxBool CreateEventManager() const { return m_flags1.m_bit7; }
+	const MxBool CreateEventManager() const { return m_flags1.m_bit7; }
 
 	// FUNCTION: BETA10 0x10130dd0
-	inline const MxBool CreateTimer() const { return m_flags2.m_bit1; }
+	const MxBool CreateTimer() const { return m_flags2.m_bit1; }
 
 	// FUNCTION: BETA10 0x10130e00
-	inline const MxBool CreateStreamer() const { return m_flags2.m_bit2; }
+	const MxBool CreateStreamer() const { return m_flags2.m_bit2; }
 
 private:
 	FlagBitfield m_flags1;

--- a/LEGO1/omni/include/mxpalette.h
+++ b/LEGO1/omni/include/mxpalette.h
@@ -30,7 +30,7 @@ public:
 	void SetPalette(LPDIRECTDRAWPALETTE p_palette);
 
 	// FUNCTION: BETA10 0x100d92c0
-	inline void SetOverrideSkyColor(MxBool p_value) { m_overrideSkyColor = p_value; }
+	void SetOverrideSkyColor(MxBool p_value) { m_overrideSkyColor = p_value; }
 
 	// SYNTHETIC: LEGO1 0x100beeb0
 	// SYNTHETIC: BETA10 0x10144640

--- a/LEGO1/omni/include/mxpoint32.h
+++ b/LEGO1/omni/include/mxpoint32.h
@@ -16,14 +16,14 @@ public:
 		this->m_y = p_point.m_y;
 	}
 
-	inline MxS32 GetX() const { return m_x; }
-	inline MxS32 GetY() const { return m_y; }
+	MxS32 GetX() const { return m_x; }
+	MxS32 GetY() const { return m_y; }
 
-	inline void SetX(MxS32 p_x) { m_x = p_x; }
-	inline void SetY(MxS32 p_y) { m_y = p_y; }
+	void SetX(MxS32 p_x) { m_x = p_x; }
+	void SetY(MxS32 p_y) { m_y = p_y; }
 
 private:
-	inline void CopyFrom(MxS32 p_x, MxS32 p_y)
+	void CopyFrom(MxS32 p_x, MxS32 p_y)
 	{
 		this->m_x = p_x;
 		this->m_y = p_y;

--- a/LEGO1/omni/include/mxpresenter.h
+++ b/LEGO1/omni/include/mxpresenter.h
@@ -42,13 +42,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000bfe0
 	// FUNCTION: BETA10 0x1004d9b0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000bff0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxPresenter::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -81,7 +81,7 @@ protected:
 
 	virtual void ParseExtra(); // vtable+0x30
 
-	inline void ProgressTickleState(TickleState p_tickleState)
+	void ProgressTickleState(TickleState p_tickleState)
 	{
 		m_previousTickleStates |= 1 << (MxU8) m_currentTickleState;
 		m_currentTickleState = p_tickleState;
@@ -118,20 +118,20 @@ public:
 	void SendToCompositePresenter(MxOmni* p_omni);
 	MxBool IsEnabled();
 
-	inline MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
-	inline MxPoint32 GetLocation() const { return this->m_location; }
-	inline MxS32 GetX() const { return this->m_location.GetX(); }
-	inline MxS32 GetY() const { return this->m_location.GetY(); }
-	inline MxS32 GetDisplayZ() const { return this->m_displayZ; }
-	inline MxDSAction* GetAction() const { return this->m_action; }
-	inline void SetAction(MxDSAction* p_action) { m_action = p_action; }
+	MxS32 GetCurrentTickleState() const { return this->m_currentTickleState; }
+	MxPoint32 GetLocation() const { return this->m_location; }
+	MxS32 GetX() const { return this->m_location.GetX(); }
+	MxS32 GetY() const { return this->m_location.GetY(); }
+	MxS32 GetDisplayZ() const { return this->m_displayZ; }
+	MxDSAction* GetAction() const { return this->m_action; }
+	void SetAction(MxDSAction* p_action) { m_action = p_action; }
 
-	inline void SetCompositePresenter(MxCompositePresenter* p_compositePresenter)
+	void SetCompositePresenter(MxCompositePresenter* p_compositePresenter)
 	{
 		m_compositePresenter = p_compositePresenter;
 	}
 
-	inline void SetDisplayZ(MxS32 p_displayZ) { m_displayZ = p_displayZ; }
+	void SetDisplayZ(MxS32 p_displayZ) { m_displayZ = p_displayZ; }
 
 	// SYNTHETIC: LEGO1 0x1000c070
 	// MxPresenter::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxramstreamcontroller.h
+++ b/LEGO1/omni/include/mxramstreamcontroller.h
@@ -10,17 +10,17 @@ class MxDSStreamingAction;
 // SIZE 0x98
 class MxRAMStreamController : public MxStreamController {
 public:
-	inline MxRAMStreamController() {}
+	MxRAMStreamController() {}
 
 	// FUNCTION: LEGO1 0x100b9430
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102118
 		return "MxRAMStreamController";
 	}
 
 	// FUNCTION: LEGO1 0x100b9440
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxRAMStreamController::ClassName()) ||
 			   !strcmp(p_name, MxStreamController::ClassName()) || MxCore::IsA(p_name);

--- a/LEGO1/omni/include/mxramstreamprovider.h
+++ b/LEGO1/omni/include/mxramstreamprovider.h
@@ -11,14 +11,14 @@ public:
 	~MxRAMStreamProvider() override;
 
 	// FUNCTION: LEGO1 0x100d0970
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102864
 		return "MxRAMStreamProvider";
 	}
 
 	// FUNCTION: LEGO1 0x100d0980
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxRAMStreamProvider::ClassName()) || MxStreamProvider::IsA(p_name);
 	}
@@ -29,7 +29,7 @@ public:
 	MxU32 GetLengthInDWords() override;                                 // vtable+0x24
 	MxU32* GetBufferForDWords() override;                               // vtable+0x28
 
-	inline MxU8* GetBufferOfFileSize() { return m_pBufferOfFileSize; }
+	MxU8* GetBufferOfFileSize() { return m_pBufferOfFileSize; }
 
 protected:
 	MxU32 m_bufferSize;        // 0x10

--- a/LEGO1/omni/include/mxrect16.h
+++ b/LEGO1/omni/include/mxrect16.h
@@ -9,33 +9,33 @@ struct MxRect16 {
 	MxRect16() {}
 
 	// FUNCTION: BETA10 0x100981f0
-	inline void SetLeft(MxS16 p_left) { m_left = p_left; }
+	void SetLeft(MxS16 p_left) { m_left = p_left; }
 
 	// FUNCTION: BETA10 0x10098220
-	inline void SetTop(MxS16 p_top) { m_top = p_top; }
+	void SetTop(MxS16 p_top) { m_top = p_top; }
 
 	// FUNCTION: BETA10 0x10098250
-	inline void SetRight(MxS16 p_right) { m_right = p_right; }
+	void SetRight(MxS16 p_right) { m_right = p_right; }
 
 	// FUNCTION: BETA10 0x10098280
-	inline void SetBottom(MxS16 p_bottom) { m_bottom = p_bottom; }
+	void SetBottom(MxS16 p_bottom) { m_bottom = p_bottom; }
 
 	// FUNCTION: BETA10 0x10098300
-	inline MxS16 GetLeft() const { return m_left; }
+	MxS16 GetLeft() const { return m_left; }
 
 	// FUNCTION: BETA10 0x10098330
-	inline MxS16 GetTop() const { return m_top; }
+	MxS16 GetTop() const { return m_top; }
 
 	// There is no GetRight()
 
 	// FUNCTION: BETA10 0x10098360
-	inline MxS16 GetBottom() const { return m_bottom; }
+	MxS16 GetBottom() const { return m_bottom; }
 
 	// FUNCTION: BETA10 0x10098390
-	inline MxS16 GetWidth() const { return m_right - m_left + 1; }
+	MxS16 GetWidth() const { return m_right - m_left + 1; }
 
 	// FUNCTION: BETA10 0x100983c0
-	inline MxS16 GetHeight() const { return m_bottom - m_top + 1; }
+	MxS16 GetHeight() const { return m_bottom - m_top + 1; }
 
 private:
 	MxS16 m_left;   // 0x00

--- a/LEGO1/omni/include/mxrect32.h
+++ b/LEGO1/omni/include/mxrect32.h
@@ -26,7 +26,7 @@ public:
 		return *this;
 	}
 
-	inline void Intersect(const MxRect32& p_rect)
+	void Intersect(const MxRect32& p_rect)
 	{
 		m_left = Max(p_rect.m_left, m_left);
 		m_top = Max(p_rect.m_top, m_top);
@@ -34,13 +34,13 @@ public:
 		m_bottom = Min(p_rect.m_bottom, m_bottom);
 	}
 
-	inline void SetPoint(const MxPoint32& p_point)
+	void SetPoint(const MxPoint32& p_point)
 	{
 		this->m_left = p_point.GetX();
 		this->m_top = p_point.GetY();
 	}
 
-	inline void AddPoint(const MxPoint32& p_point)
+	void AddPoint(const MxPoint32& p_point)
 	{
 		this->m_left += p_point.GetX();
 		this->m_top += p_point.GetY();
@@ -48,7 +48,7 @@ public:
 		this->m_bottom += p_point.GetY();
 	}
 
-	inline void SubtractPoint(const MxPoint32& p_point)
+	void SubtractPoint(const MxPoint32& p_point)
 	{
 		this->m_left -= p_point.GetX();
 		this->m_top -= p_point.GetY();
@@ -56,7 +56,7 @@ public:
 		this->m_bottom -= p_point.GetY();
 	}
 
-	inline void UpdateBounds(const MxRect32& p_rect)
+	void UpdateBounds(const MxRect32& p_rect)
 	{
 		m_left = Min(m_left, p_rect.m_left);
 		m_top = Min(m_top, p_rect.m_top);
@@ -64,31 +64,31 @@ public:
 		m_bottom = Max(m_bottom, p_rect.m_bottom);
 	}
 
-	inline MxBool IsValid() const { return m_left < m_right && m_top < m_bottom; }
+	MxBool IsValid() const { return m_left < m_right && m_top < m_bottom; }
 
-	inline MxBool IntersectsWith(const MxRect32& p_rect) const
+	MxBool IntersectsWith(const MxRect32& p_rect) const
 	{
 		return m_left < p_rect.m_right && p_rect.m_left < m_right && m_top < p_rect.m_bottom && p_rect.m_top < m_bottom;
 	}
 
-	inline MxS32 GetWidth() const { return (m_right - m_left) + 1; }
-	inline MxS32 GetHeight() const { return (m_bottom - m_top) + 1; }
+	MxS32 GetWidth() const { return (m_right - m_left) + 1; }
+	MxS32 GetHeight() const { return (m_bottom - m_top) + 1; }
 
-	inline MxPoint32 GetPoint() const { return MxPoint32(this->m_left, this->m_top); }
-	inline MxSize32 GetSize() const { return MxSize32(this->m_right, this->m_bottom); }
+	MxPoint32 GetPoint() const { return MxPoint32(this->m_left, this->m_top); }
+	MxSize32 GetSize() const { return MxSize32(this->m_right, this->m_bottom); }
 
-	inline MxS32 GetLeft() const { return m_left; }
-	inline MxS32 GetTop() const { return m_top; }
-	inline MxS32 GetRight() const { return m_right; }
-	inline MxS32 GetBottom() const { return m_bottom; }
+	MxS32 GetLeft() const { return m_left; }
+	MxS32 GetTop() const { return m_top; }
+	MxS32 GetRight() const { return m_right; }
+	MxS32 GetBottom() const { return m_bottom; }
 
-	inline void SetLeft(MxS32 p_left) { m_left = p_left; }
-	inline void SetTop(MxS32 p_top) { m_top = p_top; }
-	inline void SetRight(MxS32 p_right) { m_right = p_right; }
-	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
+	void SetLeft(MxS32 p_left) { m_left = p_left; }
+	void SetTop(MxS32 p_top) { m_top = p_top; }
+	void SetRight(MxS32 p_right) { m_right = p_right; }
+	void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
 private:
-	inline void CopyFrom(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_bottom)
+	void CopyFrom(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_bottom)
 	{
 		this->m_left = p_left;
 		this->m_top = p_top;
@@ -96,7 +96,7 @@ private:
 		this->m_bottom = p_bottom;
 	}
 
-	inline void CopyFrom(const MxRect32& p_rect)
+	void CopyFrom(const MxRect32& p_rect)
 	{
 		this->m_left = p_rect.m_left;
 		this->m_top = p_rect.m_top;
@@ -106,7 +106,7 @@ private:
 
 	// The address might also be the constructor that calls CopyFrom
 	// FUNCTION: LEGO1 0x100b6fc0
-	inline MxRect32* CopyFrom(const MxPoint32& p_point, const MxSize32& p_size)
+	MxRect32* CopyFrom(const MxPoint32& p_point, const MxSize32& p_size)
 	{
 		this->m_left = p_point.GetX();
 		this->m_top = p_point.GetY();
@@ -115,8 +115,8 @@ private:
 		return this;
 	}
 
-	inline static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; }
-	inline static MxS32 Max(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_b : p_a; }
+	static MxS32 Min(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_a : p_b; }
+	static MxS32 Max(MxS32 p_a, MxS32 p_b) { return p_a <= p_b ? p_b : p_a; }
 
 	MxS32 m_left;   // 0x00
 	MxS32 m_top;    // 0x04

--- a/LEGO1/omni/include/mxregion.h
+++ b/LEGO1/omni/include/mxregion.h
@@ -18,8 +18,8 @@ public:
 	virtual MxBool VTable0x1c(MxRect32& p_rect); // vtable+0x1c
 	virtual MxBool VTable0x20();                 // vtable+0x20
 
-	inline MxRegionTopBottomList* GetTopBottomList() const { return m_list; }
-	inline const MxRect32& GetRect() const { return m_rect; }
+	MxRegionTopBottomList* GetTopBottomList() const { return m_list; }
+	const MxRect32& GetRect() const { return m_rect; }
 
 	friend class MxRegionCursor;
 

--- a/LEGO1/omni/include/mxregionlist.h
+++ b/LEGO1/omni/include/mxregionlist.h
@@ -13,13 +13,13 @@ struct MxRegionLeftRight {
 
 	MxRegionLeftRight* Clone() { return new MxRegionLeftRight(m_left, m_right); }
 
-	inline MxS32 GetLeft() { return m_left; }
-	inline MxS32 GetRight() { return m_right; }
+	MxS32 GetLeft() { return m_left; }
+	MxS32 GetRight() { return m_right; }
 
-	inline void SetLeft(MxS32 p_left) { m_left = p_left; }
-	inline void SetRight(MxS32 p_right) { m_right = p_right; }
+	void SetLeft(MxS32 p_left) { m_left = p_left; }
+	void SetRight(MxS32 p_right) { m_right = p_right; }
 
-	inline MxBool IntersectsWith(MxRect32& p_rect) { return m_left < p_rect.GetRight() && p_rect.GetTop() < m_right; }
+	MxBool IntersectsWith(MxRect32& p_rect) { return m_left < p_rect.GetRight() && p_rect.GetTop() < m_right; }
 
 private:
 	MxS32 m_left;  // 0x00
@@ -67,13 +67,13 @@ struct MxRegionTopBottom {
 	void MergeOrExpandRegions(MxS32 p_left, MxS32 p_right);
 	MxBool CheckHorizontalOverlap(MxRect32& p_rect);
 
-	inline MxS32 GetTop() { return m_top; }
-	inline MxS32 GetBottom() { return m_bottom; }
+	MxS32 GetTop() { return m_top; }
+	MxS32 GetBottom() { return m_bottom; }
 
-	inline void SetTop(MxS32 p_top) { m_top = p_top; }
-	inline void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
+	void SetTop(MxS32 p_top) { m_top = p_top; }
+	void SetBottom(MxS32 p_bottom) { m_bottom = p_bottom; }
 
-	inline MxBool IntersectsWith(MxRect32& p_rect) { return m_top < p_rect.GetBottom() && p_rect.GetTop() < m_bottom; }
+	MxBool IntersectsWith(MxRect32& p_rect) { return m_top < p_rect.GetBottom() && p_rect.GetTop() < m_bottom; }
 
 	friend class MxRegionTopBottomList;
 	friend class MxRegionCursor;

--- a/LEGO1/omni/include/mxsize32.h
+++ b/LEGO1/omni/include/mxsize32.h
@@ -8,11 +8,11 @@ public:
 	MxSize32() {}
 	MxSize32(MxS32 p_width, MxS32 p_height) { CopyFrom(p_width, p_height); }
 
-	inline MxS32 GetWidth() const { return m_width; }
-	inline MxS32 GetHeight() const { return m_height; }
+	MxS32 GetWidth() const { return m_width; }
+	MxS32 GetHeight() const { return m_height; }
 
 private:
-	inline void CopyFrom(MxS32 p_width, MxS32 p_height)
+	void CopyFrom(MxS32 p_width, MxS32 p_height)
 	{
 		this->m_width = p_width;
 		this->m_height = p_height;

--- a/LEGO1/omni/include/mxsmkpresenter.h
+++ b/LEGO1/omni/include/mxsmkpresenter.h
@@ -21,13 +21,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100b3730
 	// FUNCTION: BETA10 0x1013b8c0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100b3740
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxSmkPresenter::ClassName()) || MxVideoPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxsoundmanager.h
+++ b/LEGO1/omni/include/mxsoundmanager.h
@@ -20,7 +20,7 @@ public:
 	virtual void Pause();                                                // vtable+0x34
 	virtual void Resume();                                               // vtable+0x38
 
-	inline LPDIRECTSOUND GetDirectSound() { return m_directSound; }
+	LPDIRECTSOUND GetDirectSound() { return m_directSound; }
 
 	MxS32 GetAttenuation(MxU32 p_volume);
 

--- a/LEGO1/omni/include/mxsoundpresenter.h
+++ b/LEGO1/omni/include/mxsoundpresenter.h
@@ -19,13 +19,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000d4a0
 	// FUNCTION: BETA10 0x1008ca40
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d4b0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxSoundPresenter::ClassName()) || MxAudioPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxstillpresenter.h
+++ b/LEGO1/omni/include/mxstillpresenter.h
@@ -22,13 +22,13 @@ public:
 
 	// FUNCTION: LEGO1 0x100435c0
 	// FUNCTION: BETA10 0x10098090
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x100435d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxStillPresenter::ClassName()) || MxVideoPresenter::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxstreamchunk.h
+++ b/LEGO1/omni/include/mxstreamchunk.h
@@ -10,23 +10,23 @@ class MxStreamListMxDSSubscriber;
 // SIZE 0x20
 class MxStreamChunk : public MxDSChunk {
 public:
-	inline MxStreamChunk() : m_buffer(NULL) {}
+	MxStreamChunk() : m_buffer(NULL) {}
 	~MxStreamChunk() override;
 
 	// FUNCTION: LEGO1 0x100b1fe0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e5c
 		return "MxStreamChunk";
 	}
 
 	// FUNCTION: LEGO1 0x100b1ff0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxStreamChunk::ClassName()) || MxDSChunk::IsA(p_name);
 	}
 
-	inline MxDSBuffer* GetBuffer() { return m_buffer; }
+	MxDSBuffer* GetBuffer() { return m_buffer; }
 
 	MxResult ReadChunk(MxDSBuffer* p_buffer, MxU8* p_chunkData);
 	MxU32 ReadChunkHeader(MxU8* p_chunkData);

--- a/LEGO1/omni/include/mxstreamcontroller.h
+++ b/LEGO1/omni/include/mxstreamcontroller.h
@@ -20,14 +20,14 @@ public:
 	~MxStreamController() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100c0f10
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10102130
 		return "MxStreamController";
 	}
 
 	// FUNCTION: LEGO1 0x100c0f20
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxStreamController::ClassName()) || MxCore::IsA(p_name);
 	}
@@ -51,11 +51,11 @@ public:
 	MxResult InsertActionToList54(MxDSAction* p_action);
 	MxNextActionDataStart* FindNextActionDataStartFromStreamingAction(MxDSStreamingAction* p_action);
 
-	inline MxAtomId& GetAtom() { return m_atom; }
-	inline MxStreamProvider* GetProvider() { return m_provider; }
-	inline MxStreamListMxDSAction& GetUnk0x3c() { return m_unk0x3c; }
-	inline MxStreamListMxDSAction& GetUnk0x54() { return m_unk0x54; }
-	inline MxStreamListMxDSSubscriber& GetSubscriberList() { return m_subscriberList; }
+	MxAtomId& GetAtom() { return m_atom; }
+	MxStreamProvider* GetProvider() { return m_provider; }
+	MxStreamListMxDSAction& GetUnk0x3c() { return m_unk0x3c; }
+	MxStreamListMxDSAction& GetUnk0x54() { return m_unk0x54; }
+	MxStreamListMxDSSubscriber& GetSubscriberList() { return m_subscriberList; }
 
 protected:
 	MxCriticalSection m_criticalSection;                // 0x08

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -20,7 +20,7 @@ typedef MxMemoryPool<128, 2> MxMemoryPool128;
 // SIZE 0x10
 class MxStreamerNotification : public MxNotificationParam {
 public:
-	inline MxStreamerNotification(NotificationId p_type, MxCore* p_sender, MxStreamController* p_ctrlr)
+	MxStreamerNotification(NotificationId p_type, MxCore* p_sender, MxStreamController* p_ctrlr)
 		: MxNotificationParam(p_type, p_sender)
 	{
 		m_controller = p_ctrlr;
@@ -53,14 +53,14 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100b9000
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x1010210c
 		return "MxStreamer";
 	}
 
 	// FUNCTION: LEGO1 0x100b9010
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxStreamer::ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxstreamprovider.h
+++ b/LEGO1/omni/include/mxstreamprovider.h
@@ -12,16 +12,16 @@ class MxDSFile;
 // SIZE 0x10
 class MxStreamProvider : public MxCore {
 public:
-	inline MxStreamProvider() : m_pLookup(NULL), m_pFile(NULL) {}
+	MxStreamProvider() : m_pLookup(NULL), m_pFile(NULL) {}
 
 	// FUNCTION: LEGO1 0x100d07e0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return "MxStreamProvider";
 	}
 
 	// FUNCTION: LEGO1 0x100d07f0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxStreamProvider::ClassName()) || MxCore::IsA(p_name);
 	}

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -27,16 +27,16 @@ public:
 	static void CharSwap(char* p_a, char* p_b);
 
 	// FUNCTION: BETA10 0x10017c50
-	inline char* GetData() const { return m_data; }
+	char* GetData() const { return m_data; }
 
 	// FUNCTION: BETA10 0x10067630
-	inline const MxU16 GetLength() const { return m_length; }
+	const MxU16 GetLength() const { return m_length; }
 
 	// FUNCTION: BETA10 0x100d8a30
-	inline MxBool Equal(const MxString& p_str) const { return strcmp(m_data, p_str.m_data) == 0; }
+	MxBool Equal(const MxString& p_str) const { return strcmp(m_data, p_str.m_data) == 0; }
 
 	// FUNCTION: BETA10 0x1012a810
-	inline MxS8 Compare(const MxString& p_str) const { return strcmp(m_data, p_str.m_data); }
+	MxS8 Compare(const MxString& p_str) const { return strcmp(m_data, p_str.m_data); }
 
 	// SYNTHETIC: LEGO1 0x100ae280
 	// SYNTHETIC: BETA10 0x1012c9d0

--- a/LEGO1/omni/include/mxthread.h
+++ b/LEGO1/omni/include/mxthread.h
@@ -19,7 +19,7 @@ public:
 	void Terminate();
 	void Sleep(MxS32 p_milliseconds);
 
-	inline MxBool IsRunning() { return m_running; }
+	MxBool IsRunning() { return m_running; }
 
 	// SYNTHETIC: LEGO1 0x100bf580
 	// MxThread::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxticklemanager.h
+++ b/LEGO1/omni/include/mxticklemanager.h
@@ -10,19 +10,19 @@ class MxTickleClient {
 public:
 	MxTickleClient(MxCore* p_client, MxTime p_interval);
 
-	inline MxCore* GetClient() const { return m_client; }
+	MxCore* GetClient() const { return m_client; }
 
-	inline MxTime GetTickleInterval() const { return m_interval; }
+	MxTime GetTickleInterval() const { return m_interval; }
 
-	inline MxTime GetLastUpdateTime() const { return m_lastUpdateTime; }
+	MxTime GetLastUpdateTime() const { return m_lastUpdateTime; }
 
-	inline MxU16 GetFlags() const { return m_flags; }
+	MxU16 GetFlags() const { return m_flags; }
 
-	inline void SetTickleInterval(MxTime p_interval) { m_interval = p_interval; }
+	void SetTickleInterval(MxTime p_interval) { m_interval = p_interval; }
 
-	inline void SetLastUpdateTime(MxTime p_lastUpdateTime) { m_lastUpdateTime = p_lastUpdateTime; }
+	void SetLastUpdateTime(MxTime p_lastUpdateTime) { m_lastUpdateTime = p_lastUpdateTime; }
 
-	inline void SetFlags(MxU16 p_flags) { m_flags = p_flags; }
+	void SetFlags(MxU16 p_flags) { m_flags = p_flags; }
 
 private:
 	MxCore* m_client;        // 0x00
@@ -37,7 +37,7 @@ typedef list<MxTickleClient*> MxTickleClientPtrList;
 // SIZE 0x14
 class MxTickleManager : public MxCore {
 public:
-	inline MxTickleManager() {}
+	MxTickleManager() {}
 	~MxTickleManager() override;
 
 	MxResult Tickle() override;                                                // vtable+0x08

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -14,7 +14,7 @@ public:
 
 	MxLong GetRealTime();
 
-	inline MxLong GetTime()
+	MxLong GetTime()
 	{
 		if (this->m_isRunning) {
 			return g_lastTimeTimerStarted;

--- a/LEGO1/omni/include/mxvariable.h
+++ b/LEGO1/omni/include/mxvariable.h
@@ -39,7 +39,7 @@ public:
 	virtual void Destroy() { delete this; } // vtable+0x08
 
 	// FUNCTION: BETA10 0x1012a7f0
-	inline const MxString* GetKey() const { return &m_key; }
+	const MxString* GetKey() const { return &m_key; }
 
 protected:
 	MxString m_key;   // 0x04

--- a/LEGO1/omni/include/mxvideomanager.h
+++ b/LEGO1/omni/include/mxvideomanager.h
@@ -40,10 +40,10 @@ public:
 	void SortPresenterList();
 	void UpdateRegion();
 
-	inline MxVideoParam& GetVideoParam() { return this->m_videoParam; }
-	inline LPDIRECTDRAW GetDirectDraw() { return this->m_pDirectDraw; }
-	inline MxDisplaySurface* GetDisplaySurface() { return this->m_displaySurface; }
-	inline MxRegion* GetRegion() { return this->m_region; }
+	MxVideoParam& GetVideoParam() { return this->m_videoParam; }
+	LPDIRECTDRAW GetDirectDraw() { return this->m_pDirectDraw; }
+	MxDisplaySurface* GetDisplaySurface() { return this->m_displaySurface; }
+	MxRegion* GetRegion() { return this->m_region; }
 
 	// SYNTHETIC: LEGO1 0x100be280
 	// MxVideoManager::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxvideoparam.h
+++ b/LEGO1/omni/include/mxvideoparam.h
@@ -22,25 +22,25 @@ public:
 	MxVideoParam& operator=(const MxVideoParam& p_videoParam);
 
 	// FUNCTION: BETA10 0x100886e0
-	inline MxVideoParamFlags& Flags() { return m_flags; }
+	MxVideoParamFlags& Flags() { return m_flags; }
 
 	// FUNCTION: BETA10 0x100d81f0
-	inline MxRect32& GetRect() { return m_rect; }
+	MxRect32& GetRect() { return m_rect; }
 
 	// FUNCTION: BETA10 0x100d8210
-	inline MxPalette* GetPalette() { return m_palette; }
+	MxPalette* GetPalette() { return m_palette; }
 
 	// FUNCTION: BETA10 0x100d8240
-	inline void SetPalette(MxPalette* p_palette) { m_palette = p_palette; }
+	void SetPalette(MxPalette* p_palette) { m_palette = p_palette; }
 
 	// FUNCTION: BETA10 0x100d8270
-	inline char* GetDeviceName() { return m_deviceId; }
+	char* GetDeviceName() { return m_deviceId; }
 
 	// FUNCTION: BETA10 0x10141f60
-	inline MxU32 GetBackBuffers() { return m_backBuffers; }
+	MxU32 GetBackBuffers() { return m_backBuffers; }
 
 	// FUNCTION: BETA10 0x10141fe0
-	inline void SetBackBuffers(MxU32 p_backBuffers) { m_backBuffers = p_backBuffers; }
+	void SetBackBuffers(MxU32 p_backBuffers) { m_backBuffers = p_backBuffers; }
 
 private:
 	MxRect32 m_rect;           // 0x00

--- a/LEGO1/omni/include/mxvideoparamflags.h
+++ b/LEGO1/omni/include/mxvideoparamflags.h
@@ -10,55 +10,55 @@ public:
 	MxVideoParamFlags();
 
 	// inlined in ISLE
-	inline void SetFullScreen(MxBool p_e) { m_flags1.m_bit0 = p_e; }
+	void SetFullScreen(MxBool p_e) { m_flags1.m_bit0 = p_e; }
 
 	// FUNCTION: BETA10 0x10141f80
-	inline void SetFlipSurfaces(MxBool p_e) { m_flags1.m_bit1 = p_e; }
+	void SetFlipSurfaces(MxBool p_e) { m_flags1.m_bit1 = p_e; }
 
 	// FUNCTION: BETA10 0x10141fb0
-	inline void SetBackBuffers(MxBool p_e) { m_flags1.m_bit2 = p_e; }
+	void SetBackBuffers(MxBool p_e) { m_flags1.m_bit2 = p_e; }
 
 	// FUNCTION: BETA10 0x100d9250
-	inline void SetF1bit3(MxBool p_e) { m_flags1.m_bit3 = p_e; }
+	void SetF1bit3(MxBool p_e) { m_flags1.m_bit3 = p_e; }
 
 	// inlined in ISLE
-	inline void Set16Bit(MxBool p_e) { m_flags1.m_bit5 = p_e; }
+	void Set16Bit(MxBool p_e) { m_flags1.m_bit5 = p_e; }
 
 	// inlined in ISLE
-	inline void SetWideViewAngle(MxBool p_e) { m_flags1.m_bit6 = p_e; }
+	void SetWideViewAngle(MxBool p_e) { m_flags1.m_bit6 = p_e; }
 
 	// inlined in ISLE
-	inline void SetF1bit7(MxBool p_e) { m_flags1.m_bit7 = p_e; }
+	void SetF1bit7(MxBool p_e) { m_flags1.m_bit7 = p_e; }
 
 	// FUNCTION: BETA10 0x100d81b0
-	inline void SetF2bit0(MxBool p_e) { m_flags2.m_bit0 = p_e; }
+	void SetF2bit0(MxBool p_e) { m_flags2.m_bit0 = p_e; }
 
 	// inlined in ISLE
-	inline void SetF2bit1(MxBool p_e) { m_flags2.m_bit1 = p_e; }
+	void SetF2bit1(MxBool p_e) { m_flags2.m_bit1 = p_e; }
 
 	// FUNCTION: BETA10 0x1009e770
-	inline MxBool GetFullScreen() { return m_flags1.m_bit0; }
+	MxBool GetFullScreen() { return m_flags1.m_bit0; }
 
 	// FUNCTION: BETA10 0x100d80f0
-	inline MxBool GetFlipSurfaces() { return m_flags1.m_bit1; }
+	MxBool GetFlipSurfaces() { return m_flags1.m_bit1; }
 
 	// FUNCTION: BETA10 0x100d8120
-	inline MxBool GetBackBuffers() { return m_flags1.m_bit2; }
+	MxBool GetBackBuffers() { return m_flags1.m_bit2; }
 
 	// FUNCTION: BETA10 0x10142010
-	inline MxBool GetF1bit3() { return m_flags1.m_bit3; }
+	MxBool GetF1bit3() { return m_flags1.m_bit3; }
 
 	// FUNCTION: BETA10 0x100d8150
-	inline MxBool Get16Bit() { return m_flags1.m_bit5; }
+	MxBool Get16Bit() { return m_flags1.m_bit5; }
 
 	// FUNCTION: BETA10 0x100d8180
-	inline MxBool GetWideViewAngle() { return m_flags1.m_bit6; }
+	MxBool GetWideViewAngle() { return m_flags1.m_bit6; }
 
 	// FUNCTION: BETA10 0x100886b0
-	inline MxBool GetF2bit0() { return m_flags2.m_bit0; }
+	MxBool GetF2bit0() { return m_flags2.m_bit0; }
 
 	// FUNCTION: BETA10 0x10142050
-	inline MxBool GetF2bit1() { return m_flags2.m_bit1; }
+	MxBool GetF2bit1() { return m_flags2.m_bit1; }
 
 private:
 	FlagBitfield m_flags1;

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -26,13 +26,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000c820
 	// FUNCTION: BETA10 0x10055180
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000c830
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxVideoPresenter::ClassName()) || MxMediaPresenter::IsA(p_name);
 	}
@@ -99,20 +99,20 @@ public:
 	};
 
 	inline MxS32 PrepareRects(RECT& p_rectDest, RECT& p_rectSrc);
-	inline MxBitmap* GetBitmap() { return m_frameBitmap; }
-	inline AlphaMask* GetAlphaMask() { return m_alpha; }
+	MxBitmap* GetBitmap() { return m_frameBitmap; }
+	AlphaMask* GetAlphaMask() { return m_alpha; }
 
-	inline void SetBit0(BOOL p_e) { m_flags.m_bit0 = p_e; }
-	inline void SetBit1(BOOL p_e) { m_flags.m_bit1 = p_e; }
-	inline void SetBit2(BOOL p_e) { m_flags.m_bit2 = p_e; }
-	inline void SetBit3(BOOL p_e) { m_flags.m_bit3 = p_e; }
-	inline void SetBit4(BOOL p_e) { m_flags.m_bit4 = p_e; }
+	void SetBit0(BOOL p_e) { m_flags.m_bit0 = p_e; }
+	void SetBit1(BOOL p_e) { m_flags.m_bit1 = p_e; }
+	void SetBit2(BOOL p_e) { m_flags.m_bit2 = p_e; }
+	void SetBit3(BOOL p_e) { m_flags.m_bit3 = p_e; }
+	void SetBit4(BOOL p_e) { m_flags.m_bit4 = p_e; }
 
-	inline BYTE GetBit0() { return m_flags.m_bit0; }
-	inline BYTE GetBit1() { return m_flags.m_bit1; }
-	inline BYTE GetBit2() { return m_flags.m_bit2; }
-	inline BYTE GetBit3() { return m_flags.m_bit3; }
-	inline BYTE GetBit4() { return m_flags.m_bit4; }
+	BYTE GetBit0() { return m_flags.m_bit0; }
+	BYTE GetBit1() { return m_flags.m_bit1; }
+	BYTE GetBit2() { return m_flags.m_bit2; }
+	BYTE GetBit3() { return m_flags.m_bit3; }
+	BYTE GetBit4() { return m_flags.m_bit4; }
 
 	// SYNTHETIC: LEGO1 0x1000c910
 	// MxVideoPresenter::`scalar deleting destructor'

--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -24,13 +24,13 @@ public:
 
 	// FUNCTION: LEGO1 0x1000d6c0
 	// FUNCTION: BETA10 0x1008ccd0
-	inline const char* ClassName() const override // vtable+0x0c
+	const char* ClassName() const override // vtable+0x0c
 	{
 		return HandlerClassName();
 	}
 
 	// FUNCTION: LEGO1 0x1000d6d0
-	inline MxBool IsA(const char* p_name) const override // vtable+0x10
+	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxWavePresenter::ClassName()) || MxSoundPresenter::IsA(p_name);
 	}

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -17,7 +17,7 @@ struct UnknownMatrixType {
 class Matrix4 {
 public:
 	// FUNCTION: LEGO1 0x10004500
-	inline Matrix4(float (*p_data)[4]) { SetData(p_data); }
+	Matrix4(float (*p_data)[4]) { SetData(p_data); }
 
 	// Note: virtual function overloads appear in the virtual table
 	// in reverse order of appearance.
@@ -112,7 +112,7 @@ public:
 	inline virtual int FromQuaternion(const Vector4& p_vec); // vtable+0x44
 
 	// FUNCTION: LEGO1 0x100a0ff0
-	inline void Scale(const float& p_x, const float& p_y, const float& p_z)
+	void Scale(const float& p_x, const float& p_y, const float& p_z)
 	{
 		for (int i = 0; i < 4; i++) {
 			m_data[i][0] *= p_x;
@@ -121,7 +121,7 @@ public:
 		}
 	}
 
-	inline void RotateX(const float& p_angle)
+	void RotateX(const float& p_angle)
 	{
 		float s = sin(p_angle);
 		float c = cos(p_angle);
@@ -134,7 +134,7 @@ public:
 	}
 
 	// FUNCTION: BETA10 0x1001fd60
-	inline void RotateY(const float& p_angle)
+	void RotateY(const float& p_angle)
 	{
 		float s = sin(p_angle);
 		float c = cos(p_angle);
@@ -147,7 +147,7 @@ public:
 	}
 
 	// FUNCTION: BETA10 0x1006ab10
-	inline void RotateZ(const float& p_angle)
+	void RotateZ(const float& p_angle)
 	{
 		float s = sin(p_angle);
 		float c = cos(p_angle);
@@ -162,7 +162,7 @@ public:
 	inline int Unknown(Matrix4& p_mat);
 
 	// FUNCTION: LEGO1 0x1006b500
-	inline void Swap(int p_d1, int p_d2)
+	void Swap(int p_d1, int p_d2)
 	{
 		for (int i = 0; i < 4; i++) {
 			float e = m_data[p_d1][i];

--- a/LEGO1/realtime/realtimeview.h
+++ b/LEGO1/realtime/realtimeview.h
@@ -14,7 +14,7 @@ public:
 	static void UpdateMaxLOD();
 	static void SetUserMaxLOD(float);
 
-	inline static float GetUserMaxLodPower() { return g_userMaxLodPower; }
+	static float GetUserMaxLodPower() { return g_userMaxLodPower; }
 };
 
 #endif // REALTIMEVIEW_H

--- a/LEGO1/realtime/roi.h
+++ b/LEGO1/realtime/roi.h
@@ -112,8 +112,8 @@ public:
 	int GetLODCount() const { return lods ? lods->Size() : 0; }
 	const CompoundObject* GetComp() const { return comp; }
 
-	inline unsigned char GetVisibility() { return m_visible; }
-	inline void SetVisibility(unsigned char p_visible) { m_visible = p_visible; }
+	unsigned char GetVisibility() { return m_visible; }
+	void SetVisibility(unsigned char p_visible) { m_visible = p_visible; }
 
 	// SYNTHETIC: LEGO1 0x100a5d60
 	// ROI::`scalar deleting destructor'

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -14,7 +14,7 @@
 class Vector2 {
 public:
 	// FUNCTION: LEGO1 0x1000c0f0
-	inline Vector2(float* p_data) { SetData(p_data); }
+	Vector2(float* p_data) { SetData(p_data); }
 
 	// Note: virtual function overloads appear in the virtual table
 	// in reverse order of appearance.
@@ -149,13 +149,13 @@ public:
 	// SYNTHETIC: LEGO1 0x10010be0
 	// Vector3::operator=
 
-	inline Vector2& operator=(const Vector2& p_other)
+	Vector2& operator=(const Vector2& p_other)
 	{
 		Vector2::SetVector(&p_other);
 		return *this;
 	}
-	inline float& operator[](int idx) { return m_data[idx]; }
-	inline const float& operator[](int idx) const { return m_data[idx]; }
+	float& operator[](int idx) { return m_data[idx]; }
+	const float& operator[](int idx) const { return m_data[idx]; }
 
 protected:
 	float* m_data; // 0x04
@@ -166,20 +166,20 @@ protected:
 class Vector3 : public Vector2 {
 public:
 	// FUNCTION: LEGO1 0x1001d150
-	inline Vector3(float* p_data) : Vector2(p_data) {}
+	Vector3(float* p_data) : Vector2(p_data) {}
 
 	// Hack: Some code initializes a Vector3 from a (most likely) const float* source.
 	// Example: LegoCameraController::GetWorldUp
 	// Vector3 however is a class that can mutate its underlying source, making
 	// initialization with a const source fundamentally incompatible.
-	inline Vector3(const float* p_data) : Vector2((float*) p_data) {}
+	Vector3(const float* p_data) : Vector2((float*) p_data) {}
 
 	// Note: virtual function overloads appear in the virtual table
 	// in reverse order of appearance.
 
 	// FUNCTION: LEGO1 0x10002270
 	// FUNCTION: BETA10 0x100064a1
-	inline virtual void EqualsCrossImpl(float* p_a, float* p_b)
+	virtual void EqualsCrossImpl(float* p_a, float* p_b)
 	{
 		m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
 		m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
@@ -230,7 +230,7 @@ public:
 	} // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10003b20
-	inline void MulScalarImpl(float* p_value) override
+	void MulScalarImpl(float* p_value) override
 	{
 		m_data[0] *= *p_value;
 		m_data[1] *= *p_value;
@@ -279,7 +279,7 @@ public:
 // SIZE 0x08
 class Vector4 : public Vector3 {
 public:
-	inline Vector4(float* p_data) : Vector3(p_data) {}
+	Vector4(float* p_data) : Vector3(p_data) {}
 
 	// Note: virtual function overloads appear in the virtual table
 	// in reverse order of appearance.

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -85,12 +85,12 @@ public:
 	// vtable+0x30
 	Result SetTextureDefaultColorCount(unsigned long) override;
 
-	inline HRESULT CreateTextureFromSurface(LPDIRECTDRAWSURFACE pSurface, LPDIRECT3DRMTEXTURE2* pTexture2)
+	HRESULT CreateTextureFromSurface(LPDIRECTDRAWSURFACE pSurface, LPDIRECT3DRMTEXTURE2* pTexture2)
 	{
 		return m_data->CreateTextureFromSurface(pSurface, pTexture2);
 	}
 
-	inline IDirect3DRM2* ImplementationData() const { return m_data; }
+	IDirect3DRM2* ImplementationData() const { return m_data; }
 
 public:
 	inline Result Create();
@@ -148,7 +148,7 @@ public:
 	void InitFromD3DDevice(Device*) override;
 	void InitFromWindowsDevice(Device*) override;
 
-	inline IDirect3DRMDevice2* ImplementationData() const { return m_data; }
+	IDirect3DRMDevice2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
@@ -198,7 +198,7 @@ public:
 		int& rPickedGroupCount
 	) override;
 
-	inline IDirect3DRMViewport* ImplementationData() const { return m_data; }
+	IDirect3DRMViewport* ImplementationData() const { return m_data; }
 
 	static Result ViewportCreateAppData(IDirect3DRM2*, IDirect3DRMViewport*, IDirect3DRMFrame2*);
 
@@ -225,7 +225,7 @@ public:
 	// vtable+0x08
 	Result SetTransformation(FloatMatrix4&) override;
 
-	inline IDirect3DRMFrame2* ImplementationData() const { return m_data; }
+	IDirect3DRMFrame2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
@@ -251,7 +251,7 @@ public:
 	Result SetTransformation(FloatMatrix4&) override;
 	Result SetColor(float r, float g, float b) override;
 
-	inline IDirect3DRMFrame2* ImplementationData() const { return m_data; }
+	IDirect3DRMFrame2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
@@ -293,8 +293,8 @@ public:
 
 	typedef MeshData* MeshDataType;
 
-	inline const MeshDataType& ImplementationData() const { return m_data; }
-	inline MeshDataType& ImplementationData() { return m_data; }
+	const MeshDataType& ImplementationData() const { return m_data; }
+	MeshDataType& ImplementationData() { return m_data; }
 
 	friend class RendererImpl;
 
@@ -335,7 +335,7 @@ public:
 	// vtable+0x30
 	Result Unknown() override;
 
-	inline IDirect3DRMFrame2* ImplementationData() const { return m_data; }
+	IDirect3DRMFrame2* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
@@ -373,7 +373,7 @@ public:
 	// vtable+0x10
 	MeshBuilder* Clone() override;
 
-	inline IDirect3DRMMesh* ImplementationData() const { return m_data; }
+	IDirect3DRMMesh* ImplementationData() const { return m_data; }
 
 	friend class RendererImpl;
 
@@ -446,8 +446,8 @@ public:
 	) override;
 	Result SetPalette(int entryCount, PaletteEntry* entries) override;
 
-	inline IDirect3DRMTexture* ImplementationData() const { return m_data; }
-	inline void SetImplementation(IDirect3DRMTexture* pData) { m_data = pData; }
+	IDirect3DRMTexture* ImplementationData() const { return m_data; }
+	void SetImplementation(IDirect3DRMTexture* pData) { m_data = pData; }
 
 	friend class RendererImpl;
 

--- a/LEGO1/viewmanager/viewmanager.h
+++ b/LEGO1/viewmanager/viewmanager.h
@@ -39,8 +39,8 @@ public:
 	inline static int Unknown2(float p_und1, float p_und2, ViewROI* p_roi);
 	inline static int Unknown3(ViewROI* p_roi);
 
-	inline const CompoundObject& GetROIs() { return rois; }
-	inline void Add(ViewROI* p_roi) { rois.push_back(p_roi); }
+	const CompoundObject& GetROIs() { return rois; }
+	void Add(ViewROI* p_roi) { rois.push_back(p_roi); }
 
 	// SYNTHETIC: LEGO1 0x100a6000
 	// ViewManager::`scalar deleting destructor'

--- a/LEGO1/viewmanager/viewroi.h
+++ b/LEGO1/viewmanager/viewroi.h
@@ -16,7 +16,7 @@
 // SIZE 0xe4
 class ViewROI : public OrientableROI {
 public:
-	inline ViewROI(Tgl::Renderer* pRenderer, ViewLODList* lodList)
+	ViewROI(Tgl::Renderer* pRenderer, ViewLODList* lodList)
 	{
 		SetLODList(lodList);
 		geometry = pRenderer->CreateGroup();
@@ -24,14 +24,14 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100a9e20
-	inline ~ViewROI() override
+	~ViewROI() override
 	{
 		// SetLODList() will decrease refCount of LODList
 		SetLODList(0);
 		delete geometry;
 	}
 
-	inline void SetLODList(ViewLODList* lodList)
+	void SetLODList(ViewLODList* lodList)
 	{
 		// ??? inherently type unsafe - kind of... because, now, ROI
 		//     does not expose SetLODs() ...
@@ -56,8 +56,8 @@ public:
 	virtual Tgl::Group* GetGeometry();                           // vtable+0x30
 	virtual const Tgl::Group* GetGeometry() const;               // vtable+0x34
 
-	inline int GetUnknown0xe0() { return m_unk0xe0; }
-	inline void SetUnknown0xe0(int p_unk0xe0) { m_unk0xe0 = p_unk0xe0; }
+	int GetUnknown0xe0() { return m_unk0xe0; }
+	void SetUnknown0xe0(int p_unk0xe0) { m_unk0xe0 = p_unk0xe0; }
 
 	static undefined SetUnk101013d8(undefined p_flag);
 


### PR DESCRIPTION
This PR adds the `readability-redundant-inline-specifier` introduced in `clang-tidy` version 18. The goal is to introduce consistency with regards to the use of the `inline` keyword. Up until now we've had many places that used the keyword, and many that didn't, for no particular reason.

Based on the original developer's style guide, they did not explicitly use the `inline` keyword if not required:

![image](https://github.com/isledecomp/isle/assets/1135351/88089d3c-65e1-49a5-bc5e-5a0dc81e0068)

![image](https://github.com/isledecomp/isle/assets/1135351/f7a50ca9-ec43-4698-8c20-d34c7e39dcdc)

The alpha code base also suggests that the keyword has not been used most of the time in cases where it is redundant, so I believe it's a good idea to enforce the consistency using `clang-tidy`.