### PR TITLE
More legoracers functions

### DIFF
--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -38,7 +38,7 @@ public:
 		override;                   // vtable+0x98
 	MxResult VTable0x9c() override; // vtable+0x9c
 
-	virtual void FUN_10080590();
+	virtual void FUN_10080590(float);
 
 	// FUNCTION: LEGO1 0x10012bb0
 	virtual void FUN_10012bb0(float p_unk0x14) { m_unk0x14 = p_unk0x14; }

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -5,7 +5,7 @@
 #include "legoracemap.h"
 
 #define LEGORACECAR_UNKNOWN_0 0
-#define LEGORACECAR_UNKNOWN_1 1 // name guessed
+#define LEGORACECAR_UNKNOWN_1 1
 #define LEGORACECAR_KICK1 2 // name guessed
 #define LEGORACECAR_KICK2 4 // name validated by BETA10 0x100cb659
 

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -4,7 +4,8 @@
 #include "legocarraceactor.h"
 #include "legoracemap.h"
 
-#define LEGORACECAR_UNKNOWN_STATE 0
+#define LEGORACECAR_UNKNOWN_0 0
+#define LEGORACECAR_UNKNOWN_1 1 // name guessed
 #define LEGORACECAR_KICK1 2 // name guessed
 #define LEGORACECAR_KICK2 4 // name validated by BETA10 0x100cb659
 
@@ -86,9 +87,12 @@ private:
 	LegoPathBoundary* m_unk0x7c;    // 0x7c
 
 	static EdgeReference g_edgeReferences[];
-	static const SkeletonKickPhase g_skeletonKickPhases[]; // TODO: better name
-
+	static const SkeletonKickPhase g_skeletonKickPhases[];
+	static const char* g_strSpeedCopy;
+	static const char* g_srt001ra;
 	static const char* g_soundSkel3;
+	static MxS32 g_unk0x100f0b88;
+	static MxBool g_unk0x100f0b8c;
 };
 
 #endif // LEGORACERS_H

--- a/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocarraceactor.cpp
@@ -28,7 +28,7 @@ LegoCarRaceActor::LegoCarRaceActor()
 }
 
 // STUB: LEGO1 0x10080590
-void LegoCarRaceActor::FUN_10080590()
+void LegoCarRaceActor::FUN_10080590(float)
 {
 }
 

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -65,7 +65,8 @@ const SkeletonKickPhase LegoRaceCar::g_skeletonKickPhases[] = {
 };
 
 // GLOBAL: LEGO1 0x100f0b10
-const char* LegoRaceCar::g_strSpeedCopy = g_strSPEED;
+// STRING: LEGO1 0x100f09cc
+const char* LegoRaceCar::g_strSpeedCopy = "SPEED";
 
 // GLOBAL: LEGO1 0x100f0b6c
 // STRING: LEGO1 0x100f08c4
@@ -81,7 +82,7 @@ int LegoRaceCar::g_unk0x100f0b88 = 0;
 
 // GLOBAL: LEGO1 0x100f0b8c
 // GLOBAL: BETA10 0x101f5f98
-MxBool LegoRaceCar::g_unk0x100f0b8c = FALSE;
+MxBool LegoRaceCar::g_unk0x100f0b8c = TRUE;
 
 // FUNCTION: LEGO1 0x10012950
 LegoRaceCar::LegoRaceCar()

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -279,14 +279,14 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 // FUNCTION: BETA10 0x100cb88a
 void LegoRaceCar::VTable0x70(float p_float)
 {
-	if (m_userNavFlag != 0 && (m_userState == LEGORACECAR_KICK1 || m_userState == LEGORACECAR_KICK2)) {
+	if (m_userNavFlag && (m_userState == LEGORACECAR_KICK1 || m_userState == LEGORACECAR_KICK2)) {
 		FUN_10012ff0(p_float);
 		return;
 	}
 
 	LegoCarRaceActor::VTable0x70(p_float);
 
-	if (m_userNavFlag != 0 && m_userState == LEGORACECAR_UNKNOWN_1) {
+	if (m_userNavFlag && m_userState == LEGORACECAR_UNKNOWN_1) {
 		if (HandleSkeletonKicks(p_float)) {
 			return;
 		}
@@ -295,7 +295,7 @@ void LegoRaceCar::VTable0x70(float p_float)
 	if (LegoCarRaceActor::m_unk0x0c == 1) {
 		FUN_1005d4b0();
 
-		if (m_userNavFlag == 0) {
+		if (!m_userNavFlag) {
 			FUN_10080590(p_float);
 			return;
 		}

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -78,7 +78,7 @@ const char* LegoRaceCar::g_soundSkel3 = "skel3";
 
 // GLOBAL: LEGO1 0x100f0b88
 // GLOBAL: BETA10 0x101f5f94
-int LegoRaceCar::g_unk0x100f0b88 = 0;
+MxS32 LegoRaceCar::g_unk0x100f0b88 = 0;
 
 // GLOBAL: LEGO1 0x100f0b8c
 // GLOBAL: BETA10 0x101f5f98
@@ -310,12 +310,12 @@ void LegoRaceCar::VTable0x70(float p_float)
 
 		if (m_sound) {
 			// pitches up the engine sound based on the velocity
-			if (0.83 * maximumSpeed < absoluteSpeed) {
+			if (absoluteSpeed > 0.83 * maximumSpeed) {
 				m_frequencyFactor = 1.9f;
 			}
 			else {
 				// this value seems to simulate RPM based on the gear
-				int gearRpmFactor = (int) (6.0 * absoluteSpeed) % 100;
+				MxS32 gearRpmFactor = (MxS32) (6.0 * absoluteSpeed) % 100;
 				m_frequencyFactor = gearRpmFactor / 80.0 + 0.7;
 			}
 		}
@@ -325,7 +325,7 @@ void LegoRaceCar::VTable0x70(float p_float)
 			g_unk0x100f0b8c = FALSE;
 		}
 
-		if (5000.0f < p_float - g_unk0x100f0b88 && !g_unk0x100f0b8c) {
+		if (p_float - g_unk0x100f0b88 > 5000.0f && !g_unk0x100f0b8c) {
 			SoundManager()->GetCacheSoundManager()->Play(g_srt001ra, NULL, 0);
 			g_unk0x100f0b8c = TRUE;
 		}

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -5,6 +5,7 @@
 #include "define.h"
 #include "legocachesoundmanager.h"
 #include "legocameracontroller.h"
+#include "legonavcontroller.h"
 #include "legorace.h"
 #include "legosoundmanager.h"
 #include "misc.h"
@@ -12,6 +13,7 @@
 #include "mxmisc.h"
 #include "mxnotificationmanager.h"
 #include "mxutilities.h"
+#include "mxvariabletable.h"
 #include "raceskel.h"
 
 DECOMP_SIZE_ASSERT(EdgeReference, 0x08)
@@ -62,9 +64,24 @@ const SkeletonKickPhase LegoRaceCar::g_skeletonKickPhases[] = {
 	{&LegoRaceCar::g_edgeReferences[3], 0.8, 0.9, LEGORACECAR_KICK2},
 };
 
+// GLOBAL: LEGO1 0x100f0b10
+const char* LegoRaceCar::g_strSpeedCopy = g_strSPEED;
+
+// GLOBAL: LEGO1 0x100f0b6c
+// STRING: LEGO1 0x100f08c4
+const char* LegoRaceCar::g_srt001ra = "srt001ra";
+
 // GLOBAL: LEGO1 0x100f0b70
 // STRING: LEGO1 0x100f08bc
 const char* LegoRaceCar::g_soundSkel3 = "skel3";
+
+// GLOBAL: LEGO1 0x100f0b88
+// GLOBAL: BETA10 0x101f5f94
+int LegoRaceCar::g_unk0x100f0b88 = 0;
+
+// GLOBAL: LEGO1 0x100f0b8c
+// GLOBAL: BETA10 0x101f5f98
+MxBool LegoRaceCar::g_unk0x100f0b8c = FALSE;
 
 // FUNCTION: LEGO1 0x10012950
 LegoRaceCar::LegoRaceCar()
@@ -188,7 +205,7 @@ void LegoRaceCar::FUN_10012ff0(float p_param)
 				m_boundary = m_unk0x7c;
 			}
 
-			m_userState = LEGORACECAR_UNKNOWN_STATE;
+			m_userState = LEGORACECAR_UNKNOWN_0;
 		}
 		else if (a->GetAnimTreePtr()->GetCamAnim()) {
 			MxMatrix transformationMatrix;
@@ -257,10 +274,61 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 	return TRUE;
 }
 
-// STUB: LEGO1 0x100131f0
+// FUNCTION: LEGO1 0x100131f0
+// FUNCTION: BETA10 0x100cb88a
 void LegoRaceCar::VTable0x70(float p_float)
 {
-	// TODO
+	if (m_userNavFlag != 0 && (m_userState == LEGORACECAR_KICK1 || m_userState == LEGORACECAR_KICK2)) {
+		FUN_10012ff0(p_float);
+		return;
+	}
+
+	LegoCarRaceActor::VTable0x70(p_float);
+
+	if (m_userNavFlag != 0 && m_userState == LEGORACECAR_UNKNOWN_1) {
+		if (HandleSkeletonKicks(p_float)) {
+			return;
+		}
+	}
+
+	if (LegoCarRaceActor::m_unk0x0c == 1) {
+		FUN_1005d4b0();
+
+		if (m_userNavFlag == 0) {
+			FUN_10080590(p_float);
+			return;
+		}
+
+		float absoluteSpeed = abs(m_worldSpeed);
+		float maximumSpeed = NavController()->GetMaxLinearVel();
+		char buffer[200];
+
+		sprintf(buffer, "%g", absoluteSpeed / maximumSpeed);
+
+		VariableTable()->SetVariable(g_strSpeedCopy, buffer);
+
+		if (m_sound) {
+			// pitches up the engine sound based on the velocity
+			if (0.83 * maximumSpeed < absoluteSpeed) {
+				m_frequencyFactor = 1.9f;
+			}
+			else {
+				// this value seems to simulate RPM based on the gear
+				int gear_rpm_factor = (int) (6.0 * absoluteSpeed) % 100;
+				m_frequencyFactor = gear_rpm_factor / 80.0 + 0.7;
+			}
+		}
+
+		if (absoluteSpeed != 0.0f) {
+			g_unk0x100f0b88 = p_float;
+			g_unk0x100f0b8c = FALSE;
+		}
+
+		if (5000.0f < p_float - g_unk0x100f0b88 && !g_unk0x100f0b8c) {
+			SoundManager()->GetCacheSoundManager()->Play(g_srt001ra, NULL, 0);
+			g_unk0x100f0b8c = TRUE;
+		}
+	}
 }
 
 // STUB: LEGO1 0x100133c0

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -315,8 +315,8 @@ void LegoRaceCar::VTable0x70(float p_float)
 			}
 			else {
 				// this value seems to simulate RPM based on the gear
-				int gear_rpm_factor = (int) (6.0 * absoluteSpeed) % 100;
-				m_frequencyFactor = gear_rpm_factor / 80.0 + 0.7;
+				int gearRpmFactor = (int) (6.0 * absoluteSpeed) % 100;
+				m_frequencyFactor = gearRpmFactor / 80.0 + 0.7;
 			}
 		}
 


### PR DESCRIPTION
Matches to 100 %.

There is one minor detail where I'm unsure whether it is an issue or not:
```c++
// GLOBAL: LEGO1 0x100f0b10
// STRING: LEGO1 0x100f09cc
const char* LegoRaceCar::g_strSpeedCopy = "SPEED";
```
points at the same string as the following string in `define.cpp`:
```c++
// GLOBAL: LEGO1 0x101020b8
// STRING: LEGO1 0x100f09cc
const char* g_strSPEED = "SPEED";
```
However, I first tried
```c++
// GLOBAL: LEGO1 0x100f0b10
const char* LegoRaceCar::g_strSpeedCopy = g_strSPEED;
```
which led to an datacmp error `initialized : uninitialized`. Not sure if the latter syntax is not allowed in C++ or if datacmp does not correctly detect the latter string.