### PR TITLE
Implement/match `LegoRaceCar::VTable0x94`

### DIFF
--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -86,6 +86,7 @@ public:
 
 	// FUNCTION: BETA10 0x1000f2f0
 	LegoROI* GetROI() { return m_roi; }
+
 	MxU8 GetType() { return m_type; }
 	MxBool GetCameraFlag() { return m_cameraFlag; }
 

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -83,6 +83,8 @@ public:
 	MxBool GetFlagsIsSet(MxU8 p_flag) { return m_flags & p_flag; }
 	MxU8 GetFlags() { return m_flags; }
 	MxFloat GetWorldSpeed() { return m_worldSpeed; }
+
+	// FUNCTION: BETA10 0x1000f2f0
 	LegoROI* GetROI() { return m_roi; }
 	MxU8 GetType() { return m_type; }
 	MxBool GetCameraFlag() { return m_cameraFlag; }

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -13,6 +13,8 @@ struct LegoPathEdgeContainer;
 struct LegoUnknown100db7f4;
 class LegoWEEdge;
 
+extern MxLong g_unk0x100f3308;
+
 // VTABLE: LEGO1 0x100d6e28
 // SIZE 0x154
 class LegoPathActor : public LegoActor {

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -129,6 +129,7 @@ public:
 
 	// FUNCTION: BETA10 0x1001c860
 	MxU32 GetState() { return m_state; }
+
 	LegoPathController* GetController() { return m_controller; }
 	MxBool GetCollideBox() { return m_collideBox; }
 
@@ -136,6 +137,7 @@ public:
 
 	// FUNCTION: BETA10 0x10013430
 	void SetState(MxU32 p_state) { m_state = p_state; }
+
 	void SetController(LegoPathController* p_controller) { m_controller = p_controller; }
 
 	// SYNTHETIC: LEGO1 0x1002d800

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -124,11 +124,15 @@ public:
 	virtual void VTable0xc8(MxU8 p_unk0x148) { m_unk0x148 = p_unk0x148; } // vtable+0xc8
 
 	LegoPathBoundary* GetBoundary() { return m_boundary; }
+
+	// FUNCTION: BETA10 0x1001c860
 	MxU32 GetState() { return m_state; }
 	LegoPathController* GetController() { return m_controller; }
 	MxBool GetCollideBox() { return m_collideBox; }
 
 	void SetBoundary(LegoPathBoundary* p_boundary) { m_boundary = p_boundary; }
+
+	// FUNCTION: BETA10 0x10013430
 	void SetState(MxU32 p_state) { m_state = p_state; }
 	void SetController(LegoPathController* p_controller) { m_controller = p_controller; }
 

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -102,7 +102,7 @@ private:
 	static MxLong g_timeLastSoundPlayed;
 	static MxS32 g_unk0x100f0b88;
 	static MxBool g_unk0x100f0b8c;
-	static Mx3DPointFloat g_vector020;
+	static Mx3DPointFloat g_unk0x10102af0;
 };
 
 #endif // LEGORACERS_H

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -102,7 +102,6 @@ private:
 	static MxLong g_timeLastSoundPlayed;
 	static MxS32 g_unk0x100f0b88;
 	static MxBool g_unk0x100f0b8c;
-	static MxLong g_unk0x100f3308;
 	static Mx3DPointFloat g_vector020;
 };
 

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -88,11 +88,22 @@ private:
 
 	static EdgeReference g_edgeReferences[];
 	static const SkeletonKickPhase g_skeletonKickPhases[];
-	static const char* g_strSpeedCopy;
+	static const char* g_strSpeed;
+	static const char* g_srtsl18to29[];
+	static const char* g_srtsl6to10[];
+	static const char* g_emptySoundKeyList[];
+	static const char* g_srtrh[];
 	static const char* g_srt001ra;
 	static const char* g_soundSkel3;
+	static MxU32 g_srtsl18to29Index;
+	static MxU32 g_srtsl6to10Index;
+	static MxU32 g_emptySoundKeyListIndex;
+	static MxU32 g_srtrhIndex;
+	static MxLong g_timeLastSoundPlayed;
 	static MxS32 g_unk0x100f0b88;
 	static MxBool g_unk0x100f0b8c;
+	static MxLong g_unk0x100f3308;
+	static Mx3DPointFloat g_vector020;
 };
 
 #endif // LEGORACERS_H

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -103,13 +103,13 @@ const char* LegoRaceCar::g_srt001ra = "srt001ra";
 const char* LegoRaceCar::g_soundSkel3 = "skel3";
 
 // GLOBAL: LEGO1 0x100f0b74
-undefined4 LegoRaceCar::g_srtsl18to29Index = 0;
+MxU32 LegoRaceCar::g_srtsl18to29Index = 0;
 
 // GLOBAL: LEGO1 0x100f0b78
-undefined4 LegoRaceCar::g_srtsl6to10Index = 0;
+MxU32 LegoRaceCar::g_srtsl6to10Index = 0;
 
 // GLOBAL: LEGO1 0x100f0b7c
-undefined4 LegoRaceCar::g_emptySoundKeyListIndex = 0;
+MxU32 LegoRaceCar::g_emptySoundKeyListIndex = 0;
 
 // GLOBAL: LEGO1 0x100f0b80
 MxU32 LegoRaceCar::g_srtrhIndex = 0;

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -127,7 +127,7 @@ MxBool LegoRaceCar::g_unk0x100f0b8c = TRUE;
 
 // Initialized at LEGO1 0x10012db0
 // GLOBAL: LEGO1 0x10102af0
-Mx3DPointFloat LegoRaceCar::g_vector020 = Mx3DPointFloat(0.0f, 2.0f, 0.0f);
+Mx3DPointFloat LegoRaceCar::g_unk0x10102af0 = Mx3DPointFloat(0.0f, 2.0f, 0.0f);
 
 // FUNCTION: LEGO1 0x10012950
 LegoRaceCar::LegoRaceCar()
@@ -391,7 +391,7 @@ MxResult LegoRaceCar::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 			MxMatrix matr;
 			matr = roi->GetLocal2World();
 
-			Vector3(matr[3]).Add(g_vector020);
+			Vector3(matr[3]).Add(g_unk0x10102af0);
 			roi->FUN_100a58f0(matr);
 
 			p_actor->SetState(2);
@@ -400,8 +400,7 @@ MxResult LegoRaceCar::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 		if (m_userNavFlag) {
 			MxBool actorIsStuds = strcmpi(p_actor->GetROI()->GetName(), "studs") == 0;
 			MxBool actorIsRhoda = strcmpi(p_actor->GetROI()->GetName(), "rhoda") == 0;
-			MxTimer* timer = Timer();
-			MxLong time = timer->GetTime();
+			MxLong time = Timer()->GetTime();
 
 			const char* soundKey = NULL;
 			MxLong timeElapsed = time - g_timeLastSoundPlayed;

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -125,11 +125,6 @@ MxS32 LegoRaceCar::g_unk0x100f0b88 = 0;
 // GLOBAL: BETA10 0x101f5f98
 MxBool LegoRaceCar::g_unk0x100f0b8c = TRUE;
 
-// Not sure why the next two are so far away from the rest in address space
-
-// GLOBAL: LEGO1 0x100f3308
-MxLong LegoRaceCar::g_unk0x100f3308 = 0;
-
 // Initialized at LEGO1 0x10012db0
 // GLOBAL: LEGO1 0x10102af0
 Mx3DPointFloat LegoRaceCar::g_vector020 = Mx3DPointFloat(0.0f, 2.0f, 0.0f);

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -12,6 +12,7 @@
 #include "mxdebug.h"
 #include "mxmisc.h"
 #include "mxnotificationmanager.h"
+#include "mxtimer.h"
 #include "mxutilities.h"
 #include "mxvariabletable.h"
 #include "raceskel.h"
@@ -66,7 +67,32 @@ const SkeletonKickPhase LegoRaceCar::g_skeletonKickPhases[] = {
 
 // GLOBAL: LEGO1 0x100f0b10
 // STRING: LEGO1 0x100f09cc
-const char* LegoRaceCar::g_strSpeedCopy = "SPEED";
+const char* LegoRaceCar::g_strSpeed = "SPEED";
+
+// GLOBAL: LEGO1 0x100f0b18
+const char* LegoRaceCar::g_srtsl18to29[] = {
+	"srt018sl",
+	"srt019sl",
+	"srt020sl",
+	"srt021sl",
+	"srt022sl",
+	"srt023sl",
+	"srt024sl",
+	"srt025sl",
+	"srt026sl",
+	"srt027sl",
+	"srt028sl",
+	"srt029sl"
+};
+
+// GLOBAL: LEGO1 0x100f0b48
+const char* LegoRaceCar::g_srtsl6to10[] = {"srt006sl", "srt007sl", "srt008sl", "srt009sl", "srt010sl"};
+
+// GLOBAL: LEGO1 0x100f0b5c
+const char* LegoRaceCar::g_emptySoundKeyList[] = {NULL};
+
+// GLOBAL: LEGO1 0x100f0b60
+const char* LegoRaceCar::g_srtrh[] = {"srt004rh", "srt005rh", "srt006rh"};
 
 // GLOBAL: LEGO1 0x100f0b6c
 // STRING: LEGO1 0x100f08c4
@@ -76,6 +102,21 @@ const char* LegoRaceCar::g_srt001ra = "srt001ra";
 // STRING: LEGO1 0x100f08bc
 const char* LegoRaceCar::g_soundSkel3 = "skel3";
 
+// GLOBAL: LEGO1 0x100f0b74
+undefined4 LegoRaceCar::g_srtsl18to29Index = 0;
+
+// GLOBAL: LEGO1 0x100f0b78
+undefined4 LegoRaceCar::g_srtsl6to10Index = 0;
+
+// GLOBAL: LEGO1 0x100f0b7c
+undefined4 LegoRaceCar::g_emptySoundKeyListIndex = 0;
+
+// GLOBAL: LEGO1 0x100f0b80
+MxU32 LegoRaceCar::g_srtrhIndex = 0;
+
+// GLOBAL: LEGO1 0x100f0b84
+MxLong LegoRaceCar::g_timeLastSoundPlayed = 0;
+
 // GLOBAL: LEGO1 0x100f0b88
 // GLOBAL: BETA10 0x101f5f94
 MxS32 LegoRaceCar::g_unk0x100f0b88 = 0;
@@ -83,6 +124,15 @@ MxS32 LegoRaceCar::g_unk0x100f0b88 = 0;
 // GLOBAL: LEGO1 0x100f0b8c
 // GLOBAL: BETA10 0x101f5f98
 MxBool LegoRaceCar::g_unk0x100f0b8c = TRUE;
+
+// Not sure why the next two are so far away from the rest in address space
+
+// GLOBAL: LEGO1 0x100f3308
+MxLong LegoRaceCar::g_unk0x100f3308 = 0;
+
+// Initialized at LEGO1 0x10012db0
+// GLOBAL: LEGO1 0x10102af0
+Mx3DPointFloat LegoRaceCar::g_vector020 = Mx3DPointFloat(0.0f, 2.0f, 0.0f);
 
 // FUNCTION: LEGO1 0x10012950
 LegoRaceCar::LegoRaceCar()
@@ -260,7 +310,6 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 		MxTrace(
 			// STRING: BETA10 0x101f64c8
 			"Got kicked in boundary %s %d %g:%g %g\n",
-			// TODO: same as in above comparison
 			m_boundary->GetName(),
 			skeletonCurAnimPosition,
 			skeletonCurAnimDuration,
@@ -306,7 +355,7 @@ void LegoRaceCar::VTable0x70(float p_float)
 
 		sprintf(buffer, "%g", absoluteSpeed / maximumSpeed);
 
-		VariableTable()->SetVariable(g_strSpeedCopy, buffer);
+		VariableTable()->SetVariable(g_strSpeed, buffer);
 
 		if (m_sound) {
 			// pitches up the engine sound based on the velocity
@@ -332,11 +381,80 @@ void LegoRaceCar::VTable0x70(float p_float)
 	}
 }
 
-// STUB: LEGO1 0x100133c0
+// FUNCTION: LEGO1 0x100133c0
+// FUNCTION: BETA10 0x100cbb84
 MxResult LegoRaceCar::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 {
-	// TODO
-	return 0;
+	if (!p_actor->GetUserNavFlag()) {
+		if (p_actor->GetState()) {
+			return FAILURE;
+		}
+
+		if (p_bool) {
+			LegoROI* roi = p_actor->GetROI(); // name verified by BETA10 0x100cbbf5
+			assert(roi);
+			MxMatrix matr;
+			matr = roi->GetLocal2World();
+
+			Vector3(matr[3]).Add(g_vector020);
+			roi->FUN_100a58f0(matr);
+
+			p_actor->SetState(2);
+		}
+
+		if (m_userNavFlag) {
+			MxBool actorIsStuds = strcmpi(p_actor->GetROI()->GetName(), "studs") == 0;
+			MxBool actorIsRhoda = strcmpi(p_actor->GetROI()->GetName(), "rhoda") == 0;
+			MxTimer* timer = Timer();
+			MxLong time = timer->GetTime();
+
+			const char* soundKey = NULL;
+			MxLong timeElapsed = time - g_timeLastSoundPlayed;
+
+			if (timeElapsed > 3000) {
+				if (p_bool) {
+					if (actorIsStuds) {
+						soundKey = g_srtsl18to29[g_srtsl18to29Index++];
+						if (g_srtsl18to29Index >= sizeOfArray(g_srtsl18to29)) {
+							g_srtsl18to29Index = 0;
+						}
+					}
+					else if (actorIsRhoda) {
+						soundKey = g_emptySoundKeyList[g_emptySoundKeyListIndex++];
+						if (g_emptySoundKeyListIndex >= sizeOfArray(g_emptySoundKeyList)) {
+							g_emptySoundKeyListIndex = 0;
+						}
+					}
+				}
+				else {
+					if (actorIsStuds) {
+						soundKey = g_srtsl6to10[g_srtsl6to10Index++];
+						if (g_srtsl6to10Index >= sizeOfArray(g_srtsl6to10)) {
+							g_srtsl6to10Index = 0;
+						}
+					}
+					else if (actorIsRhoda) {
+						soundKey = g_srtrh[g_srtrhIndex++];
+						if (g_srtrhIndex >= sizeOfArray(g_srtrh)) {
+							g_srtrhIndex = 0;
+						}
+					}
+				}
+
+				if (soundKey) {
+					SoundManager()->GetCacheSoundManager()->Play(soundKey, NULL, FALSE);
+					g_timeLastSoundPlayed = g_unk0x100f3308 = time;
+				}
+			}
+
+			if (p_bool && m_worldSpeed != 0) {
+				return SUCCESS;
+			}
+
+			return FAILURE;
+		}
+	}
+	return SUCCESS;
 }
 
 // STUB: LEGO1 0x10013600

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -62,6 +62,7 @@ public:
 
 	// FUNCTION: BETA10 0x1000f320
 	const LegoChar* GetName() const { return m_name; }
+
 	LegoEntity* GetEntity() { return m_entity; }
 
 	void SetEntity(LegoEntity* p_entity) { m_entity = p_entity; }

--- a/LEGO1/lego/sources/roi/legoroi.h
+++ b/LEGO1/lego/sources/roi/legoroi.h
@@ -60,6 +60,7 @@ public:
 	);
 	static LegoBool FUN_100a9cf0(const LegoChar* p_param, unsigned char* paletteEntries, LegoU32 p_numEntries);
 
+	// FUNCTION: BETA10 0x1000f320
 	const LegoChar* GetName() const { return m_name; }
 	LegoEntity* GetEntity() { return m_entity; }
 

--- a/LEGO1/mxgeometry/mxmatrix.h
+++ b/LEGO1/mxgeometry/mxmatrix.h
@@ -16,6 +16,7 @@ public:
 
 	MxMatrix(const Matrix4& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
 
+	// FUNCTION: BETA10 0x10010860
 	float* operator[](int idx) { return m_data[idx]; }
 	const float* operator[](int idx) const { return m_data[idx]; }
 

--- a/LEGO1/mxgeometry/mxmatrix.h
+++ b/LEGO1/mxgeometry/mxmatrix.h
@@ -18,6 +18,7 @@ public:
 
 	// FUNCTION: BETA10 0x10010860
 	float* operator[](int idx) { return m_data[idx]; }
+
 	const float* operator[](int idx) const { return m_data[idx]; }
 
 	// FUNCTION: LEGO1 0x10002850

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -24,6 +24,14 @@ public:
 		}
 	}
 
+	MxLong GetStartTime() { return m_startTime; }
+	MxBool IsRunning() { return m_isRunning; }
+	inline static MxLong GetLastTimeCalculated() { return g_lastTimeCalculated; }
+	inline static MxLong GetLastTimeTimerStarted() { return g_lastTimeTimerStarted; }
+
+	// FUNCTION: BETA10 0x1000f320
+	inline MxLong GetTimeElapsed() { return g_lastTimeCalculated - m_startTime; }
+
 	// SYNTHETIC: LEGO1 0x100ae0d0
 	// MxTimer::`scalar deleting destructor'
 

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -20,22 +20,20 @@ public:
 			return g_lastTimeTimerStarted;
 		}
 		else {
-			return GetTimeElapsed();
+			return GetTimeSinceStart();
 		}
 	}
-
-	MxLong GetStartTime() { return m_startTime; }
-	MxBool IsRunning() { return m_isRunning; }
-	static MxLong GetLastTimeCalculated() { return g_lastTimeCalculated; }
-	static MxLong GetLastTimeTimerStarted() { return g_lastTimeTimerStarted; }
-
-	// FUNCTION: BETA10 0x10017810
-	MxLong GetTimeElapsed() { return g_lastTimeCalculated - m_startTime; }
 
 	// SYNTHETIC: LEGO1 0x100ae0d0
 	// MxTimer::`scalar deleting destructor'
 
 private:
+	// This function appears to be public in BETA10; this function may also be
+	// an older version of GetTime() instead of a private subroutine.
+	// None of this matters for the release build since these functions are inlined.
+	// FUNCTION: BETA10 0x10017810
+	MxLong GetTimeSinceStart() { return g_lastTimeCalculated - m_startTime; }
+
 	MxLong m_startTime; // 0x08
 	MxBool m_isRunning; // 0x0c
 

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -14,13 +14,15 @@ public:
 
 	MxLong GetRealTime();
 
+	// FUNCTION: BETA10 0x10017810
 	MxLong GetTime()
 	{
+		// Note that the BETA10 implementation differs - it only consists of the second branch of this `if` call
 		if (this->m_isRunning) {
 			return g_lastTimeTimerStarted;
 		}
 		else {
-			return GetTimeSinceStart();
+			return g_lastTimeCalculated - this->m_startTime;
 		}
 	}
 
@@ -28,12 +30,6 @@ public:
 	// MxTimer::`scalar deleting destructor'
 
 private:
-	// This function appears to be public in BETA10; this function may also be
-	// an older version of GetTime() instead of a private subroutine.
-	// None of this matters for the release build since these functions are inlined.
-	// FUNCTION: BETA10 0x10017810
-	MxLong GetTimeSinceStart() { return g_lastTimeCalculated - m_startTime; }
-
 	MxLong m_startTime; // 0x08
 	MxBool m_isRunning; // 0x0c
 

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -20,7 +20,7 @@ public:
 			return g_lastTimeTimerStarted;
 		}
 		else {
-			return g_lastTimeCalculated - this->m_startTime;
+			return GetTimeElapsed();
 		}
 	}
 
@@ -29,7 +29,7 @@ public:
 	static MxLong GetLastTimeCalculated() { return g_lastTimeCalculated; }
 	static MxLong GetLastTimeTimerStarted() { return g_lastTimeTimerStarted; }
 
-	// FUNCTION: BETA10 0x1000f320
+	// FUNCTION: BETA10 0x10017810
 	MxLong GetTimeElapsed() { return g_lastTimeCalculated - m_startTime; }
 
 	// SYNTHETIC: LEGO1 0x100ae0d0

--- a/LEGO1/omni/include/mxtimer.h
+++ b/LEGO1/omni/include/mxtimer.h
@@ -26,11 +26,11 @@ public:
 
 	MxLong GetStartTime() { return m_startTime; }
 	MxBool IsRunning() { return m_isRunning; }
-	inline static MxLong GetLastTimeCalculated() { return g_lastTimeCalculated; }
-	inline static MxLong GetLastTimeTimerStarted() { return g_lastTimeTimerStarted; }
+	static MxLong GetLastTimeCalculated() { return g_lastTimeCalculated; }
+	static MxLong GetLastTimeTimerStarted() { return g_lastTimeTimerStarted; }
 
 	// FUNCTION: BETA10 0x1000f320
-	inline MxLong GetTimeElapsed() { return g_lastTimeCalculated - m_startTime; }
+	MxLong GetTimeElapsed() { return g_lastTimeCalculated - m_startTime; }
 
 	// SYNTHETIC: LEGO1 0x100ae0d0
 	// MxTimer::`scalar deleting destructor'

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -39,6 +39,7 @@ public:
 	void FUN_100a58f0(const Matrix4& p_transform);
 	void FUN_100a5a30(const Vector3& p_world_velocity);
 
+	// FUNCTION: BETA10 0x1000fbf0
 	const Matrix4& GetLocal2World() const { return m_local2world; }
 	const float* GetWorldPosition() const { return m_local2world[3]; }
 	const float* GetWorldDirection() const { return m_local2world[2]; }

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -41,6 +41,7 @@ public:
 
 	// FUNCTION: BETA10 0x1000fbf0
 	const Matrix4& GetLocal2World() const { return m_local2world; }
+
 	const float* GetWorldPosition() const { return m_local2world[3]; }
 	const float* GetWorldDirection() const { return m_local2world[2]; }
 	const float* GetWorldUp() const { return m_local2world[1]; }


### PR DESCRIPTION
Most of the remaining discrepancy is due to compiler entropy. I was unable to get the return statements to an exact match (the logic should be correct). Here is the remaining diff:
```
0x100135bd : mov ecx, dword ptr [eax + 4]
0x100135c0 : -mov eax, 0
0x100135c5 : -test dword ptr [ecx + ebp - 0x30], 0x7fffffff
0x100135cd : -jne 0x20
           : +test dword ptr [ecx + esi - 0x30], 0x7fffffff
           : +je 0xc
           : +xor eax, eax
0x100135cf : pop ebp
0x100135d0 : -mov eax, 0xffffffff
0x100135d5 : pop edi
```
As mentioned on Matrix, I encountered a static instance of an `Mx3DPointFloat`:
```
Mx3DPointFloat LegoRaceCar::g_vector020 = Mx3DPointFloat(0.0f, 2.0f, 0.0f);
```
It is being initialised by a dedicated function at `LEGO1 0x10012db0`, though I don't if there is an annotation for this case. From what I can tell, there is no stable debug symbol for this function in the recomp. Currently, it is named `$E49`:
```
(00009C) S_LPROC32: [0001:0004C3C0], Cb: 00000005, Type:             0x17E6, $E49
         Parent: 00000000, End: 000000C8, Next: 00000000
         Debug start: 00000000, Debug end: 00000005
```

Looking forward to your feedback!