### PR TITLE
Implement/match the rest of `LegoRaceCar`, BETA10 improvements

### DIFF
--- a/LEGO1/lego/legoomni/include/legocarraceactor.h
+++ b/LEGO1/lego/legoomni/include/legocarraceactor.h
@@ -60,6 +60,9 @@ public:
 
 	virtual void VTable0x1c(); // vtable+0x1c
 
+	// SYNTHETIC: LEGO1 0x10012c30
+	// LegoCarRaceActor::`vbase destructor'
+
 	// SYNTHETIC: LEGO1 0x10081620
 	// LegoCarRaceActor::`scalar deleting destructor'
 

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -62,6 +62,7 @@ public:
 	virtual void ResetWorldTransform(MxBool p_cameraFlag); // vtable+0x2c
 
 	// FUNCTION: LEGO1 0x10001090
+	// FUNCTION: BETA10 0x10013260
 	virtual void SetWorldSpeed(MxFloat p_worldSpeed) { m_worldSpeed = p_worldSpeed; } // vtable+0x30
 
 	virtual void ClickSound(MxBool p_und);    // vtable+0x34

--- a/LEGO1/lego/legoomni/include/legoraceactor.h
+++ b/LEGO1/lego/legoomni/include/legoraceactor.h
@@ -33,6 +33,9 @@ public:
 	// FUNCTION: LEGO1 0x10014aa0
 	virtual MxResult FUN_10014aa0() { return SUCCESS; }
 
+	// SYNTHETIC: LEGO1 0x10012c10
+	// LegoRaceActor::`vbase destructor'
+
 	// SYNTHETIC: LEGO1 0x10014ac0
 	// LegoRaceActor::`scalar deleting destructor'
 

--- a/LEGO1/lego/legoomni/include/legoracemap.h
+++ b/LEGO1/lego/legoomni/include/legoracemap.h
@@ -21,6 +21,9 @@ public:
 	// LegoRaceMap vtable
 	virtual void FUN_1005d4b0(); // vtable+0x00
 
+	// SYNTHETIC: LEGO1 0x10012c50
+	// LegoRaceMap::`vbase destructor'
+
 	// SYNTHETIC: LEGO1 0x1005d5d0
 	// LegoRaceMap::`scalar deleting destructor'
 

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -79,15 +79,23 @@ public:
 	// LegoRaceCar::`scalar deleting destructor'
 
 private:
-	undefined m_userState;          // 0x54
-	float m_unk0x58;                // 0x58
-	Mx3DPointFloat m_unk0x5c;       // 0x5c
-	LegoAnimActorStruct* m_unk0x70; // 0x70
-	LegoAnimActorStruct* m_unk0x74; // 0x74
-	LegoPathBoundary* m_unk0x78;    // 0x78
-	LegoPathBoundary* m_unk0x7c;    // 0x7c
+	undefined m_userState;    // 0x54
+	float m_unk0x58;          // 0x58
+	Mx3DPointFloat m_unk0x5c; // 0x5c
 
-	static EdgeReference g_skBMap[]; // name verified by BETA10 0x100cbee6
+	// Names verified by BETA10 0x100cb4a9
+	LegoAnimActorStruct* m_skelKick1Anim; // 0x70
+	LegoAnimActorStruct* m_skelKick2Anim; // 0x74
+
+	// Name verified by BETA10 0x100cb4f0
+	LegoPathBoundary* m_kick1B; // 0x78
+
+	// Name verified by BETA10 0x100cb537
+	LegoPathBoundary* m_kick2B; // 0x7c
+
+	// name verified by BETA10 0x100cbee6
+	static EdgeReference g_skBMap[];
+
 	static const SkeletonKickPhase g_skeletonKickPhases[];
 	static const char* g_strSpeed;
 	static const char* g_srtsl18to29[];

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -11,8 +11,9 @@
 
 // SIZE 0x08
 struct EdgeReference {
-	const char* m_name;       // 0x00
-	LegoPathBoundary* m_data; // 0x04
+	const char* m_name; // 0x00
+	// name verified by BETA10 0x100cbee6
+	LegoPathBoundary* m_b; // 0x04
 };
 
 // SIZE 0x10
@@ -86,7 +87,7 @@ private:
 	LegoPathBoundary* m_unk0x78;    // 0x78
 	LegoPathBoundary* m_unk0x7c;    // 0x7c
 
-	static EdgeReference g_edgeReferences[];
+	static EdgeReference g_skBMap[]; // name verified by BETA10 0x100cbee6
 	static const SkeletonKickPhase g_skeletonKickPhases[];
 	static const char* g_strSpeed;
 	static const char* g_srtsl18to29[];

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -33,6 +33,7 @@ DECOMP_SIZE_ASSERT(LegoPathEdgeContainer, 0x3c)
 const char* g_strHIT_WALL_SOUND = "HIT_WALL_SOUND";
 
 // GLOBAL: LEGO1 0x100f3308
+// GLOBAL: BETA10 0x101f1e1c
 MxLong g_unk0x100f3308 = 0;
 
 // FUNCTION: LEGO1 0x1002d700

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -484,9 +484,9 @@ MxResult LegoRaceCar::VTable0x9c()
 
 	if (m_userNavFlag) {
 		result = LegoCarRaceActor::VTable0x9c();
-		MxS32 bVar2 = 0;
 
 		if (m_boundary) {
+			MxS32 bVar2 = 0;
 
 			for (MxS32 i = 0; i < sizeOfArray(g_skBMap); i++) {
 				assert(g_skBMap[i].m_b);

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -22,6 +22,7 @@ DECOMP_SIZE_ASSERT(SkeletonKickPhase, 0x10)
 DECOMP_SIZE_ASSERT(LegoRaceCar, 0x200)
 
 // GLOBAL: LEGO1 0x100f0a20
+// GLOBAL: BETA10 0x101f5e34
 EdgeReference LegoRaceCar::g_skBMap[] = {
 	{// STRING: LEGO1 0x100f0a10
 	 "EDG03_772",
@@ -50,6 +51,7 @@ EdgeReference LegoRaceCar::g_skBMap[] = {
 };
 
 // GLOBAL: LEGO1 0x100f0a50
+// GLOBAL: BETA10 0x101f5e60
 const SkeletonKickPhase LegoRaceCar::g_skeletonKickPhases[] = {
 	{&LegoRaceCar::g_skBMap[0], 0.1, 0.2, LEGORACECAR_KICK2},
 	{&LegoRaceCar::g_skBMap[1], 0.2, 0.3, LEGORACECAR_KICK2},
@@ -70,6 +72,7 @@ const SkeletonKickPhase LegoRaceCar::g_skeletonKickPhases[] = {
 const char* LegoRaceCar::g_strSpeed = "SPEED";
 
 // GLOBAL: LEGO1 0x100f0b18
+// GLOBAL: BETA10 0x101f5f28
 const char* LegoRaceCar::g_srtsl18to29[] = {
 	"srt018sl",
 	"srt019sl",
@@ -86,12 +89,15 @@ const char* LegoRaceCar::g_srtsl18to29[] = {
 };
 
 // GLOBAL: LEGO1 0x100f0b48
+// GLOBAL: BETA10 0x101f5f58
 const char* LegoRaceCar::g_srtsl6to10[] = {"srt006sl", "srt007sl", "srt008sl", "srt009sl", "srt010sl"};
 
 // GLOBAL: LEGO1 0x100f0b5c
+// GLOBAL: BETA10 0x101f5f6c
 const char* LegoRaceCar::g_emptySoundKeyList[] = {NULL};
 
 // GLOBAL: LEGO1 0x100f0b60
+// GLOBAL: BETA10 0x101f5f70
 const char* LegoRaceCar::g_srtrh[] = {"srt004rh", "srt005rh", "srt006rh"};
 
 // GLOBAL: LEGO1 0x100f0b6c
@@ -103,18 +109,23 @@ const char* LegoRaceCar::g_srt001ra = "srt001ra";
 const char* LegoRaceCar::g_soundSkel3 = "skel3";
 
 // GLOBAL: LEGO1 0x100f0b74
+// GLOBAL: BETA10 0x101f5f80
 MxU32 LegoRaceCar::g_srtsl18to29Index = 0;
 
 // GLOBAL: LEGO1 0x100f0b78
+// GLOBAL: BETA10 0x101f5f84
 MxU32 LegoRaceCar::g_srtsl6to10Index = 0;
 
 // GLOBAL: LEGO1 0x100f0b7c
+// GLOBAL: BETA10 0x101f5f88
 MxU32 LegoRaceCar::g_emptySoundKeyListIndex = 0;
 
 // GLOBAL: LEGO1 0x100f0b80
+// GLOBAL: BETA10 0x101f5f8c
 MxU32 LegoRaceCar::g_srtrhIndex = 0;
 
 // GLOBAL: LEGO1 0x100f0b84
+// GLOBAL: BETA10 0x101f5f90
 MxLong LegoRaceCar::g_timeLastSoundPlayed = 0;
 
 // GLOBAL: LEGO1 0x100f0b88
@@ -127,18 +138,19 @@ MxBool LegoRaceCar::g_unk0x100f0b8c = TRUE;
 
 // Initialized at LEGO1 0x10012db0
 // GLOBAL: LEGO1 0x10102af0
+// GLOBAL: BETA10 0x102114c0
 Mx3DPointFloat LegoRaceCar::g_unk0x10102af0 = Mx3DPointFloat(0.0f, 2.0f, 0.0f);
 
 // FUNCTION: LEGO1 0x10012950
 LegoRaceCar::LegoRaceCar()
 {
 	m_userState = 0;
-	m_unk0x70 = 0;
-	m_unk0x74 = 0;
+	m_skelKick1Anim = 0;
+	m_skelKick2Anim = 0;
 	m_unk0x5c.Clear();
 	m_unk0x58 = 0;
-	m_unk0x78 = 0;
-	m_unk0x7c = 0;
+	m_kick1B = 0;
+	m_kick2B = 0;
 	NotificationManager()->Register(this);
 }
 
@@ -155,6 +167,7 @@ MxLong LegoRaceCar::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x10012e60
+// FUNCTION: BETA10 0x100cb191
 void LegoRaceCar::SetWorldSpeed(MxFloat p_worldSpeed)
 {
 	if (!m_userNavFlag) {
@@ -164,11 +177,12 @@ void LegoRaceCar::SetWorldSpeed(MxFloat p_worldSpeed)
 		LegoAnimActor::SetWorldSpeed(p_worldSpeed);
 	}
 	else {
-		m_worldSpeed = p_worldSpeed;
+		LegoEntity::SetWorldSpeed(p_worldSpeed);
 	}
 }
 
 // FUNCTION: LEGO1 0x10012ea0
+// FUNCTION: BETA10 0x100cb220
 void LegoRaceCar::SetMaxLinearVelocity(float p_maxLinearVelocity)
 {
 	if (p_maxLinearVelocity < 0) {
@@ -182,6 +196,7 @@ void LegoRaceCar::SetMaxLinearVelocity(float p_maxLinearVelocity)
 }
 
 // FUNCTION: LEGO1 0x10012ef0
+// FUNCTION: BETA10 0x100cb2aa
 void LegoRaceCar::ParseAction(char* p_extra)
 {
 	char buffer[256];
@@ -195,26 +210,36 @@ void LegoRaceCar::ParseAction(char* p_extra)
 	}
 
 	if (m_userNavFlag) {
-		for (MxU32 i = 0; i < m_animMaps.size(); i++) {
+		MxS32 i;
+
+		for (i = 0; i < m_animMaps.size(); i++) {
+			// It appears that the implementation in BETA10 does not use this variable
 			LegoAnimActorStruct* animMap = m_animMaps[i];
 
 			if (animMap->m_unk0x00 == -1.0f) {
-				m_unk0x70 = animMap;
+				m_skelKick1Anim = animMap;
 			}
 			else if (animMap->m_unk0x00 == -2.0f) {
-				m_unk0x74 = animMap;
+				m_skelKick2Anim = animMap;
 			}
 		}
 
+		assert(m_skelKick1Anim && m_skelKick2Anim);
+
 		// STRING: LEGO1 0x100f0bc4
 		const char* edge0344 = "EDG03_44";
-		m_unk0x78 = currentWorld->FindPathBoundary(edge0344);
+		m_kick1B = currentWorld->FindPathBoundary(edge0344);
+		assert(m_kick1B);
+
 		// STRING: LEGO1 0x100f0bb8
 		const char* edge0354 = "EDG03_54";
-		m_unk0x7c = currentWorld->FindPathBoundary(edge0354);
+		m_kick2B = currentWorld->FindPathBoundary(edge0354);
+		assert(m_kick2B);
 
-		for (MxS32 j = 0; j < sizeOfArray(g_skBMap); j++) {
-			g_skBMap[j].m_b = currentWorld->FindPathBoundary(g_skBMap[j].m_name);
+		for (i = 0; i < sizeOfArray(g_skBMap); i++) {
+			assert(g_skBMap[i].m_name);
+			g_skBMap[i].m_b = currentWorld->FindPathBoundary(g_skBMap[i].m_name);
+			assert(g_skBMap[i].m_b);
 		}
 	}
 }
@@ -227,11 +252,11 @@ void LegoRaceCar::FUN_10012ff0(float p_param)
 	float deltaTime;
 
 	if (m_userState == LEGORACECAR_KICK1) {
-		a = m_unk0x70;
+		a = m_skelKick1Anim;
 	}
 	else {
 		assert(m_userState == LEGORACECAR_KICK2);
-		a = m_unk0x74;
+		a = m_skelKick2Anim;
 	}
 
 	assert(a && a->GetAnimTreePtr() && a->GetAnimTreePtr()->GetCamAnim());
@@ -241,14 +266,14 @@ void LegoRaceCar::FUN_10012ff0(float p_param)
 
 		if (a->GetDuration() <= deltaTime || deltaTime < 0.0) {
 			if (m_userState == LEGORACECAR_KICK1) {
-				LegoEdge** edges = m_unk0x78->GetEdges();
+				LegoEdge** edges = m_kick1B->GetEdges();
 				m_destEdge = (LegoUnknown100db7f4*) (edges[2]);
-				m_boundary = m_unk0x78;
+				m_boundary = m_kick1B;
 			}
 			else {
-				LegoEdge** edges = m_unk0x78->GetEdges();
+				LegoEdge** edges = m_kick1B->GetEdges();
 				m_destEdge = (LegoUnknown100db7f4*) (edges[1]);
-				m_boundary = m_unk0x7c;
+				m_boundary = m_kick2B;
 			}
 
 			m_userState = LEGORACECAR_UNKNOWN_0;
@@ -459,9 +484,9 @@ MxResult LegoRaceCar::VTable0x9c()
 
 	if (m_userNavFlag) {
 		result = LegoCarRaceActor::VTable0x9c();
+		MxS32 bVar2 = 0;
 
 		if (m_boundary) {
-			MxS32 bVar2 = 0;
 
 			for (MxS32 i = 0; i < sizeOfArray(g_skBMap); i++) {
 				assert(g_skBMap[i].m_b);


### PR DESCRIPTION
The implementation of `LegoRaceCar` should be completed with this PR.

I also added some additional BETA10 references and corrections, notably a number of variable names. Unfortunately, these re-introduced the entropy issue in `LegoRaceCar::VTable0x94` - it seems to be one of those functions that just goes back and forth with its register allocation.