### PR TITLE
Ghidra Import: Support virtual inheritance

### DIFF
--- a/tools/ghidra_scripts/lego_util/function_importer.py
+++ b/tools/ghidra_scripts/lego_util/function_importer.py
@@ -215,7 +215,7 @@ class PdbFunctionImporter:
         """Replace the function declaration in Ghidra by the one derived from C++."""
 
         if ghidra_function.hasCustomVariableStorage():
-            # Unfortunately, Ghidra has a bug where setting custom variable storage back to `False`
+            # Unfortunately, calling `ghidra_function.setCustomVariableStorage(False)`
             # leads to two `this` parameters. Therefore, we first need to remove all `this` parameters
             # and then re-generate a new one
             ghidra_function.replaceParameters(
@@ -330,7 +330,7 @@ class PdbFunctionImporter:
         ghidra_function: Function,
     ):
         """
-        Then `this adjust` is non-zero, the pointer type of `this` needs to be replaced by an offset version.
+        When `this adjust` is non-zero, the pointer type of `this` needs to be replaced by an offset version.
         The offset can only be set on a typedef on the pointer. We also must enable custom storage so we can modify
         the auto-generated `this` parameter.
         """

--- a/tools/ghidra_scripts/lego_util/function_importer.py
+++ b/tools/ghidra_scripts/lego_util/function_importer.py
@@ -17,7 +17,7 @@ from lego_util.pdb_extraction import (
     CppStackSymbol,
 )
 from lego_util.ghidra_helper import (
-    add_pointer_type,
+    get_or_add_pointer_type,
     get_ghidra_namespace,
     sanitize_name,
 )
@@ -91,7 +91,10 @@ class PdbFunctionImporter:
         if (
             (not return_type_match)
             and (self.return_type.getLength() > 4)
-            and (add_pointer_type(self.api, self.return_type) == ghidra_return_type)
+            and (
+                get_or_add_pointer_type(self.api, self.return_type)
+                == ghidra_return_type
+            )
             and any(
                 param
                 for param in ghidra_function.getParameters()

--- a/tools/ghidra_scripts/lego_util/pdb_extraction.py
+++ b/tools/ghidra_scripts/lego_util/pdb_extraction.py
@@ -36,6 +36,8 @@ class FunctionSignature:
     return_type: str
     class_type: Optional[str]
     stack_symbols: list[CppStackOrRegisterSymbol]
+    # if non-zero: an offset to the `this` parameter in a __thiscall
+    this_adjust: int
 
 
 @dataclass
@@ -119,6 +121,9 @@ class PdbFunctionExtractor:
 
         call_type = self._call_type_map[function_type["call_type"]]
 
+        # parse as hex number, default to 0
+        this_adjust = int(function_type.get("this_adjust", "0"), 16)
+
         return FunctionSignature(
             original_function_symbol=fn,
             call_type=call_type,
@@ -126,6 +131,7 @@ class PdbFunctionExtractor:
             return_type=function_type["return_type"],
             class_type=class_type,
             stack_symbols=stack_symbols,
+            this_adjust=this_adjust,
         )
 
     def get_function_list(self) -> list[PdbFunction]:

--- a/tools/ghidra_scripts/lego_util/type_importer.py
+++ b/tools/ghidra_scripts/lego_util/type_importer.py
@@ -214,7 +214,7 @@ class PdbTypeImporter:
         class_size: int = type_in_pdb["size"]
         class_name_with_namespace: str = sanitize_name(type_in_pdb["name"])
         if slim_for_vbase:
-            class_name_with_namespace += "::_vbase_slim"
+            class_name_with_namespace += "_vbase_slim"
 
         if class_name_with_namespace in self.handled_structs:
             logger.debug(

--- a/tools/ghidra_scripts/lego_util/type_importer.py
+++ b/tools/ghidra_scripts/lego_util/type_importer.py
@@ -262,19 +262,18 @@ class PdbTypeImporter:
         if slim_for_vbase:
             # Make a "slim" version: shrink the size to the fields that are actually present.
             # This makes a difference when the current class uses virtual inheritance
-
             assert (
                 len(components) > 0
             ), f"Error: {class_name_with_namespace} should not be empty. There must be at least one direct or indirect vbase pointer."
             last_component = components[-1]
             class_size = last_component["offset"] + last_component["type"].getLength()
 
-            self._overwrite_struct(
-                class_name_with_namespace,
-                new_ghidra_struct,
-                class_size,
-                components,
-            )
+        self._overwrite_struct(
+            class_name_with_namespace,
+            new_ghidra_struct,
+            class_size,
+            components,
+        )
 
         logger.info("Finished importing class %s", class_name_with_namespace)
 
@@ -352,7 +351,9 @@ class PdbTypeImporter:
             # Set a default value of -4 for the pointer offset. While this appears to be correct in many cases,
             # it does not always lead to the best decompile. It can be fine-tuned by hand; the next function call
             # makes sure that we don't overwrite this value on re-running the import.
-            ComponentOffsetSettingsDefinition.DEF.setValue(vbase_ghidra_pointer_typedef.getDefaultSettings(), -4)
+            ComponentOffsetSettingsDefinition.DEF.setValue(
+                vbase_ghidra_pointer_typedef.getDefaultSettings(), -4
+            )
 
             vbase_ghidra_pointer_typedef = add_data_type_or_reuse_existing(
                 self.api, vbase_ghidra_pointer_typedef
@@ -400,7 +401,6 @@ class PdbTypeImporter:
             )
 
         for component in components:
-
             offset: int = component["offset"]
             logger.debug(
                 "Adding component %s to class: %s", component, class_name_with_namespace

--- a/tools/ghidra_scripts/lego_util/type_importer.py
+++ b/tools/ghidra_scripts/lego_util/type_importer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Iterator, Optional, TypeVar
 
 # Disable spurious warnings in vscode / pylance
 # pyright: reportMissingModuleSource=false
@@ -7,6 +7,7 @@ from typing import Any, Callable, TypeVar
 # pylint: disable=too-many-return-statements # a `match` would be better, but for now we are stuck with Python 3.9
 # pylint: disable=no-else-return # Not sure why this rule even is a thing, this is great for checking exhaustiveness
 
+from isledecomp.cvdump.types import VirtualBasePointer
 from lego_util.exceptions import (
     ClassOrNamespaceNotFoundInGhidraError,
     TypeNotFoundError,
@@ -56,10 +57,19 @@ class PdbTypeImporter:
     def types(self):
         return self.extraction.compare.cv.types
 
-    def import_pdb_type_into_ghidra(self, type_index: str) -> DataType:
+    def import_pdb_type_into_ghidra(
+        self, type_index: str, slim_for_vbase: bool = False
+    ) -> DataType:
         """
         Recursively imports a type from the PDB into Ghidra.
         @param type_index Either a scalar type like `T_INT4(...)` or a PDB reference like `0x10ba`
+        @param slim_for_vbase If true, the current invocation
+            imports a superclass of some class where virtual inheritance is involved (directly or indirectly).
+            This case requires special handling: Let's say we have `class C: B` and `class B: virtual A`. Then cvdump
+            reports a size for B that includes both B's fields as well as the A contained at an offset within B,
+            which is not the correct structure to be contained in C. Therefore, we need to create a "slim" version of B
+            that fits inside C.
+            This value should always be `False` when the referenced type is not (a pointer to) a class.
         """
         type_index_lower = type_index.lower()
         if type_index_lower.startswith("t_"):
@@ -76,14 +86,19 @@ class PdbTypeImporter:
 
         # follow forward reference (class, struct, union)
         if type_pdb.get("is_forward_ref", False):
-            return self._import_forward_ref_type(type_index_lower, type_pdb)
+            return self._import_forward_ref_type(
+                type_index_lower, type_pdb, slim_for_vbase
+            )
 
         if type_category == "LF_POINTER":
             return add_pointer_type(
-                self.api, self.import_pdb_type_into_ghidra(type_pdb["element_type"])
+                self.api,
+                self.import_pdb_type_into_ghidra(
+                    type_pdb["element_type"], slim_for_vbase
+                ),
             )
         elif type_category in ["LF_CLASS", "LF_STRUCTURE"]:
-            return self._import_class_or_struct(type_pdb)
+            return self._import_class_or_struct(type_pdb, slim_for_vbase)
         elif type_category == "LF_ARRAY":
             return self._import_array(type_pdb)
         elif type_category == "LF_ENUM":
@@ -120,7 +135,10 @@ class PdbTypeImporter:
         return get_ghidra_type(self.api, scalar_cpp_type)
 
     def _import_forward_ref_type(
-        self, type_index, type_pdb: dict[str, Any]
+        self,
+        type_index,
+        type_pdb: dict[str, Any],
+        slim_for_vbase: bool = False,
     ) -> DataType:
         referenced_type = type_pdb.get("udt") or type_pdb.get("modifies")
         if referenced_type is None:
@@ -136,7 +154,7 @@ class PdbTypeImporter:
             type_index,
             referenced_type,
         )
-        return self.import_pdb_type_into_ghidra(referenced_type)
+        return self.import_pdb_type_into_ghidra(referenced_type, slim_for_vbase)
 
     def _import_array(self, type_pdb: dict[str, Any]) -> DataType:
         inner_type = self.import_pdb_type_into_ghidra(type_pdb["array_type"])
@@ -182,12 +200,18 @@ class PdbTypeImporter:
 
         return result
 
-    def _import_class_or_struct(self, type_in_pdb: dict[str, Any]) -> DataType:
+    def _import_class_or_struct(
+        self,
+        type_in_pdb: dict[str, Any],
+        slim_for_vbase: bool = False,
+    ) -> DataType:
         field_list_type: str = type_in_pdb["field_list_type"]
         field_list = self.types.keys[field_list_type.lower()]
 
         class_size: int = type_in_pdb["size"]
         class_name_with_namespace: str = sanitize_name(type_in_pdb["name"])
+        if slim_for_vbase:
+            class_name_with_namespace += "::_vbase_slim"
 
         if class_name_with_namespace in self.handled_structs:
             logger.debug(
@@ -205,11 +229,11 @@ class PdbTypeImporter:
 
         self._get_or_create_namespace(class_name_with_namespace)
 
-        data_type = self._get_or_create_struct_data_type(
+        new_ghidra_struct = self._get_or_create_struct_data_type(
             class_name_with_namespace, class_size
         )
 
-        if (old_size := data_type.getLength()) != class_size:
+        if (old_size := new_ghidra_struct.getLength()) != class_size:
             logger.warning(
                 "Existing class %s had incorrect size %d. Setting to %d...",
                 class_name_with_namespace,
@@ -220,39 +244,172 @@ class PdbTypeImporter:
         logger.info("Adding class data type %s", class_name_with_namespace)
         logger.debug("Class information: %s", type_in_pdb)
 
-        data_type.deleteAll()
-        data_type.growStructure(class_size)
+        components: list[dict[str, Any]] = []
+        components.extend(self._get_components_from_base_classes(field_list))
+        # can be missing when no new fields are declared
+        components.extend(self._get_components_from_members(field_list))
+        components.extend(
+            self._get_components_from_vbase(
+                field_list, class_name_with_namespace, new_ghidra_struct
+            )
+        )
+
+        components.sort(key=lambda c: c["offset"])
+
+        if slim_for_vbase:
+            # Make a "slim" version: shrink the size to the fields that are actually present.
+            # This makes a difference when the current class uses virtual inheritance
+
+            assert (
+                len(components) > 0
+            ), f"Error: {class_name_with_namespace} should not be empty. There must be at least one direct or indirect vbase pointer."
+            last_component = components[-1]
+            class_size = last_component["offset"] + last_component["type"].getLength()
+
+            self._overwrite_struct(
+                class_name_with_namespace,
+                new_ghidra_struct,
+                class_size,
+                components,
+            )
+
+        logger.info("Finished importing class %s", class_name_with_namespace)
+
+        return new_ghidra_struct
+
+    def _get_components_from_base_classes(self, field_list) -> Iterator[dict[str, Any]]:
+        non_virtual_base_classes: dict[str, int] = field_list.get("super", {})
+
+        for super_type, offset in non_virtual_base_classes.items():
+            # If we have virtual inheritance _and_ a non-virtual base class here, we play safe and import slim version.
+            # This is technically not needed if only one of the superclasses uses virtual inheritance, but I am not aware of any instance.
+            import_slim_vbase_version_of_superclass = "vbase" in field_list
+            ghidra_type = self.import_pdb_type_into_ghidra(
+                super_type, slim_for_vbase=import_slim_vbase_version_of_superclass
+            )
+
+            yield {
+                "type": ghidra_type,
+                "offset": offset,
+                "name": "base" if offset == 0 else f"base_{ghidra_type.getName()}",
+            }
+
+    def _get_components_from_members(self, field_list: dict[str, Any]):
+        members: list[dict[str, Any]] = field_list.get("members") or []
+        for member in members:
+            yield member | {"type": self.import_pdb_type_into_ghidra(member["type"])}
+
+    def _get_components_from_vbase(
+        self,
+        field_list: dict[str, Any],
+        class_name_with_namespace: str,
+        current_type: StructureInternal,
+    ) -> Iterator[dict[str, Any]]:
+        vbasepointer: Optional[VirtualBasePointer] = field_list.get("vbase", None)
+
+        if vbasepointer is not None and any(x.direct for x in vbasepointer.bases):
+            vbaseptr_type = add_pointer_type(
+                self.api,
+                self._import_vbaseptr(
+                    current_type, class_name_with_namespace, vbasepointer
+                ),
+            )
+            yield {
+                "type": vbaseptr_type,
+                "offset": vbasepointer.vboffset,
+                "name": "vbase_offset",
+            }
+
+    def _import_vbaseptr(
+        self,
+        current_type: StructureInternal,
+        class_name_with_namespace: str,
+        vbasepointer: VirtualBasePointer,
+    ) -> StructureInternal:
+        pointer_size = 4
+
+        components = [
+            {
+                "offset": 0,
+                "type": add_pointer_type(self.api, current_type),
+                "name": "o_self",
+            }
+        ]
+        for vbase in vbasepointer.bases:
+            vbase_ghidra_type = self.import_pdb_type_into_ghidra(vbase.type)
+
+            components.append(
+                {
+                    "offset": vbase.index * pointer_size,
+                    "type": add_pointer_type(self.api, vbase_ghidra_type),
+                    "name": f"o_{vbase_ghidra_type.getName()}",
+                }
+            )
+            
+        size = len(components) * pointer_size
+
+        new_ghidra_struct = self._get_or_create_struct_data_type(
+            f"{class_name_with_namespace}::VBasePtr", size
+        )
+
+        self._overwrite_struct(
+            f"{class_name_with_namespace}::VBasePtr",
+            new_ghidra_struct,
+            size,
+            components,
+        )
+
+        return new_ghidra_struct
+
+    def _overwrite_struct(
+        self,
+        class_name_with_namespace: str,
+        new_ghidra_struct: StructureInternal,
+        class_size: int,
+        components: list[dict[str, Any]],
+    ):
+        new_ghidra_struct.deleteAll()
+        new_ghidra_struct.growStructure(class_size)
 
         # this case happened e.g. for IUnknown, which linked to an (incorrect) existing library, and some other types as well.
         # Unfortunately, we don't get proper error handling for read-only types.
         # However, we really do NOT want to do this every time because the type might be self-referential and partially imported.
-        if data_type.getLength() != class_size:
-            data_type = self._delete_and_recreate_struct_data_type(
-                class_name_with_namespace, class_size, data_type
+        if new_ghidra_struct.getLength() != class_size:
+            new_ghidra_struct = self._delete_and_recreate_struct_data_type(
+                class_name_with_namespace, class_size, new_ghidra_struct
             )
 
-        # can be missing when no new fields are declared
-        components: list[dict[str, Any]] = field_list.get("members") or []
-
-        super_type = field_list.get("super")
-        if super_type is not None:
-            components.insert(0, {"type": super_type, "offset": 0, "name": "base"})
-
         for component in components:
-            ghidra_type = self.import_pdb_type_into_ghidra(component["type"])
-            logger.debug("Adding component to class: %s", component)
+
+            offset: int = component["offset"]
+            logger.debug(
+                "Adding component %s to class: %s", component, class_name_with_namespace
+            )
 
             try:
-                # for better logs
-                data_type.replaceAtOffset(
-                    component["offset"], ghidra_type, -1, component["name"], None
+                # Make sure there is room for the new structure and that we have no collision.
+                existing_type = new_ghidra_struct.getComponentAt(offset)
+                assert (
+                    existing_type is not None
+                ), f"Struct collision: Offset {offset} in {class_name_with_namespace} is overlapped by another component"
+
+                if existing_type.getDataType().getName() != "undefined":
+                    # collision of structs beginning in the same place -> likely due to unions
+                    logger.warning(
+                        "Struct collision: Offset %d of %s already has a field (likely an inline union)",
+                        offset,
+                        class_name_with_namespace,
+                    )
+
+                new_ghidra_struct.replaceAtOffset(
+                    offset,
+                    component["type"],
+                    -1,  # set to -1 for fixed-size components
+                    component["name"],  # name
+                    None,  # comment
                 )
             except Exception as e:
-                raise StructModificationError(type_in_pdb) from e
-
-        logger.info("Finished importing class %s", class_name_with_namespace)
-
-        return data_type
+                raise StructModificationError(class_name_with_namespace) from e
 
     def _get_or_create_namespace(self, class_name_with_namespace: str):
         colon_split = class_name_with_namespace.split("::")

--- a/tools/isledecomp/isledecomp/cvdump/types.py
+++ b/tools/isledecomp/isledecomp/cvdump/types.py
@@ -230,7 +230,7 @@ class CvdumpTypesParser:
         re.compile(r"\s*Arg list type = (?P<arg_list_type>[\w()]+)$"),
         re.compile(
             r"\s*This adjust = (?P<this_adjust>[\w()]+)$"
-        ),  # TODO: figure out the meaning
+        ),  # By how much the incoming pointers are shifted in virtual inheritance; hex value without `0x` prefix
         re.compile(
             r"\s*Func attr = (?P<func_attr>[\w()]+)$"
         ),  # Only for completeness, is always `none`
@@ -559,7 +559,6 @@ class CvdumpTypesParser:
 
         # virtual base class (direct or indirect)
         elif (match := self.VBCLASS_RE.match(line)) is not None:
-
             virtual_base_pointer = self.keys[self.last_key].setdefault(
                 "vbase",
                 VirtualBasePointer(

--- a/tools/isledecomp/tests/test_cvdump_types.py
+++ b/tools/isledecomp/tests/test_cvdump_types.py
@@ -6,6 +6,9 @@ from isledecomp.cvdump.types import (
     CvdumpTypesParser,
     CvdumpKeyError,
     CvdumpIntegrityError,
+    FieldListItem,
+    VirtualBaseClass,
+    VirtualBasePointer,
 )
 
 TEST_LINES = """
@@ -245,10 +248,111 @@ NESTED,     enum name = JukeBox::JukeBoxScript, UDT(0x00003cc2)
     list[12] = LF_MEMBER, private, type = T_USHORT(0021), offset = 12
         member name = 'm_length'
 
+
+0x4dee : Length = 406, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x15EA
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 3
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1183
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 1
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1468
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 2
+	list[3] = LF_VFUNCTAB, type = 0x2B95
+	list[4] = LF_ONEMETHOD, public, VANILLA, index = 0x15C2, name = 'LegoRaceMap'
+	list[5] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15C3, name = '~LegoRaceMap'
+	list[6] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15C5, name = 'Notify'
+	list[7] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15C4, name = 'ParseAction'
+	list[8] = LF_ONEMETHOD, public, VIRTUAL, index = 0x4DED, name = 'VTable0x70'
+	list[9] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x15C2,
+		vfptr offset = 0, name = 'FUN_1005d4b0'
+	list[10] = LF_MEMBER, private, type = T_UCHAR(0020), offset = 8
+		member name = 'm_parentClass2Field1'
+	list[11] = LF_MEMBER, private, type = T_32PVOID(0403), offset = 12
+		member name = 'm_parentClass2Field2'
+
+0x4def : Length = 34, Leaf = 0x1504 LF_CLASS
+	# members = 21,  field list type 0x4dee, CONSTRUCTOR,
+	Derivation list type 0x0000, VT shape type 0x12a0
+	Size = 436, class name = LegoRaceMap, UDT(0x00004def)
+
 0x4db6 : Length = 30, Leaf = 0x1504 LF_CLASS
     # members = 16,  field list type 0x4db5, CONSTRUCTOR, OVERLOAD,
     Derivation list type 0x0000, VT shape type 0x1266
     Size = 16, class name = MxString, UDT(0x00004db6)
+
+0x5591 : Length = 570, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x15EA
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 3
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1183
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 1
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1468
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 2
+	list[3] = LF_VFUNCTAB, type = 0x4E11
+	list[4] = LF_ONEMETHOD, public, VANILLA, index = 0x1ABD, name = 'LegoCarRaceActor'
+	list[5] = LF_ONEMETHOD, public, VIRTUAL, index = 0x1AE0, name = 'ClassName'
+	list[6] = LF_ONEMETHOD, public, VIRTUAL, index = 0x1AE1, name = 'IsA'
+	list[7] = LF_ONEMETHOD, public, VIRTUAL, index = 0x1ADD, name = 'VTable0x6c'
+	list[8] = LF_ONEMETHOD, public, VIRTUAL, index = 0x1ADB, name = 'VTable0x70'
+	list[9] = LF_ONEMETHOD, public, VIRTUAL, index = 0x1ADA, name = 'SwitchBoundary'
+	list[10] = LF_ONEMETHOD, public, VIRTUAL, index = 0x1ADC, name = 'VTable0x9c'
+	list[11] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x558E,
+		vfptr offset = 0, name = 'FUN_10080590'
+	list[12] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1AD8,
+		vfptr offset = 4, name = 'FUN_10012bb0'
+	list[13] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1AD9,
+		vfptr offset = 8, name = 'FUN_10012bc0'
+	list[14] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1AD8,
+		vfptr offset = 12, name = 'FUN_10012bd0'
+	list[15] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1AD9,
+		vfptr offset = 16, name = 'FUN_10012be0'
+	list[16] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1AD8,
+		vfptr offset = 20, name = 'FUN_10012bf0'
+	list[17] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1AD9,
+		vfptr offset = 24, name = 'FUN_10012c00'
+	list[18] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1ABD,
+		vfptr offset = 28, name = 'VTable0x1c'
+	list[19] = LF_MEMBER, protected, type = T_REAL32(0040), offset = 8
+		member name = 'm_parentClass1Field1'
+	list[25] = LF_ONEMETHOD, public, VIRTUAL, (compgenx), index = 0x15D1, name = '~LegoCarRaceActor'
+
+0x5592 : Length = 38, Leaf = 0x1504 LF_CLASS
+	# members = 26,  field list type 0x5591, CONSTRUCTOR,
+	Derivation list type 0x0000, VT shape type 0x34c7
+	Size = 416, class name = LegoCarRaceActor, UDT(0x00005592)
+
+0x5593 : Length = 638, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x5592, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x4DEF, offset = 32
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1183
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 1
+	list[3] = LF_IVBCLASS, public, indirect base type = 0x1468
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 2
+	list[4] = LF_IVBCLASS, public, indirect base type = 0x15EA
+		virtual base ptr = 0x43E9, vbpoff = 4, vbind = 3
+	list[5] = LF_ONEMETHOD, public, VANILLA, index = 0x15CD, name = 'LegoRaceCar'
+	list[6] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15CE, name = '~LegoRaceCar'
+	list[7] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15D2, name = 'Notify'
+	list[8] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15E8, name = 'ClassName'
+	list[9] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15E9, name = 'IsA'
+	list[10] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15D5, name = 'ParseAction'
+	list[11] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15D3, name = 'SetWorldSpeed'
+	list[12] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15DF, name = 'VTable0x6c'
+	list[13] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15D3, name = 'VTable0x70'
+	list[14] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15DC, name = 'VTable0x94'
+	list[15] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15E5, name = 'SwitchBoundary'
+	list[16] = LF_ONEMETHOD, public, VIRTUAL, index = 0x15DD, name = 'VTable0x9c'
+	list[17] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x15D4,
+		vfptr offset = 32, name = 'SetMaxLinearVelocity'
+	list[18] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x15D4,
+		vfptr offset = 36, name = 'FUN_10012ff0'
+	list[19] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x5588,
+		vfptr offset = 40, name = 'HandleSkeletonKicks'
+	list[20] = LF_MEMBER, private, type = T_UCHAR(0020), offset = 84
+		member name = 'm_childClassField'
+
+0x5594 : Length = 34, Leaf = 0x1504 LF_CLASS
+	# members = 30,  field list type 0x5593, CONSTRUCTOR,
+	Derivation list type 0x0000, VT shape type 0x2d1e
+	Size = 512, class name = LegoRaceCar, UDT(0x000055bb)
 """
 
 
@@ -308,6 +412,31 @@ def test_members(parser: CvdumpTypesParser):
         (8, "m_data", "T_32PRCHAR"),
         (12, "m_length", "T_USHORT"),
     ]
+
+    # LegoRaceCar with multiple superclasses
+    assert parser.get("0x5594").members == [
+        FieldListItem(offset=0, name="vftable", type="T_32PVOID"),
+        FieldListItem(offset=0, name="vftable", type="T_32PVOID"),
+        FieldListItem(offset=8, name="m_parentClass1Field1", type="T_REAL32"),
+        FieldListItem(offset=8, name="m_parentClass2Field1", type="T_UCHAR"),
+        FieldListItem(offset=12, name="m_parentClass2Field2", type="T_32PVOID"),
+        FieldListItem(offset=84, name="m_childClassField", type="T_UCHAR"),
+    ]
+
+
+def test_virtual_base_classes(parser: CvdumpTypesParser):
+    """Make sure that virtual base classes are parsed correctly."""
+
+    lego_car_race_actor = parser.keys.get("0x5591")
+    assert lego_car_race_actor is not None
+    assert lego_car_race_actor["vbase"] == VirtualBasePointer(
+        vboffset=4,
+        bases=[
+            VirtualBaseClass(type="0x1183", index=1, direct=False),
+            VirtualBaseClass(type="0x1468", index=2, direct=False),
+            VirtualBaseClass(type="0x15EA", index=3, direct=True),
+        ],
+    )
 
 
 def test_members_recursive(parser: CvdumpTypesParser):


### PR DESCRIPTION
Here are some of the changes to improve the situation with virtual inhertiance (as best as possible, but with limitations).

For the sake of simplicity, let's say we have three classes A, B, C with `class B: virtual A` and `class C: B`.

* Multiple non-virtual inheritance is now supported (see e.g. `LegoRaceCar`).
* Parsing virtual base class information from the PDB is now supported (with a unit test).
* The reported class sizes in the PDB include "unallocated" space for the virtual base classes:
  * An instance of `B` consists of (in this order)
    * its vtable,
    * vboffset,
    * its own fields,
    * some "unallocated" space to account for an `A` (the exact offset is not specified in the PDB).
  * This causes problems for class `C`, which consists of (in this order)
    * The parts of `B` directly it inherits directly (vtable, vboffset, B's fields),
    * its own fields,
    * space to account for an `A`.
  * Hence, the entirety of `B` does not fit into `A` at offset 0, but only the "allocated" parts.
  * Therefore, a class `B_vbase_slim` is generated as the superclass of `C` which is identical to `B` but does not contain unallocated space.
* Virtual base offsets are now automatically generated whenever a type has a direct virtual superclass (class `B` in the above example).
* The virtual base offsets form their own `struct`. This allows Ghidra to _sometimes_ correctly infer type information.
  * Unfortunately, all the typed base offsets are offset by an additional `-4` — likely because the pointer to the virtual base offsets itself is located at offset `4` within class `B`, and the offsets in the virtual base offset struct are relative to that location.
  * I have used a rather unknown feature of Ghidra to fix this: It is possible to define a *typedef* of a pointer and then declare an offset on it. All of the virtual base pointers receive a default offset of `-4` which is **not** overwritten when re-running the script (so if it turns out to be wrong, it can be fixed by hand permanently).
  * I think I have also observed cases where different offsets need to be used depending on which function you are decompiling. This is another argument in favour of giving the user flexibility here.
* `This adjust` is now supported: Overriding virtual functions on virtual superclasses requires that the input argument is shifted by some value that is encoded in the `This adjust` value in the PDB dump. Functions with a non-zero value of `This adjust` now get their `this` argument type replaced by an offset typedef, similar to the case explained above.
  * This was especially annoying in the past, because Ghidra would always decompile code like `this[-1]->field_0x180`.

I will post some screenshots and examples later. Note that I have not yet commited a version of the shared repository after running this version (so we don't need to rollback in case changes are desired), but I am happy to do so if it facilitates the review.