### PR TITLE
Implement `LegoCarRaceActor::VTable0x70` and `VTable0x1c`

### DIFF
--- a/LEGO1/lego/legoomni/include/carrace.h
+++ b/LEGO1/lego/legoomni/include/carrace.h
@@ -5,10 +5,12 @@
 #include "legorace.h"
 
 // VTABLE: LEGO1 0x100d4b70
+// VTABLE: BETA10 0x101bd5f0
 // SIZE 0x2c
 class CarRaceState : public RaceState {
 public:
 	// FUNCTION: LEGO1 0x1000dd30
+	// FUNCTION: BETA10 0x100a9100
 	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f009c
@@ -16,6 +18,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x1000dd40
+	// FUNCTION: BETA10 0x100a9130
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, CarRaceState::ClassName()) || RaceState::IsA(p_name);
@@ -26,12 +29,14 @@ public:
 };
 
 // VTABLE: LEGO1 0x100d5e50
+// VTABLE: BETA10 0x101be290
 // SIZE 0x154
 class CarRace : public LegoRace {
 public:
 	CarRace();
 
 	// FUNCTION: LEGO1 0x10016b20
+	// FUNCTION: BETA10 0x100c9870
 	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x100f0528
@@ -39,6 +44,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10016b30
+	// FUNCTION: BETA10 0x100c98a0
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, CarRace::ClassName()) || LegoRace::IsA(p_name);

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -34,7 +34,7 @@ public:
 		Vector3& p_v3
 	) override;                                                       // vtable+0x6c
 	void VTable0x70(float p_float) override;                          // vtable+0x70
-	MxS32 VTable0x1c(undefined4 p_param1, LegoEdge* p_edge) override; // vtable+0x1c
+	MxS32 VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edge) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x10081d50
 	// LegoJetskiRaceActor::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -32,8 +32,8 @@ public:
 		float p_f1,
 		float p_f2,
 		Vector3& p_v3
-	) override;                                                       // vtable+0x6c
-	void VTable0x70(float p_float) override;                          // vtable+0x70
+	) override;                                                                // vtable+0x6c
+	void VTable0x70(float p_float) override;                                   // vtable+0x70
 	MxS32 VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edge) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x10081d50

--- a/LEGO1/lego/legoomni/include/legoracespecial.h
+++ b/LEGO1/lego/legoomni/include/legoracespecial.h
@@ -64,7 +64,7 @@ public:
 	// FUNCTION: LEGO1 0x10012c00
 	virtual float FUN_10012c00() { return m_unk0x18; }
 
-	virtual MxS32 VTable0x1c(undefined4 p_param1, LegoEdge* p_edge); // vtable+0x1c
+	virtual MxS32 VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edge); // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x10012c30
 	// LegoCarRaceActor::`vbase destructor'

--- a/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
@@ -12,7 +12,7 @@ LegoJetskiRaceActor::LegoJetskiRaceActor()
 }
 
 // STUB: LEGO1 0x10081120
-MxS32 LegoJetskiRaceActor::VTable0x1c(undefined4 p_param1, LegoEdge* p_edge)
+MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edge)
 {
 	// TODO
 	return 0;

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -256,24 +256,23 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		m_destEdge->FUN_1002ddc0(*m_boundary, local_50);
 		m_destEdge->FUN_1002ddc0(*m_boundary, local_20);
 
-
 		local_3c.EqualsCross(&local_50, m_boundary->GetUnknown0x14());
 		local_78.EqualsCross(m_boundary->GetUnknown0x14(), &local_20);
 
 		local_3c.Unitize();
 		local_78.Unitize();
 
-
 		((Vector3*) &local_3c)->Mul(5.0f);
 		((Vector3*) &local_78)->Mul(5.0f);
 
+		MxResult res = VTable0x80(Vector3(m_roi->GetWorldPosition()), local_3c, local_64, local_78);
 
-		MxResult res = LegoPathActor::VTable0x80(Vector3(m_roi->GetWorldPosition()), local_3c, local_64, local_78);
-		// BETA10 only?
+#ifndef NDEBUG // BETA10 only
 		if (res) {
 			assert(0);
 			return -1;
 		}
+#endif
 
 		// Proceed here
 	}

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -243,29 +243,29 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		Vector3* v2 = m_destEdge->CCWVertex(*m_boundary);
 		assert(v1 && v2);
 
-		Mx3DPointFloat local_64;
-		local_64[0] = (*v1)[0] + ((*v2)[0] - (*v1)[0]) * m_unk0xe4;
-		local_64[1] = (*v1)[1] + ((*v2)[1] - (*v1)[1]) * m_unk0xe4;
-		local_64[2] = (*v1)[2] + ((*v2)[2] - (*v1)[2]) * m_unk0xe4;
+		Mx3DPointFloat point1;
+		point1[0] = (*v1)[0] + ((*v2)[0] - (*v1)[0]) * m_unk0xe4;
+		point1[1] = (*v1)[1] + ((*v2)[1] - (*v1)[1]) * m_unk0xe4;
+		point1[2] = (*v1)[2] + ((*v2)[2] - (*v1)[2]) * m_unk0xe4;
 
-		Mx3DPointFloat local_50;
-		Mx3DPointFloat local_20;
-		Mx3DPointFloat local_3c;
-		Mx3DPointFloat local_78;
+		Mx3DPointFloat point2;
+		Mx3DPointFloat point3;
+		Mx3DPointFloat point4;
+		Mx3DPointFloat point5;
 
-		m_destEdge->FUN_1002ddc0(*m_boundary, local_50);
-		m_destEdge->FUN_1002ddc0(*m_boundary, local_20);
+		m_destEdge->FUN_1002ddc0(*m_boundary, point2);
+		m_destEdge->FUN_1002ddc0(*m_boundary, point3);
 
-		local_3c.EqualsCross(&local_50, m_boundary->GetUnknown0x14());
-		local_78.EqualsCross(m_boundary->GetUnknown0x14(), &local_20);
+		point4.EqualsCross(&point2, m_boundary->GetUnknown0x14());
+		point5.EqualsCross(m_boundary->GetUnknown0x14(), &point3);
 
-		local_3c.Unitize();
-		local_78.Unitize();
+		point4.Unitize();
+		point5.Unitize();
 
-		((Vector3*) &local_3c)->Mul(5.0f);
-		((Vector3*) &local_78)->Mul(5.0f);
+		((Vector3*) &point4)->Mul(5.0f);
+		((Vector3*) &point5)->Mul(5.0f);
 
-		MxResult res = VTable0x80(Vector3(m_roi->GetWorldPosition()), local_3c, local_64, local_78);
+		MxResult res = VTable0x80(Vector3(m_roi->GetWorldPosition()), point4, point1, point5);
 
 #ifndef NDEBUG // BETA10 only
 		if (res) {

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -232,8 +232,53 @@ void LegoCarRaceActor::VTable0x70(float p_float)
 // FUNCTION: BETA10 0x100cdc54
 MxResult LegoCarRaceActor::VTable0x9c()
 {
-	VTable0x1c(m_boundary, m_destEdge);
+	MxS32 iVar4 = VTable0x1c(m_boundary, m_destEdge);
 
+	if (iVar4) {
+		SwitchBoundary(m_boundary, m_destEdge, m_unk0xe4);
+		assert(m_boundary && m_destEdge);
+
+		// variable names verified by BETA10
+		Vector3* v1 = m_destEdge->CWVertex(*m_boundary);
+		Vector3* v2 = m_destEdge->CCWVertex(*m_boundary);
+		assert(v1 && v2);
+
+		Mx3DPointFloat local_64;
+		local_64[0] = (*v1)[0] + ((*v2)[0] - (*v1)[0]) * m_unk0xe4;
+		local_64[1] = (*v1)[1] + ((*v2)[1] - (*v1)[1]) * m_unk0xe4;
+		local_64[2] = (*v1)[2] + ((*v2)[2] - (*v1)[2]) * m_unk0xe4;
+
+		Mx3DPointFloat local_50;
+		Mx3DPointFloat local_20;
+		Mx3DPointFloat local_3c;
+		Mx3DPointFloat local_78;
+
+		m_destEdge->FUN_1002ddc0(*m_boundary, local_50);
+		m_destEdge->FUN_1002ddc0(*m_boundary, local_20);
+
+
+		local_3c.EqualsCross(&local_50, m_boundary->GetUnknown0x14());
+		local_78.EqualsCross(m_boundary->GetUnknown0x14(), &local_20);
+
+		local_3c.Unitize();
+		local_78.Unitize();
+
+
+		((Vector3*) &local_3c)->Mul(5.0f);
+		((Vector3*) &local_78)->Mul(5.0f);
+
+
+		MxResult res = LegoPathActor::VTable0x80(Vector3(m_roi->GetWorldPosition()), local_3c, local_64, local_78);
+		// BETA10 only?
+		if (res) {
+			assert(0);
+			return -1;
+		}
+
+		// Proceed here
+	}
+
+	m_unk0x7c = 0;
 
 	return SUCCESS;
 }

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -277,7 +277,6 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		m_unk0x7c = 0;
 	}
 
-
 	return SUCCESS;
 }
 

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -101,7 +101,7 @@ void LegoCarRaceActor::FUN_10080590(float p_float)
 
 // FUNCTION: LEGO1 0x10080740
 // FUNCTION: BETA10 0x100cece0
-MxS32 LegoCarRaceActor::VTable0x1c(undefined4 p_param1, LegoEdge* p_edge)
+MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edge)
 {
 	Mx3DPointFloat pointUnknown;
 	Mx3DPointFloat destEdgeUnknownVector;
@@ -228,10 +228,13 @@ void LegoCarRaceActor::VTable0x70(float p_float)
 	}
 }
 
-// STUB: LEGO1 0x10080be0
+// FUNCTION: LEGO1 0x10080be0
+// FUNCTION: BETA10 0x100cdc54
 MxResult LegoCarRaceActor::VTable0x9c()
 {
-	// TODO
+	VTable0x1c(m_boundary, m_destEdge);
+
+
 	return SUCCESS;
 }
 

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -12,9 +12,17 @@
 
 DECOMP_SIZE_ASSERT(LegoCarRaceActor, 0x1a0)
 
+// GLOBAL: LEGO1 0x100f0c68
+// STRING: LEGO1 0x100f0c5c
+const char* g_raceState = "RACE_STATE";
+
 // GLOBAL: LEGO1 0x100f7af0
 // STRING: LEGO1 0x100f7ae4
 const char* g_fuel = "FUEL";
+
+// GLOBAL: LEGO1 0x100f0c6c
+// STRING: LEGO1 0x100f0c54
+const char* g_racing = "RACING";
 
 // GLOBAL: LEGO1 0x100f7aec
 MxFloat LegoCarRaceActor::g_unk0x100f7aec = 8.0f;
@@ -200,10 +208,24 @@ void LegoCarRaceActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown
 	LegoPathActor::SwitchBoundary(m_boundary, m_destEdge, m_unk0xe4);
 }
 
-// STUB: LEGO1 0x10080b70
+// FUNCTION: LEGO1 0x10080b70
+// FUNCTION: BETA10 0x1000366b
 void LegoCarRaceActor::VTable0x70(float p_float)
 {
-	// TODO
+	// m_unk0x0c is not an MxBool, there are places where it is set to 2 or higher
+	if (m_unk0x0c == 0) {
+		const char* value = VariableTable()->GetVariable(g_raceState);
+
+		if (strcmpi(value, g_racing) == 0) {
+			m_unk0x0c = 1;
+			m_lastTime = p_float - 1.0f;
+			m_unk0x1c = p_float;
+		}
+	}
+
+	if (m_unk0x0c == 1) {
+		LegoAnimActor::VTable0x70(p_float);
+	}
 }
 
 // STUB: LEGO1 0x10080be0

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -7,7 +7,8 @@
 #include "misc.h"
 #include "mxmisc.h"
 #include "mxvariabletable.h"
-#include "vec.h"
+
+#include <vec.h>
 
 // File name verified by BETA10 0x100cedf7
 
@@ -280,6 +281,7 @@ MxResult LegoCarRaceActor::VTable0x9c()
 }
 
 // STUB: LEGO1 0x10081840
+// FUNCTION: BETA10 0x100cf680
 MxU32 LegoCarRaceActor::VTable0x6c(
 	LegoPathBoundary* p_boundary,
 	Vector3& p_v1,
@@ -289,6 +291,11 @@ MxU32 LegoCarRaceActor::VTable0x6c(
 	Vector3& p_v3
 )
 {
+	// LegoAnimPresenterSet& presenters = p_boundary->GetPresenters();
+
+	// Significant overlap with parent function -> Try to copy-paste LegoPathActor::VTable0x6c here
+	// and see by how much we diverge
+
 	// TODO
 	return 0;
 }

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -7,6 +7,7 @@
 #include "misc.h"
 #include "mxmisc.h"
 #include "mxvariabletable.h"
+#include "vec.h"
 
 // File name verified by BETA10 0x100cedf7
 
@@ -156,9 +157,7 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 			Vector3* v2 = m_destEdge->CWVertex(*m_boundary);
 			assert(v1 && v2);
 
-			pointUnknown[0] = (*v1)[0] + ((*v2)[0] - (*v1)[0]) * m_unk0xe4;
-			pointUnknown[1] = (*v1)[1] + ((*v2)[1] - (*v1)[1]) * m_unk0xe4;
-			pointUnknown[2] = (*v1)[2] + ((*v2)[2] - (*v1)[2]) * m_unk0xe4;
+			LERP3(pointUnknown, *v1, *v2, m_unk0xe4);
 
 			m_destEdge->FUN_1002ddc0(*m_boundary, destEdgeUnknownVector);
 
@@ -232,9 +231,11 @@ void LegoCarRaceActor::VTable0x70(float p_float)
 // FUNCTION: BETA10 0x100cdc54
 MxResult LegoCarRaceActor::VTable0x9c()
 {
-	MxS32 iVar4 = VTable0x1c(m_boundary, m_destEdge);
+	LegoUnknown100db7f4* d = m_destEdge;
 
-	if (iVar4) {
+	if (VTable0x1c(m_boundary, m_destEdge)) {
+		LegoPathBoundary* b = m_boundary;
+
 		SwitchBoundary(m_boundary, m_destEdge, m_unk0xe4);
 		assert(m_boundary && m_destEdge);
 
@@ -244,16 +245,14 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		assert(v1 && v2);
 
 		Mx3DPointFloat point1;
-		point1[0] = (*v1)[0] + ((*v2)[0] - (*v1)[0]) * m_unk0xe4;
-		point1[1] = (*v1)[1] + ((*v2)[1] - (*v1)[1]) * m_unk0xe4;
-		point1[2] = (*v1)[2] + ((*v2)[2] - (*v1)[2]) * m_unk0xe4;
+		LERP3(point1, *v1, *v2, m_unk0xe4);
 
 		Mx3DPointFloat point2;
 		Mx3DPointFloat point3;
 		Mx3DPointFloat point4;
 		Mx3DPointFloat point5;
 
-		m_destEdge->FUN_1002ddc0(*m_boundary, point2);
+		d->FUN_1002ddc0(*b, point2);
 		m_destEdge->FUN_1002ddc0(*m_boundary, point3);
 
 		point4.EqualsCross(&point2, m_boundary->GetUnknown0x14());
@@ -265,7 +264,7 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		((Vector3*) &point4)->Mul(5.0f);
 		((Vector3*) &point5)->Mul(5.0f);
 
-		MxResult res = VTable0x80(Vector3(m_roi->GetWorldPosition()), point4, point1, point5);
+		MxResult res = VTable0x80(m_roi->GetWorldPosition(), point4, point1, point5);
 
 #ifndef NDEBUG // BETA10 only
 		if (res) {

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -274,10 +274,9 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		}
 #endif
 
-		// Proceed here
+		m_unk0x7c = 0;
 	}
 
-	m_unk0x7c = 0;
 
 	return SUCCESS;
 }

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -42,6 +42,7 @@ public:
 	// FUNCTION: BETA10 0x1000fbf0
 	const Matrix4& GetLocal2World() const { return m_local2world; }
 
+	// FUNCTION: BETA10 0x10011750
 	const float* GetWorldPosition() const { return m_local2world[3]; }
 
 	// FUNCTION: BETA10 0x10011780


### PR DESCRIPTION
`VTable0x70` matches to 100 %.

I am somewhat stuck on `VTable0x1c` - the logic seems to be correct, but the stack layout does not quite match and I have run out of ideas; some variables are off by 4 bytes. Suggestions are greatly appreciated.