### PR TITLE
Some improvements to MxSmack

### DIFF
--- a/LEGO1/library_smack.h
+++ b/LEGO1/library_smack.h
@@ -1,18 +1,23 @@
 #ifdef 0
 
 // LIBRARY: LEGO1 0x100cd782
+// LIBRARY: BETA10 0x1015fb82
 // _SmackGetSizeTables
 
 // LIBRARY: LEGO1 0x100cd7e8
+// LIBRARY: BETA10 0x1015fbe8
 // _SmackDoTables
 
 // LIBRARY: LEGO1 0x100cda83
+// LIBRARY: BETA10 0x1015fe83
 // _SmackDoFrameToBuffer
 
 // LIBRARY: LEGO1 0x100d052c
+// LIBRARY: BETA10 0x1016292c
 // _SmackGetSizeDeltas
 
 // LIBRARY: LEGO1 0x100d0543
+// LIBRARY: BETA10 0x10162943
 // _SmackGetRect
 
 #endif

--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -90,7 +90,7 @@ public:
 	// DECOMP: This could be a free function. It is static here because it has no
 	// reference to "this". In the beta it is called in two places:
 	// 1. GetBmiHeightAbs
-	// 2. at 0x101523b9, in reference to BITMAPINFOHEADER.biHeight
+	// 2. MxSmack::LoadFrame
 	// FUNCTION: BETA10 0x1002c690
 	static MxLong HeightAbs(MxLong p_value) { return p_value > 0 ? p_value : -p_value; }
 


### PR DESCRIPTION
`LoadHeader` is almost 100%. The only diff now is the order of the members on this line:
```cpp
p_mxSmack->m_huffmanTables = new MxU8[smackTag->codesize +
                                      smackTag->detailsize +
                                      smackTag->typesize +
                                      smackTag->absize +
                                      sizetables];
```
They are ordered how they appear in the beta, but compiler entropy scrambles them.

- Beta addrs for the Smacker lib functions and MxSmack class.

- The beta tells us that the `Abs` function from `MxBitmap` is used in `LoadFrame`, so I updated that and removed the temp one.
