### PR TITLE
Minor tweak to MxList template

### DIFF
--- a/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
+++ b/LEGO1/lego/legoomni/include/legopathcontrollerlist.h
@@ -6,21 +6,27 @@
 #include "mxtypes.h"
 
 // VTABLE: LEGO1 0x100d6380
+// VTABLE: BETA10 0x101bf130
 // class MxCollection<LegoPathController *>
 
 // VTABLE: LEGO1 0x100d6398
+// VTABLE: BETA10 0x101bf110
 // class MxList<LegoPathController *>
 
 // VTABLE: LEGO1 0x100d6320
+// VTABLE: BETA10 0x101bf0f0
 // class MxPtrList<LegoPathController>
 
 // VTABLE: LEGO1 0x100d6338
+// VTABLE: BETA10 0x101bf0d0
 // SIZE 0x18
 class LegoPathControllerList : public MxPtrList<LegoPathController> {
 public:
+	// FUNCTION: BETA10 0x100dd060
 	LegoPathControllerList(MxBool p_ownership = FALSE) : MxPtrList<LegoPathController>(p_ownership) {}
 
 	// FUNCTION: LEGO1 0x1001d210
+	// FUNCTION: BETA10 0x100dd100
 	MxS8 Compare(LegoPathController* p_a, LegoPathController* p_b) override
 	{
 		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
@@ -28,70 +34,122 @@ public:
 };
 
 // VTABLE: LEGO1 0x100d6578
+// VTABLE: BETA10 0x101bf200
 // class MxListCursor<LegoPathController *>
 
 // VTABLE: LEGO1 0x100d6548
+// VTABLE: BETA10 0x101bf1e8
 // class MxPtrListCursor<LegoPathController>
 
 // VTABLE: LEGO1 0x100d6560
+// VTABLE: BETA10 0x101bf1d0
 // SIZE 0x10
 class LegoPathControllerListCursor : public MxPtrListCursor<LegoPathController> {
 public:
+	// FUNCTION: BETA10 0x100dfd00
 	LegoPathControllerListCursor(LegoPathControllerList* p_list) : MxPtrListCursor<LegoPathController>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x1001d230
+// TEMPLATE: BETA10 0x100dd1f0
 // MxCollection<LegoPathController *>::Compare
 
 // TEMPLATE: LEGO1 0x1001d240
+// TEMPLATE: BETA10 0x100dd210
 // MxList<LegoPathController *>::MxList<LegoPathController *>
 
 // TEMPLATE: LEGO1 0x1001d2d0
+// TEMPLATE: BETA10 0x100dd370
 // MxCollection<LegoPathController *>::~MxCollection<LegoPathController *>
 
 // TEMPLATE: LEGO1 0x1001d320
+// TEMPLATE: BETA10 0x100dd430
 // MxCollection<LegoPathController *>::Destroy
 
 // TEMPLATE: LEGO1 0x1001d330
+// TEMPLATE: BETA10 0x100dd450
 // MxList<LegoPathController *>::~MxList<LegoPathController *>
 
 // TEMPLATE: LEGO1 0x1001d3c0
+// TEMPLATE: BETA10 0x100dd530
 // MxPtrList<LegoPathController>::Destroy
 
 // SYNTHETIC: LEGO1 0x1001d3d0
+// SYNTHETIC: BETA10 0x100dd580
 // LegoPathControllerList::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x1001d440
+// TEMPLATE: BETA10 0x100dd5d0
 // MxPtrList<LegoPathController>::~MxPtrList<LegoPathController>
 
 // SYNTHETIC: LEGO1 0x1001d490
+// SYNTHETIC: BETA10 0x100dd650
 // MxCollection<LegoPathController *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x1001d500
+// SYNTHETIC: BETA10 0x100dd6a0
 // MxList<LegoPathController *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x1001d5b0
+// SYNTHETIC: BETA10 0x100dd6f0
 // MxPtrList<LegoPathController>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x1001d620
+// SYNTHETIC: BETA10 0x100dd740
 // LegoPathControllerList::~LegoPathControllerList
 
 // SYNTHETIC: LEGO1 0x1001f830
+// SYNTHETIC: BETA10 0x100dfef0
 // LegoPathControllerListCursor::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x1001f8a0
+// TEMPLATE: BETA10 0x100dff40
 // MxPtrListCursor<LegoPathController>::~MxPtrListCursor<LegoPathController>
 
 // SYNTHETIC: LEGO1 0x1001f8f0
+// SYNTHETIC: BETA10 0x100dffc0
 // MxListCursor<LegoPathController *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x1001f960
+// SYNTHETIC: BETA10 0x100e0010
 // MxPtrListCursor<LegoPathController>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x1001f9d0
+// TEMPLATE: BETA10 0x100e0060
 // MxListCursor<LegoPathController *>::~MxListCursor<LegoPathController *>
 
 // FUNCTION: LEGO1 0x1001fa20
+// FUNCTION: BETA10 0x100e00e0
 // LegoPathControllerListCursor::~LegoPathControllerListCursor
+
+// TEMPLATE: BETA10 0x100dd150
+// MxPtrList<LegoPathController>::MxPtrList<LegoPathController>
+
+// TEMPLATE: BETA10 0x100dd2c0
+// MxCollection<LegoPathController *>::MxCollection<LegoPathController *>
+
+// TEMPLATE: BETA10 0x100dd400
+// MxCollection<LegoPathController *>::SetDestroy
+
+// TEMPLATE: BETA10 0x100dd4e0
+// MxPtrList<LegoPathController>::SetOwnership
+
+// TEMPLATE: BETA10 0x100dfda0
+// MxPtrListCursor<LegoPathController>::MxPtrListCursor<LegoPathController>
+
+// TEMPLATE: BETA10 0x100dfe40
+// MxListCursor<LegoPathController *>::MxListCursor<LegoPathController *>
+
+// TEMPLATE: BETA10 0x100e1cb0
+// MxList<LegoPathController *>::DeleteAll
+
+// TEMPLATE: BETA10 0x100e1d70
+// MxListCursor<LegoPathController *>::Next
+
+// TEMPLATE: BETA10 0x100e1ff0
+// MxListEntry<LegoPathController *>::GetNext
+
+// TEMPLATE: BETA10 0x100e2050
+// MxListEntry<LegoPathController *>::GetValue
 
 #endif // LEGOPATHCONTROLLERLIST_H

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -106,6 +106,7 @@ MxResult LegoWorld::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1001e9d0
+// FUNCTION: BETA10 0x100d99ea
 void LegoWorld::Destroy(MxBool p_fromDestructor)
 {
 	m_destroyed = TRUE;

--- a/LEGO1/omni/include/mxcore.h
+++ b/LEGO1/omni/include/mxcore.h
@@ -48,4 +48,7 @@ private:
 	MxU32 m_id; // 0x04
 };
 
+// SYNTHETIC: BETA10 0x10096940
+// MxCore::operator=
+
 #endif // MXCORE_H

--- a/LEGO1/omni/include/mxdsactionlist.h
+++ b/LEGO1/omni/include/mxdsactionlist.h
@@ -6,18 +6,23 @@
 #include "mxlist.h"
 
 // VTABLE: LEGO1 0x100dcea8
+// VTABLE: BETA10 0x101c2928
 // class MxCollection<MxDSAction *>
 
 // VTABLE: LEGO1 0x100dcec0
+// VTABLE: BETA10 0x101c2910
 // class MxList<MxDSAction *>
 
 // VTABLE: LEGO1 0x100dced8
+// VTABLE: BETA10 0x101c28f8
 // SIZE 0x1c
 class MxDSActionList : public MxList<MxDSAction*> {
 public:
+	// FUNCTION: BETA10 0x1015ad10
 	MxDSActionList() { this->m_unk0x18 = 0; }
 
 	// FUNCTION: LEGO1 0x100c9c90
+	// FUNCTION: BETA10 0x1015ad90
 	MxS8 Compare(MxDSAction* p_a, MxDSAction* p_b) override
 	{
 		return p_a == p_b ? 0 : p_a < p_b ? -1 : 1;
@@ -27,6 +32,7 @@ public:
 	static void Destroy(MxDSAction* p_action) { delete p_action; }
 
 	// SYNTHETIC: LEGO1 0x100c9dc0
+	// SYNTHETIC: BETA10 0x1015b070
 	// MxDSActionList::`scalar deleting destructor'
 
 private:
@@ -34,31 +40,103 @@ private:
 };
 
 // VTABLE: LEGO1 0x100d7e68
+// VTABLE: BETA10 0x101baf30
 // class MxListCursor<MxDSAction *>
 
 // VTABLE: LEGO1 0x100d7e50
+// VTABLE: BETA10 0x101baf18
 // SIZE 0x10
 class MxDSActionListCursor : public MxListCursor<MxDSAction*> {
 public:
+	// FUNCTION: BETA10 0x1004db00
 	MxDSActionListCursor(MxDSActionList* p_list) : MxListCursor<MxDSAction*>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x100c9cc0
+// TEMPLATE: BETA10 0x1015aed0
 // MxCollection<MxDSAction *>::Compare
 
 // TEMPLATE: LEGO1 0x100c9cd0
+// TEMPLATE: BETA10 0x1015af80
 // MxCollection<MxDSAction *>::~MxCollection<MxDSAction *>
 
 // TEMPLATE: LEGO1 0x100c9d20
+// TEMPLATE: BETA10 0x1015aff0
 // MxCollection<MxDSAction *>::Destroy
 
 // TEMPLATE: LEGO1 0x100c9d30
+// TEMPLATE: BETA10 0x1015b000
 // MxList<MxDSAction *>::~MxList<MxDSAction *>
 
 // SYNTHETIC: LEGO1 0x100c9e30
+// SYNTHETIC: BETA10 0x1015b0b0
 // MxCollection<MxDSAction *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c9ea0
+// SYNTHETIC: BETA10 0x1015b0f0
 // MxList<MxDSAction *>::`scalar deleting destructor'
+
+// TEMPLATE: BETA10 0x1004dba0
+// MxListCursor<MxDSAction *>::MxListCursor<MxDSAction *>
+
+// TEMPLATE: BETA10 0x1004e460
+// MxListCursor<MxDSAction *>::Head
+
+// TEMPLATE: BETA10 0x1004e4b0
+// ?Next@?$MxListCursor@PAVMxDSAction@@@@QAEEXZ
+
+// TEMPLATE: BETA10 0x1004e530
+// MxListCursor<MxDSAction *>::Current
+
+// TEMPLATE: BETA10 0x1004e590
+// MxListEntry<MxDSAction *>::GetNext
+
+// TEMPLATE: BETA10 0x1004e5c0
+// MxListEntry<MxDSAction *>::GetValue
+
+// TEMPLATE: BETA10 0x10137190
+// ?Next@?$MxListCursor@PAVMxDSAction@@@@QAEEAAPAVMxDSAction@@@Z
+
+// TEMPLATE: BETA10 0x101384e0
+// MxListCursor<MxDSAction *>::Find
+
+// TEMPLATE: BETA10 0x10138580
+// MxListCursor<MxDSAction *>::Detach
+
+// TEMPLATE: BETA10 0x101385c0
+// MxList<MxDSAction *>::DeleteEntry
+
+// TEMPLATE: BETA10 0x10138670
+// MxListEntry<MxDSAction *>::GetPrev
+
+// TEMPLATE: BETA10 0x10138690
+// MxListEntry<MxDSAction *>::SetPrev
+
+// TEMPLATE: BETA10 0x101386c0
+// MxListEntry<MxDSAction *>::SetNext
+
+// TEMPLATE: BETA10 0x1015ae10
+// MxCollection<MxDSAction *>::SetDestroy
+
+// TEMPLATE: BETA10 0x1015ae40
+// MxList<MxDSAction *>::MxList<MxDSAction *>
+
+// TEMPLATE: BETA10 0x1015aef0
+// MxCollection<MxDSAction *>::MxCollection<MxDSAction *>
+
+// SYNTHETIC: BETA10 0x1015b130
+// MxDSActionList::~MxDSActionList
+
+// TEMPLATE: BETA10 0x1015b250
+// MxList<MxDSAction *>::Append
+
+// TEMPLATE: BETA10 0x1015bca0
+// MxList<MxDSAction *>::InsertEntry
+
+// TEMPLATE: BETA10 0x1015c140
+// MxListEntry<MxDSAction *>::MxListEntry<MxDSAction *>
+
+// TEMPLATE: BETA10 0x1015bd90
+// MxList<MxDSAction *>::DeleteAll
 
 #endif // MXDSACTIONLIST_H

--- a/LEGO1/omni/include/mxdsmultiaction.h
+++ b/LEGO1/omni/include/mxdsmultiaction.h
@@ -36,6 +36,7 @@ public:
 	MxBool HasId(MxU32 p_objectId) override;                     // vtable+34;
 	void SetUnknown90(MxLong p_unk0x90) override;                // vtable+38;
 
+	// FUNCTION: BETA10 0x1004e180
 	MxDSActionList* GetActionList() const { return m_actions; }
 
 	// SYNTHETIC: LEGO1 0x100ca040
@@ -47,15 +48,19 @@ protected:
 };
 
 // SYNTHETIC: LEGO1 0x1004ad10
+// SYNTHETIC: BETA10 0x1004dc50
 // MxDSActionListCursor::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x1004ad80
+// TEMPLATE: BETA10 0x1004dca0
 // MxListCursor<MxDSAction *>::~MxListCursor<MxDSAction *>
 
 // SYNTHETIC: LEGO1 0x1004add0
+// SYNTHETIC: BETA10 0x1004dd20
 // MxListCursor<MxDSAction *>::`scalar deleting destructor'
 
 // FUNCTION: LEGO1 0x1004ae40
+// FUNCTION: BETA10 0x1004dd70
 // MxDSActionListCursor::~MxDSActionListCursor
 
 #endif // MXDSMULTIACTION_H

--- a/LEGO1/omni/include/mxdsselectaction.h
+++ b/LEGO1/omni/include/mxdsselectaction.h
@@ -41,15 +41,19 @@ private:
 };
 
 // SYNTHETIC: LEGO1 0x100cbbd0
+// SYNTHETIC: BETA10 0x1015bb60
 // MxStringListCursor::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100cbc40
+// TEMPLATE: BETA10 0x1015bba0
 // MxListCursor<MxString>::~MxListCursor<MxString>
 
 // SYNTHETIC: LEGO1 0x100cbc90
+// SYNTHETIC: BETA10 0x1015bc00
 // MxListCursor<MxString>::`scalar deleting destructor'
 
 // FUNCTION: LEGO1 0x100cbd00
+// FUNCTION: BETA10 0x1015bc40
 // MxStringListCursor::~MxStringListCursor
 
 #endif // MXDSSELECTACTION_H

--- a/LEGO1/omni/include/mxlist.h
+++ b/LEGO1/omni/include/mxlist.h
@@ -45,17 +45,14 @@ private:
 template <class T>
 class MxList : protected MxCollection<T> {
 public:
-	MxList()
-	{
-		m_last = NULL;
-		m_first = NULL;
-	}
+	MxList() { m_first = m_last = NULL; }
 
 	~MxList() override;
 
 	void Append(T p_obj) { InsertEntry(p_obj, this->m_last, NULL); }
 	void Prepend(T p_obj) { InsertEntry(p_obj, NULL, this->m_first); }
-	void DeleteAll(MxBool p_destroy = TRUE);
+	void DeleteAll();
+	void Empty();
 	MxU32 GetCount() { return this->m_count; }
 
 	friend class MxListCursor<T>;
@@ -136,27 +133,33 @@ MxList<T>::~MxList()
 	DeleteAll();
 }
 
+// Delete entries and values
 template <class T>
-inline void MxList<T>::DeleteAll(MxBool p_destroy)
+inline void MxList<T>::DeleteAll()
 {
-	for (MxListEntry<T>* t = m_first;;) {
-		if (!t) {
-			break;
-		}
-
-		MxListEntry<T>* next = t->GetNext();
-
-		if (p_destroy) {
-			this->m_customDestructor(t->GetValue());
-		}
-
+	MxListEntry<T>* next;
+	for (MxListEntry<T>* t = m_first; t; t = next) {
+		next = t->GetNext();
+		this->m_customDestructor(t->GetValue());
 		delete t;
-		t = next;
 	}
 
 	this->m_count = 0;
-	m_last = NULL;
-	m_first = NULL;
+	m_first = m_last = NULL;
+}
+
+// Delete entries only
+template <class T>
+inline void MxList<T>::Empty()
+{
+	MxListEntry<T>* next;
+	for (MxListEntry<T>* t = m_first; t; t = next) {
+		next = t->GetNext();
+		delete t;
+	}
+
+	this->m_count = 0;
+	m_first = m_last = NULL;
 }
 
 template <class T>

--- a/LEGO1/omni/include/mxrectlist.h
+++ b/LEGO1/omni/include/mxrectlist.h
@@ -5,85 +5,157 @@
 #include "mxrect32.h"
 
 // VTABLE: LEGO1 0x100dc3f0
+// VTABLE: BETA10 0x101c1fb8
 // SIZE 0x18
 class MxRectList : public MxPtrList<MxRect32> {
 public:
+	// FUNCTION: BETA10 0x1013b980
 	MxRectList(MxBool p_ownership = FALSE) : MxPtrList<MxRect32>(p_ownership) {}
 };
 
 // VTABLE: LEGO1 0x100dc438
+// VTABLE: BETA10 0x101c2048
 // class MxListCursor<MxRect32 *>
 
 // VTABLE: LEGO1 0x100dc408
+// VTABLE: BETA10 0x101c2030
 // class MxPtrListCursor<MxRect32>
 
 // VTABLE: LEGO1 0x100dc420
+// VTABLE: BETA10 0x101c2018
 class MxRectListCursor : public MxPtrListCursor<MxRect32> {
 public:
+	// FUNCTION: BETA10 0x1013bf10
 	MxRectListCursor(MxRectList* p_list) : MxPtrListCursor<MxRect32>(p_list) {}
 };
 
 // VTABLE: LEGO1 0x100dc3d8
+// VTABLE: BETA10 0x101c1fd0
 // class MxPtrList<MxRect32>
 
 // VTABLE: LEGO1 0x100dc450
+// VTABLE: BETA10 0x101c1fe8
 // class MxList<MxRect32 *>
 
 // VTABLE: LEGO1 0x100dc468
+// VTABLE: BETA10 0x101c2000
 // class MxCollection<MxRect32 *>
 
 // TEMPLATE: LEGO1 0x100b3c00
+// TEMPLATE: BETA10 0x1013ba00
 // MxCollection<MxRect32 *>::Compare
 
 // TEMPLATE: LEGO1 0x100b3c10
+// TEMPLATE: BETA10 0x1013bb30
 // MxCollection<MxRect32 *>::MxCollection<MxRect32 *>
 
 // TEMPLATE: LEGO1 0x100b3c80
+// TEMPLATE: BETA10 0x1013bbc0
 // MxCollection<MxRect32 *>::~MxCollection<MxRect32 *>
 
 // TEMPLATE: LEGO1 0x100b3cd0
+// TEMPLATE: BETA10 0x1013bc60
 // MxCollection<MxRect32 *>::Destroy
 
 // TEMPLATE: LEGO1 0x100b3ce0
+// TEMPLATE: BETA10 0x1013bc70
 // MxList<MxRect32 *>::~MxList<MxRect32 *>
 
 // TEMPLATE: LEGO1 0x100b3d70
+// TEMPLATE: BETA10 0x1013bd20
 // MxPtrList<MxRect32>::Destroy
 
 // SYNTHETIC: LEGO1 0x100b3d80
+// SYNTHETIC: BETA10 0x1013bd50
 // MxRectList::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b3df0
+// TEMPLATE: BETA10 0x1013bd90
 // MxPtrList<MxRect32>::~MxPtrList<MxRect32>
 
 // SYNTHETIC: LEGO1 0x100b3e40
+// SYNTHETIC: BETA10 0x1013bdf0
 // MxCollection<MxRect32 *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100b3eb0
+// SYNTHETIC: BETA10 0x1013be30
 // MxList<MxRect32 *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100b3f60
+// SYNTHETIC: BETA10 0x1013be70
 // MxPtrList<MxRect32>::`scalar deleting destructor'
 
-// TEMPLATE: LEGO1 0x100b3fd0
+// SYNTHETIC: LEGO1 0x100b3fd0
+// SYNTHETIC: BETA10 0x1013beb0
 // MxRectList::~MxRectList
 
 // SYNTHETIC: LEGO1 0x100b4020
+// SYNTHETIC: BETA10 0x1013c0a0
 // MxRectListCursor::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b4090
+// TEMPLATE: BETA10 0x1013c0e0
 // MxPtrListCursor<MxRect32>::~MxPtrListCursor<MxRect32>
 
 // SYNTHETIC: LEGO1 0x100b40e0
+// SYNTHETIC: BETA10 0x1013c140
 // MxListCursor<MxRect32 *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100b4150
+// SYNTHETIC: BETA10 0x1013c180
 // MxPtrListCursor<MxRect32>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b41c0
+// TEMPLATE: BETA10 0x1013c1c0
 // MxListCursor<MxRect32 *>::~MxListCursor<MxRect32 *>
 
-// TEMPLATE: LEGO1 0x100b4210
+// SYNTHETIC: LEGO1 0x100b4210
+// SYNTHETIC: BETA10 0x1013c220
 // MxRectListCursor::~MxRectListCursor
+
+// TEMPLATE: BETA10 0x1013ba20
+// MxPtrList<MxRect32>::MxPtrList<MxRect32>
+
+// TEMPLATE: BETA10 0x1013baa0
+// MxList<MxRect32 *>::MxList<MxRect32 *>
+
+// TEMPLATE: BETA10 0x1013bc30
+// MxCollection<MxRect32 *>::SetDestroy
+
+// TEMPLATE: BETA10 0x1013bce0
+// MxPtrList<MxRect32>::SetOwnership
+
+// TEMPLATE: BETA10 0x1013bf90
+// MxPtrListCursor<MxRect32>::MxPtrListCursor<MxRect32>
+
+// TEMPLATE: BETA10 0x1013c010
+// MxListCursor<MxRect32 *>::MxListCursor<MxRect32 *>
+
+// TEMPLATE: BETA10 0x1013c3c0
+// MxList<MxRect32 *>::DeleteAll
+
+// TEMPLATE: BETA10 0x1013c450
+// MxListCursor<MxRect32 *>::Next
+
+// TEMPLATE: BETA10 0x1013c610
+// MxListEntry<MxRect32 *>::GetNext
+
+// TEMPLATE: BETA10 0x1013c630
+// MxListEntry<MxRect32 *>::GetValue
+
+// TEMPLATE: BETA10 0x10152860
+// MxList<MxRect32 *>::Append
+
+// TEMPLATE: BETA10 0x10152890
+// MxList<MxRect32 *>::InsertEntry
+
+// TEMPLATE: BETA10 0x10152980
+// MxListEntry<MxRect32 *>::MxListEntry<MxRect32 *>
+
+// TEMPLATE: BETA10 0x101529c0
+// MxListEntry<MxRect32 *>::SetPrev
+
+// TEMPLATE: BETA10 0x101529f0
+// MxListEntry<MxRect32 *>::SetNext
 
 #endif // MXRECTLIST_H

--- a/LEGO1/omni/include/mxregionlist.h
+++ b/LEGO1/omni/include/mxregionlist.h
@@ -27,33 +27,43 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dcc40
+// VTABLE: BETA10 0x101c2628
 // class MxCollection<MxRegionLeftRight *>
 
 // VTABLE: LEGO1 0x100dcc58
+// VTABLE: BETA10 0x101c2610
 // class MxList<MxRegionLeftRight *>
 
 // VTABLE: LEGO1 0x100dcc70
+// VTABLE: BETA10 0x101c25f8
 // class MxPtrList<MxRegionLeftRight>
 
 // VTABLE: LEGO1 0x100dcc88
+// VTABLE: BETA10 0x101c25e0
 // SIZE 0x18
 class MxRegionLeftRightList : public MxPtrList<MxRegionLeftRight> {
 public:
+	// FUNCTION: BETA10 0x1014bdd0
 	MxRegionLeftRightList() : MxPtrList<MxRegionLeftRight>(TRUE) {}
 
 	// SYNTHETIC: LEGO1 0x100c4e90
+	// SYNTHETIC: BETA10 0x1014c1a0
 	// MxRegionLeftRightList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dcbf8
+// VTABLE: BETA10 0x101c25b0
 // class MxPtrListCursor<MxRegionLeftRight>
 
 // VTABLE: LEGO1 0x100dcc28
+// VTABLE: BETA10 0x101c25c8
 // class MxListCursor<MxRegionLeftRight *>
 
 // VTABLE: LEGO1 0x100dcc10
+// VTABLE: BETA10 0x101c2598
 class MxRegionLeftRightListCursor : public MxPtrListCursor<MxRegionLeftRight> {
 public:
+	// FUNCTION: BETA10 0x1014ba10
 	MxRegionLeftRightListCursor(MxRegionLeftRightList* p_list) : MxPtrListCursor<MxRegionLeftRight>(p_list) {}
 };
 
@@ -85,28 +95,36 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dcb10
+// VTABLE: BETA10 0x101c24f8
 // class MxCollection<MxRegionTopBottom *>
 
 // VTABLE: LEGO1 0x100dcb28
+// VTABLE: BETA10 0x101c24e0
 // class MxList<MxRegionTopBottom *>
 
 // VTABLE: LEGO1 0x100dcb40
+// VTABLE: BETA10 0x101c24c8
 // class MxPtrList<MxRegionTopBottom>
 
 // VTABLE: LEGO1 0x100dcb58
+// VTABLE: BETA10 0x101c24b0
 // SIZE 0x18
 class MxRegionTopBottomList : public MxPtrList<MxRegionTopBottom> {
 public:
+	// FUNCTION: BETA10 0x1014abb0
 	MxRegionTopBottomList() : MxPtrList<MxRegionTopBottom>(TRUE) {}
 
 	// SYNTHETIC: LEGO1 0x100c3410
+	// SYNTHETIC: BETA10 0x1014af90
 	// MxRegionTopBottomList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dcb70
+// VTABLE: BETA10 0x101c2528
 // class MxPtrListCursor<MxRegionTopBottom>
 
 // VTABLE: LEGO1 0x100dcba0
+// VTABLE: BETA10 0x101c2540
 // class MxListCursor<MxRegionTopBottom *>
 
 // TODO: The initialize list param type should be MxRegionTopBottomList, but doing that
@@ -114,96 +132,127 @@ public:
 // It also works with MxPtrList, so we'll do that until we figure this out.
 
 // VTABLE: LEGO1 0x100dcb88
+// VTABLE: BETA10 0x101c2510
 class MxRegionTopBottomListCursor : public MxPtrListCursor<MxRegionTopBottom> {
 public:
+	// FUNCTION: BETA10 0x1014b470
 	MxRegionTopBottomListCursor(MxPtrList<MxRegionTopBottom>* p_list) : MxPtrListCursor<MxRegionTopBottom>(p_list) {}
 };
 
 // TEMPLATE: LEGO1 0x100c32e0
+// TEMPLATE: BETA10 0x1014ac30
 // MxCollection<MxRegionTopBottom *>::Compare
 
 // TEMPLATE: LEGO1 0x100c32f0
+// TEMPLATE: BETA10 0x1014adf0
 // MxCollection<MxRegionTopBottom *>::~MxCollection<MxRegionTopBottom *>
 
 // TEMPLATE: LEGO1 0x100c3340
+// TEMPLATE: BETA10 0x1014ae90
 // MxCollection<MxRegionTopBottom *>::Destroy
 
 // TEMPLATE: LEGO1 0x100c3350
+// TEMPLATE: BETA10 0x1014aea0
 // MxList<MxRegionTopBottom *>::~MxList<MxRegionTopBottom *>
 
 // TEMPLATE: LEGO1 0x100c33e0
+// TEMPLATE: BETA10 0x1014af50
 // MxPtrList<MxRegionTopBottom>::Destroy
 
 // TEMPLATE: LEGO1 0x100c3480
+// TEMPLATE: BETA10 0x1014afd0
 // MxPtrList<MxRegionTopBottom>::~MxPtrList<MxRegionTopBottom>
 
 // SYNTHETIC: LEGO1 0x100c34d0
+// SYNTHETIC: BETA10 0x1014b030
 // MxCollection<MxRegionTopBottom *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c3540
+// SYNTHETIC: BETA10 0x1014b070
 // MxList<MxRegionTopBottom *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c35f0
+// SYNTHETIC: BETA10 0x1014b130
 // MxPtrList<MxRegionTopBottom>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c3be0
+// SYNTHETIC: BETA10 0x1014b600
 // MxRegionTopBottomListCursor::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100c3c50
+// TEMPLATE: BETA10 0x1014b640
 // MxPtrListCursor<MxRegionTopBottom>::~MxPtrListCursor<MxRegionTopBottom>
 
 // SYNTHETIC: LEGO1 0x100c3ca0
+// SYNTHETIC: BETA10 0x1014b6a0
 // MxListCursor<MxRegionTopBottom *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c3d10
+// SYNTHETIC: BETA10 0x1014b6e0
 // MxPtrListCursor<MxRegionTopBottom>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100c3d80
+// TEMPLATE: BETA10 0x1014b720
 // MxListCursor<MxRegionTopBottom *>::~MxListCursor<MxRegionTopBottom *>
 
 // FUNCTION: LEGO1 0x100c3dd0
+// FUNCTION: BETA10 0x1014b780
 // MxRegionTopBottomListCursor::~MxRegionTopBottomListCursor
 
 // SYNTHETIC: LEGO1 0x100c4790
+// SYNTHETIC: BETA10 0x1014bba0
 // MxRegionLeftRightListCursor::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100c4800
+// TEMPLATE: BETA10 0x1014bbe0
 // MxPtrListCursor<MxRegionLeftRight>::~MxPtrListCursor<MxRegionLeftRight>
 
 // SYNTHETIC: LEGO1 0x100c4850
+// SYNTHETIC: BETA10 0x1014bc40
 // MxListCursor<MxRegionLeftRight *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c48c0
+// SYNTHETIC: BETA10 0x1014bc80
 // MxPtrListCursor<MxRegionLeftRight>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100c4930
+// TEMPLATE: BETA10 0x1014bcc0
 // MxListCursor<MxRegionLeftRight *>::~MxListCursor<MxRegionLeftRight *>
 
 // TEMPLATE: LEGO1 0x100c4d80
+// TEMPLATE: BETA10 0x1014be50
 // MxCollection<MxRegionLeftRight *>::Compare
 
 // TEMPLATE: LEGO1 0x100c4d90
+// TEMPLATE: BETA10 0x1014c010
 // MxCollection<MxRegionLeftRight *>::~MxCollection<MxRegionLeftRight *>
 
 // TEMPLATE: LEGO1 0x100c4de0
+// TEMPLATE: BETA10 0x1014c0b0
 // MxCollection<MxRegionLeftRight *>::Destroy
 
 // TEMPLATE: LEGO1 0x100c4df0
+// TEMPLATE: BETA10 0x1014c0c0
 // MxList<MxRegionLeftRight *>::~MxList<MxRegionLeftRight *>
 
 // TEMPLATE: LEGO1 0x100c4f00
+// TEMPLATE: BETA10 0x1014c1e0
 // MxPtrList<MxRegionLeftRight>::~MxPtrList<MxRegionLeftRight>
 
 // SYNTHETIC: LEGO1 0x100c4f50
+// SYNTHETIC: BETA10 0x1014c240
 // MxCollection<MxRegionLeftRight *>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100c4e80
+// TEMPLATE: BETA10 0x1014c170
 // MxPtrList<MxRegionLeftRight>::Destroy
 
 // SYNTHETIC: LEGO1 0x100c4fc0
+// SYNTHETIC: BETA10 0x1014c280
 // MxList<MxRegionLeftRight *>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100c5070
+// SYNTHETIC: BETA10 0x1014c2c0
 // MxPtrList<MxRegionLeftRight>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100c54f0
@@ -216,15 +265,163 @@ public:
 // MxListCursor<MxRegionLeftRight *>::operator=
 
 // TEMPLATE: LEGO1 0x100c58c0
+// TEMPLATE: BETA10 0x1014c650
 // MxList<MxRegionLeftRight *>::InsertEntry
 
 // TEMPLATE: LEGO1 0x100c5970
+// TEMPLATE: BETA10 0x1014cb20
 // MxList<MxRegionTopBottom *>::InsertEntry
 
 // TEMPLATE: LEGO1 0x100c5a20
+// TEMPLATE: BETA10 0x1014d050
 // MxListEntry<MxRegionTopBottom *>::MxListEntry<MxRegionTopBottom *>
 
 // TEMPLATE: LEGO1 0x100c5a40
+// TEMPLATE: BETA10 0x1014d150
 // MxList<MxRegionLeftRight *>::DeleteEntry
+
+// TEMPLATE: BETA10 0x1014ac50
+// MxPtrList<MxRegionTopBottom>::MxPtrList<MxRegionTopBottom>
+
+// TEMPLATE: BETA10 0x1014acd0
+// MxList<MxRegionTopBottom *>::MxList<MxRegionTopBottom *>
+
+// TEMPLATE: BETA10 0x1014ad60
+// MxCollection<MxRegionTopBottom *>::MxCollection<MxRegionTopBottom *>
+
+// TEMPLATE: BETA10 0x1014ae60
+// MxCollection<MxRegionTopBottom *>::SetDestroy
+
+// TEMPLATE: BETA10 0x1014af10
+// MxPtrList<MxRegionTopBottom>::SetOwnership
+
+// FUNCTION: BETA10 0x1014b170
+// MxRegionTopBottomList::~MxRegionTopBottomList
+
+// TEMPLATE: BETA10 0x1014b440
+// MxList<MxRegionTopBottom *>::Append
+
+// TEMPLATE: BETA10 0x1014b4f0
+// MxPtrListCursor<MxRegionTopBottom>::MxPtrListCursor<MxRegionTopBottom>
+
+// TEMPLATE: BETA10 0x1014b570
+// MxListCursor<MxRegionTopBottom *>::MxListCursor<MxRegionTopBottom *>
+
+// TEMPLATE: BETA10 0x1014ba90
+// MxPtrListCursor<MxRegionLeftRight>::MxPtrListCursor<MxRegionLeftRight>
+
+// TEMPLATE: BETA10 0x1014bb10
+// MxListCursor<MxRegionLeftRight *>::MxListCursor<MxRegionLeftRight *>
+
+// FUNCTION: BETA10 0x1014bd20
+// MxRegionLeftRightListCursor::~MxRegionLeftRightListCursor
+
+// TEMPLATE: BETA10 0x1014be70
+// MxPtrList<MxRegionLeftRight>::MxPtrList<MxRegionLeftRight>
+
+// TEMPLATE: BETA10 0x1014bef0
+// MxList<MxRegionLeftRight *>::MxList<MxRegionLeftRight *>
+
+// TEMPLATE: BETA10 0x1014bf80
+// MxCollection<MxRegionLeftRight *>::MxCollection<MxRegionLeftRight *>
+
+// TEMPLATE: BETA10 0x1014c080
+// MxCollection<MxRegionLeftRight *>::SetDestroy
+
+// TEMPLATE: BETA10 0x1014c130
+// MxPtrList<MxRegionLeftRight>::SetOwnership
+
+// FUNCTION: BETA10 0x1014c300
+// MxRegionLeftRightList::~MxRegionLeftRightList
+
+// TEMPLATE: BETA10 0x1014c390
+// MxList<MxRegionLeftRight *>::Append
+
+// SYNTHETIC: BETA10 0x1014c3c0
+// MxRegionLeftRightListCursor::operator=
+
+// SYNTHETIC: BETA10 0x1014c3f0
+// MxPtrListCursor<MxRegionLeftRight>::operator=
+
+// SYNTHETIC: BETA10 0x1014c420
+// MxListCursor<MxRegionLeftRight *>::operator=
+
+// TEMPLATE: BETA10 0x1014c740
+// MxList<MxRegionLeftRight *>::DeleteAll
+
+// TEMPLATE: BETA10 0x1014c7d0
+// MxListCursor<MxRegionLeftRight *>::First
+
+// TEMPLATE: BETA10 0x1014c830
+// MxListCursor<MxRegionLeftRight *>::Last
+
+// TEMPLATE: BETA10 0x1014c890
+// MxListCursor<MxRegionLeftRight *>::Next
+
+// TEMPLATE: BETA10 0x1014c970
+// MxListCursor<MxRegionLeftRight *>::Prev
+
+// TEMPLATE: BETA10 0x1014c9f0
+// MxListCursor<MxRegionLeftRight *>::Current
+
+// TEMPLATE: BETA10 0x1014ca40
+// MxListCursor<MxRegionLeftRight *>::Prepend
+
+// TEMPLATE: BETA10 0x1014ca90
+// MxListCursor<MxRegionLeftRight *>::Destroy
+
+// TEMPLATE: BETA10 0x1014caf0
+// MxListCursor<MxRegionLeftRight *>::HasMatch
+
+// TEMPLATE: BETA10 0x1014cc10
+// MxList<MxRegionTopBottom *>::DeleteAll
+
+// TEMPLATE: BETA10 0x1014cd20
+// MxListCursor<MxRegionTopBottom *>::Next
+
+// TEMPLATE: BETA10 0x1014cda0
+// MxListCursor<MxRegionTopBottom *>::Prev
+
+// TEMPLATE: BETA10 0x1014ce70
+// MxListCursor<MxRegionTopBottom *>::Prepend
+
+// TEMPLATE: BETA10 0x1014cec0
+// MxListCursor<MxRegionTopBottom *>::Destroy
+
+// TEMPLATE: BETA10 0x1014cf50
+// MxListEntry<MxRegionLeftRight *>::MxListEntry<MxRegionLeftRight *>
+
+// TEMPLATE: BETA10 0x1014cf90
+// MxListEntry<MxRegionLeftRight *>::GetPrev
+
+// TEMPLATE: BETA10 0x1014cfb0
+// MxListEntry<MxRegionLeftRight *>::SetPrev
+
+// TEMPLATE: BETA10 0x1014cfe0
+// MxListEntry<MxRegionLeftRight *>::GetNext
+
+// TEMPLATE: BETA10 0x1014d000
+// MxListEntry<MxRegionLeftRight *>::SetNext
+
+// TEMPLATE: BETA10 0x1014d030
+// MxListEntry<MxRegionLeftRight *>::GetValue
+
+// TEMPLATE: BETA10 0x1014d090
+// MxListEntry<MxRegionTopBottom *>::GetPrev
+
+// TEMPLATE: BETA10 0x1014d0b0
+// MxListEntry<MxRegionTopBottom *>::SetPrev
+
+// TEMPLATE: BETA10 0x1014d0e0
+// MxListEntry<MxRegionTopBottom *>::GetNext
+
+// TEMPLATE: BETA10 0x1014d100
+// MxListEntry<MxRegionTopBottom *>::SetNext
+
+// TEMPLATE: BETA10 0x1014d130
+// MxListEntry<MxRegionTopBottom *>::GetValue
+
+// TEMPLATE: BETA10 0x1014d200
+// MxList<MxRegionTopBottom *>::DeleteEntry
 
 #endif // MXREGIONLIST_H

--- a/LEGO1/omni/include/mxstringlist.h
+++ b/LEGO1/omni/include/mxstringlist.h
@@ -5,56 +5,112 @@
 #include "mxstring.h"
 
 // VTABLE: LEGO1 0x100dd040
+// VTABLE: BETA10 0x101c2a18
 // SIZE 0x18
 class MxStringList : public MxList<MxString> {};
 
+// SYNTHETIC: BETA10 0x1015b520
+// MxStringList::MxStringList
+
+// SYNTHETIC: LEGO1 0x100cb860
+// SYNTHETIC: BETA10 0x1015b920
+// MxStringList::`scalar deleting destructor'
+
+// SYNTHETIC: BETA10 0x1015b960
+// MxStringList::~MxStringList
+
 // VTABLE: LEGO1 0x100dd058
+// VTABLE: BETA10 0x101c2a60
 // SIZE 0x10
 class MxStringListCursor : public MxListCursor<MxString> {
 public:
+	// FUNCTION: BETA10 0x1015ba50
 	MxStringListCursor(MxStringList* p_list) : MxListCursor<MxString>(p_list) {}
-
-	// SYNTHETIC: LEGO1 0x100cb860
-	// MxStringList::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dd010
+// VTABLE: BETA10 0x101c2a48
 // class MxCollection<MxString>
 
 // VTABLE: LEGO1 0x100dd028
+// VTABLE: BETA10 0x101c2a30
 // class MxList<MxString>
 
 // VTABLE: LEGO1 0x100dd070
+// VTABLE: BETA10 0x101c2a78
 // class MxListCursor<MxString>
 
 // TEMPLATE: LEGO1 0x100cb3c0
+// TEMPLATE: BETA10 0x1015b590
 // MxCollection<MxString>::Compare
 
 // TEMPLATE: LEGO1 0x100cb420
+// TEMPLATE: BETA10 0x1015b730
 // MxCollection<MxString>::~MxCollection<MxString>
 
 // TEMPLATE: LEGO1 0x100cb470
+// TEMPLATE: BETA10 0x1015b7d0
 // MxCollection<MxString>::Destroy
 
 // TEMPLATE: LEGO1 0x100cb4c0
+// TEMPLATE: BETA10 0x1015b830
 // MxList<MxString>::~MxList<MxString>
 
 // SYNTHETIC: LEGO1 0x100cb590
+// SYNTHETIC: BETA10 0x1015b8a0
 // MxCollection<MxString>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100cb600
+// SYNTHETIC: BETA10 0x1015b8e0
 // MxList<MxString>::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100cbb40
+// TEMPLATE: BETA10 0x1015b9c0
 // MxList<MxString>::Append
 
 // TEMPLATE: LEGO1 0x100cc2d0
+// TEMPLATE: BETA10 0x1015be50
 // MxList<MxString>::InsertEntry
 
 // TEMPLATE: LEGO1 0x100cc3c0
+// TEMPLATE: BETA10 0x1015c180
 // MxListEntry<MxString>::MxListEntry<MxString>
 
 // TEMPLATE: LEGO1 0x100cc450
+// TEMPLATE: BETA10 0x1015c2a0
 // MxListEntry<MxString>::GetValue
+
+// TEMPLATE: BETA10 0x1015b610
+// MxList<MxString>::MxList<MxString>
+
+// TEMPLATE: BETA10 0x1015b6a0
+// MxCollection<MxString>::MxCollection<MxString>
+
+// TEMPLATE: BETA10 0x1015b7a0
+// MxCollection<MxString>::SetDestroy
+
+// TEMPLATE: BETA10 0x1015bad0
+// MxListCursor<MxString>::MxListCursor<MxString>
+
+// TEMPLATE: BETA10 0x1015bf80
+// MxList<MxString>::DeleteAll
+
+// TEMPLATE: BETA10 0x1015c070
+// MxListCursor<MxString>::Next
+
+// TEMPLATE: BETA10 0x1015c220
+// MxListEntry<MxString>::SetPrev
+
+// TEMPLATE: BETA10 0x1015c250
+// MxListEntry<MxString>::GetNext
+
+// TEMPLATE: BETA10 0x1015c270
+// MxListEntry<MxString>::SetNext
+
+// SYNTHETIC: BETA10 0x1015c310
+// MxListEntry<MxString>::`scalar deleting destructor'
+
+// TEMPLATE: BETA10 0x1015c350
+// MxListEntry<MxString>::~MxListEntry<MxString>
 
 #endif // MXSTRINGLIST_H

--- a/LEGO1/omni/src/action/mxdsmultiaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmultiaction.cpp
@@ -22,6 +22,7 @@ MxDSMultiAction::~MxDSMultiAction()
 }
 
 // FUNCTION: LEGO1 0x100ca0d0
+// FUNCTION: BETA10 0x101595ad
 void MxDSMultiAction::CopyFrom(MxDSMultiAction& p_dsMultiAction)
 {
 	this->m_actions->DeleteAll();

--- a/LEGO1/omni/src/action/mxdsselectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsselectaction.cpp
@@ -26,6 +26,7 @@ MxDSSelectAction::~MxDSSelectAction()
 }
 
 // FUNCTION: LEGO1 0x100cb950
+// FUNCTION: BETA10 0x1015a6ae
 void MxDSSelectAction::CopyFrom(MxDSSelectAction& p_dsSelectAction)
 {
 	this->m_unk0x9c = p_dsSelectAction.m_unk0x9c;
@@ -82,6 +83,7 @@ MxU32 MxDSSelectAction::GetSizeOnDisk()
 }
 
 // FUNCTION: LEGO1 0x100cbf60
+// FUNCTION: BETA10 0x1015aa30
 void MxDSSelectAction::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxString string;

--- a/LEGO1/omni/src/common/mxcompositepresenter.cpp
+++ b/LEGO1/omni/src/common/mxcompositepresenter.cpp
@@ -23,6 +23,7 @@ MxCompositePresenter::~MxCompositePresenter()
 }
 
 // FUNCTION: LEGO1 0x100b6410
+// FUNCTION: BETA10 0x100e9d37
 MxResult MxCompositePresenter::StartAction(MxStreamController* p_controller, MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
@@ -76,6 +77,7 @@ MxResult MxCompositePresenter::StartAction(MxStreamController* p_controller, MxD
 }
 
 // FUNCTION: LEGO1 0x100b65e0
+// FUNCTION: BETA10 0x101375bc
 void MxCompositePresenter::EndAction()
 {
 	AUTOLOCK(m_criticalSection);

--- a/LEGO1/omni/src/common/mxcompositepresenter.cpp
+++ b/LEGO1/omni/src/common/mxcompositepresenter.cpp
@@ -86,7 +86,7 @@ void MxCompositePresenter::EndAction()
 		return;
 	}
 
-	((MxDSMultiAction*) m_action)->GetActionList()->DeleteAll(FALSE);
+	((MxDSMultiAction*) m_action)->GetActionList()->Empty();
 
 	while (!m_list.empty()) {
 		MxPresenter* presenter = m_list.front();

--- a/LEGO1/omni/src/video/mxregion.cpp
+++ b/LEGO1/omni/src/video/mxregion.cpp
@@ -7,6 +7,7 @@ DECOMP_SIZE_ASSERT(MxRegionTopBottom, 0x0c);
 DECOMP_SIZE_ASSERT(MxRegionLeftRight, 0x08);
 
 // FUNCTION: LEGO1 0x100c31c0
+// FUNCTION: BETA10 0x10148f00
 MxRegion::MxRegion()
 {
 	m_list = new MxRegionTopBottomList;
@@ -28,6 +29,7 @@ MxRegion::~MxRegion()
 }
 
 // FUNCTION: LEGO1 0x100c3700
+// FUNCTION: BETA10 0x1014907a
 void MxRegion::Reset()
 {
 	m_list->DeleteAll();
@@ -35,6 +37,7 @@ void MxRegion::Reset()
 }
 
 // FUNCTION: LEGO1 0x100c3750
+// FUNCTION: BETA10 0x101490bd
 void MxRegion::VTable0x18(MxRect32& p_rect)
 {
 	MxRect32 rect(p_rect);
@@ -117,6 +120,7 @@ MxRegionTopBottom::MxRegionTopBottom(MxS32 p_top, MxS32 p_bottom)
 }
 
 // FUNCTION: LEGO1 0x100c50e0
+// FUNCTION: BETA10 0x1014a2d6
 MxRegionTopBottom::MxRegionTopBottom(MxRect32& p_rect)
 {
 	m_top = p_rect.GetTop();
@@ -128,6 +132,7 @@ MxRegionTopBottom::MxRegionTopBottom(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c5280
+// FUNCTION: BETA10 0x1014a3fc
 void MxRegionTopBottom::MergeOrExpandRegions(MxS32 p_left, MxS32 p_right)
 {
 	MxRegionLeftRightListCursor a(m_leftRightList);

--- a/LEGO1/omni/src/video/mxregioncursor.cpp
+++ b/LEGO1/omni/src/video/mxregioncursor.cpp
@@ -3,6 +3,7 @@
 DECOMP_SIZE_ASSERT(MxRegionCursor, 0x18);
 
 // FUNCTION: LEGO1 0x100c3f70
+// FUNCTION: BETA10 0x10149663
 MxRegionCursor::MxRegionCursor(MxRegion* p_region)
 {
 	m_region = p_region;


### PR DESCRIPTION
This is a very small code change bundled with a huge number of beta addresses for `MxList` and related template classes.

Prior to this change, these functions call `DeleteAll` on an `MxList`[^1]:
- LegoWorld::Destroy
- MxDSMultiAction::CopyFrom
- MxDSSelectAction::CopyFrom
- MxDSSelectAction::Deserialize
- MxRegion::Reset
- MxCompositePresenter::EndAction

`MxCompositePresenter::EndAction` is a special case; it is the only one of these that skips destroying the values for each entry in the list. The optional parameter has a default of `TRUE`, but we use `FALSE` explicitly here.

The beta shows that these are two different functions and no parameter is passed. It doesn't seem to be a case where the destroy-or-not option is part of the template, because `MxCompositePresenter` calls the same functions on `MxList<MxDSAction *>` as other functions that use this list. I changed `DeleteAll()` and the new function `Empty()` so the for-loop matches the beta.

The functions that call `DeleteAll()` or `Empty()` appear unaffected, but this change generated the usual noise to other functions. Setting the `m_first` and `m_last` members to null in one line matched the beta but generated no diff in retail.

__Other stuff:__

The beta supports a change to the `Next` and `Prev` functions of `MxListCursor` where the if-block is reversed, but this drops accuracy across the board so I left it alone. i.e.:

```cpp
// Retail (how it is now)
if (!m_match) {
    m_match = m_list->m_first;
}
else {
    m_match = m_match->GetNext();
}

// Beta
if (m_match) {
    m_match = m_match->GetNext();
}
else {
    m_match = m_list->m_first;
}

```

There's a note in `mxregionlist.h` about the `MxRegionTopBottomListCursor` constructor. I couldn't find any clear evidence that this should be `MxRegionTopBottomList` versus `MxPtrList<MxRegionTopBottom>*`, but the addrs are there so we can take another look.

[^1]: Each `MxList` destructor also calls `DeleteAll`.