### PR TITLE
Implement/match `LegoCarRaceActor::VTable0x6c`

### DIFF
--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -56,7 +56,10 @@ public:
 	MxU32 FUN_10057fe0(LegoAnimPresenter* p_presenter);
 	MxU32 FUN_100586e0(LegoAnimPresenter* p_presenter);
 
+	// FUNCTION: BETA10 0x1001ffb0
 	LegoPathActorSet& GetActors() { return m_actors; }
+
+	// FUNCTION: BETA10 0x10082b10
 	LegoAnimPresenterSet& GetPresenters() { return m_presenters; }
 
 	// SYNTHETIC: LEGO1 0x10047a80
@@ -169,6 +172,9 @@ private:
 
 // TEMPLATE: LEGO1 0x100589a0
 // _Distance
+
+// TEMPLATE: LEGO1 0x10081cd0
+// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::lower_bound
 
 // GLOBAL: LEGO1 0x100f11a4
 // _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Nil

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -424,6 +424,7 @@ void LegoPathActor::VTable0x70(float p_time)
 // FUNCTION: BETA10 0x100af2f7
 void LegoPathActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 {
+	assert(m_boundary);
 	m_boundary->SwitchBoundary(this, p_boundary, p_edge, p_unk0xe4);
 }
 

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -292,7 +292,7 @@ MxU32 LegoCarRaceActor::VTable0x6c(
 )
 {
 	// STRING: LEGO1 0x100f7af4
-	const char* g_rcdor = "rcdor";
+	const char* str_rcdor = "rcdor";
 
 	LegoAnimPresenterSet& presenters = p_boundary->GetPresenters();
 
@@ -313,7 +313,7 @@ MxU32 LegoCarRaceActor::VTable0x6c(
 				LegoROI* roi = actor->GetROI();
 
 				if (roi != NULL && (roi->GetVisibility() || actor->GetCameraFlag())) {
-					if (strncmp(roi->GetName(), g_rcdor, 5) == 0) {
+					if (strncmp(roi->GetName(), str_rcdor, 5) == 0) {
 						const CompoundObject* co = roi->GetComp(); // name verified by BETA10 0x100cf8ba
 
 						if (co) {

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -280,7 +280,7 @@ MxResult LegoCarRaceActor::VTable0x9c()
 	return SUCCESS;
 }
 
-// STUB: LEGO1 0x10081840
+// FUNCTION: LEGO1 0x10081840
 // FUNCTION: BETA10 0x100cf680
 MxU32 LegoCarRaceActor::VTable0x6c(
 	LegoPathBoundary* p_boundary,
@@ -291,11 +291,90 @@ MxU32 LegoCarRaceActor::VTable0x6c(
 	Vector3& p_v3
 )
 {
-	// LegoAnimPresenterSet& presenters = p_boundary->GetPresenters();
+	// STRING: LEGO1 0x100f7af4
+	const char* g_rcdor = "rcdor";
 
-	// Significant overlap with parent function -> Try to copy-paste LegoPathActor::VTable0x6c here
-	// and see by how much we diverge
+	LegoAnimPresenterSet& presenters = p_boundary->GetPresenters();
 
-	// TODO
+	for (LegoAnimPresenterSet::iterator itap = presenters.begin(); itap != presenters.end(); itap++) {
+		if ((*itap)->VTable0x94(p_v1, p_v2, p_f1, p_f2, p_v3)) {
+			return 1;
+		}
+	}
+
+	LegoPathActorSet& plpas = p_boundary->GetActors();
+	LegoPathActorSet lpas(plpas);
+
+	for (LegoPathActorSet::iterator itpa = lpas.begin(); itpa != lpas.end(); itpa++) {
+		if (plpas.end() != plpas.find(*itpa)) {
+			LegoPathActor* actor = *itpa;
+
+			if (actor != this) {
+				LegoROI* roi = actor->GetROI();
+
+				if (roi != NULL && (roi->GetVisibility() || actor->GetCameraFlag())) {
+					if (strncmp(roi->GetName(), g_rcdor, 5) == 0) {
+						const CompoundObject* co = roi->GetComp(); // name verified by BETA10 0x100cf8ba
+
+						if (co) {
+							assert(co->size() == 2);
+
+							LegoROI* firstROI = (LegoROI*) co->front();
+
+							if (firstROI->FUN_100a9410(
+									p_v1,
+									p_v2,
+									p_f1,
+									p_f2,
+									p_v3,
+									m_collideBox && actor->GetCollideBox()
+								)) {
+								VTable0x94(actor, TRUE);
+
+								if (actor->VTable0x94(this, FALSE) < 0) {
+									return 0;
+								}
+								else {
+									return 2;
+								}
+							}
+
+							LegoROI* lastROI = (LegoROI*) co->back();
+
+							if (lastROI->FUN_100a9410(
+									p_v1,
+									p_v2,
+									p_f1,
+									p_f2,
+									p_v3,
+									m_collideBox && actor->GetCollideBox()
+								)) {
+								VTable0x94(actor, TRUE);
+
+								if (actor->VTable0x94(this, FALSE) < 0) {
+									return 0;
+								}
+								else {
+									return 2;
+								}
+							}
+						}
+					}
+					else {
+						if (roi->FUN_100a9410(p_v1, p_v2, p_f1, p_f2, p_v3, m_collideBox && actor->GetCollideBox())) {
+							VTable0x94(actor, TRUE);
+							if (actor->VTable0x94(this, FALSE) < 0) {
+								return 0;
+							}
+							else {
+								return 2;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return 0;
 }

--- a/LEGO1/realtime/roi.h
+++ b/LEGO1/realtime/roi.h
@@ -110,6 +110,8 @@ public:
 		return (*lods)[i];
 	}
 	int GetLODCount() const { return lods ? lods->Size() : 0; }
+
+	// FUNCTION: BETA10 0x10027110
 	const CompoundObject* GetComp() const { return comp; }
 
 	unsigned char GetVisibility() { return m_visible; }


### PR DESCRIPTION
The logic and structure of this function appears to be correct, but there are some mismatches coming from the inlined iterator functions. The overall match percentage is 89 %. Since `LegoPathActor::VTable0x6c` is affected by the same problem, I think that these mismatches have a common root cause that is caused by something else.