### PR TITLE
Remove USHRT_MAX from ParseExtra functions

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
@@ -77,10 +77,10 @@ void LegoActionControlPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[1024];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strACTION, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -241,10 +241,10 @@ void LegoAnimMMPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[1024];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strANIMMAN_ID, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
@@ -244,10 +244,10 @@ void MxControlPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[256];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[256];
 		if (KeyValueStringParse(output, g_strSTYLE, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
@@ -40,10 +40,10 @@ void LegoMeterPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[256];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[256];
 		if (KeyValueStringParse(output, g_strTYPE, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/entity/legoactorpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoactorpresenter.cpp
@@ -34,10 +34,10 @@ void LegoActorPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		m_entity->ParseAction(extraCopy);
 	}

--- a/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
@@ -96,10 +96,10 @@ void LegoEntityPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		m_entity->ParseAction(extraCopy);
 	}

--- a/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
@@ -429,10 +429,10 @@ void LegoWorldPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[1024];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strWORLD, extraCopy)) {

--- a/LEGO1/lego/legoomni/src/paths/legopathpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathpresenter.cpp
@@ -122,10 +122,10 @@ void LegoPathPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[256], output[256];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		strupr(extraCopy);
 

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -942,18 +942,18 @@ void LegoAnimPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[256];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[256];
 		if (KeyValueStringParse(NULL, g_strFROM_PARENT, extraCopy) && m_compositePresenter != NULL) {
 			m_compositePresenter->GetAction()->GetExtra(extraLength, extraData);
 
-			if (extraLength & USHRT_MAX) {
-				memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-				extraCopy[extraLength & USHRT_MAX] = '\0';
+			if (extraLength) {
+				memcpy(extraCopy, extraData, extraLength);
+				extraCopy[extraLength] = '\0';
 			}
 		}
 

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -297,11 +297,11 @@ void LegoModelPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[1024], output[1024];
 		output[0] = '\0';
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		if (KeyValueStringParse(output, g_strAUTO_CREATE, extraCopy) != 0) {
 			char* token = strtok(output, g_parseExtraTokens);

--- a/LEGO1/omni/src/audio/mxwavepresenter.cpp
+++ b/LEGO1/omni/src/audio/mxwavepresenter.cpp
@@ -331,10 +331,10 @@ void MxWavePresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char soundValue[512];
 		if (KeyValueStringParse(soundValue, g_strSOUND, extraCopy)) {

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -87,10 +87,10 @@ void MxPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char worldValue[512];
 		if (KeyValueStringParse(worldValue, g_strWORLD, extraCopy)) {
@@ -251,10 +251,10 @@ MxEntity* MxPresenter::CreateEntity(const char* p_defaultName)
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 		KeyValueStringParse(objectName, g_strOBJECT, extraCopy);
 	}
 

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -202,10 +202,10 @@ void MxStillPresenter::ParseExtra()
 	char* extraData;
 	m_action->GetExtra(extraLength, extraData);
 
-	if (extraLength & USHRT_MAX) {
+	if (extraLength) {
 		char extraCopy[512];
-		memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
-		extraCopy[extraLength & USHRT_MAX] = '\0';
+		memcpy(extraCopy, extraData, extraLength);
+		extraCopy[extraLength] = '\0';
 
 		char output[512];
 		if (KeyValueStringParse(output, g_strVISIBILITY, extraCopy)) {


### PR DESCRIPTION
The `extraLength` variable in the various `ParseExtra` functions is a 16-bit variable. Occasionally the compiler will place it in one of the registers and mask out the top 16 bits. For example:

```asm
; From MxPresenter::ParseExtra

100b5012  MOV     EAX,dword ptr [EBP + extraLength]
100b501b  AND     EAX,0xffff

; set in ECX for upcoming REP MOVSD
100b5022  MOV     this,EAX
```

We have been doing this mask explicitly in the code:

```cpp
if (extraLength & USHRT_MAX) {
    char extraCopy[512];
    memcpy(extraCopy, extraData, extraLength & USHRT_MAX);
    extraCopy[extraLength & USHRT_MAX] = '\0';
```

At one point I think this _was_ necessary for accuracy (I may have even added it) but now that the functions are built out, removing it doesn't change anything.

There are masks like this in a few other spots but those seem to involve the type of the function parameter where they are used, so it's a separate task to fix those.