### PR TITLE
BETA10: reccomp support and Ghidra imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,16 @@ ENV/
 VENV/
 env.bak/
 venv.bak/
-ISLE.EXE
-LEGO1.DLL
 /build/
+/build_debug/
+/legobin/
 *.swp
 LEGO1PROGRESS.*
 ISLEPROGRESS.*
 *.pyc
 tools/ghidra_scripts/import.log
+
+# By convention we put the retail binaries into ./legobin.
+# These entries are kept for now since that convention has not always been around.
+ISLE.EXE
+LEGO1.DLL

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -209,7 +209,7 @@ void LegoCarRaceActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown
 }
 
 // FUNCTION: LEGO1 0x10080b70
-// FUNCTION: BETA10 0x1000366b
+// FUNCTION: BETA10 0x100cdbae
 void LegoCarRaceActor::VTable0x70(float p_float)
 {
 	// m_unk0x0c is not an MxBool, there are places where it is set to 2 or higher

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -89,7 +89,7 @@ public:
 	virtual float Dot(float* p_a, float* p_b) const { return DotImpl(p_a, p_b); } // vtable+0x3c
 
 	// FUNCTION: LEGO1 0x100020f0
-	// FUNCTION: BETA10 0x100028f6
+	// FUNCTION: BETA10 0x100108c0
 	virtual float Dot(Vector2* p_a, Vector2* p_b) const { return DotImpl(p_a->m_data, p_b->m_data); } // vtable+0x38
 
 	// FUNCTION: LEGO1 0x10002110
@@ -188,7 +188,7 @@ public:
 	// in reverse order of appearance.
 
 	// FUNCTION: LEGO1 0x10002270
-	// FUNCTION: BETA10 0x100064a1
+	// FUNCTION: BETA10 0x10011350
 	virtual void EqualsCrossImpl(float* p_a, float* p_b)
 	{
 		m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
@@ -275,7 +275,7 @@ public:
 	void EqualsImpl(float* p_data) override { memcpy(m_data, p_data, sizeof(float) * 3); } // vtable+0x20
 
 	// FUNCTION: LEGO1 0x10003bc0
-	// FUNCTION: BETA10 0x1000132a
+	// FUNCTION: BETA10 0x100114f0
 	void Clear() override { memset(m_data, 0, sizeof(float) * 3); } // vtable+0x2c
 
 	// FUNCTION: LEGO1 0x10003bd0

--- a/tools/ghidra_scripts/import_functions_and_types_from_pdb.py
+++ b/tools/ghidra_scripts/import_functions_and_types_from_pdb.py
@@ -228,7 +228,6 @@ def log_and_track_failure(
 
 
 def main():
-
     if GLOBALS.running_from_ghidra:
         origfile_name = getProgramFile().getName()
 
@@ -237,7 +236,9 @@ def main():
         elif origfile_name in ["LEGO1D.DLL", "BETA10.DLL"]:
             module = SupportedModules.BETA10
         else:
-            raise Lego1Exception(f"Unsupported file name in import script: {origfile_name}")
+            raise Lego1Exception(
+                f"Unsupported file name in import script: {origfile_name}"
+            )
     else:
         module = SupportedModules.LEGO1
 
@@ -262,7 +263,9 @@ def main():
     with Bin(str(origfile_path), find_str=True) as origfile, Bin(
         str(recompiledfile_path)
     ) as recompfile:
-        isle_compare = IsleCompare(origfile, recompfile, str(pdbfile_path), str(repo_root))
+        isle_compare = IsleCompare(
+            origfile, recompfile, str(pdbfile_path), str(repo_root)
+        )
 
     logger.info("Comparison complete.")
 

--- a/tools/ghidra_scripts/lego_util/function_importer.py
+++ b/tools/ghidra_scripts/lego_util/function_importer.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 class PdbFunctionImporter(ABC):
     """A representation of a function from the PDB with each type replaced by a Ghidra type instance."""
+
     def __init__(
         self,
         api: FlatProgramAPI,
@@ -71,10 +72,12 @@ class PdbFunctionImporter(ABC):
         )
 
     @abstractmethod
-    def matches_ghidra_function(self, ghidra_function: Function) -> bool: ...
+    def matches_ghidra_function(self, ghidra_function: Function) -> bool:
+        ...
 
     @abstractmethod
-    def overwrite_ghidra_function(self, ghidra_function: Function): ...
+    def overwrite_ghidra_function(self, ghidra_function: Function):
+        ...
 
 
 class ThunkPdbFunctionImport(PdbFunctionImporter):
@@ -101,6 +104,7 @@ class ThunkPdbFunctionImport(PdbFunctionImporter):
 # pylint: disable=too-many-instance-attributes
 class FullPdbFunctionImporter(PdbFunctionImporter):
     """For importing functions into Ghidra where all information are available."""
+
     def __init__(
         self,
         api: FlatProgramAPI,

--- a/tools/ghidra_scripts/lego_util/ghidra_helper.py
+++ b/tools/ghidra_scripts/lego_util/ghidra_helper.py
@@ -80,8 +80,10 @@ def create_ghidra_namespace(
             namespace = api.createNamespace(namespace, part)
     return namespace
 
+
 # These appear in debug builds
 THUNK_OF_RE = re.compile(r"^Thunk of '(.*)'$")
+
 
 def sanitize_name(name: str) -> str:
     """

--- a/tools/ghidra_scripts/lego_util/ghidra_helper.py
+++ b/tools/ghidra_scripts/lego_util/ghidra_helper.py
@@ -1,6 +1,7 @@
 """A collection of helper functions for the interaction with Ghidra."""
 
 import logging
+import re
 
 from lego_util.exceptions import (
     ClassOrNamespaceNotFoundInGhidraError,
@@ -79,26 +80,41 @@ def create_ghidra_namespace(
             namespace = api.createNamespace(namespace, part)
     return namespace
 
+# These appear in debug builds
+THUNK_OF_RE = re.compile(r"^Thunk of '(.*)'$")
 
 def sanitize_name(name: str) -> str:
     """
     Takes a full class or function name and replaces characters not accepted by Ghidra.
-    Applies mostly to templates and names like `vbase destructor`.
+    Applies mostly to templates, names like `vbase destructor`, and thunks in debug build.
     """
-    new_class_name = (
+    if (match := THUNK_OF_RE.fullmatch(name)) is not None:
+        is_thunk = True
+        name = match.group(1)
+    else:
+        is_thunk = False
+
+    # Replace characters forbidden in Ghidra
+    new_name = (
         name.replace("<", "[")
         .replace(">", "]")
         .replace("*", "#")
         .replace(" ", "_")
         .replace("`", "'")
     )
-    if "<" in name:
-        new_class_name = "_template_" + new_class_name
 
-    if new_class_name != name:
-        logger.warning(
-            "Class or function name contains characters forbidden by Ghidra, changing from '%s' to '%s'",
+    if "<" in name:
+        new_name = "_template_" + new_name
+
+    if is_thunk:
+        split = new_name.split("::")
+        split[-1] = "_thunk_" + split[-1]
+        new_name = "::".join(split)
+
+    if new_name != name:
+        logger.info(
+            "Changed class or function name from '%s' to '%s' to avoid Ghidra issues",
             name,
-            new_class_name,
+            new_name,
         )
-    return new_class_name
+    return new_name

--- a/tools/ghidra_scripts/lego_util/headers.pyi
+++ b/tools/ghidra_scripts/lego_util/headers.pyi
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import TypeVar, Any
 import ghidra
 
 # pylint: disable=invalid-name,unused-argument
@@ -17,3 +17,4 @@ def getFunctionAt(
 def createFunction(
     entryPoint: ghidra.program.model.address.Address, name: str
 ) -> ghidra.program.model.listing.Function: ...
+def getProgramFile() -> Any: ... # actually java.io.File

--- a/tools/ghidra_scripts/lego_util/headers.pyi
+++ b/tools/ghidra_scripts/lego_util/headers.pyi
@@ -17,4 +17,4 @@ def getFunctionAt(
 def createFunction(
     entryPoint: ghidra.program.model.address.Address, name: str
 ) -> ghidra.program.model.listing.Function: ...
-def getProgramFile() -> Any: ... # actually java.io.File
+def getProgramFile() -> Any: ...  # actually java.io.File

--- a/tools/isledecomp/isledecomp/compare/db.py
+++ b/tools/isledecomp/isledecomp/compare/db.py
@@ -381,18 +381,6 @@ class CompareDb:
 
         return True
 
-    def is_thunk_of(self, recomp_addr: int) -> bool:
-        """Check whether this function is a thunk of a debug build based on its name."""
-
-        name = self._db.execute(
-            """SELECT name
-            FROM `symbols`
-            WHERE recomp_addr = ?""",
-            (recomp_addr,),
-        ).fetchone()[0]
-
-        return name.startswith("Thunk of")
-
     def _find_potential_match(
         self, name: str, compare_type: SymbolType
     ) -> Optional[int]:

--- a/util/decomp.h
+++ b/util/decomp.h
@@ -1,6 +1,12 @@
 #ifndef DECOMP_H
 #define DECOMP_H
 
+#ifndef NDEBUG
+// Disable size assertions for debug builds because the sizes differ between debug and release builds.
+// The release LEGO1.DLL is what we ultimately want to decompile, so this is what we assert against.
+#undef ENABLE_DECOMP_ASSERTS
+#endif
+
 #if defined(ENABLE_DECOMP_ASSERTS)
 #define DECOMP_STATIC_ASSERT(V)                                                                                        \
 	namespace                                                                                                          \


### PR DESCRIPTION
Changes:
- A small issue was fixed that caused `reccmp` to crash when comparing a debug build to BETA10.
- A debug build can now be imported into Ghidra using the import script. I will upload a version to the shared Ghidra repository after the review.
- The import script received some improvements regarding thunks, which also has a positive effect on the LEGO1 repository.
- I fixed a few obviously wrong BETA10 annotations (probably made by me) that I found after running `reccmp`.

This is clearly not perfect since the codebase differs between BETA10 and LEGO1, but it has still shown to be rather helpful. In the future we could add some dedicated annotations / blacklists in case we want to maintain some BETA10/LEGO1 differences in the BETA10 Ghidra repository by hand, that shouldn't be overwritten by the import script. Vtable mismatches are also a slight issue right now (they can be shorter in BETA10).

Overall, the BETA10 got a match of 85 %, which I found surprisingly high. Matching BETA10 might also help getting a few difficult functions up to 100 % in both BETA10 and LEGO1.

If you want to use the import script, create a debug build in `./build_debug`. I added a note on creating a debug build in the tools README in my last PR.

Looking forward to your thoughts!