### PR TITLE
Sanitize args for assert in BETA10

### DIFF
--- a/tools/isledecomp/isledecomp/compare/asm/fixes.py
+++ b/tools/isledecomp/isledecomp/compare/asm/fixes.py
@@ -300,3 +300,15 @@ def find_effective_match(
     )
 
     return corrections.issuperset(recomp_lines_disputed)
+
+
+def assert_fixup(asm: List[Tuple[str, str]]):
+    """Detect assert calls and replace the code filename and line number
+    values with macros (from assert.h)."""
+    for i, (_, line) in enumerate(asm):
+        if "_assert" in line and line.startswith("call"):
+            try:
+                asm[i - 3] = (asm[i - 3][0], "push __LINE__")
+                asm[i - 2] = (asm[i - 2][0], "push __FILE__")
+            except IndexError:
+                continue

--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -13,7 +13,7 @@ from isledecomp.parser import DecompCodebase
 from isledecomp.dir import walk_source_dir
 from isledecomp.types import SymbolType
 from isledecomp.compare.asm import ParseAsm
-from isledecomp.compare.asm.fixes import find_effective_match
+from isledecomp.compare.asm.fixes import assert_fixup, find_effective_match
 from .db import CompareDb, MatchInfo
 from .diff import combined_diff
 from .lines import LinesDb
@@ -660,6 +660,11 @@ class Compare:
 
         if self.debug:
             self._dump_asm(orig_combined, recomp_combined)
+
+        # Check for assert calls only if we expect to find them
+        if self.orig_bin.is_debug or self.recomp_bin.is_debug:
+            assert_fixup(orig_combined)
+            assert_fixup(recomp_combined)
 
         # Detach addresses from asm lines for the text diff.
         orig_asm = [x[1] for x in orig_combined]


### PR DESCRIPTION
Calls to `assert` push the code filename and line number along with the assert expression. From assert.h:

```cpp
#define assert(exp) (void)( (exp) || (_assert(#exp, __FILE__, __LINE__), 0) )
```

Line numbers almost never match. We are using the same code filenames where these are known, but the full filepath in these strings won't match either. To eliminate diff noise, this adds a post-sanitization step to replace both pushed values with the `__LINE__` and `__FILE__` macros. We only need to do this for debug builds (BETA10) because release builds have no asserts.