### PR TITLE
Brute force string search for BETA10

### DIFF
--- a/tools/isledecomp/isledecomp/bin.py
+++ b/tools/isledecomp/isledecomp/bin.py
@@ -465,6 +465,22 @@ class Bin:
             for (func_addr, name_addr) in combined
         ]
 
+    def iter_string(self, encoding: str = "ascii") -> Iterator[Tuple[int, str]]:
+        """Search for possible strings at each verified address in .data."""
+        section = self.get_section_by_name(".data")
+        for addr in self._relocated_addrs:
+            if section.contains_vaddr(addr):
+                raw = self.read_string(addr)
+                if raw is None:
+                    continue
+
+                try:
+                    string = raw.decode(encoding)
+                except UnicodeDecodeError:
+                    continue
+
+                yield (addr, string)
+
     def get_section_by_name(self, name: str) -> Section:
         section = next(
             filter(lambda section: section.match_name(name), self.sections),

--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -354,7 +354,6 @@ class Compare:
                         addr, SymbolType.STRING, string, len(string)
                     )
 
-        if self.recomp_bin.is_debug:
             for addr, string in self.recomp_bin.iter_string("latin1"):
                 if is_real_string(string):
                     self._db.set_recomp_symbol(

--- a/tools/isledecomp/isledecomp/compare/core.py
+++ b/tools/isledecomp/isledecomp/compare/core.py
@@ -348,7 +348,6 @@ class Compare:
         # When we sanitize the asm, the result is the same regardless.
         if self.orig_bin.is_debug:
             for addr, string in self.orig_bin.iter_string("latin1"):
-                # Arbitrary threshold of 4, but I think this is what Ghidra does too
                 if is_real_string(string):
                     self._db.set_orig_symbol(
                         addr, SymbolType.STRING, string, len(string)


### PR DESCRIPTION
String constants in release builds are de-duplicated (meaning: the string appears once in the binary even if it's used in multiple places). Because the strings are a unique item in the binary, they also get a symbol. For example: "Helicopter" is in the PDB under the symbol: `??_C@_0L@OPFI@Helicopter?$AA@` ([Reference](https://en.wikiversity.org/wiki/Visual_C%2B%2B_name_mangling))

Debug builds (i.e. BETA10) don't de-dupe the strings, which means that only one occurrence of the string gets assigned a symbol, with the majority left unidentified. We could solve this with annotation coverage (`// STRING`) or just scan each binary to find them. This PR adds that brute force search and some code to weed out junk data. 

This should cover all of the assert strings so they will now stand out in the diff.