### PR TITLE
Beta match* MxStreamer

### DIFF
--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -74,6 +74,13 @@ public:
 	MxBool operator!=(const MxAtomId& p_atomId) const { return this->m_internal != p_atomId.m_internal; }
 #endif
 
+	// TODO:
+	// BETA10 0x1007dc20 operator==
+	// BETA10 0x10096970 operator!=
+
+	// FUNCTION: BETA10 0x10146dd0
+	MxBool operator==(const char* p_internal) const { return p_internal && !strcmp(m_internal, p_internal); }
+
 	// FUNCTION: BETA10 0x10025d40
 	MxAtomId() { this->m_internal = 0; }
 

--- a/LEGO1/omni/include/mxbitset.h
+++ b/LEGO1/omni/include/mxbitset.h
@@ -92,4 +92,76 @@ private:
 	MxU32 m_blocks[e_blocksRequired + 1]; // 0x00
 };
 
+// TEMPLATE: BETA10 0x10146600
+// MxBitset<2>::MxBitset<2>
+
+// TEMPLATE: BETA10 0x101464e0
+// MxBitset<22>::MxBitset<22>
+
+// TEMPLATE: BETA10 0x10146510
+// MxBitset<22>::Tidy
+
+// TEMPLATE: BETA10 0x10146570
+// MxBitset<22>::Trim
+
+// TEMPLATE: BETA10 0x10146630
+// MxBitset<2>::Tidy
+
+// TEMPLATE: BETA10 0x10146690
+// MxBitset<2>::Trim
+
+// TEMPLATE: BETA10 0x10146880
+// MxBitset<22>::Size
+
+// TEMPLATE: BETA10 0x101469d0
+// MxBitset<2>::Size
+
+// TEMPLATE: BETA10 0x101587a0
+// MxBitset<22>::Reference::Flip
+
+// TEMPLATE: BETA10 0x101587d0
+// MxBitset<22>::Reference::operator int
+
+// TEMPLATE: BETA10 0x10158800
+// MxBitset<22>::operator[]
+
+// TEMPLATE: BETA10 0x10158830
+// MxBitset<22>::Reference::Reference
+
+// TEMPLATE: BETA10 0x10158860
+// MxBitset<22>::Flip
+
+// STUB: BETA10 0x101588b0
+// MxBitset<22>::Count
+
+// TEMPLATE: BETA10 0x10158930
+// MxBitset<22>::Test
+
+// TEMPLATE: BETA10 0x10158990
+// MxBitset<22>::Xran
+
+// TEMPLATE: BETA10 0x10158b70
+// MxBitset<2>::Reference::Flip
+
+// TEMPLATE: BETA10 0x10158ba0
+// MxBitset<2>::Reference::operator int
+
+// TEMPLATE: BETA10 0x10158bd0
+// MxBitset<2>::operator[]
+
+// TEMPLATE: BETA10 0x10158c00
+// MxBitset<2>::Reference::Reference
+
+// TEMPLATE: BETA10 0x10158c30
+// MxBitset<2>::Flip
+
+// STUB: BETA10 0x10158c80
+// MxBitset<2>::Count
+
+// TEMPLATE: BETA10 0x10158d00
+// MxBitset<2>::Test
+
+// TEMPLATE: BETA10 0x10158d60
+// MxBitset<2>::Xran
+
 #endif // MXBITSET_H

--- a/LEGO1/omni/include/mxmemorypool.h
+++ b/LEGO1/omni/include/mxmemorypool.h
@@ -78,4 +78,42 @@ void MxMemoryPool<BS, NB>::Release(MxU8* p_buf)
 	MxTrace("Release> %d pool: busy %d blocks\n", m_blockSize, m_blockRef.Count());
 }
 
+// TEMPLATE: BETA10 0x101464a0
+// MxMemoryPool<64,22>::MxMemoryPool<64,22>
+
+// TEMPLATE: LEGO1 0x100b9100
+// TEMPLATE: BETA10 0x10146590
+// MxMemoryPool<64,22>::~MxMemoryPool<64,22>
+
+// TEMPLATE: BETA10 0x101465c0
+// MxMemoryPool<128,2>::MxMemoryPool<128,2>
+
+// TEMPLATE: LEGO1 0x100b9110
+// TEMPLATE: BETA10 0x101466b0
+// MxMemoryPool<128,2>::~MxMemoryPool<128,2>
+
+// TEMPLATE: BETA10 0x10146780
+// MxMemoryPool<64,22>::Allocate
+
+// TEMPLATE: BETA10 0x101468a0
+// MxMemoryPool<64,22>::GetPoolSize
+
+// TEMPLATE: BETA10 0x101468d0
+// MxMemoryPool<128,2>::Allocate
+
+// TEMPLATE: BETA10 0x101469f0
+// MxMemoryPool<128,2>::GetPoolSize
+
+// TEMPLATE: BETA10 0x10158610
+// MxMemoryPool<64,22>::Release
+
+// TEMPLATE: BETA10 0x101589e0
+// MxMemoryPool<128,2>::Release
+
+// TEMPLATE: BETA10 0x10158e50
+// MxMemoryPool<64,22>::Get
+
+// TEMPLATE: BETA10 0x10158f90
+// MxMemoryPool<128,2>::Get
+
 #endif // MXMEMORYPOOL_H

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -35,16 +35,23 @@ enum NotificationId {
 };
 
 // VTABLE: LEGO1 0x100d56e0
+// VTABLE: BETA10 0x101b86a8
 // SIZE 0x0c
 class MxNotificationParam : public MxParam {
 public:
 	MxNotificationParam() : m_type(c_notificationType0), m_sender(NULL) {}
+
+	// FUNCTION: BETA10 0x10013490
 	MxNotificationParam(NotificationId p_type, MxCore* p_sender) : MxParam(), m_type(p_type), m_sender(p_sender) {}
 
 	// FUNCTION: LEGO1 0x10010390
+	// FUNCTION: BETA10 0x100135f0
 	virtual MxNotificationParam* Clone() const { return new MxNotificationParam(m_type, m_sender); } // vtable+0x04
 
+	// FUNCTION: BETA10 0x100135c0
 	NotificationId GetNotification() const { return m_type; }
+
+	// FUNCTION: BETA10 0x1003c960
 	MxCore* GetSender() const { return m_sender; }
 
 	void SetNotification(NotificationId p_type) { m_type = p_type; }
@@ -56,9 +63,11 @@ protected:
 };
 
 // SYNTHETIC: LEGO1 0x10010430
+// SYNTHETIC: BETA10 0x100136c0
 // MxNotificationParam::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100104a0
+// SYNTHETIC: BETA10 0x10013740
 // MxNotificationParam::~MxNotificationParam
 
 #endif // MXNOTIFICATIONPARAM_H

--- a/LEGO1/omni/include/mxparam.h
+++ b/LEGO1/omni/include/mxparam.h
@@ -3,16 +3,22 @@
 
 // VTABLE: ISLE 0x40f018
 // VTABLE: LEGO1 0x100d56e8
+// VTABLE: BETA10 0x101b86b4
 // SIZE 0x04
 class MxParam {
 public:
 	// FUNCTION: ISLE 0x401530
 	// FUNCTION: LEGO1 0x10010360
+	// FUNCTION: BETA10 0x10013540
 	virtual ~MxParam() {}
 };
 
+// SYNTHETIC: BETA10 0x10013710
+// MxParam::MxParam
+
 // SYNTHETIC: ISLE 0x401540
 // SYNTHETIC: LEGO1 0x10010370
+// SYNTHETIC: BETA10 0x10013570
 // MxParam::`scalar deleting destructor'
 
 #endif // MXPARAM_H

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -158,6 +158,9 @@ private:
 // TEMPLATE: BETA10 0x10147020
 // list<MxStreamController *,allocator<MxStreamController *> >::iterator::operator==
 
+// TEMPLATE: BETA10 0x10147060
+// list<MxStreamController *,allocator<MxStreamController *> >::push_back
+
 // TEMPLATE: BETA10 0x10147200
 // ??9@YAHABViterator@?$list@PAVMxStreamController@@V?$allocator@PAVMxStreamController@@@@@@0@Z
 

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -17,9 +17,11 @@ typedef MxMemoryPool<64, 22> MxMemoryPool64;
 typedef MxMemoryPool<128, 2> MxMemoryPool128;
 
 // VTABLE: LEGO1 0x100dc760
+// VTABLE: BETA10 0x101c23c8
 // SIZE 0x10
 class MxStreamerNotification : public MxNotificationParam {
 public:
+	// FUNCTION: BETA10 0x10146e40
 	MxStreamerNotification(NotificationId p_type, MxCore* p_sender, MxStreamController* p_ctrlr)
 		: MxNotificationParam(p_type, p_sender)
 	{
@@ -28,6 +30,7 @@ public:
 
 	MxNotificationParam* Clone() const override;
 
+	// FUNCTION: BETA10 0x10147190
 	MxStreamController* GetController() { return m_controller; }
 
 private:
@@ -53,6 +56,7 @@ public:
 	MxLong Notify(MxParam& p_param) override; // vtable+0x04
 
 	// FUNCTION: LEGO1 0x100b9000
+	// FUNCTION: BETA10 0x10145ee0
 	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x1010210c
@@ -60,6 +64,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100b9010
+	// FUNCTION: BETA10 0x10145f00
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxStreamer::ClassName()) || MxCore::IsA(p_name);
@@ -74,6 +79,7 @@ public:
 	MxResult FUN_100b99b0(MxDSAction* p_action);
 	MxResult DeleteObject(MxDSAction* p_dsAction);
 
+	// FUNCTION: BETA10 0x10158db0
 	MxU8* GetMemoryBlock(MxU32 p_blockSize)
 	{
 		switch (p_blockSize) {
@@ -91,6 +97,7 @@ public:
 		return NULL;
 	}
 
+	// FUNCTION: BETA10 0x10158570
 	void ReleaseMemoryBlock(MxU8* p_block, MxU32 p_blockSize)
 	{
 		switch (p_blockSize) {
@@ -116,26 +123,47 @@ private:
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100b9090
-// TEMPLATE: BETA10 0x10146720
+// TEMPLATE: BETA10 0x10146020
 // list<MxStreamController *,allocator<MxStreamController *> >::~list<MxStreamController *,allocator<MxStreamController *> >
 // clang-format on
 
-// TEMPLATE: LEGO1 0x100b9100
-// MxMemoryPool<64,22>::~MxMemoryPool<64,22>
+// TEMPLATE: BETA10 0x10146090
+// list<MxStreamController *,allocator<MxStreamController *> >::begin
 
-// TEMPLATE: LEGO1 0x100b9110
-// MxMemoryPool<128,2>::~MxMemoryPool<128,2>
+// TEMPLATE: BETA10 0x10146120
+// list<MxStreamController *,allocator<MxStreamController *> >::end
+
+// TEMPLATE: BETA10 0x101461b0
+// list<MxStreamController *,allocator<MxStreamController *> >::iterator::operator++
 
 // SYNTHETIC: LEGO1 0x100b9120
+// SYNTHETIC: BETA10 0x101466e0
 // MxStreamer::`scalar deleting destructor'
 
 // TEMPLATE: LEGO1 0x100b9140
+// TEMPLATE: BETA10 0x10146720
 // List<MxStreamController *>::~List<MxStreamController *>
 
+// TEMPLATE: BETA10 0x10146ab0
+// list<MxStreamController *,allocator<MxStreamController *> >::iterator::operator*
+
 // SYNTHETIC: LEGO1 0x100b97b0
+// SYNTHETIC: BETA10 0x10146f80
 // MxStreamerNotification::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100b9820
+// SYNTHETIC: BETA10 0x10146fc0
 // MxStreamerNotification::~MxStreamerNotification
+
+// TEMPLATE: BETA10 0x10147020
+// list<MxStreamController *,allocator<MxStreamController *> >::iterator::operator==
+
+// TEMPLATE: BETA10 0x10147200
+// ??9@YAHABViterator@?$list@PAVMxStreamController@@V?$allocator@PAVMxStreamController@@@@@@0@Z
+
+// clang-format off
+// TEMPLATE: BETA10 0x10147230
+// ?find@@YA?AViterator@?$list@PAVMxStreamController@@V?$allocator@PAVMxStreamController@@@@@@V12@0ABQAVMxStreamController@@@Z
+// clang-format on
 
 #endif // MXSTREAMER_H

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -116,7 +116,7 @@ public:
 	}
 
 private:
-	list<MxStreamController*> m_openStreams; // 0x08
+	list<MxStreamController*> m_controllers; // 0x08
 	MxMemoryPool64 m_pool64;                 // 0x14
 	MxMemoryPool128 m_pool128;               // 0x20
 };

--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -63,6 +63,7 @@ MxResult MxNotificationManager::Create(MxU32 p_frequencyMS, MxBool p_createThrea
 }
 
 // FUNCTION: LEGO1 0x100ac6c0
+// FUNCTION: BETA10 0x10125b57
 MxResult MxNotificationManager::Send(MxCore* p_listener, const MxNotificationParam& p_param)
 {
 	AUTOLOCK(m_lock);

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -156,6 +156,7 @@ MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController* p_stream)
 
 	assert(it == m_openStreams.end());
 
+	// DECOMP: Retail is missing the optimization that skips this check if find() reaches the end.
 	if (it == m_openStreams.end()) {
 		m_openStreams.push_back(p_stream);
 		return SUCCESS;
@@ -199,7 +200,7 @@ MxResult MxStreamer::DeleteObject(MxDSAction* p_dsAction)
 	MxResult result = FAILURE;
 	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
 		// TODO: MxAtomId operator== used here for NULL test. BETA10 0x1007dc20
-		if (p_dsAction->GetAtomId().GetInternal() != NULL || p_dsAction->GetAtomId() == (*it)->GetAtom()) {
+		if (p_dsAction->GetAtomId().GetInternal() == NULL || p_dsAction->GetAtomId() == (*it)->GetAtom()) {
 			tempAction.SetAtomId((*it)->GetAtom());
 			result = (*it)->VTable0x24(&tempAction);
 		}

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -37,8 +37,8 @@ MxResult MxStreamer::Create()
 // FUNCTION: BETA10 0x10145268
 MxStreamer::~MxStreamer()
 {
-	while (!m_openStreams.empty()) {
-		MxStreamController* controller = m_openStreams.front();
+	while (!m_controllers.empty()) {
+		MxStreamController* controller = m_controllers.front();
 
 #ifdef COMPAT_MODE
 		{
@@ -49,7 +49,7 @@ MxStreamer::~MxStreamer()
 		assert(controller->IsStoped(&MxDSAction()));
 #endif
 
-		m_openStreams.pop_front();
+		m_controllers.pop_front();
 		delete controller;
 	}
 
@@ -99,11 +99,11 @@ MxLong MxStreamer::Close(const char* p_name)
 	MxDSAction ds;
 	ds.SetUnknown24(-2);
 
-	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
+	for (list<MxStreamController*>::iterator it = m_controllers.begin(); it != m_controllers.end(); it++) {
 		MxStreamController* c = *it;
 
 		if (!p_name || c->GetAtom() == p_name) {
-			m_openStreams.erase(it);
+			m_controllers.erase(it);
 
 			if (c->IsStoped(&ds)) {
 				delete c;
@@ -130,7 +130,7 @@ MxNotificationParam* MxStreamerNotification::Clone() const
 // FUNCTION: BETA10 0x1014584b
 MxStreamController* MxStreamer::GetOpenStream(const char* p_name)
 {
-	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
+	for (list<MxStreamController*>::iterator it = m_controllers.begin(); it != m_controllers.end(); it++) {
 		if ((*it)->GetAtom() == p_name) {
 			return *it;
 		}
@@ -152,13 +152,13 @@ void MxStreamer::FUN_100b98f0(MxDSAction* p_action)
 // FUNCTION: BETA10 0x101458e5
 MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController* p_stream)
 {
-	list<MxStreamController*>::iterator it = find(m_openStreams.begin(), m_openStreams.end(), p_stream);
+	list<MxStreamController*>::iterator i = find(m_controllers.begin(), m_controllers.end(), p_stream);
 
-	assert(it == m_openStreams.end());
+	assert(i == m_controllers.end());
 
 	// DECOMP: Retail is missing the optimization that skips this check if find() reaches the end.
-	if (it == m_openStreams.end()) {
-		m_openStreams.push_back(p_stream);
+	if (i == m_controllers.end()) {
+		m_controllers.push_back(p_stream);
 		return SUCCESS;
 	}
 
@@ -198,7 +198,7 @@ MxResult MxStreamer::DeleteObject(MxDSAction* p_dsAction)
 	}
 
 	MxResult result = FAILURE;
-	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
+	for (list<MxStreamController*>::iterator it = m_controllers.begin(); it != m_controllers.end(); it++) {
 		// TODO: MxAtomId operator== used here for NULL test. BETA10 0x1007dc20
 		if (p_dsAction->GetAtomId().GetInternal() == NULL || p_dsAction->GetAtomId() == (*it)->GetAtom()) {
 			tempAction.SetAtomId((*it)->GetAtom());

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -102,7 +102,7 @@ MxLong MxStreamer::Close(const char* p_name)
 	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
 		MxStreamController* c = *it;
 
-		if (!p_name || !strcmp(p_name, c->GetAtom().GetInternal())) {
+		if (!p_name || c->GetAtom() == p_name) {
 			m_openStreams.erase(it);
 
 			if (c->IsStoped(&ds)) {
@@ -120,6 +120,7 @@ MxLong MxStreamer::Close(const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x100b9700
+// FUNCTION: BETA10 0x10146ed0
 MxNotificationParam* MxStreamerNotification::Clone() const
 {
 	return new MxStreamerNotification(m_type, m_sender, m_controller);
@@ -130,12 +131,8 @@ MxNotificationParam* MxStreamerNotification::Clone() const
 MxStreamController* MxStreamer::GetOpenStream(const char* p_name)
 {
 	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
-		MxStreamController* c = *it;
-		MxAtomId& atom = c->GetAtom();
-		if (p_name) {
-			if (!strcmp(atom.GetInternal(), p_name)) {
-				return *it;
-			}
+		if ((*it)->GetAtom() == p_name) {
+			return *it;
 		}
 	}
 
@@ -152,9 +149,14 @@ void MxStreamer::FUN_100b98f0(MxDSAction* p_action)
 }
 
 // FUNCTION: LEGO1 0x100b9930
+// FUNCTION: BETA10 0x101458e5
 MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController* p_stream)
 {
-	if (find(m_openStreams.begin(), m_openStreams.end(), p_stream) == m_openStreams.end()) {
+	list<MxStreamController*>::iterator it = find(m_openStreams.begin(), m_openStreams.end(), p_stream);
+
+	assert(it == m_openStreams.end());
+
+	if (it == m_openStreams.end()) {
 		m_openStreams.push_back(p_stream);
 		return SUCCESS;
 	}
@@ -163,37 +165,41 @@ MxResult MxStreamer::AddStreamControllerToOpenList(MxStreamController* p_stream)
 }
 
 // FUNCTION: LEGO1 0x100b99b0
+// FUNCTION: BETA10 0x101459ad
 MxResult MxStreamer::FUN_100b99b0(MxDSAction* p_action)
 {
-	MxStreamController* controller;
-	if (p_action != NULL && p_action->GetAtomId().GetInternal() != NULL && p_action->GetObjectId() != -1) {
-		controller = GetOpenStream(p_action->GetAtomId().GetInternal());
-		if (controller == NULL) {
-			return FAILURE;
-		}
-		return controller->VTable0x20(p_action);
+	// TODO: MxAtomId operator== used here for NULL test. BETA10 0x1007dc20
+	if (p_action == NULL || p_action->GetAtomId().GetInternal() == NULL || p_action->GetObjectId() == -1) {
+		return FAILURE;
 	}
-	return FAILURE;
+
+	MxStreamController* controller = GetOpenStream(p_action->GetAtomId().GetInternal());
+	if (controller == NULL) {
+		return FAILURE;
+	}
+
+	return controller->VTable0x20(p_action);
 }
 
 // FUNCTION: LEGO1 0x100b99f0
+// FUNCTION: BETA10 0x10145a54
 MxResult MxStreamer::DeleteObject(MxDSAction* p_dsAction)
 {
 	MxDSAction tempAction;
 
-	if (p_dsAction == NULL) {
-		tempAction.SetUnknown24(-2);
-	}
-	else {
+	if (p_dsAction) {
 		tempAction.SetObjectId(p_dsAction->GetObjectId());
 		tempAction.SetAtomId(p_dsAction->GetAtomId());
 		tempAction.SetUnknown24(p_dsAction->GetUnknown24());
 	}
+	else {
+		tempAction.SetUnknown24(-2);
+	}
 
 	MxResult result = FAILURE;
 	for (list<MxStreamController*>::iterator it = m_openStreams.begin(); it != m_openStreams.end(); it++) {
-		const char* id = p_dsAction->GetAtomId().GetInternal();
-		if (!id || id == (*it)->GetAtom().GetInternal()) {
+		// TODO: MxAtomId operator== used here for NULL test. BETA10 0x1007dc20
+		if (p_dsAction->GetAtomId().GetInternal() != NULL || p_dsAction->GetAtomId() == (*it)->GetAtom()) {
 			tempAction.SetAtomId((*it)->GetAtom());
 			result = (*it)->VTable0x24(&tempAction);
 		}
@@ -203,6 +209,7 @@ MxResult MxStreamer::DeleteObject(MxDSAction* p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100b9b30
+// FUNCTION: BETA10 0x10145d01
 MxBool MxStreamer::FUN_100b9b30(MxDSObject& p_dsObject)
 {
 	MxStreamController* controller = GetOpenStream(p_dsObject.GetAtomId().GetInternal());
@@ -213,14 +220,18 @@ MxBool MxStreamer::FUN_100b9b30(MxDSObject& p_dsObject)
 }
 
 // FUNCTION: LEGO1 0x100b9b60
+// FUNCTION: BETA10 0x10145d51
 MxLong MxStreamer::Notify(MxParam& p_param)
 {
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationStreamer) {
+	MxStreamerNotification& s = static_cast<MxStreamerNotification&>(p_param);
+
+	switch (s.GetNotification()) {
+	case c_notificationStreamer: {
+		// DECOMP: Beta does not use a variable, but this matches retail better.
+		MxStreamController* c = s.GetController();
+
 		MxDSAction ds;
-
 		ds.SetUnknown24(-2);
-
-		MxStreamController* c = static_cast<MxStreamerNotification&>(p_param).GetController();
 
 		if (c->IsStoped(&ds)) {
 			delete c;
@@ -228,6 +239,12 @@ MxLong MxStreamer::Notify(MxParam& p_param)
 		else {
 			NotificationManager()->Send(this, MxStreamerNotification(c_notificationStreamer, NULL, c));
 		}
+
+		break;
+	}
+	default:
+		assert(0);
+		break;
 	}
 
 	return 0;


### PR DESCRIPTION
- Added more beta addrs for `MxBitSet` and `MxMemoryPool` that I had in my local file.
- Renamed `m_openStreams` to `m_controllers` based on the assert in `AddStreamControllerToOpenList`.
- `Notify` does not match the beta exactly because it calls `GetController` each time it is used. Retail gets to 100% if you save this in a variable. Maybe this could (or should) be optimized away?
- `AddStreamControllerToOpenList` does not match retail 100%, but this should be fine for now (unless it was at 100% earlier). The previous code looked like this:

```cpp
if (find(m_controllers.begin(), m_controllers.end(), p_stream) == m_controllers.end()) {
    m_controllers.push_back(p_stream);
    return SUCCESS;
}
```

This is closer to what we have in the assembly; if we know we reached the end of the list without a match, skip straight to the `push_back` call. With `find` broken out to match the beta, the jump distance is a little off, but I don't think it will present a problem because we are just checking against `end()` twice. I didn't test so hopefully this is the case!

- There are two more operator overloads in `MxAtomId`, but I'm not sure what the type is supposed to be. The `operator==` at `0x1007dc20` is used to check whether `m_internal` is null, but what gets sent in is not an `MxAtomId` because no constructor is called. For example:

```asm
                     LAB_1008e75d                                    XREF[1]:     1008e746(j)  
1008e75d c7 45 cc        MOV        dword ptr [EBP + local_38],0x0
1008e764 8d 45 cc        LEA        EAX=>local_38,[EBP + -0x34]
1008e767 89 45 c0        MOV        dword ptr [EBP + local_44],EAX
1008e76a 8b 45 c0        MOV        EAX,dword ptr [EBP + local_44]
1008e76d 50              PUSH       EAX
1008e76e 8b 4d 08        MOV        this,dword ptr [EBP + param_1]
1008e771 e8 2b 5f        CALL       thunk_FUN_1007dc20
         f7 ff
```

I marked where this should go once we figure it out, or maybe someone has an idea now.