### PR TITLE
MxStreamListMxDSAction helper functions

### DIFF
--- a/LEGO1/omni/include/mxstreamlist.h
+++ b/LEGO1/omni/include/mxstreamlist.h
@@ -24,7 +24,11 @@ public:
 // SIZE 0x0c
 class MxStreamListMxDSAction : public MxStreamList<MxDSAction*> {
 public:
-	MxDSAction* Find(MxDSAction* p_action, MxBool p_delete);
+	// FUNCTION: BETA10 0x10150e30
+	MxDSAction* FindAndErase(MxDSAction* p_action) { return FindInternal(p_action, TRUE); }
+
+	// FUNCTION: BETA10 0x10150fc0
+	MxDSAction* Find(MxDSAction* p_action) { return FindInternal(p_action, FALSE); }
 
 	// There chance this list actually holds MxDSStreamingListAction
 	// instead of MxDSAction. Until then, we use this helper.
@@ -38,6 +42,9 @@ public:
 		pop_front();
 		return TRUE;
 	}
+
+private:
+	MxDSAction* FindInternal(MxDSAction* p_action, MxBool p_delete);
 };
 
 // SIZE 0x0c

--- a/LEGO1/omni/include/mxstreamlist.h
+++ b/LEGO1/omni/include/mxstreamlist.h
@@ -60,4 +60,10 @@ public:
 	MxDSSubscriber* Find(MxDSObject* p_object);
 };
 
+// TEMPLATE: BETA10 0x10150950
+// MxStreamList<MxDSAction *>::PopFront
+
+// TEMPLATE: BETA10 0x10150a70
+// MxStreamList<MxDSSubscriber *>::PopFront
+
 #endif // MXSTREAMLIST_H

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -340,10 +340,10 @@ MxLong MxOmni::HandleEndAction(MxParam& p_param)
 	MxStreamController* controller = Streamer()->GetOpenStream(action->GetAtomId().GetInternal());
 
 	if (controller != NULL) {
-		action = controller->GetUnk0x54().Find(action, FALSE);
+		action = controller->GetUnk0x54().Find(action);
 		if (action) {
 			if (ActionSourceEquals(action, "LegoLoopingAnimPresenter") == FALSE) {
-				delete controller->GetUnk0x54().Find(action, TRUE);
+				delete controller->GetUnk0x54().FindAndErase(action);
 			}
 		}
 	}

--- a/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
@@ -187,7 +187,7 @@ MxResult MxDiskStreamController::VTable0x30(MxDSAction* p_action)
 
 	MxDSStreamingAction* item;
 	while (TRUE) {
-		item = (MxDSStreamingAction*) m_list0x90.Find(p_action, TRUE);
+		item = (MxDSStreamingAction*) m_list0x90.FindAndErase(p_action);
 		if (item == NULL) {
 			break;
 		}
@@ -195,7 +195,7 @@ MxResult MxDiskStreamController::VTable0x30(MxDSAction* p_action)
 	}
 
 	while (TRUE) {
-		item = (MxDSStreamingAction*) m_list0x64.Find(p_action, TRUE);
+		item = (MxDSStreamingAction*) m_list0x64.FindAndErase(p_action);
 		if (item == NULL) {
 			break;
 		}
@@ -286,8 +286,7 @@ void MxDiskStreamController::FUN_100c7f40(MxDSStreamingAction* p_streamingaction
 MxResult MxDiskStreamController::VTable0x20(MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
-	MxDSStreamingAction* entry =
-		(MxDSStreamingAction*) m_list0x80.Find(p_action, FALSE); // TODO: is this a seperate class?
+	MxDSStreamingAction* entry = (MxDSStreamingAction*) m_list0x80.Find(p_action); // TODO: is this a seperate class?
 	if (entry) {
 		MxDSStreamingAction* action = new MxDSStreamingAction(*p_action, 0);
 		action->SetUnknown28(entry->GetUnknown28());
@@ -320,7 +319,7 @@ void MxDiskStreamController::FUN_100c8120(MxDSAction* p_action)
 	}
 
 	while (TRUE) {
-		MxDSAction* found = m_unk0x54.Find(p_action, TRUE);
+		MxDSAction* found = m_unk0x54.FindAndErase(p_action);
 		if (!found) {
 			break;
 		}
@@ -332,7 +331,7 @@ void MxDiskStreamController::FUN_100c8120(MxDSAction* p_action)
 MxResult MxDiskStreamController::VTable0x24(MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
-	if (m_unk0x54.Find(p_action, FALSE) == NULL) {
+	if (m_unk0x54.Find(p_action) == NULL) {
 		if (VTable0x30(p_action) == SUCCESS) {
 			MxOmni::GetInstance()->NotifyCurrentEntity(
 				MxEndActionNotificationParam(c_notificationEndAction, NULL, p_action, TRUE)
@@ -368,7 +367,7 @@ MxResult MxDiskStreamController::FUN_100c8360(MxDSStreamingAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
 	MxDSBuffer* buffer = p_action->GetUnknowna0();
-	MxDSStreamingAction* action2 = (MxDSStreamingAction*) m_list0x90.Find(p_action, TRUE);
+	MxDSStreamingAction* action2 = (MxDSStreamingAction*) m_list0x90.FindAndErase(p_action);
 	buffer->FUN_100c6f80(p_action->GetUnknown94() - p_action->GetBufferOffset());
 	buffer->FUN_100c67b0(this, p_action, &action2);
 

--- a/LEGO1/omni/src/stream/mxdiskstreamprovider.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamprovider.cpp
@@ -144,7 +144,7 @@ void MxDiskStreamProvider::VTable0x20(MxDSAction* p_action)
 		do {
 			{
 				AUTOLOCK(m_criticalSection);
-				action = (MxDSStreamingAction*) m_list.Find(p_action, TRUE);
+				action = (MxDSStreamingAction*) m_list.FindAndErase(p_action);
 			}
 
 			if (!action) {

--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -103,7 +103,7 @@ MxResult MxDSBuffer::FUN_100c67b0(
 {
 	MxResult result = FAILURE;
 
-	m_unk0x30 = (MxDSStreamingAction*) p_controller->GetUnk0x3c().Find(p_action, FALSE);
+	m_unk0x30 = (MxDSStreamingAction*) p_controller->GetUnk0x3c().Find(p_action);
 	if (m_unk0x30 == NULL) {
 		return FAILURE;
 	}

--- a/LEGO1/omni/src/stream/mxramstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxramstreamcontroller.cpp
@@ -43,20 +43,20 @@ MxResult MxRAMStreamController::VTable0x20(MxDSAction* p_action)
 
 	if (p_action->GetUnknown24() == -1) {
 		p_action->SetUnknown24(-3);
-		MxDSAction* action = m_unk0x54.Find(p_action, FALSE);
+		MxDSAction* action = m_unk0x54.Find(p_action);
 		if (action != NULL) {
 			unk0x24 = action->GetUnknown24() + 1;
 		}
 		p_action->SetUnknown24(unk0x24);
 	}
 	else {
-		if (m_unk0x54.Find(p_action, FALSE)) {
+		if (m_unk0x54.Find(p_action)) {
 			return FAILURE;
 		}
 	}
 
 	if (MxStreamController::VTable0x20(p_action) == SUCCESS) {
-		MxDSStreamingAction* action = (MxDSStreamingAction*) m_unk0x3c.Find(p_action, FALSE);
+		MxDSStreamingAction* action = (MxDSStreamingAction*) m_unk0x3c.Find(p_action);
 		MxDSStreamingAction streamingaction(*action);
 		result = DeserializeObject(streamingaction);
 	}
@@ -89,7 +89,7 @@ MxResult MxRAMStreamController::DeserializeObject(MxDSStreamingAction& p_action)
 		m_buffer.FUN_100c6f80(p_action.GetUnknown94());
 		// Probably not MxResult, see below
 		result = m_buffer.FUN_100c67b0(this, &p_action, &value);
-	} while (m_unk0x3c.Find(&p_action, FALSE) != NULL);
+	} while (m_unk0x3c.Find(&p_action) != NULL);
 
 	return result == SUCCESS ? SUCCESS : FAILURE;
 }

--- a/LEGO1/omni/src/stream/mxstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxstreamcontroller.cpp
@@ -135,7 +135,7 @@ MxResult MxStreamController::VTable0x24(MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
 	VTable0x30(p_action);
-	m_action0x60 = m_unk0x54.Find(p_action, TRUE);
+	m_action0x60 = m_unk0x54.FindAndErase(p_action);
 	if (m_action0x60 == NULL) {
 		return FAILURE;
 	}
@@ -198,7 +198,7 @@ MxResult MxStreamController::FUN_100c1a00(MxDSAction* p_action, MxU32 p_offset)
 		p_action->SetUnknown24(newUnknown24 + 1);
 	}
 	else {
-		if (m_unk0x3c.Find(p_action, FALSE)) {
+		if (m_unk0x3c.Find(p_action)) {
 			return FAILURE;
 		}
 	}
@@ -235,7 +235,7 @@ MxResult MxStreamController::VTable0x30(MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
 	MxResult result = FAILURE;
-	MxDSAction* action = m_unk0x3c.Find(p_action, TRUE);
+	MxDSAction* action = m_unk0x3c.FindAndErase(p_action);
 	if (action != NULL) {
 		MxNextActionDataStart* data = m_nextActionList.FindAndErase(action->GetObjectId(), action->GetUnknown24());
 		delete action;
@@ -266,7 +266,7 @@ MxPresenter* MxStreamController::FUN_100c1e70(MxDSAction& p_action)
 	AUTOLOCK(m_criticalSection);
 	MxPresenter* result = NULL;
 	if (p_action.GetObjectId() != -1) {
-		MxDSAction* action = m_unk0x3c.Find(&p_action, FALSE);
+		MxDSAction* action = m_unk0x3c.Find(&p_action);
 		if (action != NULL) {
 			result = action->GetUnknown28();
 		}

--- a/LEGO1/omni/src/stream/mxstreamlist.cpp
+++ b/LEGO1/omni/src/stream/mxstreamlist.cpp
@@ -6,6 +6,7 @@ DECOMP_SIZE_ASSERT(MxStreamListMxNextActionDataStart, 0x0c);
 DECOMP_SIZE_ASSERT(MxStreamListMxDSSubscriber, 0x0c);
 
 // FUNCTION: LEGO1 0x100b8450
+// FUNCTION: BETA10 0x10134c1d
 MxDSSubscriber* MxStreamListMxDSSubscriber::Find(MxDSObject* p_object)
 {
 	for (iterator it = begin(); it != end(); it++) {
@@ -52,6 +53,7 @@ MxDSAction* MxStreamListMxDSAction::FindInternal(MxDSAction* p_action, MxBool p_
 }
 
 // FUNCTION: LEGO1 0x100c21e0
+// FUNCTION: BETA10 0x1014f4e6
 MxNextActionDataStart* MxStreamListMxNextActionDataStart::Find(MxU32 p_id, MxS16 p_value)
 {
 	for (iterator it = begin(); it != end(); it++) {
@@ -64,6 +66,7 @@ MxNextActionDataStart* MxStreamListMxNextActionDataStart::Find(MxU32 p_id, MxS16
 }
 
 // FUNCTION: LEGO1 0x100c2240
+// FUNCTION: BETA10 0x1014f58c
 MxNextActionDataStart* MxStreamListMxNextActionDataStart::FindAndErase(MxU32 p_id, MxS16 p_value)
 {
 	MxNextActionDataStart* match = NULL;

--- a/LEGO1/omni/src/stream/mxstreamlist.cpp
+++ b/LEGO1/omni/src/stream/mxstreamlist.cpp
@@ -20,7 +20,8 @@ MxDSSubscriber* MxStreamListMxDSSubscriber::Find(MxDSObject* p_object)
 }
 
 // FUNCTION: LEGO1 0x100bfa80
-MxDSAction* MxStreamListMxDSAction::Find(MxDSAction* p_action, MxBool p_delete)
+// FUNCTION: BETA10 0x10147e02
+MxDSAction* MxStreamListMxDSAction::FindInternal(MxDSAction* p_action, MxBool p_delete)
 {
 	// DECOMP ALPHA 0x1008b99d ?
 


### PR DESCRIPTION
`MxStreamListMxDSAction::Find` has a `p_delete` parameter that removes the matching item from the STL list. The beta shows that this is not called directly, but aliased by two other functions. `Find` is now `FindInternal` and the helper functions are `Find` and `FindAndErase`. These names match similar functions we already have for `MxStreamListMxNextActionDataStart`, but the ones in _that_ class are unique functions. (i.e. the helpers are not part of the main `MxStreamList` template.)

Relatively small impact from compiler randomness this time. The functions that call `Find` look to be unaffected.