### PR TITLE
Fix spurious reccmp warnings

### DIFF
--- a/tools/isledecomp/isledecomp/cvdump/symbols.py
+++ b/tools/isledecomp/isledecomp/cvdump/symbols.py
@@ -79,7 +79,6 @@ class CvdumpSymbolsParser:
         "S_THUNK32",
         "S_LABEL32",
         "S_LDATA32",
-        "S_LPROC32",
         "S_UDT",
     ]
 
@@ -117,7 +116,7 @@ class CvdumpSymbolsParser:
         symbol_type: str = line_match.group("symbol_type")
         second_part: Optional[str] = line_match.group("second_part")
 
-        if symbol_type == "S_GPROC32":
+        if symbol_type in ["S_GPROC32", "S_LPROC32"]:
             assert second_part is not None
             if (match := self._symbol_line_function_regex.match(second_part)) is None:
                 logger.error("Invalid function symbol: %s", line[:-1])


### PR DESCRIPTION
This small change fixes a lot of spurious errors logged e.g. in `reccmp`, particularly when working with `BETA10`. I first considered not adding the `LPROC32` functions to the list of known symbols, but they do not appear to cause any harm and might come in handy at some point.