### PR TITLE
BETA10 import: Fix `FUN_...` collisions

### DIFF
--- a/tools/ghidra_scripts/import_functions_and_types_from_pdb.py
+++ b/tools/ghidra_scripts/import_functions_and_types_from_pdb.py
@@ -54,6 +54,7 @@ reload_module("lego_util.statistics")
 reload_module("lego_util.globals")
 from lego_util.globals import GLOBALS, SupportedModules
 
+
 def setup_logging():
     logging.root.handlers.clear()
     formatter = logging.Formatter("%(levelname)-8s %(message)s")
@@ -205,7 +206,9 @@ def main():
     logger.info("Importing file: %s", GLOBALS.module.orig_filename())
 
     repo_root = get_repository_root()
-    origfile_path = repo_root.joinpath("legobin").joinpath(GLOBALS.module.orig_filename())
+    origfile_path = repo_root.joinpath("legobin").joinpath(
+        GLOBALS.module.orig_filename()
+    )
     build_directory = repo_root.joinpath(GLOBALS.module.build_dir_name())
     recompiledfile_name = f"{GLOBALS.module.recomp_filename_without_extension()}.DLL"
     recompiledfile_path = build_directory.joinpath(recompiledfile_name)

--- a/tools/ghidra_scripts/lego_util/ghidra_helper.py
+++ b/tools/ghidra_scripts/lego_util/ghidra_helper.py
@@ -8,6 +8,7 @@ from lego_util.exceptions import (
     TypeNotFoundInGhidraError,
     MultipleTypesFoundInGhidraError,
 )
+from lego_util.globals import GLOBALS, SupportedModules
 
 # Disable spurious warnings in vscode / pylance
 # pyright: reportMissingModuleSource=false
@@ -104,6 +105,12 @@ def sanitize_name(name: str) -> str:
         .replace(" ", "_")
         .replace("`", "'")
     )
+
+    # Importing function names like `FUN_10001234` into BETA10 can be confusing
+    # because Ghidra's auto-generated functions look exactly the same.
+    # Therefore, such function names are replaced by `LEGO_10001234` in the BETA10 import.
+    if GLOBALS.module == SupportedModules.BETA10:
+        new_name = re.sub(r"FUN_([0-9a-f]{8})", r"LEGO1_\1", new_name)
 
     if "<" in name:
         new_name = "_template_" + new_name

--- a/tools/ghidra_scripts/lego_util/globals.py
+++ b/tools/ghidra_scripts/lego_util/globals.py
@@ -1,0 +1,42 @@
+import logging
+from enum import Enum
+from dataclasses import dataclass, field
+from lego_util.statistics import Statistics
+
+
+class SupportedModules(Enum):
+    LEGO1 = 1
+    BETA10 = 2
+
+    def orig_filename(self):
+        if self == self.LEGO1:
+            return "LEGO1.DLL"
+        return "BETA10.DLL"
+
+    def recomp_filename_without_extension(self):
+        # in case we want to support more functions
+        return "LEGO1"
+
+    def build_dir_name(self):
+        if self == self.BETA10:
+            return "build_debug"
+        return "build"
+
+
+@dataclass
+class Globals:
+    verbose: bool
+    loglevel: int
+    module: SupportedModules
+    running_from_ghidra: bool = False
+    # statistics
+    statistics: Statistics = field(default_factory=Statistics)
+
+
+# hard-coded settings that we don't want to prompt in Ghidra every time
+GLOBALS = Globals(
+    verbose=False,
+    # loglevel=logging.INFO,
+    loglevel=logging.DEBUG,
+    module=SupportedModules.LEGO1,  # this default value will be used when run outside of Ghidra
+)


### PR DESCRIPTION
A lot of functions in our codebase are named `FUN_$address` which is fine for LEGO1 Ghidra imports, but it is confusing for BETA10 - it is hard to tell apart imported functions from Ghidra's autodetected ones. This new behaviour does the following:
* Nothing changes for the LEGO1 import
* In the BETA10 import, `FUN_$address` in function names is replaced by `LEGO1_$address`.

Let me know what you think.