### PR TITLE
Refactor various `operator[]` based on BETA10

### DIFF
--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -9,6 +9,7 @@ class LegoEntity;
 class MxDSChunk;
 
 // VTABLE: LEGO1 0x100d4e50
+// VTABLE: BETA10 0x101bcd88
 // SIZE 0x6c
 class LegoModelPresenter : public MxVideoPresenter {
 public:

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -789,9 +789,9 @@ void LegoAnimPresenter::StartingTickle()
 	FUN_1006c8a0(TRUE);
 
 	if (m_unk0x78 == NULL) {
-		if (fabs(m_action->GetDirection().GetX()) >= 0.00000047683716F ||
-			fabs(m_action->GetDirection().GetY()) >= 0.00000047683716F ||
-			fabs(m_action->GetDirection().GetZ()) >= 0.00000047683716F) {
+		if (fabs(m_action->GetDirection()[0]) >= 0.00000047683716F ||
+			fabs(m_action->GetDirection()[1]) >= 0.00000047683716F ||
+			fabs(m_action->GetDirection()[2]) >= 0.00000047683716F) {
 			m_unk0x78 = new MxMatrix();
 			CalcLocalTransform(m_action->GetLocation(), m_action->GetDirection(), m_action->GetUp(), *m_unk0x78);
 		}

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -50,6 +50,7 @@ void LegoModelPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x1007f6b0
+// FUNCTION: BETA10 0x1009845e
 MxResult LegoModelPresenter::CreateROI(MxDSChunk* p_chunk)
 {
 	MxResult result = FAILURE;
@@ -171,13 +172,9 @@ MxResult LegoModelPresenter::CreateROI(MxDSChunk* p_chunk)
 	// Get scripted location, direction and up vectors
 
 	CalcLocalTransform(
-		Mx3DPointFloat(m_action->GetLocation().GetX(), m_action->GetLocation().GetY(), m_action->GetLocation().GetZ()),
-		Mx3DPointFloat(
-			m_action->GetDirection().GetX(),
-			m_action->GetDirection().GetY(),
-			m_action->GetDirection().GetZ()
-		),
-		Mx3DPointFloat(m_action->GetUp().GetX(), m_action->GetUp().GetY(), m_action->GetUp().GetZ()),
+		Mx3DPointFloat(m_action->GetLocation()[0], m_action->GetLocation()[1], m_action->GetLocation()[2]),
+		Mx3DPointFloat(m_action->GetDirection()[0], m_action->GetDirection()[1], m_action->GetDirection()[2]),
+		Mx3DPointFloat(m_action->GetUp()[0], m_action->GetUp()[1], m_action->GetUp()[2]),
 		mat
 	);
 	m_roi->UpdateTransformationRelativeToParent(mat);
@@ -234,6 +231,7 @@ MxResult LegoModelPresenter::FUN_1007ff70(
 }
 
 // FUNCTION: LEGO1 0x10080050
+// FUNCTION: BETA10 0x100991c2
 void LegoModelPresenter::ReadyTickle()
 {
 	if (m_compositePresenter != NULL && m_compositePresenter->IsA("LegoEntityPresenter") &&

--- a/LEGO1/lego/sources/geom/legounkown100db7f4.h
+++ b/LEGO1/lego/sources/geom/legounkown100db7f4.h
@@ -25,9 +25,9 @@ public:
 	LegoResult FUN_1002ddc0(LegoWEEdge& p_f, Vector3& p_point)
 	{
 		if (p_f.IsEqual(*m_faceA)) {
-			p_point[0] = -m_unk0x28[0];
-			p_point[1] = -m_unk0x28[1];
-			p_point[2] = -m_unk0x28[2];
+			p_point[0] = -m_unk0x28.index_operator(0);
+			p_point[1] = -m_unk0x28.index_operator(1);
+			p_point[2] = -m_unk0x28.index_operator(2);
 		}
 		else {
 			// clang-format off

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -710,14 +710,17 @@
 // LIBRARY: BETA10 0x100fa0e0
 // atof
 
-// // LIBRARY: BETA10 0x1005a9c0
-// // fabs
-//
-// // LIBRARY: BETA10 0x1005a9f0
-// // fabsf
-//
-// // LIBRARY: BETA10 0x100f9bb0
-// // _fabs
+// LIBRARY: BETA10 0x1005a9c0
+// fabs
+
+// LIBRARY: BETA10 0x1005a9f0
+// fabsf
+
+// LIBRARY: BETA10 0x100f9bb0
+// _fabs
+
+// LIBRARY: BETA10 0x100f9570
+// memset
 
 // LIBRARY: BETA10 0x100ff82b
 // __ctrandisp1

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -710,6 +710,15 @@
 // LIBRARY: BETA10 0x100fa0e0
 // atof
 
+// // LIBRARY: BETA10 0x1005a9c0
+// // fabs
+//
+// // LIBRARY: BETA10 0x1005a9f0
+// // fabsf
+//
+// // LIBRARY: BETA10 0x100f9bb0
+// // _fabs
+
 // LIBRARY: BETA10 0x100ff82b
 // __ctrandisp1
 

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -32,13 +32,10 @@ public:
 	// FUNCTION: LEGO1 0x10003c10
 	virtual void operator=(const Vector3& p_impl) { EqualsImpl(p_impl.m_data); } // vtable+0x88
 
-	float GetX() { return m_data[0]; }
-	float GetY() { return m_data[1]; }
-	float GetZ() { return m_data[2]; }
-
 	// FUNCTION: BETA10 0x10013460
 	float& operator[](int idx) { return m_data[idx]; }
 
+	// FUNCTION: BETA10 0x100373c0
 	const float& operator[](int idx) const { return m_data[idx]; }
 
 	// SYNTHETIC: LEGO1 0x10010c00

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -35,8 +35,12 @@ public:
 	// FUNCTION: BETA10 0x10013460
 	float& operator[](int idx) { return m_data[idx]; }
 
+	// According to the PDB, BETA10 will not link this one if it is never used
+	// const float& operator[](int idx) const { return m_data[idx]; }
+
+	// only used by LegoUnknown100db7f4::FUN_1002ddc0() for some unknown reason
 	// FUNCTION: BETA10 0x100373c0
-	const float& operator[](int idx) const { return m_data[idx]; }
+	float& index_operator(int idx) { return m_data[idx]; }
 
 	// SYNTHETIC: LEGO1 0x10010c00
 	// Mx3DPointFloat::operator=

--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -86,13 +86,13 @@ public:
 	void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
 
 	// FUNCTION: BETA10 0x1003db50
-	Mx3DPointFloat& GetLocation() { return m_location; }
+	Vector3& GetLocation() { return m_location; }
 
 	// FUNCTION: BETA10 0x1003db80
-	Mx3DPointFloat& GetDirection() { return m_direction; }
+	Vector3& GetDirection() { return m_direction; }
 
 	// FUNCTION: BETA10 0x1003dbb0
-	Mx3DPointFloat& GetUp() { return m_up; }
+	Vector3& GetUp() { return m_up; }
 
 	void SetLocation(const Vector3& p_location) { m_location = p_location; }
 	void SetDirection(const Vector3& p_direction) { m_direction = p_direction; }

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -25,6 +25,7 @@ public:
 	// in reverse order of appearance.
 
 	// FUNCTION: LEGO1 0x10002320
+	// FUNCTION: BETA10 0x1000fcb0
 	virtual void Equals(float (*p_data)[4]) { memcpy(m_data, p_data, sizeof(float) * 4 * 4); } // vtable+0x04
 
 	// FUNCTION: LEGO1 0x10002340
@@ -35,27 +36,35 @@ public:
 	} // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10002360
+	// FUNCTION: BETA10 0x1000fd30
 	virtual void SetData(float (*p_data)[4]) { m_data = p_data; } // vtable+0x0c
 
 	// FUNCTION: LEGO1 0x10002370
+	// FUNCTION: BETA10 0x1000fd60
 	virtual void SetData(UnknownMatrixType& p_matrix) { m_data = p_matrix.m_data; } // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10002380
+	// FUNCTION: BETA10 0x1000fd90
 	virtual float (*GetData())[4] { return m_data; } // vtable+0x14
 
 	// FUNCTION: LEGO1 0x10002390
+	// FUNCTION: BETA10 0x1000fdc0
 	virtual float (*GetData() const)[4] { return m_data; } // vtable+0x10
 
 	// FUNCTION: LEGO1 0x100023a0
+	// FUNCTION: BETA10 0x1000fdf0
 	virtual float* Element(int p_row, int p_col) { return &m_data[p_row][p_col]; } // vtable+0x1c
 
 	// FUNCTION: LEGO1 0x100023c0
+	// FUNCTION: BETA10 0x1000fe30
 	virtual const float* Element(int p_row, int p_col) const { return &m_data[p_row][p_col]; } // vtable+0x18
 
 	// FUNCTION: LEGO1 0x100023e0
+	// FUNCTION: BETA10 0x1000fe70
 	virtual void Clear() { memset(m_data, 0, 16 * sizeof(float)); } // vtable+0x20
 
 	// FUNCTION: LEGO1 0x100023f0
+	// FUNCTION: BETA10 0x1000feb0
 	virtual void SetIdentity()
 	{
 		Clear();
@@ -66,9 +75,11 @@ public:
 	} // vtable+0x24
 
 	// FUNCTION: LEGO1 0x10002420
+	// FUNCTION: BETA10 0x1000ff20
 	virtual void operator=(const Matrix4& p_matrix) { Equals(p_matrix); } // vtable+0x28
 
 	// FUNCTION: LEGO1 0x10002430
+	// FUNCTION: BETA10 0x1000ff50
 	virtual Matrix4& operator+=(float (*p_data)[4])
 	{
 		for (int i = 0; i < 16; i++) {
@@ -78,6 +89,7 @@ public:
 	} // vtable+0x2c
 
 	// FUNCTION: LEGO1 0x10002460
+	// FUNCTION: BETA10 0x1000ffc0
 	virtual void TranslateBy(const float& p_x, const float& p_y, const float& p_z)
 	{
 		m_data[3][0] += p_x;
@@ -86,6 +98,7 @@ public:
 	} // vtable+0x30
 
 	// FUNCTION: LEGO1 0x100024a0
+	// FUNCTION: BETA10 0x10010040
 	virtual void SetTranslation(const float& p_x, const float& p_y, const float& p_z)
 	{
 		m_data[3][0] = p_x;
@@ -94,6 +107,7 @@ public:
 	} // vtable+0x34
 
 	// FUNCTION: LEGO1 0x100024d0
+	// FUNCTION: BETA10 0x100100a0
 	virtual void Product(float (*p_a)[4], float (*p_b)[4])
 	{
 		float* cur = (float*) m_data;
@@ -109,6 +123,7 @@ public:
 	} // vtable+0x3c
 
 	// FUNCTION: LEGO1 0x10002530
+	// FUNCTION: BETA10 0x10010180
 	virtual void Product(const Matrix4& p_a, const Matrix4& p_b) { Product(p_a.m_data, p_b.m_data); } // vtable+0x38
 
 	inline virtual void ToQuaternion(Vector4& p_resultQuat); // vtable+0x40

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -416,6 +416,11 @@ public:
 		m_data[3] = p_value;
 	} // vtable+0x84
 
+	float& operator[](int idx) { return m_data[idx]; }
+
+	// FUNCTION: BETA10 0x10010890
+	const float& operator[](int idx) const { return m_data[idx]; }
+
 	friend class Mx4DPointFloat;
 };
 

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -163,14 +163,6 @@ public:
 		return *this;
 	}
 
-	// There is another candidate for `Vector2::operator[]` at BETA10 0x10010890, which is called from only three
-	// functions in BETA10:
-	// - `Matrix4::FromQuaternion()`
-	// - `Matrix4::ToQuaternion()`
-	// - `UnknownMx4DPointFloat::FUN_100040a0()`
-	// Maybe there is another subclass of `Vector4` involved that has the same VTABLE but a different `operator[]`.
-	// It is also interesting that `Matrix4::operator[]` is located right above at BETA10 0x10010860.
-
 	// FUNCTION: BETA10 0x1001d140
 	float& operator[](int idx) { return m_data[idx]; }
 


### PR DESCRIPTION
As discussed in https://github.com/isledecomp/isle/pull/1109#discussion_r1788641625, I have investigated the various index operators in BETA10. Please let me know what you think. Overall, the match percentage on BETA10 goes down a bit, but that is misleading - the correctness actually increases. As for LEGO1, we see a **lot** of entropy on changes especially in `vector.h`. I will add some details below. Overall, I have not found that anything seriously breaks in LEGO1, but I'd appreciate if someone else took a look.