### PR TITLE
Use alias functions from Lego3DManager

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -222,6 +222,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10083500
+// FUNCTION: BETA10 0x10074345
 LegoROI* LegoCharacterManager::GetActorROI(const char* p_name, MxBool p_createEntity)
 {
 	LegoCharacter* character = NULL;
@@ -428,6 +429,7 @@ void LegoCharacterManager::ReleaseAutoROI(LegoROI* p_roi)
 }
 
 // FUNCTION: LEGO1 0x10084010
+// FUNCTION: BETA10 0x10074e20
 void LegoCharacterManager::RemoveROI(LegoROI* p_roi)
 {
 	VideoManager()->Get3DManager()->Remove(*p_roi);
@@ -944,6 +946,7 @@ void LegoCharacterManager::SetCustomizeAnimFile(const char* p_value)
 }
 
 // FUNCTION: LEGO1 0x10085210
+// FUNCTION: BETA10 0x10076995
 LegoROI* LegoCharacterManager::CreateAutoROI(const char* p_name, const char* p_lodName, MxBool p_createEntity)
 {
 	LegoROI* roi = NULL;

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -206,6 +206,7 @@ void LegoGameState::RemoveActor()
 }
 
 // FUNCTION: LEGO1 0x10039940
+// FUNCTION: BETA10 0x10084069
 void LegoGameState::ResetROI()
 {
 	if (m_actorId) {
@@ -215,8 +216,8 @@ void LegoGameState::ResetROI()
 			LegoROI* roi = actor->GetROI();
 
 			if (roi) {
-				VideoManager()->Get3DManager()->GetLego3DView()->Remove(*roi);
-				VideoManager()->Get3DManager()->GetLego3DView()->Add(*roi);
+				VideoManager()->Get3DManager()->Remove(*roi);
+				VideoManager()->Get3DManager()->Add(*roi);
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -172,6 +172,7 @@ LegoTreeNode* GetTreeNode(LegoTreeNode* p_node, MxU32 p_index)
 }
 
 // FUNCTION: LEGO1 0x1003e050
+// FUNCTION: BETA10 0x100d3abc
 void FUN_1003e050(LegoAnimPresenter* p_presenter)
 {
 	MxMatrix viewMatrix;

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -87,6 +87,7 @@ MxResult LegoEntity::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10010810
+// FUNCTION: BETA10 0x1007e5b9
 void LegoEntity::Destroy(MxBool p_fromDestructor)
 {
 	if (m_roi) {

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -99,7 +99,7 @@ void LegoEntity::Destroy(MxBool p_fromDestructor)
 			CharacterManager()->ReleaseActor(m_roi);
 		}
 		else {
-			VideoManager()->Get3DManager()->GetLego3DView()->Remove(*m_roi);
+			VideoManager()->Get3DManager()->Remove(*m_roi);
 			delete m_roi;
 		}
 	}
@@ -119,6 +119,7 @@ void LegoEntity::SetWorld()
 }
 
 // FUNCTION: LEGO1 0x100108a0
+// FUNCTION: BETA10 0x1007e724
 void LegoEntity::SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2)
 {
 	m_roi = p_roi;
@@ -137,7 +138,7 @@ void LegoEntity::SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2)
 		}
 
 		m_roi->SetEntity(this);
-		VideoManager()->Get3DManager()->GetLego3DView()->Moved(*m_roi);
+		VideoManager()->Get3DManager()->Moved(*m_roi);
 
 		if (p_bool1) {
 			ClearFlag(c_bit1);
@@ -149,6 +150,7 @@ void LegoEntity::SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2)
 }
 
 // FUNCTION: LEGO1 0x100109b0
+// FUNCTION: BETA10 0x1007e8b8
 void LegoEntity::SetLocation(const Vector3& p_location, const Vector3& p_direction, const Vector3& p_up, MxBool p_und)
 {
 	Mx3DPointFloat direction;
@@ -174,7 +176,7 @@ void LegoEntity::SetLocation(const Vector3& p_location, const Vector3& p_directi
 		);
 
 		m_roi->UpdateTransformationRelativeToParent(mat);
-		VideoManager()->Get3DManager()->GetLego3DView()->Moved(*m_roi);
+		VideoManager()->Get3DManager()->Moved(*m_roi);
 
 		if (p_und) {
 			FUN_10010c30();

--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -403,6 +403,7 @@ MxBool LegoNavController::CalculateNewPosDir(
 }
 
 // FUNCTION: LEGO1 0x10055500
+// FUNCTION: BETA10 0x1009bff8
 MxResult LegoNavController::UpdateLocation(const char* p_location)
 {
 	MxResult result = FAILURE;
@@ -436,6 +437,7 @@ MxResult LegoNavController::UpdateLocation(const char* p_location)
 }
 
 // FUNCTION: LEGO1 0x10055620
+// FUNCTION: BETA10 0x1009c145
 MxResult LegoNavController::UpdateLocation(MxU32 p_location)
 {
 	MxResult result = FAILURE;

--- a/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
@@ -138,6 +138,7 @@ void LegoPointOfViewController::AffectPointOfView()
 }
 
 // FUNCTION: LEGO1 0x10065930
+// FUNCTION: BETA10 0x100c724d
 MxResult LegoPointOfViewController::Tickle()
 {
 	ViewROI* pov = m_lego3DView->GetPointOfView();

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -199,6 +199,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x1007ff70
+// FUNCTION: BETA10 0x10099061
 MxResult LegoModelPresenter::FUN_1007ff70(
 	MxDSChunk& p_chunk,
 	LegoEntity* p_entity,
@@ -211,8 +212,8 @@ MxResult LegoModelPresenter::FUN_1007ff70(
 	ParseExtra();
 
 	if (m_roi == NULL && (result = CreateROI(&p_chunk)) == SUCCESS && p_entity != NULL) {
-		VideoManager()->Get3DManager()->GetLego3DView()->Add(*m_roi);
-		VideoManager()->Get3DManager()->GetLego3DView()->Moved(*m_roi);
+		VideoManager()->Get3DManager()->Add(*m_roi);
+		VideoManager()->Get3DManager()->Moved(*m_roi);
 	}
 
 	if (m_roi != NULL) {
@@ -266,8 +267,8 @@ void LegoModelPresenter::ReadyTickle()
 			m_subscriber->FreeDataChunk(chunk);
 
 			if (result == SUCCESS) {
-				VideoManager()->Get3DManager()->GetLego3DView()->Add(*m_roi);
-				VideoManager()->Get3DManager()->GetLego3DView()->Moved(*m_roi);
+				VideoManager()->Get3DManager()->Add(*m_roi);
+				VideoManager()->Get3DManager()->Moved(*m_roi);
 
 				if (m_compositePresenter != NULL && m_compositePresenter->IsA("LegoEntityPresenter")) {
 					((LegoEntityPresenter*) m_compositePresenter)->GetInternalEntity()->SetROI(m_roi, TRUE, TRUE);
@@ -289,6 +290,7 @@ void LegoModelPresenter::ReadyTickle()
 }
 
 // FUNCTION: LEGO1 0x100801b0
+// FUNCTION: BETA10 0x10099443
 void LegoModelPresenter::ParseExtra()
 {
 	MxU16 extraLength;
@@ -319,8 +321,8 @@ void LegoModelPresenter::ParseExtra()
 					roiList.erase(it);
 
 					m_addedToView = TRUE;
-					VideoManager()->Get3DManager()->GetLego3DView()->Add(*m_roi);
-					VideoManager()->Get3DManager()->GetLego3DView()->Moved(*m_roi);
+					VideoManager()->Get3DManager()->Add(*m_roi);
+					VideoManager()->Get3DManager()->Moved(*m_roi);
 					break;
 				}
 			}

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -69,6 +69,7 @@ MxResult LegoVideoManager::CreateDirect3D()
 }
 
 // FUNCTION: LEGO1 0x1007ac40
+// FUNCTION: BETA10 0x100d5cf4
 MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS, MxBool p_createThread)
 {
 	MxResult result = FAILURE;
@@ -219,6 +220,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x1007b5e0
+// FUNCTION: BETA10 0x100d6816
 void LegoVideoManager::Destroy()
 {
 	if (m_cursorSurface != NULL) {

--- a/LEGO1/lego/sources/3dmanager/lego3dmanager.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dmanager.h
@@ -73,6 +73,7 @@ private:
 //
 // Lego3DManager implementaion
 
+// FUNCTION: BETA10 0x10079bd0
 inline BOOL Lego3DManager::Add(ViewROI& rROI)
 {
 	assert(m_pLego3DView);
@@ -80,6 +81,7 @@ inline BOOL Lego3DManager::Add(ViewROI& rROI)
 	return m_pLego3DView->Add(rROI);
 }
 
+// FUNCTION: BETA10 0x10037430
 inline BOOL Lego3DManager::Remove(ViewROI& rROI)
 {
 	assert(m_pLego3DView);
@@ -87,6 +89,7 @@ inline BOOL Lego3DManager::Remove(ViewROI& rROI)
 	return m_pLego3DView->Remove(rROI);
 }
 
+// FUNCTION: BETA10 0x100d8990
 inline BOOL Lego3DManager::SetPointOfView(ViewROI& rROI)
 {
 	assert(m_pLego3DView);
@@ -94,6 +97,7 @@ inline BOOL Lego3DManager::SetPointOfView(ViewROI& rROI)
 	return m_pLego3DView->SetPointOfView(rROI);
 }
 
+// FUNCTION: BETA10 0x1004af70
 inline BOOL Lego3DManager::Moved(ViewROI& rROI)
 {
 	assert(m_pLego3DView);

--- a/LEGO1/lego/sources/3dmanager/lego3dview.cpp
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.cpp
@@ -74,6 +74,7 @@ void Lego3DView::Destroy()
 }
 
 // FUNCTION: LEGO1 0x100ab100
+// FUNCTION: BETA10 0x1017d038
 BOOL Lego3DView::Add(ViewROI& rROI)
 {
 	assert(m_pViewManager);
@@ -84,6 +85,7 @@ BOOL Lego3DView::Add(ViewROI& rROI)
 }
 
 // FUNCTION: LEGO1 0x100ab170
+// FUNCTION: BETA10 0x1017d096
 BOOL Lego3DView::Remove(ViewROI& rROI)
 {
 	assert(m_pViewManager);
@@ -99,6 +101,7 @@ BOOL Lego3DView::Remove(ViewROI& rROI)
 }
 
 // FUNCTION: LEGO1 0x100ab1b0
+// FUNCTION: BETA10 0x1017d123
 BOOL Lego3DView::SetPointOfView(ViewROI& rROI)
 {
 	Tgl::FloatMatrix4 transformation;

--- a/LEGO1/lego/sources/3dmanager/lego3dview.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.h
@@ -46,6 +46,7 @@ private:
 //
 // Lego3DView implementation
 
+// FUNCTION: BETA10 0x100576b0
 inline ViewManager* Lego3DView::GetViewManager()
 {
 	return m_pViewManager;


### PR DESCRIPTION
Lego3DView provides four functions: Add, Remove, SetPointOfView, and Moved. Lego3DManager has the same four functions: they are an alias to Lego3DView via the `m_pLego3DView` member.

The typical use case is:
```cpp
VideoManager()->Get3DManager()->GetLego3DView()->Remove(*roi);
VideoManager()->Get3DManager()->GetLego3DView()->Add(*roi);
```

The beta shows that the Lego3DView functions are rarely called directly, so we get:

```cpp
VideoManager()->Get3DManager()->Remove(*roi);
VideoManager()->Get3DManager()->Add(*roi);
```

I fixed this anywhere the beta supported fixing it, and put in addresses for the calling functions. The exception is `Lego3DView::Moved`, which _is_ called directly in a few places. Those are marked too.

`LegoModelPresenter::FUN_1007ff70` should be an effective match, but swapping `ebp` in place of `ebx` makes two of the instructions one byte larger. The tools don't detect that we are jumping to the same instruction.