### PR TITLE
Implement new functions in LegoAnimManager

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -155,9 +155,9 @@ public:
 	MxBool FindVehicle(const char* p_name, MxU32& p_index);
 	MxResult ReadAnimInfo(LegoFile* p_file, AnimInfo* p_info);
 	MxResult ReadModelInfo(LegoFile* p_file, ModelInfo* p_info);
-	void FUN_10060480(LegoChar* p_param1[], undefined4 p_param2);
+	void FUN_10060480(LegoChar* p_characterNames[], MxU32 p_numCharacterNames);
 	void FUN_100604d0(MxBool p_unk0x08);
-	void FUN_100604f0(MxS32* p_param1, undefined4 p_param2);
+	void FUN_100604f0(MxS32 p_objectIds[], undefined4 p_numObjectIds);
 	void FUN_10060540(MxBool p_unk0x29);
 	void FUN_10060570(MxBool p_unk0x1a);
 	MxResult StartEntityAction(MxDSAction& p_dsAction, LegoEntity* p_entity);
@@ -183,7 +183,7 @@ public:
 	MxResult FUN_10064670(Vector3* p_position);
 	MxResult FUN_10064740(Vector3* p_position);
 	MxResult FUN_10064880(const char* p_name, MxS32 p_unk0x0c, MxS32 p_unk0x10);
-	undefined FUN_10064ee0(MxU32 p_param);
+	MxBool FUN_10064ee0(MxU32 p_objectId);
 
 	static void configureLegoAnimationManager(MxS32 p_legoAnimationManagerConfig);
 

--- a/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimmmpresenter.h
@@ -61,7 +61,7 @@ public:
 
 	// SYNTHETIC: LEGO1 0x1004aa40
 	// LegoAnimMMPresenter::`scalar deleting destructor'
-
+	MxBool FUN_1004b830();
 	void FUN_1004b840();
 	MxBool FUN_1004b8b0();
 	void FUN_1004b8c0();

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -246,6 +246,7 @@ const char* g_cycles[11][17] = {
 };
 
 // GLOBAL: LEGO1 0x100f7048
+// GLOBAL: BETA10 0x101e1ee8
 LegoAnimationManager::Character g_characters[47] = {
 	{"pepper", FALSE, 6, 0, FALSE, FALSE, TRUE, 1500, 20000, FALSE, 50, 1},
 	{"mama", FALSE, -1, 0, FALSE, FALSE, FALSE, 1500, 20000, FALSE, 0, 2},
@@ -878,11 +879,17 @@ void LegoAnimationManager::DeleteAnimations()
 	m_suspended = suspended;
 }
 
-// STUB: LEGO1 0x10060480
-// STUB: BETA10 0x100412a9
-void LegoAnimationManager::FUN_10060480(LegoChar* p_param1[], undefined4 p_param2)
+// FUNCTION: LEGO1 0x10060480
+// FUNCTION: BETA10 0x100412a9
+void LegoAnimationManager::FUN_10060480(LegoChar* p_characterNames[], MxU32 p_numCharacterNames)
 {
-	// TODO
+	for (MxS32 i = 0; i < p_numCharacterNames; i++) {
+		for (MxS32 j = 0; j < sizeOfArray(g_characters); j++) {
+			if (!stricmp(g_characters[j].m_name, p_characterNames[i])) {
+				g_characters[j].m_unk0x08 = TRUE;
+			}
+		}
+	}
 }
 
 // FUNCTION: LEGO1 0x100604d0
@@ -894,11 +901,17 @@ void LegoAnimationManager::FUN_100604d0(MxBool p_unk0x08)
 	}
 }
 
-// STUB: LEGO1 0x100604f0
-// STUB: BETA10 0x1004137b
-void LegoAnimationManager::FUN_100604f0(MxS32* p_param1, undefined4 p_param2)
+// FUNCTION: LEGO1 0x100604f0
+// FUNCTION: BETA10 0x1004137b
+void LegoAnimationManager::FUN_100604f0(MxS32 p_objectIds[], undefined4 p_numObjectIds)
 {
-	// TODO
+	for (MxS32 i = 0; i < p_numObjectIds; i++) {
+		for (MxS32 j = 0; j < m_animCount; j++) {
+			if (m_anims[j].m_objectId == p_objectIds[i]) {
+				m_anims[j].m_unk0x29 = TRUE;
+			}
+		}
+	}
 }
 
 // FUNCTION: LEGO1 0x10060540
@@ -2837,10 +2850,25 @@ void LegoAnimationManager::FUN_10064b50(MxLong p_time)
 	}
 }
 
-// STUB: LEGO1 0x10064ee0
-undefined LegoAnimationManager::FUN_10064ee0(MxU32 p_param)
+// FUNCTION: LEGO1 0x10064ee0
+MxBool LegoAnimationManager::FUN_10064ee0(MxU32 p_objectId)
 {
-	// TODO
+	if (m_tranInfoList != NULL) {
+		LegoTranInfoListCursor cursor(m_tranInfoList);
+		LegoTranInfo* tranInfo;
+
+		while (cursor.Next(tranInfo)) {
+			if (tranInfo->m_animInfo->m_objectId == p_objectId) {
+				if (tranInfo->m_presenter) {
+					return tranInfo->m_presenter->FUN_1004b830();
+				}
+				else {
+					return FALSE;
+				}
+			}
+		}
+	}
+
 	return FALSE;
 }
 

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -466,6 +466,12 @@ MxBool LegoAnimMMPresenter::FUN_1004b6d0(MxLong p_time)
 	return TRUE;
 }
 
+// FUNCTION: LEGO1 0x1004b830
+MxBool LegoAnimMMPresenter::FUN_1004b830()
+{
+	return !(m_unk0x58 < 6);
+}
+
 // FUNCTION: LEGO1 0x1004b840
 // FUNCTION: BETA10 0x1004d033
 void LegoAnimMMPresenter::FUN_1004b840()


### PR DESCRIPTION
The new functions match correctly, but `FUN_100604f0` seems to be susceptible to entropy - it matches to 100 % on BETA10 and it looks correct on LEGO1.