### PR TITLE
Clean up unused annotations to reduce errors

### DIFF
--- a/LEGO1/lego/legoomni/include/buildings.h
+++ b/LEGO1/lego/legoomni/include/buildings.h
@@ -11,7 +11,7 @@ class RaceStandsEntity : public BuildingEntity {
 	// FUNCTION: LEGO1 0x1000efa0
 	const char* ClassName() const override // vtable+0x0c
 	{
-		// STRING: LEGO1 0x100f0300
+		// at LEGO1 0x100f0300, needs no annotation
 		return "RaceStandsEntity";
 	}
 
@@ -125,7 +125,7 @@ class CaveEntity : public BuildingEntity {
 	// FUNCTION: LEGO1 0x1000f1e0
 	const char* ClassName() const override // vtable+0x0c
 	{
-		// STRING: LEGO1 0x100f0300
+		// at LEGO1 0x100f0300, needs no annotation
 		return "RaceStandsEntity";
 	}
 
@@ -147,7 +147,7 @@ class JailEntity : public BuildingEntity {
 	// FUNCTION: LEGO1 0x1000f0c0
 	const char* ClassName() const override // vtable+0x0c
 	{
-		// STRING: LEGO1 0x100f0300
+		// at LEGO1 0x100f0300, needs no annotation
 		return "RaceStandsEntity";
 	}
 

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -56,8 +56,8 @@ const char* g_varTOWSPEED = "towSPEED";
 // STRING: LEGO1 0x100f439c
 const char* g_varTOWFUEL = "towFUEL";
 
+// the STRING is already declared for GLOBAL 0x101020cc
 // GLOBAL: LEGO1 0x100f3a40
-// STRING: LEGO1 0x100f3808
 const char* g_varVISIBILITY = "VISIBILITY";
 
 // GLOBAL: LEGO1 0x100f3a44
@@ -72,8 +72,8 @@ const char* g_varCURSOR = "CURSOR";
 // STRING: LEGO1 0x100f3a1c
 const char* g_varWHOAMI = "WHO_AM_I";
 
+// the STRING is already declared at LEGO1 0x100f3fb0
 // GLOBAL: LEGO1 0x100f3a50
-// STRING: LEGO1 0x100f3a18
 const char* g_delimiter2 = " \t";
 
 // GLOBAL: LEGO1 0x100f3a54

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -67,8 +67,8 @@ const SkeletonKickPhase LegoRaceCar::g_skeletonKickPhases[] = {
 	{&LegoRaceCar::g_skBMap[3], 0.8, 0.9, LEGORACECAR_KICK2},
 };
 
+// the STRING is already declared at LEGO1 0x101020b8
 // GLOBAL: LEGO1 0x100f0b10
-// STRING: LEGO1 0x100f09cc
 const char* LegoRaceCar::g_strSpeed = "SPEED";
 
 // GLOBAL: LEGO1 0x100f0b18

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -281,9 +281,6 @@
 // LIBRARY: LEGO1 0x1008fdd0
 // __dosmaperr
 
-// LIBRARY: LEGO1 0x1008fe30
-// __unlock_file
-
 // LIBRARY: LEGO1 0x1008fe50
 // __errno
 

--- a/LEGO1/mxdirectx/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectx/mxdirectdraw.cpp
@@ -873,8 +873,9 @@ int MxDirectDraw::FlipToGDISurface()
 // FUNCTION: LEGO1 0x1009e830
 void MxDirectDraw::Error(const char* p_message, int p_error)
 {
-	// GLOBAL: LEGO1 0x10100c70
+	// at LEGO1 0x10100c70, needs no annotation
 	static BOOL g_isInsideError = FALSE;
+
 	if (!g_isInsideError) {
 		g_isInsideError = TRUE;
 		Destroy();

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -49,7 +49,7 @@ Device* RendererImpl::CreateDevice(const DeviceDirect3DCreateData& data)
 // FUNCTION: LEGO1 0x100a1900
 Device* RendererImpl::CreateDevice(const DeviceDirectDrawCreateData& data)
 {
-	// GLOBAL: LEGO1 0x10101040
+	// at LEGO1 0x10101040, needs no annotation
 	static int g_SetBufferCount = 1;
 
 	DeviceImpl* device = new DeviceImpl();


### PR DESCRIPTION
This PR has no match difference compared to `master`.

It reduces the errors raised on a `reccmp` run down to the following (with some minor changes in reccmp's logging that I'll PR soon):
```
[ERROR] Failed to find function symbol with filename and line: C:\Users\Jonathan\vscode-workspace\isle\LEGO1\lego\sources\anim\legoanim.cpp:788
[ERROR] Failed to find function symbol with name annotated with 0x10092310: _siglookup
[ERROR] Failed to find function symbol with name annotated with 0x10022360: ?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z
[ERROR] Failed to find function symbol with name annotated with 0x100c7ef0: list<MxNextActionDataStart *>::insert
[ERROR] Failed to find function symbol with name annotated with 0x100c1bc0: list<MxDSAction *,allocator<MxDSAction *> >::insert
[ERROR] Failed to find string annotated with 0x100fd200: '.'
```
- I can't explain the first one.
- Errors 2, 3, 4, and 5 appear to be functions that are matched correctly but are not called at the moment, and the compiler does not include them in the build.
- The last one looks like an error in `reccmp`. Removing it or converting it into a `STRING` reduces the match percentage.

As for the changes, some of them are fixes of actual mistakes. Regarding the rest, I am not sure if it would be a better approach to try to fix them in `reccmp`, especially regarding reused strings.