### PR TITLE
Implement/match LegoAct2::Enable

### DIFF
--- a/LEGO1/lego/legoomni/include/act2brick.h
+++ b/LEGO1/lego/legoomni/include/act2brick.h
@@ -31,7 +31,8 @@ public:
 	// SYNTHETIC: LEGO1 0x1007a450
 	// Act2Brick::`scalar deleting destructor'
 
-	void StopSound();
+	void PlayWhistleSound();
+	void StopWhistleSound();
 
 private:
 	static MxLong g_lastHitActorTime;

--- a/LEGO1/lego/legoomni/include/act3.h
+++ b/LEGO1/lego/legoomni/include/act3.h
@@ -1,6 +1,7 @@
 #ifndef ACT3_H
 #define ACT3_H
 
+#include "legogamestate.h"
 #include "legostate.h"
 #include "legoworld.h"
 
@@ -69,7 +70,7 @@ public:
 	void Enable(MxBool p_enable) override;            // vtable+0x68
 
 	void SetUnknown420c(MxEntity* p_entity) { m_unk0x420c = p_entity; }
-	void SetUnknown4270(MxU32 p_unk0x4270) { m_unk0x4270 = p_unk0x4270; }
+	void SetDestLocation(LegoGameState::Area p_destLocation) { m_destLocation = p_destLocation; }
 
 	// SYNTHETIC: LEGO1 0x10072630
 	// Act3::`scalar deleting destructor'
@@ -80,10 +81,10 @@ public:
 	void FUN_10073430();
 
 protected:
-	undefined m_unk0xf8[0x4114]; // 0xf8
-	MxEntity* m_unk0x420c;       // 0x420c
-	undefined m_unk0x4210[0x60]; // 0x4210
-	MxU32 m_unk0x4270;           // 0x4270
+	undefined m_unk0xf8[0x4114];        // 0xf8
+	MxEntity* m_unk0x420c;              // 0x420c
+	undefined m_unk0x4210[0x60];        // 0x4210
+	LegoGameState::Area m_destLocation; // 0x4270
 };
 
 #endif // ACT3_H

--- a/LEGO1/lego/legoomni/include/legoact2.h
+++ b/LEGO1/lego/legoomni/include/legoact2.h
@@ -17,7 +17,7 @@ public:
 	LegoAct2State()
 	{
 		m_unk0x08 = 0;
-		m_unk0x0c = 0;
+		m_enabled = 0;
 	}
 	~LegoAct2State() override {}
 
@@ -41,12 +41,11 @@ public:
 	// LegoAct2State::`scalar deleting destructor'
 
 	undefined4 GetUnknown0x08() { return m_unk0x08; }
-	void SetUnknown0x0c(undefined p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
 
 	// TODO: Most likely getters/setters are not used according to BETA.
 
 	undefined4 m_unk0x08; // 0x08
-	undefined m_unk0x0c;  // 0x0c
+	MxBool m_enabled;     // 0x0c
 };
 
 // VTABLE: LEGO1 0x100d82e0
@@ -85,23 +84,26 @@ private:
 	MxLong HandleEndAction(MxEndActionNotificationParam& p_param);
 	MxLong HandleTransitionEnd();
 	MxLong HandlePathStruct(LegoPathStructNotificationParam& p_param);
+	void PlayMusic(JukeboxScript::Script p_objectId);
 	void FUN_10051900();
+	void InitBricks();
+	void UninitBricks();
 
-	Act2Brick m_bricks[10];     // 0x00f8
-	undefined m_unk0x10c0;      // 0x10c0
-	undefined m_unk0x10c1;      // 0x10c1
-	undefined m_unk0x10c2;      // 0x10c2
-	undefined4 m_unk0x10c4;     // 0x10c4
-	undefined4 m_unk0x10c8;     // 0x10c8
-	LegoAct2State* m_gameState; // 0x10cc
-	MxS32 m_unk0x10d0;          // 0x10d0
+	Act2Brick m_bricks[10];        // 0x00f8
+	undefined m_unk0x10c0;         // 0x10c0
+	undefined m_unk0x10c1;         // 0x10c1
+	undefined m_unk0x10c2;         // 0x10c2
+	undefined4 m_unk0x10c4;        // 0x10c4
+	JukeboxScript::Script m_music; // 0x10c8
+	LegoAct2State* m_gameState;    // 0x10cc
+	MxS32 m_unk0x10d0;             // 0x10d0
 
 	// variable name verified by BETA10 0x10014633
 	char* m_siFile; // 0x10d4
 
-	LegoROI* m_unk0x10d8;               // 0x10d8
+	LegoROI* m_pepper;                  // 0x10d8
 	MxMatrix m_unk0x10dc;               // 0x10dc
-	undefined4 m_unk0x1124;             // 0x1124
+	LegoPathBoundary* m_unk0x1124;      // 0x1124
 	LegoROI* m_ambulance;               // 0x1128
 	undefined4 m_unk0x112c;             // 0x112c
 	undefined4 m_unk0x1130;             // 0x1130
@@ -109,7 +111,7 @@ private:
 	Act2Actor* m_unk0x1138;             // 0x1138
 	undefined m_unk0x113c;              // 0x113c
 	undefined4 m_unk0x1140;             // 0x1140
-	undefined4 m_unk0x1144;             // 0x1144
+	Act2mainScript::Script m_unk0x1144; // 0x1144
 	undefined m_unk0x1148[0x08];        // 0x1148
 	LegoGameState::Area m_destLocation; // 0x1150
 };

--- a/LEGO1/lego/legoomni/include/misc.h
+++ b/LEGO1/lego/legoomni/include/misc.h
@@ -58,7 +58,7 @@ LegoWorld* FindWorld(const MxAtomId& p_atom, MxS32 p_entityid);
 MxDSAction& GetCurrentAction();
 void SetCurrentWorld(LegoWorld* p_world);
 MxTransitionManager* TransitionManager();
-void PlayMusic(JukeboxScript::Script p_script);
+void PlayMusic(JukeboxScript::Script p_objectId);
 void SetIsWorldActive(MxBool p_isWorldActive);
 void DeleteObjects(MxAtomId* p_id, MxS32 p_first, MxS32 p_last);
 

--- a/LEGO1/lego/legoomni/src/actors/buildings.cpp
+++ b/LEGO1/lego/legoomni/src/actors/buildings.cpp
@@ -62,13 +62,13 @@ MxLong InfoCenterEntity::HandleClick(LegoEventNotificationParam& p_param)
 
 		LegoAct2State* act2state = (LegoAct2State*) GameState()->GetState("LegoAct2State");
 		if (act2state) {
-			act2state->SetUnknown0x0c(0);
+			act2state->m_enabled = FALSE;
 		}
 		break;
 	}
 	case LegoGameState::Act::e_act3:
 		Act3* act3 = (Act3*) FindWorld(*g_act3Script, Act3Script::c__Act3);
-		act3->SetUnknown4270(2);
+		act3->SetDestLocation(LegoGameState::e_infomain);
 		break;
 	}
 

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -173,7 +173,7 @@ MxLong Helicopter::HandleControl(LegoControlManagerNotificationParam& p_param)
 		switch (p_param.GetClickedObjectId()) {
 		case IsleScript::c_HelicopterArms_Ctl:
 			if (*g_act3Script == script) {
-				((Act3*) CurrentWorld())->SetUnknown4270(2);
+				((Act3*) CurrentWorld())->SetDestLocation(LegoGameState::e_infomain);
 				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			}
 			else if (m_state->GetUnkown8() != 0) {

--- a/LEGO1/lego/legoomni/src/common/misc.cpp
+++ b/LEGO1/lego/legoomni/src/common/misc.cpp
@@ -208,11 +208,11 @@ MxTransitionManager* TransitionManager()
 }
 
 // FUNCTION: LEGO1 0x10015910
-void PlayMusic(JukeboxScript::Script p_script)
+void PlayMusic(JukeboxScript::Script p_objectId)
 {
 	MxDSAction action;
 	action.SetAtomId(*g_jukeboxScript);
-	action.SetObjectId(p_script);
+	action.SetObjectId(p_objectId);
 
 	LegoOmni::GetInstance()->GetBackgroundAudioManager()->PlayMusic(action, 5, MxPresenter::e_repeating);
 }

--- a/LEGO1/lego/legoomni/src/entity/act2brick.cpp
+++ b/LEGO1/lego/legoomni/src/entity/act2brick.cpp
@@ -79,7 +79,7 @@ MxLong Act2Brick::Notify(MxParam& p_param)
 		m_roi->SetVisibility(FALSE);
 
 		if (m_whistleSound != NULL) {
-			StopSound();
+			StopWhistleSound();
 		}
 
 		MxNotificationParam param(c_notificationType22, this);
@@ -90,9 +90,18 @@ MxLong Act2Brick::Notify(MxParam& p_param)
 	return 0;
 }
 
+// FUNCTION: LEGO1 0x1007a990
+// FUNCTION: BETA10 0x10012fca
+void Act2Brick::PlayWhistleSound()
+{
+	if (m_whistleSound == NULL) {
+		m_whistleSound = SoundManager()->GetCacheSoundManager()->Play("xwhistle", m_roi->GetName(), TRUE);
+	}
+}
+
 // FUNCTION: LEGO1 0x1007a9d0
 // FUNCTION: BETA10 0x1001300f
-void Act2Brick::StopSound()
+void Act2Brick::StopWhistleSound()
 {
 	if (m_whistleSound != NULL) {
 		SoundManager()->GetCacheSoundManager()->Stop(m_whistleSound);


### PR DESCRIPTION
`LegoAct2::Enable` matches to ~95%. The remaining diff is the same we have in `Isle::Enable`, and is related to the initial check `m_set0xd0.empty() == p_enable`. Functionally it should be correct.

Implementations of the other functions match 100%.