### PR TITLE
Improve `Isle::Enable` and `LegoAct2::Enable` matches

### DIFF
--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -532,7 +532,7 @@ MxLong Isle::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 // FUNCTION: BETA10 0x10034158
 void Isle::Enable(MxBool p_enable)
 {
-	if (m_set0xd0.empty() == p_enable) {
+	if ((MxBool) m_set0xd0.empty() == p_enable) {
 		return;
 	}
 

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -352,7 +352,7 @@ void LegoAct2::ReadyWorld()
 // FUNCTION: BETA10 0x1003bb2d
 void LegoAct2::Enable(MxBool p_enable)
 {
-	if (m_set0xd0.empty() == p_enable) {
+	if ((MxBool) m_set0xd0.empty() == p_enable) {
 		return;
 	}
 


### PR DESCRIPTION
The match percentage for `Isle::Enable` goes down very slightly but the code is actually more accurate.