### PR TITLE
Fix MxParam casts in Notify functions

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/ambulance.cpp
+++ b/LEGO1/lego/legoomni/src/actors/ambulance.cpp
@@ -130,8 +130,9 @@ void Ambulance::CreateState()
 MxLong Ambulance::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	switch (param.GetNotification()) {
 	case c_notificationType0:
 		result = HandleNotification0();
 		break;

--- a/LEGO1/lego/legoomni/src/actors/buildingentity.cpp
+++ b/LEGO1/lego/legoomni/src/actors/buildingentity.cpp
@@ -19,9 +19,12 @@ BuildingEntity::~BuildingEntity()
 }
 
 // FUNCTION: LEGO1 0x100150a0
+// FUNCTION: BETA10 0x10024e37
 MxLong BuildingEntity::Notify(MxParam& p_param)
 {
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationClick) {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
+	if (param.GetNotification() == c_notificationClick) {
 		return HandleClick((LegoEventNotificationParam&) p_param);
 	}
 

--- a/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
+++ b/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
@@ -33,10 +33,12 @@ BumpBouy::~BumpBouy()
 MxLong BumpBouy::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
 	IslePathActor* user = (IslePathActor*) UserActor();
 	assert(user);
 
-	if (user->IsA("Jetski") && ((MxNotificationParam&) p_param).GetNotification() == c_notificationClick) {
+	if (user->IsA("Jetski") && param.GetNotification() == c_notificationClick) {
 		VideoManager()->SetRender3D(FALSE);
 		user->SetWorldSpeed(0);
 		user->Exit();

--- a/LEGO1/lego/legoomni/src/actors/isleactor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/isleactor.cpp
@@ -25,11 +25,13 @@ MxResult IsleActor::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1002c7b0
+// FUNCTION: BETA10 0x1003622e
 MxLong IsleActor::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	switch (param.GetNotification()) {
 	case c_notificationType0:
 		result = VTable0x6c();
 		break;

--- a/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
@@ -46,11 +46,13 @@ void IslePathActor::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x1001a2c0
+// FUNCTION: BETA10 0x100364ca
 MxLong IslePathActor::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	switch (param.GetNotification()) {
 	case c_notificationType0:
 		result = HandleNotification0();
 		break;

--- a/LEGO1/lego/legoomni/src/actors/jukeboxentity.cpp
+++ b/LEGO1/lego/legoomni/src/actors/jukeboxentity.cpp
@@ -30,9 +30,12 @@ JukeBoxEntity::~JukeBoxEntity()
 }
 
 // FUNCTION: LEGO1 0x10085e40
+// FUNCTION: BETA10 0x10038c37
 MxLong JukeBoxEntity::Notify(MxParam& p_param)
 {
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationClick) {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
+	if (param.GetNotification() == c_notificationClick) {
 		if (!FUN_1003ef60()) {
 			return 1;
 		}

--- a/LEGO1/lego/legoomni/src/actors/radio.cpp
+++ b/LEGO1/lego/legoomni/src/actors/radio.cpp
@@ -81,12 +81,14 @@ Radio::~Radio()
 }
 
 // FUNCTION: LEGO1 0x1002ca30
+// FUNCTION: BETA10 0x100f19e8
 MxLong Radio::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
 
 	if (m_unk0x0c) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		MxNotificationParam& param = (MxNotificationParam&) p_param;
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/actors/towtrack.cpp
+++ b/LEGO1/lego/legoomni/src/actors/towtrack.cpp
@@ -113,11 +113,13 @@ void TowTrack::CreateState()
 }
 
 // FUNCTION: LEGO1 0x1004cc80
+// FUNCTION: BETA10 0x100f6de2
 MxLong TowTrack::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	switch (param.GetNotification()) {
 	case c_notificationType0:
 		result = HandleNotification0();
 		break;

--- a/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
@@ -196,9 +196,12 @@ void MxBackgroundAudioManager::FadeInOrFadeOut()
 }
 
 // FUNCTION: LEGO1 0x1007f170
+// FUNCTION: BETA10 0x100e8eb6
 MxLong MxBackgroundAudioManager::Notify(MxParam& p_param)
 {
-	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
+	switch (param.GetNotification()) {
 	case c_notificationStartAction:
 		StartAction(p_param);
 		return 1;

--- a/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
@@ -656,9 +656,10 @@ MxResult LegoCarBuild::Tickle()
 MxLong LegoCarBuild::Notify(MxParam& p_param)
 {
 	MxLong result = LegoWorld::Notify(p_param);
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam*) &p_param)->GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationType0:
 			FUN_10024c20((LegoEventNotificationParam*) &p_param);
 			result = 1;

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -215,9 +215,9 @@ void LegoAnimMMPresenter::DoneTickle()
 MxLong LegoAnimMMPresenter::Notify(MxParam& p_param)
 {
 	AUTOLOCK(m_criticalSection);
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationEndAction &&
-		((MxNotificationParam&) p_param).GetSender() == m_presenter) {
+	if (param.GetNotification() == c_notificationEndAction && param.GetSender() == m_presenter) {
 		m_presenter = NULL;
 	}
 

--- a/LEGO1/lego/legoomni/src/entity/act2brick.cpp
+++ b/LEGO1/lego/legoomni/src/entity/act2brick.cpp
@@ -12,6 +12,7 @@
 #include "mxtimer.h"
 #include "roi/legoroi.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <vec.h>
 
@@ -148,7 +149,9 @@ MxResult Act2Brick::Tickle()
 // FUNCTION: BETA10 0x10012ec4
 MxLong Act2Brick::Notify(MxParam& p_param)
 {
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationClick && m_roi->GetVisibility()) {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
+	if (param.GetNotification() == c_notificationClick && m_roi->GetVisibility()) {
 		m_roi->SetVisibility(FALSE);
 
 		if (m_whistleSound != NULL) {
@@ -160,6 +163,7 @@ MxLong Act2Brick::Notify(MxParam& p_param)
 		return 1;
 	}
 
+	assert(0);
 	return 0;
 }
 

--- a/LEGO1/lego/legoomni/src/entity/act2policestation.cpp
+++ b/LEGO1/lego/legoomni/src/entity/act2policestation.cpp
@@ -9,9 +9,12 @@
 DECOMP_SIZE_ASSERT(Act2PoliceStation, 0x68)
 
 // FUNCTION: LEGO1 0x1004e0e0
+// FUNCTION: BETA10 0x100137c0
 MxLong Act2PoliceStation::Notify(MxParam& p_param)
 {
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationClick) {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
+	if (param.GetNotification() == c_notificationClick) {
 		MxNotificationParam param(c_notificationType23, NULL);
 		NotificationManager()->Send(CurrentWorld(), param);
 		return 1;

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -38,6 +38,7 @@ MxResult LegoCameraController::Create()
 }
 
 // FUNCTION: LEGO1 0x10012020
+// FUNCTION: BETA10 0x10067852
 MxLong LegoCameraController::Notify(MxParam& p_param)
 {
 	switch (((MxNotificationParam&) p_param).GetNotification()) {

--- a/LEGO1/lego/legoomni/src/race/legorace.cpp
+++ b/LEGO1/lego/legoomni/src/race/legorace.cpp
@@ -89,10 +89,11 @@ LegoRace::~LegoRace()
 MxLong LegoRace::Notify(MxParam& p_param)
 {
 	LegoWorld::Notify(p_param);
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
 	MxLong result = 0;
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationType0:
 			HandleType0Notification((MxNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/race/legoracemap.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracemap.cpp
@@ -124,7 +124,9 @@ MxLong LegoRaceMap::Notify(MxParam& p_param)
 		return 1;
 	}
 
-	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationControl &&
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
+	if (param.GetNotification() == c_notificationControl &&
 		m_Map_Ctl->GetAction()->GetObjectId() ==
 			((LegoControlManagerNotificationParam&) p_param).GetClickedObjectId()) {
 

--- a/LEGO1/lego/legoomni/src/worlds/elevatorbottom.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/elevatorbottom.cpp
@@ -52,13 +52,15 @@ MxResult ElevatorBottom::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10018150
+// FUNCTION: BETA10 0x10027d60
 MxLong ElevatorBottom::Notify(MxParam& p_param)
 {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	MxLong ret = 0;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationControl:
 			ret = HandleControl((LegoControlManagerNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
@@ -100,13 +100,15 @@ MxResult GasStation::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10004a60
+// FUNCTION: BETA10 0x10028883
 MxLong GasStation::Notify(MxParam& p_param)
 {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	MxResult result = 0;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -68,12 +68,14 @@ MxResult HistoryBook::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10082680
+// FUNCTION: BETA10 0x1002b907
 MxLong HistoryBook::Notify(MxParam& p_param)
 {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationButtonUp:
 			m_destLocation = LegoGameState::Area::e_infoscor;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -106,13 +106,15 @@ MxResult Hospital::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10074990
+// FUNCTION: BETA10 0x1002ca3b
 MxLong Hospital::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -225,13 +225,15 @@ MxResult Infocenter::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1006ef10
+// FUNCTION: BETA10 0x1002eaca
 MxLong Infocenter::Notify(MxParam& p_param)
 {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	MxLong result = 0;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationType0:
 			result = HandleNotification0((MxNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
@@ -55,13 +55,15 @@ MxResult InfocenterDoor::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100379e0
+// FUNCTION: BETA10 0x10032227
 MxLong InfocenterDoor::Notify(MxParam& p_param)
 {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	MxLong result = 0;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			if (((MxEndActionNotificationParam&) p_param).GetAction()->GetAtomId() == m_atomId) {
 				BackgroundAudioManager()->RaiseVolume();

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -129,13 +129,15 @@ MxResult Isle::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10030c10
+// FUNCTION: BETA10 0x10032b63
 MxLong Isle::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;
@@ -468,6 +470,7 @@ void Isle::UpdateGlobe()
 }
 
 // FUNCTION: LEGO1 0x100315f0
+// FUNCTION: BETA10 0x10033e46
 MxLong Isle::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 {
 	MxLong result = 0;

--- a/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
@@ -68,13 +68,15 @@ MxResult JukeBox::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1005d980
+// FUNCTION: BETA10 0x10037daf
 MxLong JukeBox::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationControl:
 			result = HandleControl((LegoControlManagerNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/police.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/police.cpp
@@ -69,13 +69,15 @@ MxResult Police::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1005e480
+// FUNCTION: BETA10 0x100f04a3
 MxLong Police::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -108,13 +108,15 @@ MxResult RegistrationBook::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100770e0
+// FUNCTION: BETA10 0x100f2d98
 MxLong RegistrationBook::Notify(MxParam& p_param)
 {
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 	MxLong result = 0;
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;

--- a/LEGO1/lego/legoomni/src/worlds/score.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/score.cpp
@@ -84,13 +84,16 @@ void Score::DeleteScript()
 }
 
 // FUNCTION: LEGO1 0x10001410
+// FUNCTION: BETA10 0x100f4398
 MxLong Score::Notify(MxParam& p_param)
 {
 	MxLong ret = 0;
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
+
 	LegoWorld::Notify(p_param);
 
 	if (m_worldStarted) {
-		switch (((MxNotificationParam&) p_param).GetNotification()) {
+		switch (param.GetNotification()) {
 		case c_notificationStartAction:
 			Paint();
 			ret = 1;

--- a/LEGO1/omni/src/common/mxcompositepresenter.cpp
+++ b/LEGO1/omni/src/common/mxcompositepresenter.cpp
@@ -8,6 +8,8 @@
 #include "mxnotificationmanager.h"
 #include "mxobjectfactory.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(MxCompositePresenter, 0x4c);
 
 // FUNCTION: LEGO1 0x100b60b0
@@ -107,16 +109,22 @@ void MxCompositePresenter::EndAction()
 }
 
 // FUNCTION: LEGO1 0x100b6760
+// FUNCTION: BETA10 0x1013771e
 MxLong MxCompositePresenter::Notify(MxParam& p_param)
 {
 	AUTOLOCK(m_criticalSection);
+	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	switch (param.GetNotification()) {
 	case c_notificationEndAction:
 		VTable0x58((MxEndActionNotificationParam&) p_param);
 		break;
 	case c_notificationPresenter:
 		VTable0x5c((MxNotificationParam&) p_param);
+		break;
+	default:
+		assert(0);
+		break;
 	}
 
 	return 0;


### PR DESCRIPTION
Many (most?) of the `Notify` functions call `GetNotification()` on the given `MxParam`. This function belongs to `MxNotificationParam`, so we need to cast the incoming reference variable. The beta shows that the cast almost always happens in a separate variable (and not in-place) so I changed that where the data supported it.

I intentionally did not make other changes (for now) to limit the diff for retail. For example: reordering switch cases, or introducing a switch where we have ifs.

There doesn't seem to be any consistency as to which of these lines appear first:
```cpp
MxNotificationParam& param = (MxNotificationParam&) p_param;
MxLong result = 0;
```

You can tell by looking that two of the three accuracy drops are from entropy. `InfocenterState::InfocenterState` goes back to 100% if you add a dummy class before the function.
