### PR TITLE
Rename c_notificationDrag* enum

### DIFF
--- a/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
@@ -54,9 +54,15 @@ public:
 	MxS32 GetY() const { return m_y; }
 
 	void SetROI(LegoROI* p_roi) { m_roi = p_roi; }
+
+	// FUNCTION: BETA10 0x1007d620
 	void SetModifier(MxU8 p_modifier) { m_modifier = p_modifier; }
 	void SetKey(MxU8 p_key) { m_key = p_key; }
+
+	// FUNCTION: BETA10 0x1007d650
 	void SetX(MxS32 p_x) { m_x = p_x; }
+
+	// FUNCTION: BETA10 0x1007d680
 	void SetY(MxS32 p_y) { m_y = p_y; }
 
 protected:

--- a/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
@@ -57,6 +57,8 @@ public:
 
 	// FUNCTION: BETA10 0x1007d620
 	void SetModifier(MxU8 p_modifier) { m_modifier = p_modifier; }
+
+	// FUNCTION: BETA10 0x1007d6b0
 	void SetKey(MxU8 p_key) { m_key = p_key; }
 
 	// FUNCTION: BETA10 0x1007d650

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -42,7 +42,7 @@ MxResult LegoCameraController::Create()
 MxLong LegoCameraController::Notify(MxParam& p_param)
 {
 	switch (((MxNotificationParam&) p_param).GetNotification()) {
-	case c_notificationDrag: {
+	case c_notificationDragEnd: {
 		if (((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_lButtonState) ==
 			0) {
 			OnLButtonUp(MxPoint32(
@@ -57,7 +57,7 @@ MxLong LegoCameraController::Notify(MxParam& p_param)
 			));
 		}
 	} break;
-	case c_notificationDragEnd: {
+	case c_notificationDragStart: {
 		if ((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_lButtonState) {
 			OnLButtonDown(MxPoint32(
 				((LegoEventNotificationParam&) p_param).GetX(),
@@ -71,7 +71,7 @@ MxLong LegoCameraController::Notify(MxParam& p_param)
 			));
 		}
 	} break;
-	case c_notificationDragStart: {
+	case c_notificationDrag: {
 		OnMouseMove(
 			((LegoEventNotificationParam&) p_param).GetModifier(),
 			MxPoint32(((LegoEventNotificationParam&) p_param).GetX(), ((LegoEventNotificationParam&) p_param).GetY())

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -42,6 +42,21 @@ MxResult LegoCameraController::Create()
 MxLong LegoCameraController::Notify(MxParam& p_param)
 {
 	switch (((MxNotificationParam&) p_param).GetNotification()) {
+	case c_notificationDrag: {
+		if (((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_lButtonState) ==
+			0) {
+			OnLButtonUp(MxPoint32(
+				((LegoEventNotificationParam&) p_param).GetX(),
+				((LegoEventNotificationParam&) p_param).GetY()
+			));
+		}
+		else if (((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_rButtonState) == 0) {
+			OnRButtonUp(MxPoint32(
+				((LegoEventNotificationParam&) p_param).GetX(),
+				((LegoEventNotificationParam&) p_param).GetY()
+			));
+		}
+	} break;
 	case c_notificationDragEnd: {
 		if ((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_lButtonState) {
 			OnLButtonDown(MxPoint32(
@@ -61,21 +76,6 @@ MxLong LegoCameraController::Notify(MxParam& p_param)
 			((LegoEventNotificationParam&) p_param).GetModifier(),
 			MxPoint32(((LegoEventNotificationParam&) p_param).GetX(), ((LegoEventNotificationParam&) p_param).GetY())
 		);
-	} break;
-	case c_notificationDrag: {
-		if (((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_lButtonState) ==
-			0) {
-			OnLButtonUp(MxPoint32(
-				((LegoEventNotificationParam&) p_param).GetX(),
-				((LegoEventNotificationParam&) p_param).GetY()
-			));
-		}
-		else if (((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_rButtonState) == 0) {
-			OnRButtonUp(MxPoint32(
-				((LegoEventNotificationParam&) p_param).GetX(),
-				((LegoEventNotificationParam&) p_param).GetY()
-			));
-		}
 	} break;
 	}
 

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -379,7 +379,7 @@ MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 			if (p_param.GetKey() == VK_SHIFT) {
 				if (m_unk0x195) {
 					m_unk0x80 = FALSE;
-					p_param.SetNotification(c_notificationDrag);
+					p_param.SetNotification(c_notificationDragEnd);
 
 					if (m_camera) {
 						m_camera->Notify(p_param);
@@ -506,7 +506,7 @@ MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 		StopAutoDragTimer();
 
 		if (m_unk0x80) {
-			p_param.SetNotification(c_notificationDrag);
+			p_param.SetNotification(c_notificationDragEnd);
 			result = TRUE;
 		}
 		else if (m_unk0x81) {
@@ -538,14 +538,14 @@ MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 				if (m_unk0x195 || t > m_unk0x74) {
 					StopAutoDragTimer();
 					m_unk0x80 = TRUE;
-					p_param.SetNotification(c_notificationDragEnd);
+					p_param.SetNotification(c_notificationDragStart);
 					result = TRUE;
 					p_param.SetX(m_x);
 					p_param.SetY(m_y);
 				}
 			}
 			else {
-				p_param.SetNotification(c_notificationDragStart);
+				p_param.SetNotification(c_notificationDrag);
 				result = TRUE;
 			}
 		}
@@ -559,7 +559,7 @@ MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 				p_param.SetX(m_x);
 				p_param.SetY(m_y);
 				p_param.SetModifier(LegoEventNotificationParam::c_lButtonState);
-				p_param.SetNotification(c_notificationDragEnd);
+				p_param.SetNotification(c_notificationDragStart);
 				result = TRUE;
 			}
 			else {

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -489,11 +489,19 @@ MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1005cdf0
+// FUNCTION: BETA10 0x10089cc1
 MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 {
 	MxBool result = FALSE;
 
 	switch (p_param.GetNotification()) {
+	case c_notificationButtonDown:
+		m_x = p_param.GetX();
+		m_y = p_param.GetY();
+		m_unk0x80 = FALSE;
+		m_unk0x81 = TRUE;
+		StartAutoDragTimer();
+		break;
 	case c_notificationButtonUp:
 		StopAutoDragTimer();
 
@@ -511,13 +519,6 @@ MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 		m_unk0x80 = FALSE;
 		m_unk0x81 = FALSE;
 		break;
-	case c_notificationButtonDown:
-		m_x = p_param.GetX();
-		m_y = p_param.GetY();
-		m_unk0x80 = FALSE;
-		m_unk0x81 = TRUE;
-		StartAutoDragTimer();
-		break;
 	case c_notificationMouseMove:
 		if (m_unk0x195) {
 			p_param.SetModifier(LegoEventNotificationParam::c_lButtonState);
@@ -532,8 +533,9 @@ MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 
 				MxS32 diffX = p_param.GetX() - m_x;
 				MxS32 diffY = p_param.GetY() - m_y;
+				MxS32 t = diffX * diffX + diffY * diffY;
 
-				if (m_unk0x195 || (diffX * diffX) + (diffY * diffY) > m_unk0x74) {
+				if (m_unk0x195 || t > m_unk0x74) {
 					StopAutoDragTimer();
 					m_unk0x80 = TRUE;
 					p_param.SetNotification(c_notificationDragEnd);
@@ -571,12 +573,14 @@ MxBool LegoInputManager::FUN_1005cdf0(LegoEventNotificationParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1005cfb0
+// FUNCTION: BETA10 0x10089fc5
 void LegoInputManager::StartAutoDragTimer()
 {
 	m_autoDragTimerID = ::SetTimer(LegoOmni::GetInstance()->GetWindowHandle(), 1, m_autoDragTime, NULL);
 }
 
 // FUNCTION: LEGO1 0x1005cfd0
+// FUNCTION: BETA10 0x1008a005
 void LegoInputManager::StopAutoDragTimer()
 {
 	if (m_autoDragTimerID) {

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -55,6 +55,7 @@ public:
 	// FUNCTION: BETA10 0x1003c960
 	MxCore* GetSender() const { return m_sender; }
 
+	// FUNCTION: BETA10 0x1007d5c0
 	void SetNotification(NotificationId p_type) { m_type = p_type; }
 	void SetSender(MxCore* p_sender) { m_sender = p_sender; }
 

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -20,9 +20,9 @@ enum NotificationId {
 	c_notificationButtonDown = 9, // 100d6aa0
 	c_notificationMouseMove = 10, // 100d6aa0
 	c_notificationClick = 11,     // 100d6aa0
-	c_notificationDragEnd = 12,
-	c_notificationDragStart = 13,
-	c_notificationDrag = 14,
+	c_notificationDragStart = 12,
+	c_notificationDrag = 13,
+	c_notificationDragEnd = 14,
 	c_notificationTimer = 15, // 100d6aa0
 	c_notificationControl = 17,
 	c_notificationEndAnim = 18,    // 100d7e80

--- a/LEGO1/omni/include/mxnotificationparam.h
+++ b/LEGO1/omni/include/mxnotificationparam.h
@@ -57,6 +57,8 @@ public:
 
 	// FUNCTION: BETA10 0x1007d5c0
 	void SetNotification(NotificationId p_type) { m_type = p_type; }
+
+	// FUNCTION: BETA10 0x1007d5f0
 	void SetSender(MxCore* p_sender) { m_sender = p_sender; }
 
 protected:


### PR DESCRIPTION
The constructor for `MxNotification` is at `0x101253c6` in the beta, and it shows a debug string set at the `+0x08` offset. This conveniently provides the listing of the enum for notification type. There are other differences, but I noticed the notifications for dragging an object were out of order, so I changed those to match. `LegoCameraController::Notify` reads better now:
- if `c_notificationDragEnd` call `OnLButtonUp/OnRButtonUp`
- if `c_notificationDragStart` call `OnLButtonDown/OnRButtonDown`
- if `c_notificationDrag` call `OnMouseMove`

Accuracy boost due to slight tweaks in `LegoInputManager::FUN_1005cdf0`, but no diff other than that.