### PR TITLE
(Proposal) Introduce arithmetic operators to `Vector2`

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -52,7 +52,7 @@ MxU32 Act3Actor::VTable0x90(float p_float, Matrix4& p_transform)
 			m_state = 0;
 			m_unk0x1c = 0;
 
-			((Vector3&) positionRef).Sub(g_unk0x10104ef0);
+			positionRef -= g_unk0x10104ef0;
 			m_roi->FUN_100a58f0(p_transform);
 			m_roi->VTable0x14();
 			return TRUE;
@@ -75,7 +75,7 @@ MxResult Act3Actor::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 		MxMatrix local2world;
 		local2world = roi->GetLocal2World();
 
-		Vector3(local2world[3]).Add(g_unk0x10104ef0);
+		Vector3(local2world[3]) += g_unk0x10104ef0;
 
 		roi->FUN_100a58f0(local2world);
 		roi->VTable0x14();

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -226,8 +226,8 @@ MxLong Helicopter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				dir = m_world->GetCamera()->GetWorldDirection();
 				lookat = dir;
 				float scale = 3;
-				lookat.Mul(scale);
-				lookat.Add(loc);
+				lookat *= scale;
+				lookat += loc;
 				Mx3DPointFloat v68, v7c, v90(0, 1, 0), va4;
 				v68 = m_world->GetCamera()->GetWorldUp();
 				va4.EqualsCross(&v68, &dir);
@@ -379,9 +379,9 @@ void Helicopter::VTable0x70(float p_float)
 			mat.SetIdentity();
 			m_unk0x1f4.Unknown6(mat, f2);
 			v2.SetVector(loc);
-			v2.Sub(v);
-			v2.Mul(f2);
-			v2.Add(v);
+			v2 -= v;
+			v2 *= f2;
+			v2 += v;
 			m_world->GetCamera()->FUN_100123e0(mat, 0);
 		}
 		else {

--- a/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
@@ -126,8 +126,8 @@ void IslePathActor::Exit()
 			Mx3DPointFloat local20;
 			e->FUN_1002ddc0(*m_boundary, local20);
 
-			((Vector3&) local20).Mul(m_roi->GetWorldBoundingSphere().Radius());
-			((Vector3&) local20).Add(GetWorldPosition());
+			local20 *= m_roi->GetWorldBoundingSphere().Radius();
+			local20 += GetWorldPosition();
 
 			MxS32 j;
 			for (j = 0; j < m_boundary->GetNumEdges(); j++) {
@@ -643,7 +643,7 @@ void IslePathActor::FUN_1001b660()
 	Vector3 direction(transform[1]);
 	Vector3 up(transform[2]);
 
-	((Vector3&) up).Mul(-1.0f);
+	up *= -1.0f;
 	position.EqualsCross(&direction, &up);
 	m_roi->FUN_100a58f0(transform);
 	m_roi->VTable0x14();

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1599,8 +1599,7 @@ MxU16 LegoAnimationManager::FUN_10062110(
 			if (direction.Dot(&direction, &p_direction) > 0.707) {
 				Mx3DPointFloat position(p_roi->GetWorldPosition());
 
-				// TODO: Fix call
-				((Vector3&) position).Sub(p_position);
+				position -= p_position;
 				float len = position.LenSquared();
 				float min, max;
 
@@ -1764,9 +1763,7 @@ MxBool LegoAnimationManager::FUN_10062650(Vector3& p_position, float p_und, Lego
 {
 	if (p_roi != NULL) {
 		Mx3DPointFloat position(p_position);
-
-		// TODO: Fix call
-		((Vector3&) position).Sub(p_roi->GetWorldPosition());
+		position -= p_roi->GetWorldPosition();
 
 		float len = position.LenSquared();
 		if (len <= 0.0f) {
@@ -2174,7 +2171,7 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 			position = p_roi->GetWorldPosition();
 			direction = p_roi->GetWorldDirection();
 
-			((Vector3&) direction).Mul(-1.0f);
+			direction *= -1.0f;
 			m_extras[i].m_speed = -1.0f;
 
 			if (inExtras) {
@@ -2485,17 +2482,17 @@ MxBool LegoAnimationManager::FUN_10064010(LegoPathBoundary* p_boundary, LegoUnkn
 	Vector3* v2 = p_edge->CCWVertex(*p_boundary);
 
 	p1 = *v2;
-	((Vector3&) p1).Sub(*v1);
-	((Vector3&) p1).Mul(p_destScale);
-	((Vector3&) p1).Add(*v1);
+	p1 -= *v1;
+	p1 *= p_destScale;
+	p1 += *v1;
 
 	BoundingBox boundingBox;
 	Mx3DPointFloat vec(1.0f, 1.0f, 1.0f);
 
 	boundingBox.Min() = p1;
-	boundingBox.Min().Sub(vec);
+	boundingBox.Min() -= vec;
 	boundingBox.Max() = p1;
-	boundingBox.Max().Add(vec);
+	boundingBox.Max() += vec;
 	return GetViewManager()->IsBoundingBoxInFrustum(boundingBox) == FALSE;
 }
 
@@ -2704,7 +2701,7 @@ MxResult LegoAnimationManager::FUN_10064670(Vector3* p_position)
 
 	if (p_position != NULL) {
 		Mx3DPointFloat vec(98.875f, 0.0f, -46.1564f);
-		((Vector3&) vec).Sub(*p_position);
+		vec -= *p_position;
 
 		if (vec.LenSquared() < 800.0f) {
 			success = TRUE;
@@ -2728,7 +2725,7 @@ MxResult LegoAnimationManager::FUN_10064740(Vector3* p_position)
 
 	if (p_position != NULL) {
 		Mx3DPointFloat vec(-21.375f, 0.0f, -41.75f);
-		((Vector3&) vec).Sub(*p_position);
+		vec -= *p_position;
 
 		if (vec.LenSquared() < 1000.0f) {
 			success = TRUE;

--- a/LEGO1/lego/legoomni/src/entity/act2brick.cpp
+++ b/LEGO1/lego/legoomni/src/entity/act2brick.cpp
@@ -90,8 +90,8 @@ void Act2Brick::FUN_1007a670(MxMatrix& p_param1, MxMatrix& p_param2, LegoPathBou
 {
 	m_unk0x17c = p_param2[3];
 	m_unk0x168 = p_param2[3];
-	((Vector3&) m_unk0x168).Sub(p_param1[3]);
-	((Vector3&) m_unk0x168).Div(8.0f);
+	m_unk0x168 -= p_param1[3];
+	m_unk0x168 /= 8.0f;
 
 	m_unk0x190 = 0;
 	TickleManager()->RegisterClient(this, 20);

--- a/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
@@ -96,7 +96,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 			Mx3DPointFloat worldDirection(m_roi->GetWorldDirection());
 
 			if (!m_userNavFlag) {
-				((Vector2*) &worldDirection)->Mul(-1.0f);
+				worldDirection *= -1.0f;
 			}
 
 			if (VTable0x80(m_roi->GetWorldPosition(), worldDirection, a, c)) {

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -97,7 +97,7 @@ MxU32 LegoExtraActor::VTable0x90(float p_time, Matrix4& p_transform)
 		else {
 			m_state = 0;
 			m_scheduledTime = 0.0f;
-			((Vector3&) positionRef).Sub(g_unk0x10104c18); // TODO: Fix call
+			positionRef -= g_unk0x10104c18;
 			m_roi->FUN_100a58f0(p_transform);
 			return TRUE;
 		}
@@ -136,8 +136,7 @@ MxResult LegoExtraActor::FUN_1002aae0()
 	Vector3 dirRef(m_unk0xec[2]);
 	Vector3 positionRef(m_unk0xec[3]);
 
-	// TODO: Fix call
-	((Vector3&) dirRef).Mul(-1.0f);
+	dirRef *= -1.0f;
 	rightRef.EqualsCross(&upRef, &dirRef);
 
 	if (m_boundary == m_destEdge->m_faceA) {
@@ -216,9 +215,8 @@ MxResult LegoExtraActor::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 			Vector3 positionRef(matrix2[3]);
 			Mx3DPointFloat dir(matrix[2]);
 
-			// TODO: Fix calls
-			((Mx3DPointFloat&) dir).Mul(2.0f);
-			((Vector3&) positionRef).Add(dir);
+			dir *= 2.0f;
+			positionRef += dir;
 
 			for (MxS32 i = 0; i < m_boundary->GetNumEdges(); i++) {
 				Mx4DPointFloat* normal = m_boundary->GetEdgeNormal(i);
@@ -251,7 +249,7 @@ MxResult LegoExtraActor::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 			Mx3DPointFloat dir = p_actor->GetWorldDirection();
 			MxMatrix matrix3 = MxMatrix(roi->GetLocal2World());
 			Vector3 positionRef(matrix3[3]);
-			((Vector3&) positionRef).Add(g_unk0x10104c18);
+			positionRef += g_unk0x10104c18;
 			roi->FUN_100a58f0(matrix3);
 
 #ifdef COMPAT_MODE
@@ -463,7 +461,7 @@ MxU32 LegoExtraActor::VTable0x6c(
 						Vector3 local60(local2world[3]);
 						Mx3DPointFloat local54(p_v1);
 
-						((Vector3&) local54).Sub(local60);
+						local54 -= local60;
 						float local1c = p_v2.Dot(&p_v2, &p_v2);
 						float local24 = p_v2.Dot(&p_v2, &local54) * 2.0f;
 						float local20 = local54.Dot(&local54, &local54);

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -72,7 +72,7 @@ MxResult LegoPathActor::VTable0x80(const Vector3& p_point1, Vector3& p_point2, V
 	Mx3DPointFloat p1, p2, p3;
 
 	p1 = p_point3;
-	((Vector3&) p1).Sub(p_point1);
+	p1 -= p_point1;
 	m_BADuration = p1.LenSquared();
 
 	if (m_BADuration > 0.0f) {
@@ -106,14 +106,14 @@ MxResult LegoPathActor::VTable0x88(
 	Mx3DPointFloat p1, p2, p3, p4, p5;
 
 	p1 = *v2;
-	((Vector3&) p1).Sub(*v1);
-	((Vector3&) p1).Mul(p_srcScale);
-	((Vector3&) p1).Add(*v1);
+	p1 -= *v1;
+	p1 *= p_srcScale;
+	p1 += *v1;
 
 	p2 = *v4;
-	((Vector3&) p2).Sub(*v3);
-	((Vector3&) p2).Mul(p_destScale);
-	((Vector3&) p2).Add(*v3);
+	p2 -= *v3;
+	p2 *= p_destScale;
+	p2 += *v3;
 
 	m_boundary = p_boundary;
 	m_destEdge = &p_destEdge;
@@ -124,7 +124,7 @@ MxResult LegoPathActor::VTable0x88(
 	p_destEdge.FUN_1002ddc0(*p_boundary, p3);
 
 	p4 = p2;
-	((Vector3&) p4).Sub(p1);
+	p4 -= p1;
 	p4.Unitize();
 
 	MxMatrix matrix;
@@ -139,7 +139,7 @@ MxResult LegoPathActor::VTable0x88(
 	up = *m_boundary->GetUnknown0x14();
 
 	if (!m_cameraFlag || !m_userNavFlag) {
-		((Vector3&) dir).Mul(-1.0f);
+		dir *= -1.0f;
 	}
 
 	right.EqualsCross(&up, &dir);
@@ -181,9 +181,9 @@ MxResult LegoPathActor::VTable0x84(
 	Mx3DPointFloat p2, p3, p5;
 
 	p2 = *v4;
-	((Vector3&) p2).Sub(*v3);
-	((Vector3&) p2).Mul(p_destScale);
-	((Vector3&) p2).Add(*v3);
+	p2 -= *v3;
+	p2 *= p_destScale;
+	p2 += *v3;
 
 	m_boundary = p_boundary;
 	m_destEdge = &p_destEdge;
@@ -205,7 +205,7 @@ MxResult LegoPathActor::VTable0x84(
 	up = *m_boundary->GetUnknown0x14();
 
 	if (!m_cameraFlag || !m_userNavFlag) {
-		((Vector3&) dir).Mul(-1.0f);
+		dir *= -1.0f;
 	}
 
 	right.EqualsCross(&up, &dir);
@@ -289,12 +289,12 @@ MxS32 LegoPathActor::VTable0x8c(float p_time, Matrix4& p_transform)
 					m_worldSpeed *= m_unk0x144;
 					nav->SetLinearVel(m_worldSpeed);
 					Mx3DPointFloat p7(p2);
-					((Vector3&) p7).Sub(p6);
+					p7 -= p6;
 
 					if (p7.Unitize() == 0) {
 						float f = sqrt(p1.LenSquared()) * m_unk0x140;
-						((Vector3&) p7).Mul(f);
-						((Vector3&) p1).Add(p7);
+						p7 *= f;
+						p1 += p7;
 					}
 				}
 			}
@@ -479,7 +479,7 @@ MxU32 LegoPathActor::VTable0x6c(
 MxS32 LegoPathActor::VTable0x68(Vector3& p_v1, Vector3& p_v2, Vector3& p_v3)
 {
 	Mx3DPointFloat v2(p_v2);
-	((Vector3&) v2).Sub(p_v1);
+	v2 -= p_v1;
 
 	float len = v2.LenSquared();
 
@@ -488,7 +488,7 @@ MxS32 LegoPathActor::VTable0x68(Vector3& p_v1, Vector3& p_v2, Vector3& p_v3)
 	}
 
 	len = sqrt(len);
-	((Vector3&) v2).Div(len);
+	v2 /= len;
 
 	float radius = m_roi->GetWorldBoundingSphere().Radius();
 	list<LegoPathBoundary*> boundaries;
@@ -655,16 +655,16 @@ MxResult LegoPathActor::VTable0x9c()
 	Mx3DPointFloat local84(m_unk0xec[2]);
 	Mx3DPointFloat local70(local34);
 
-	((Vector3&) local70).Sub(localc0);
+	local70 -= localc0;
 	float len = local70.LenSquared();
 	if (len >= 0.0f) {
 		len = sqrt(len);
-		((Vector3&) local84).Mul(len);
-		((Vector3&) local48).Mul(len);
+		local84 *= len;
+		local48 *= len;
 	}
 
 	if (!m_userNavFlag) {
-		((Vector3&) local84).Mul(-1.0f);
+		local84 *= -1.0f;
 	}
 
 	if (VTable0x80(localc0, local84, local34, local48) != SUCCESS) {

--- a/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
@@ -53,11 +53,11 @@ void LegoPathBoundary::FUN_100575b0(Vector3& p_point1, Vector3& p_point2, LegoPa
 		Mx3DPointFloat v;
 
 		v = p_point1;
-		((Vector3&) v).Sub(*ccwV);
+		v -= *ccwV;
 		float dot1 = v.Dot(&v, m_unk0x50);
 
 		v = p_point2;
-		((Vector3&) v).Sub(*ccwV);
+		v -= *ccwV;
 		float dot2 = v.Dot(&v, m_unk0x50);
 
 		if (dot2 > dot1) {
@@ -201,7 +201,7 @@ MxU32 LegoPathBoundary::Intersect(
 			if (local10 == 0) {
 				local10 = 1;
 				vec = p_point2;
-				((Vector3&) vec).Sub(p_point1);
+				vec -= p_point1;
 
 				len = vec.LenSquared();
 				if (len <= 0.0f) {
@@ -209,7 +209,7 @@ MxU32 LegoPathBoundary::Intersect(
 				}
 
 				len = sqrt(len);
-				((Vector3&) vec).Div(len);
+				vec /= len;
 			}
 
 			float dot = vec.Dot(&vec, &m_edgeNormals[i]);
@@ -234,11 +234,11 @@ MxU32 LegoPathBoundary::Intersect(
 		Vector3* local5c = e->CWVertex(*this);
 
 		p_point3 = vec;
-		p_point3.Mul(localc);
-		p_point3.Add(p_point1);
+		p_point3 *= localc;
+		p_point3 += p_point1;
 
 		local50 = p_point2;
-		((Vector3&) local50).Sub(*local5c);
+		local50 -= *local5c;
 
 		e->FUN_1002ddc0(*this, local70);
 
@@ -258,7 +258,7 @@ MxU32 LegoPathBoundary::Intersect(
 
 				Vector3* local90 = local88->CWVertex(*this);
 				Mx3DPointFloat locala4(p_point3);
-				((Vector3&) locala4).Sub(*local90);
+				locala4 -= *local90;
 
 				float local8c = locala4.Dot(&locala4, &local84);
 
@@ -285,7 +285,7 @@ MxU32 LegoPathBoundary::Intersect(
 
 					Vector3* localc4 = locala8->CWVertex(*this);
 					Mx3DPointFloat locald8(p_point3);
-					((Vector3&) locald8).Sub(*localc4);
+					locald8 -= *localc4;
 
 					float localc0 = locald8.Dot(&locald8, &localbc);
 
@@ -316,8 +316,8 @@ MxU32 LegoPathBoundary::Intersect(
 		}
 		else if (local58 > 0.0f && e->m_unk0x3c > local58) {
 			p_point3 = local70;
-			p_point3.Mul(local58);
-			p_point3.Add(*local5c);
+			p_point3 *= local58;
+			p_point3 += *local5c;
 			p_edge = e;
 			return 1;
 		}
@@ -345,7 +345,7 @@ MxU32 LegoPathBoundary::FUN_10057fe0(LegoAnimPresenter* p_presenter)
 	Mx3DPointFloat unk0x30;
 
 	unk0x30 = m_unk0x30;
-	((Vector3&) unk0x30).Sub(p_presenter->m_unk0xa8);
+	unk0x30 -= p_presenter->m_unk0xa8;
 
 	float len = unk0x30.LenSquared();
 	float local20 = p_presenter->m_unk0xa4 + m_unk0x44;

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -95,8 +95,7 @@ MxResult LegoPathController::Create(MxU8* p_data, const Vector3& p_location, con
 		}
 
 		for (i = 0; i < m_numN; i++) {
-			// TODO: Fix call
-			((Vector3&) m_unk0x10[i]).Add(p_location);
+			m_unk0x10[i] += p_location;
 		}
 
 		for (i = 0; i < m_numL; i++) {
@@ -950,9 +949,9 @@ MxS32 LegoPathController::FUN_1004a240(
 
 	Mx3DPointFloat vec;
 	p_v1 = *p_edge->CCWVertex(*p_boundary);
-	p_v1.Sub(*p_edge->CWVertex(*p_boundary));
-	p_v1.Mul(p_f1);
-	p_v1.Add(*p_edge->CWVertex(*p_boundary));
+	p_v1 -= *p_edge->CWVertex(*p_boundary);
+	p_v1 *= p_f1;
+	p_v1 += *p_edge->CWVertex(*p_boundary);
 	p_edge->FUN_1002ddc0(*p_boundary, vec);
 	p_v2.EqualsCross(p_boundary->GetUnknown0x14(), &vec);
 	return 0;

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -84,7 +84,7 @@ MxU32 LegoRaceActor::VTable0x90(float p_float, Matrix4& p_transform)
 			m_state = 0;
 			m_unk0x08 = 0;
 
-			((Vector3&) positionRef).Sub(g_unk0x10102b08);
+			positionRef -= g_unk0x10102b08;
 			m_roi->FUN_100a58f0(p_transform);
 			return 1;
 		}
@@ -108,7 +108,7 @@ MxResult LegoRaceActor::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 			MxMatrix matr;
 			matr = roi->GetLocal2World();
 
-			Vector3(matr[3]).Add(g_unk0x10102b08);
+			Vector3(matr[3]) += g_unk0x10102b08;
 
 			roi->FUN_100a58f0(matr);
 

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -442,7 +442,7 @@ MxResult LegoRaceCar::VTable0x94(LegoPathActor* p_actor, MxBool p_bool)
 			MxMatrix matr;
 			matr = roi->GetLocal2World();
 
-			Vector3(matr[3]).Add(g_unk0x10102af0);
+			Vector3(matr[3]) += g_unk0x10102af0;
 			roi->FUN_100a58f0(matr);
 
 			p_actor->SetState(2);

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -172,11 +172,11 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 			Mx3DPointFloat worldDirection(Vector3(m_roi->GetWorldDirection()));
 
 			if (!m_userNavFlag) {
-				((Vector3*) &worldDirection)->Mul(-1.0f);
+				worldDirection *= -1.0f;
 			}
 
-			((Vector3*) &worldDirection)->Mul(5.0f);
-			((Vector3*) &crossProduct)->Mul(5.0f);
+			worldDirection *= 5.0f;
+			crossProduct *= 5.0f;
 
 			MxResult callResult =
 				VTable0x80(Vector3(m_roi->GetWorldPosition()), worldDirection, pointUnknown, crossProduct);
@@ -266,8 +266,8 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		point4.Unitize();
 		point5.Unitize();
 
-		((Vector3*) &point4)->Mul(5.0f);
-		((Vector3*) &point5)->Mul(5.0f);
+		point4 *= 5.0f;
+		point5 *= 5.0f;
 
 		MxResult res = VTable0x80(m_roi->GetWorldPosition(), point4, point1, point5);
 

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -649,14 +649,14 @@ void LegoAnimPresenter::PutFrame()
 
 					up = und;
 
-					((Vector3&) up).Sub(m_currentWorld->GetCamera()->GetWorldLocation());
-					((Vector3&) dir).Div(dirsqr);
+					up -= m_currentWorld->GetCamera()->GetWorldLocation();
+					dir /= dirsqr;
 					pos.EqualsCross(&dir, &up);
 					pos.Unitize();
 					up.EqualsCross(&pos, &dir);
-					((Vector3&) pos).Mul(possqr);
-					((Vector3&) dir).Mul(dirsqr);
-					((Vector3&) up).Mul(upsqr);
+					pos *= possqr;
+					dir *= dirsqr;
+					up *= upsqr;
 
 					m_unk0x8c[i]->FUN_100a58f0(mat);
 					m_unk0x8c[i]->VTable0x14();
@@ -1114,10 +1114,10 @@ void LegoAnimPresenter::FUN_1006c7a0()
 void LegoAnimPresenter::VTable0x8c()
 {
 	if (m_unk0x78) {
-		m_unk0xa8.Add((*m_unk0x78)[3]);
+		m_unk0xa8 += (*m_unk0x78)[3];
 	}
 	else {
-		m_unk0xa8.Add(m_action->GetLocation());
+		m_unk0xa8 += m_action->GetLocation();
 	}
 
 	if (m_currentWorld == NULL) {
@@ -1173,11 +1173,11 @@ MxU32 LegoAnimPresenter::VTable0x94(Vector3& p_v1, Vector3& p_v2, float p_f1, fl
 	Mx3DPointFloat a, b;
 
 	b = p_v2;
-	((Vector3&) b).Mul(p_f1);
-	((Vector3&) b).Add(p_v1);
+	b *= p_f1;
+	b += p_v1;
 
 	a = b;
-	((Vector3&) a).Sub(m_unk0xa8);
+	a -= m_unk0xa8;
 
 	float len = a.LenSquared();
 	if (len <= 0.0f) {

--- a/LEGO1/lego/legoomni/src/video/legoloopinganimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoloopinganimpresenter.cpp
@@ -66,14 +66,14 @@ void LegoLoopingAnimPresenter::PutFrame()
 
 				up = und;
 
-				((Vector3&) up).Sub(m_currentWorld->GetCamera()->GetWorldLocation());
-				((Vector3&) dir).Div(dirsqr);
+				up -= m_currentWorld->GetCamera()->GetWorldLocation();
+				dir /= dirsqr;
 				pos.EqualsCross(&dir, &up);
 				pos.Unitize();
 				up.EqualsCross(&pos, &dir);
-				((Vector3&) pos).Mul(possqr);
-				((Vector3&) dir).Mul(dirsqr);
-				((Vector3&) up).Mul(upsqr);
+				pos *= possqr;
+				dir *= dirsqr;
+				up *= upsqr;
 
 				m_unk0x8c[i]->FUN_100a58f0(mat);
 				m_unk0x8c[i]->VTable0x14();

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -721,13 +721,13 @@ void Isle::Enable(MxBool p_enable)
 				Mx3DPointFloat position(UserActor()->GetROI()->GetWorldPosition());
 
 				Mx3DPointFloat sub(-21.375f, 0.0f, -41.75f);
-				((Vector3&) sub).Sub(position);
+				sub -= position;
 				if (sub.LenSquared() < 1024.0f) {
 					AnimationManager()->FUN_10064740(NULL);
 				}
 
 				Mx3DPointFloat sub2(98.874992f, 0.0f, -46.156292f);
-				((Vector3&) sub2).Sub(position);
+				sub2 -= position;
 				if (sub2.LenSquared() < 1024.0f) {
 					AnimationManager()->FUN_10064670(NULL);
 				}

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -313,7 +313,7 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 				Mx3DPointFloat unk0x10d8(m_pepper->GetWorldPosition());
 				Mx3DPointFloat locala4(unk0x10d8);
 
-				((Vector3&) entityPosition).Sub(unk0x10d8);
+				entityPosition -= unk0x10d8;
 
 				MxMatrix local2world(m_pepper->GetLocal2World());
 				Vector3 local30(local2world[0]);
@@ -324,8 +324,8 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 				local28.Unitize();
 
 				Mx3DPointFloat local90(local28);
-				((Vector3&) local90).Mul(1.25f);
-				((Vector3&) locala4).Add(local90);
+				local90 *= 1.25f;
+				locala4 += local90;
 				locala4[1] += 0.25;
 				local30.EqualsCross(&localac, &local28);
 				local30.Unitize();
@@ -1024,7 +1024,7 @@ void LegoAct2::FUN_100521f0(MxS32 p_param1)
 	if (objectId != (Act2mainScript::Script) 0) {
 		Mx3DPointFloat local30(vec);
 		Mx3DPointFloat position(m_pepper->GetWorldPosition());
-		((Vector3&) local30).Sub(position);
+		local30 -= position;
 		Mx3DPointFloat local44 = local30;
 		local30.Unitize();
 		FUN_10052560(objectId, TRUE, TRUE, &vec, &local30, NULL);

--- a/LEGO1/lego/sources/anim/legoanim.cpp
+++ b/LEGO1/lego/sources/anim/legoanim.cpp
@@ -168,7 +168,7 @@ LegoResult LegoAnimScene::FUN_1009f490(LegoFloat p_time, Matrix4& p_matrix)
 	}
 
 	local54 = localcc;
-	((Vector3&) local54).Sub(localb8);
+	local54 -= localb8;
 
 	if (local54.Unitize() == 0) {
 		local5c.EqualsCross(&local68, &local54);
@@ -177,7 +177,7 @@ LegoResult LegoAnimScene::FUN_1009f490(LegoFloat p_time, Matrix4& p_matrix)
 			local68.EqualsCross(&local54, &local5c);
 
 			localcc = p_matrix[3];
-			((Vector3&) localcc).Add(localb0[3]);
+			localcc += localb0[3];
 
 			p_matrix[3][0] = p_matrix[3][1] = p_matrix[3][2] = localb0[3][0] = localb0[3][1] = localb0[3][2] = 0;
 

--- a/LEGO1/lego/sources/geom/legounkown100db7f4.h
+++ b/LEGO1/lego/sources/geom/legounkown100db7f4.h
@@ -71,9 +71,9 @@ public:
 	LegoFloat DistanceToMidpoint(const Vector3& p_vec)
 	{
 		Mx3DPointFloat point(*m_pointA);
-		((Vector3&) point).Add(*m_pointB);
-		((Vector3&) point).Mul(0.5f);
-		((Vector3&) point).Sub(p_vec);
+		point += *m_pointB;
+		point *= 0.5f;
+		point -= p_vec;
 		return sqrt(point.LenSquared());
 	}
 
@@ -82,11 +82,11 @@ public:
 	{
 		Mx3DPointFloat point1(*m_pointA);
 		Mx3DPointFloat point2(*p_other.m_pointA);
-		((Vector3&) point1).Add(*m_pointB);
-		((Vector3&) point1).Mul(0.5f);
-		((Vector3&) point2).Add(*p_other.m_pointB);
-		((Vector3&) point2).Mul(0.5f);
-		((Vector3&) point1).Sub(point2);
+		point1 += *m_pointB;
+		point1 *= 0.5f;
+		point2 += *p_other.m_pointB;
+		point2 *= 0.5f;
+		point1 -= point2;
 		return sqrt(point1.LenSquared());
 	}
 

--- a/LEGO1/lego/sources/misc/legounknown.cpp
+++ b/LEGO1/lego/sources/misc/legounknown.cpp
@@ -42,9 +42,9 @@ LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, L
 	}
 	else if (p_f1 >= 0.999) {
 		v1 = m_unk0x00[0];
-		((Vector3&) v1).Add(m_unk0x00[1]);
-		((Vector3&) v1).Add(m_unk0x00[2]);
-		((Vector3&) v1).Add(m_unk0x00[3]);
+		v1 += m_unk0x00[1];
+		v1 += m_unk0x00[2];
+		v1 += m_unk0x00[3];
 
 		for (LegoS32 i = 0; i < 3; i++) {
 			v4[i] = m_unk0x00[1][i] + m_unk0x00[2][i] * 2.0f + m_unk0x00[3][i] * 3.0f;
@@ -61,7 +61,7 @@ LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, L
 	}
 
 	if (p_und) {
-		((Vector3&) v4).Mul(-1.0f);
+		v4 *= -1.0f;
 	}
 
 	if (v4.Unitize() != 0) {

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -600,8 +600,8 @@ LegoU32 LegoROI::FUN_100a9410(
 {
 	if (p_collideBox) {
 		Mx3DPointFloat v2(p_v2);
-		((Vector3&) v2).Mul(p_f1);
-		((Vector3&) v2).Add(p_v1);
+		v2 *= p_f1;
+		v2 += p_v1;
 
 		Mx4DPointFloat localc0;
 		Mx4DPointFloat local9c;
@@ -621,8 +621,8 @@ LegoU32 LegoROI::FUN_100a9410(
 		localc0[3] = local9c[3] = local168[3] = 1.0f;
 
 		local38 = local58;
-		((Vector3&) local38).Add(locala8);
-		((Vector3&) local38).Mul(0.5f);
+		local38 += locala8;
+		local38 *= 0.5f;
 
 		local70 = localc0;
 		localc0.SetMatrixProduct(&local70, (float*) m_local2world.GetData());
@@ -647,7 +647,7 @@ LegoU32 LegoROI::FUN_100a9410(
 			}
 
 			if (local150[i][3] + local38.Dot(&local38, &local150[i]) < 0.0f) {
-				((Vector4&) local150[i]).Mul(-1.0f);
+				local150[i] *= -1.0f;
 			}
 		}
 
@@ -659,8 +659,8 @@ LegoU32 LegoROI::FUN_100a9410(
 
 				if (local50 >= 0.0f && local50 <= p_f1) {
 					Mx3DPointFloat local17c(p_v2);
-					((Vector3&) local17c).Mul(local50);
-					((Vector3&) local17c).Add(local4c);
+					local17c *= local50;
+					local17c += local4c;
 
 					LegoS32 j;
 					for (j = 0; j < 6; j++) {
@@ -680,7 +680,7 @@ LegoU32 LegoROI::FUN_100a9410(
 	}
 	else {
 		Mx3DPointFloat v1(p_v1);
-		((Vector3&) v1).Sub(GetWorldBoundingSphere().Center());
+		v1 -= GetWorldBoundingSphere().Center();
 
 		float local10 = GetWorldBoundingSphere().Radius();
 		float local8 = p_v2.Dot(&p_v2, &p_v2);
@@ -716,8 +716,8 @@ LegoU32 LegoROI::FUN_100a9410(
 
 				if (local1c >= 0.0f && p_f1 >= local1c) {
 					p_v3 = p_v2;
-					p_v3.Mul(local1c);
-					p_v3.Add(p_v1);
+					p_v3 *= local1c;
+					p_v3 += p_v1;
 					return 1;
 				}
 			}
@@ -744,8 +744,8 @@ void TimeROI::FUN_100a9b40(Matrix4& p_matrix, LegoTime p_time)
 		Mx3DPointFloat targetPosition(p_matrix[3]);
 		Vector3 vec(m_local2world[3]);
 
-		((Vector3&) targetPosition).Sub(vec);
-		((Vector3&) targetPosition).Div(time * 0.001);
+		targetPosition -= vec;
+		targetPosition /= time * 0.001;
 
 		FUN_100a5a30(targetPosition);
 	}

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -163,13 +163,13 @@ inline void UnknownMx4DPointFloat::Unknown7()
 		Mx4DPointFloat v2;
 
 		v1 = m_unk0x00;
-		((Vector4&) v1).Add(m_unk0x18);
+		v1 += m_unk0x18;
 
 		v2 = m_unk0x00;
-		((Vector4&) v2).Sub(m_unk0x18);
+		v2 -= m_unk0x18;
 
 		if (v1.Dot(&v1, &v1) < v2.Dot(&v2, &v2)) {
-			((Vector4&) m_unk0x18).Mul(-1.0f);
+			m_unk0x18 *= -1.0f;
 		}
 	}
 }

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -40,7 +40,7 @@ public:
 	~MxNotificationManager() override; // vtable+0x00 (scalar deleting destructor)
 
 	MxResult Tickle() override; // vtable+0x08
-	// TODO: Where does this method come from?
+
 	virtual MxResult Create(MxU32 p_frequencyMS, MxBool p_createThread); // vtable+0x14
 	void Register(MxCore* p_listener);
 	void Unregister(MxCore* p_listener);

--- a/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
@@ -287,6 +287,7 @@ MxResult MxDiskStreamController::VTable0x20(MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
 	MxDSStreamingAction* entry = (MxDSStreamingAction*) m_list0x80.Find(p_action); // TODO: is this a seperate class?
+
 	if (entry) {
 		MxDSStreamingAction* action = new MxDSStreamingAction(*p_action, 0);
 		action->SetUnknown28(entry->GetUnknown28());

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -118,6 +118,7 @@ public:
 		return -1;
 	} // vtable+0x44
 
+private:
 	// FUNCTION: LEGO1 0x100021c0
 	virtual void Add(float p_value) { AddImpl(p_value); } // vtable+0x50
 
@@ -145,6 +146,7 @@ public:
 	// FUNCTION: LEGO1 0x10002240
 	virtual void Div(const float& p_value) { DivScalarImpl((float*) &p_value); } // vtable+0x68
 
+public:
 	// FUNCTION: LEGO1 0x10002250
 	virtual void SetVector(float* p_other) { EqualsImpl(p_other); } // vtable+0x70
 
@@ -169,6 +171,19 @@ public:
 
 	// FUNCTION: BETA10 0x1001d170
 	const float& operator[](int idx) const { return m_data[idx]; }
+
+	void operator+=(float p_value) { Add(p_value); }
+	void operator+=(float* p_other) { Add(p_other); }
+	void operator+=(const Vector2& p_other) { Add(p_other); }
+
+	void operator-=(const float* p_other) { Sub(p_other); }
+	void operator-=(const Vector2& p_other) { Sub(p_other); }
+
+	void operator*=(float* p_other) { Mul(p_other); }
+	void operator*=(Vector2* p_other) { Mul(p_other); }
+	void operator*=(const float& p_value) { Mul(p_value); }
+
+	void operator/=(const float& p_value) { Div(p_value); }
 
 protected:
 	float* m_data; // 0x04

--- a/LEGO1/viewmanager/viewmanager.cpp
+++ b/LEGO1/viewmanager/viewmanager.cpp
@@ -430,10 +430,10 @@ void ViewManager::UpdateViewTransformations()
 		Vector3 normal(frustum_planes[i]);
 
 		x = c;
-		((Vector3&) x).Sub(b); // TODO: Fix call
+		x -= b;
 
 		y = a;
-		((Vector3&) y).Sub(b); // TODO: Fix call
+		y -= b;
 
 		normal.EqualsCross(&x, &y);
 		normal.Unitize();


### PR DESCRIPTION
This PR attempts to resolve the following awkward syntax we've been seeing across the code base:

`((Vector3&) positionRef).Sub(g_unk0x10104ef0);`

In all of those instances, what we are finding in the original assembly is a dynamic dispatch to the `Add`/`Sub`/`Mul`/`Div` virtual functions. However, whenever the type is known to the compiler (usually when we have a `Mx3DPointFloat` on the stack), the compiler optimizes the call and inlines the virtual function (almost all the time). What we've done so far is take a base class reference which strips away the type information, which forced dynamic dispatch. However:

* It is very unlikely the developers wrote code like this
* In *all* cases in the code base, `Add`/`Sub`/`Mul`/`Div` are never actually inlined in the original assembly
* This strange behavior is only limited to the `Add`/`Sub`/`Mul`/`Div` functions. Other virtual inline functions implemented in `vector.h` *are* being inlined

An intuition to resolve this might be to implement those 4 functions in a compilation unit so that they cannot be inlined. However, in this case the compiler will generate a static call to those functions and not use dynamic dispatch if the type is fully known. This is not what we are seeing in the original assembly.

The only reasonable explanation must be an additional indirection: if those functions are called from *within* the scope of a function implemented in the base class, the compiler will in all cases use dynamic dispatch. This looks like a limitation in terms of what MSVC 4.20 is able to optimize.

The most likely scenario is that the developers defined `operator+=`, `operator-=`, `operator*=` and `operator/=` which forward to `Add`/`Sub`/`Mul`/`Div`. This introduces the consistent dynamic dispatch - which was most likely unintended, since it's quite inefficient.

This PR introduces the operators and makes the original functions private, and refactors the existing code to use the operators. As far as I can tell this actually improves matches in many of the functions that use them.

Note: they must have added those operators after BETA 1.0 since they are not present there. Unfortunately this means we have no confirmation that they did indeed use the operators, but considering what we can see it seems very likely to me.

Note 2: I've deliberatedly decided for the operators not to return a reference to `*this` (for now). We could however experiment with this and see if it improves matches, or if chaining the operators is something they might have done in some places.