### PR TITLE
Restore annotations for ISLE and CONFIG from LEGO1 dir

### DIFF
--- a/reccmp-project.yml
+++ b/reccmp-project.yml
@@ -1,7 +1,7 @@
 targets:
   ISLE:
     filename: ISLE.EXE
-    source-root: ISLE
+    source-root: .
     hash:
       sha256: 5cf57c284973fce9d14f5677a2e4435fd989c5e938970764d00c8932ed5128ca
   LEGO1:
@@ -11,7 +11,7 @@ targets:
       sha256: 14645225bbe81212e9bc1919cd8a692b81b8622abb6561280d99b0fc4151ce17
   CONFIG:
     filename: CONFIG.EXE
-    source-root: CONFIG
+    source-root: .
     hash:
       sha256: 864766d024d78330fed5e1f6efb2faf815f1b1c3405713a9718059dc9a54e52c
   BETA10:


### PR DESCRIPTION
When we switched to using the reccmp project file, we stopped scanning the LEGO1 directory on the CONFIG and ISLE targets, and so we lost some annotations. They're back now.