### PR TITLE
Rename `LegoPathActor::VTable0x70` to `UpdateState`

### DIFF
--- a/LEGO1/lego/legoomni/include/act2actor.h
+++ b/LEGO1/lego/legoomni/include/act2actor.h
@@ -22,7 +22,7 @@ public:
 	void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2) override;   // vtable+0x24
 	void SetWorldSpeed(MxFloat p_worldSpeed) override;                      // vtable+0x30
 	MxS32 VTable0x68(Vector3& p_v1, Vector3& p_v2, Vector3& p_v3) override; // vtable+0x68
-	void VTable0x70(float p_time) override;                                 // vtable+0x70
+	void UpdateState(float p_time) override;                                // vtable+0x70
 	MxResult HitActor(LegoPathActor*, MxBool) override;                     // vtable+0x94
 	MxResult VTable0x9c() override;                                         // vtable+0x9c
 	MxS32 VTable0xa0() override;                                            // vtable+0xa0

--- a/LEGO1/lego/legoomni/include/act3actors.h
+++ b/LEGO1/lego/legoomni/include/act3actors.h
@@ -50,7 +50,7 @@ public:
 	Act3Cop();
 
 	void ParseAction(char* p_extra) override;           // vtable+0x20
-	void VTable0x70(float p_time) override;             // vtable+0x70
+	void UpdateState(float p_time) override;            // vtable+0x70
 	MxResult HitActor(LegoPathActor*, MxBool) override; // vtable+0x94
 	MxResult VTable0x9c() override;                     // vtable+0x9c
 
@@ -78,7 +78,7 @@ public:
 	~Act3Brickster() override;
 
 	void ParseAction(char* p_extra) override;                          // vtable+0x20
-	void VTable0x70(float p_time) override;                            // vtable+0x70
+	void UpdateState(float p_time) override;                           // vtable+0x70
 	MxResult HitActor(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94
 	void SwitchBoundary(
 		LegoPathBoundary*& p_boundary,
@@ -128,8 +128,8 @@ public:
 		return "Act3Shark";
 	}
 
-	void ParseAction(char*) override;       // vtable+0x20
-	void VTable0x70(float p_time) override; // vtable+0x70
+	void ParseAction(char*) override;        // vtable+0x20
+	void UpdateState(float p_time) override; // vtable+0x70
 
 	// LegoAnimActor vtable
 	virtual MxResult FUN_10042ce0(Act3Ammo* p_ammo); // vtable+0x10

--- a/LEGO1/lego/legoomni/include/act3ammo.h
+++ b/LEGO1/lego/legoomni/include/act3ammo.h
@@ -22,7 +22,7 @@ public:
 	~Act3Ammo() override;
 
 	void Destroy(MxBool p_fromDestructor) override; // vtable+0x1c
-	void VTable0x70(float p_time) override;         // vtable+0x70
+	void UpdateState(float p_time) override;        // vtable+0x70
 
 	// FUNCTION: BETA10 0x10017750
 	MxU32 IsValid() { return m_ammoFlag & c_valid; }

--- a/LEGO1/lego/legoomni/include/ambulance.h
+++ b/LEGO1/lego/legoomni/include/ambulance.h
@@ -124,7 +124,7 @@ public:
 
 	MxResult Create(MxDSAction& p_dsAction) override;                              // vtable+0x18
 	void Destroy(MxBool p_fromDestructor) override;                                // vtable+0x1c
-	void VTable0x70(float p_time) override;                                        // vtable+0x70
+	void UpdateState(float p_time) override;                                       // vtable+0x70
 	MxLong HandleClick() override;                                                 // vtable+0xcc
 	MxLong HandleControl(LegoControlManagerNotificationParam& p_param) override;   // vtable+0xd4
 	MxLong HandlePathStruct(LegoPathStructNotificationParam& p_param) override;    // vtable+0xdc

--- a/LEGO1/lego/legoomni/include/doors.h
+++ b/LEGO1/lego/legoomni/include/doors.h
@@ -25,7 +25,7 @@ public:
 	}
 
 	void ParseAction(char* p_extra) override;                          // vtable+0x20
-	void VTable0x70(float p_time) override;                            // vtable+0x70
+	void UpdateState(float p_time) override;                           // vtable+0x70
 	MxResult HitActor(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94
 	virtual MxFloat VTable0xcc(float p_time);                          // vtable+0xcc
 

--- a/LEGO1/lego/legoomni/include/dunebuggy.h
+++ b/LEGO1/lego/legoomni/include/dunebuggy.h
@@ -24,7 +24,7 @@ public:
 	}
 
 	MxResult Create(MxDSAction& p_dsAction) override;                            // vtable+0x18
-	void VTable0x70(float p_time) override;                                      // vtable+0x70
+	void UpdateState(float p_time) override;                                     // vtable+0x70
 	MxLong HandleClick() override;                                               // vtable+0xcc
 	MxLong HandleControl(LegoControlManagerNotificationParam& p_param) override; // vtable+0xd4
 	MxLong HandlePathStruct(LegoPathStructNotificationParam& p_param) override;  // vtable+0xdc

--- a/LEGO1/lego/legoomni/include/helicopter.h
+++ b/LEGO1/lego/legoomni/include/helicopter.h
@@ -68,7 +68,7 @@ public:
 	}
 
 	MxResult Create(MxDSAction& p_dsAction) override;                            // vtable+0x18
-	void VTable0x70(float p_time) override;                                      // vtable+0x70
+	void UpdateState(float p_time) override;                                     // vtable+0x70
 	void VTable0x74(Matrix4& p_transform) override;                              // vtable+0x74
 	MxLong HandleClick() override;                                               // vtable+0xcc
 	MxLong HandleControl(LegoControlManagerNotificationParam& p_param) override; // vtable+0xd4

--- a/LEGO1/lego/legoomni/include/islepathactor.h
+++ b/LEGO1/lego/legoomni/include/islepathactor.h
@@ -134,7 +134,7 @@ public:
 	void Reset()
 	{
 		m_roi->SetVisibility(TRUE);
-		SetState(0);
+		SetActorFlags(0);
 	}
 
 	void SetWorld(LegoWorld* p_world) { m_world = p_world; }

--- a/LEGO1/lego/legoomni/include/jetski.h
+++ b/LEGO1/lego/legoomni/include/jetski.h
@@ -26,7 +26,7 @@ public:
 	}
 
 	MxResult Create(MxDSAction& p_dsAction) override;                    // vtable+0x18
-	void VTable0x70(float p_time) override;                              // vtable+0x70
+	void UpdateState(float p_time) override;                             // vtable+0x70
 	MxLong HandleClick() override;                                       // vtable+0xcc
 	MxLong HandleControl(LegoControlManagerNotificationParam&) override; // vtable+0xd4
 	void Exit() override;                                                // vtable+0xe4

--- a/LEGO1/lego/legoomni/include/legoanimactor.h
+++ b/LEGO1/lego/legoomni/include/legoanimactor.h
@@ -58,7 +58,7 @@ public:
 
 	void ParseAction(char* p_extra) override;          // vtable+0x20
 	void SetWorldSpeed(MxFloat p_worldSpeed) override; // vtable+0x30
-	void VTable0x70(float p_time) override;            // vtable+0x70
+	void UpdateState(float p_time) override;           // vtable+0x70
 	void VTable0x74(Matrix4& p_transform) override;    // vtable+0x74
 
 	virtual MxResult FUN_1001c1f0(float& p_und);

--- a/LEGO1/lego/legoomni/include/legoextraactor.h
+++ b/LEGO1/lego/legoomni/include/legoextraactor.h
@@ -43,7 +43,7 @@ public:
 		float p_f2,
 		Vector3& p_v3
 	) override;                                                        // vtable+0x6c
-	void VTable0x70(float p_time) override;                            // vtable+0x70
+	void UpdateState(float p_time) override;                           // vtable+0x70
 	void VTable0x74(Matrix4& p_transform) override;                    // vtable+0x74
 	MxU32 VTable0x90(float p_time, Matrix4& p_matrix) override;        // vtable+0x90
 	MxResult HitActor(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94

--- a/LEGO1/lego/legoomni/include/legojetskiraceactor.h
+++ b/LEGO1/lego/legoomni/include/legojetskiraceactor.h
@@ -39,7 +39,7 @@ public:
 		float p_f2,
 		Vector3& p_v3
 	) override;                                                                // vtable+0x6c
-	void VTable0x70(float p_time) override;                                    // vtable+0x70
+	void UpdateState(float p_time) override;                                   // vtable+0x70
 	MxS32 VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edge) override; // vtable+0x1c
 
 	// SYNTHETIC: LEGO1 0x10013a80

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -25,7 +25,7 @@ public:
 	enum {
 		c_bit2 = 0x02,
 		c_disable = 0x04,
-		c_bit9 = 0x100
+		c_noCollide = 0x100
 	};
 
 	LegoPathActor();
@@ -54,7 +54,7 @@ public:
 		float p_f2,
 		Vector3& p_v3
 	);                                             // vtable+0x6c
-	virtual void VTable0x70(float p_time);         // vtable+0x70
+	virtual void UpdateState(float p_time);        // vtable+0x70
 	virtual void VTable0x74(Matrix4& p_transform); // vtable+0x74
 
 	// FUNCTION: LEGO1 0x10002d20
@@ -133,7 +133,7 @@ public:
 	LegoPathBoundary* GetBoundary() { return m_boundary; }
 
 	// FUNCTION: BETA10 0x1001c860
-	MxU32 GetState() { return m_state; }
+	MxU32 GetActorFlags() { return m_actorFlags; }
 
 	LegoPathController* GetController() { return m_pathController; }
 	MxBool GetCollideBox() { return m_collideBox; }
@@ -143,7 +143,7 @@ public:
 	void SetBoundary(LegoPathBoundary* p_boundary) { m_boundary = p_boundary; }
 
 	// FUNCTION: BETA10 0x10013430
-	void SetState(MxU32 p_state) { m_state = p_state; }
+	void SetActorFlags(MxU32 p_actorFlags) { m_actorFlags = p_actorFlags; }
 
 	void SetController(LegoPathController* p_pathController) { m_pathController = p_pathController; }
 	void SetLastTime(MxFloat p_lastTime) { m_lastTime = p_lastTime; }
@@ -173,7 +173,7 @@ protected:
 	MxFloat m_lastTime;                   // 0x84
 	LegoPathBoundary* m_boundary;         // 0x88
 	LegoUnknown m_unk0x8c;                // 0x8c
-	MxU32 m_state;                        // 0xdc
+	MxU32 m_actorFlags;                   // 0xdc
 	LegoUnknown100db7f4* m_destEdge;      // 0xe0
 	MxFloat m_unk0xe4;                    // 0xe4
 	MxBool m_collideBox;                  // 0xe8

--- a/LEGO1/lego/legoomni/include/legoracemap.h
+++ b/LEGO1/lego/legoomni/include/legoracemap.h
@@ -21,9 +21,9 @@ public:
 	~LegoRaceMap() override;
 
 	// LegoPathActor vtable
-	MxLong Notify(MxParam& p_param) override;   // vtable+0x04
-	void ParseAction(char* p_extra) override;   // vtable+0x20
-	void VTable0x70(float p_time) override = 0; // vtable+0x70
+	MxLong Notify(MxParam& p_param) override;    // vtable+0x04
+	void ParseAction(char* p_extra) override;    // vtable+0x20
+	void UpdateState(float p_time) override = 0; // vtable+0x70
 
 	// LegoRaceMap vtable
 	virtual void FUN_1005d4b0(); // vtable+0x00

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -67,7 +67,7 @@ public:
 		float p_f2,
 		Vector3& p_v3
 	) override;                                                        // vtable+0x6c
-	void VTable0x70(float p_time) override;                            // vtable+0x70
+	void UpdateState(float p_time) override;                           // vtable+0x70
 	MxResult HitActor(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94
 	void SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 		override;                   // vtable+0x98
@@ -163,7 +163,7 @@ public:
 		float p_f2,
 		Vector3& p_v3
 	) override;                                                        // vtable+0x6c
-	void VTable0x70(float p_time) override;                            // vtable+0x70
+	void UpdateState(float p_time) override;                           // vtable+0x70
 	MxResult HitActor(LegoPathActor* p_actor, MxBool p_bool) override; // vtable+0x94
 	void SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 		override;                   // vtable+0x98

--- a/LEGO1/lego/legoomni/include/legoracespecial.h
+++ b/LEGO1/lego/legoomni/include/legoracespecial.h
@@ -42,8 +42,8 @@ public:
 		float p_f1,
 		float p_f2,
 		Vector3& p_v3
-	) override;                             // vtable+0x6c
-	void VTable0x70(float p_time) override; // vtable+0x70
+	) override;                              // vtable+0x6c
+	void UpdateState(float p_time) override; // vtable+0x70
 	void SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown100db7f4*& p_edge, float& p_unk0xe4)
 		override;                   // vtable+0x98
 	MxResult VTable0x9c() override; // vtable+0x9c

--- a/LEGO1/lego/legoomni/include/motorcycle.h
+++ b/LEGO1/lego/legoomni/include/motorcycle.h
@@ -24,7 +24,7 @@ public:
 	}
 
 	MxResult Create(MxDSAction& p_dsAction) override;                            // vtable+0x18
-	void VTable0x70(float p_time) override;                                      // vtable+0x70
+	void UpdateState(float p_time) override;                                     // vtable+0x70
 	MxLong HandleClick() override;                                               // vtable+0xcc
 	MxLong HandleControl(LegoControlManagerNotificationParam& p_param) override; // vtable+0xd4
 	MxLong HandlePathStruct(LegoPathStructNotificationParam&) override;          // vtable+0xdc

--- a/LEGO1/lego/legoomni/include/towtrack.h
+++ b/LEGO1/lego/legoomni/include/towtrack.h
@@ -123,7 +123,7 @@ public:
 
 	MxLong Notify(MxParam& p_param) override;                                    // vtable+0x04
 	MxResult Create(MxDSAction& p_dsAction) override;                            // vtable+0x18
-	void VTable0x70(float p_time) override;                                      // vtable+0x70
+	void UpdateState(float p_time) override;                                     // vtable+0x70
 	MxLong HandleClick() override;                                               // vtable+0xcc
 	MxLong HandleControl(LegoControlManagerNotificationParam& p_param) override; // vtable+0xd4
 	MxLong HandleEndAnim(LegoEndAnimNotificationParam& p_param) override;        // vtable+0xd8

--- a/LEGO1/lego/legoomni/src/actors/act2actor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act2actor.cpp
@@ -155,7 +155,7 @@ MxResult Act2Actor::VTable0x9c()
 
 // FUNCTION: LEGO1 0x10018c30
 // FUNCTION: BETA10 0x1000cb52
-void Act2Actor::VTable0x70(float p_time)
+void Act2Actor::UpdateState(float p_time)
 {
 	int dummy1; // for BETA10, not sure what it is being used for
 
@@ -168,7 +168,7 @@ void Act2Actor::VTable0x70(float p_time)
 	g_unk0x100f0f1c = p_time;
 #endif
 
-	LegoAnimActor::VTable0x70(p_time);
+	LegoAnimActor::UpdateState(p_time);
 
 	if (m_unk0x44 != 0.0f && m_unk0x44 < p_time) {
 		SetWorldSpeed(m_unk0x28);

--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -34,13 +34,13 @@ Act3Actor::Act3Actor()
 MxU32 Act3Actor::VTable0x90(float p_time, Matrix4& p_transform)
 {
 	// Note: Code duplication with LegoExtraActor::VTable0x90
-	switch (m_state & 0xff) {
+	switch (m_actorFlags & 0xff) {
 	case 0:
 	case 1:
 		return TRUE;
 	case 2:
 		m_unk0x1c = p_time + 2000.0f;
-		m_state = 3;
+		m_actorFlags = 3;
 		m_actorTime += (p_time - m_lastTime) * m_worldSpeed;
 		m_lastTime = p_time;
 		return FALSE;
@@ -65,7 +65,7 @@ MxU32 Act3Actor::VTable0x90(float p_time, Matrix4& p_transform)
 			return FALSE;
 		}
 		else {
-			m_state = 0;
+			m_actorFlags = 0;
 			m_unk0x1c = 0;
 
 			positionRef -= g_unk0x10104ef0;
@@ -82,7 +82,7 @@ MxU32 Act3Actor::VTable0x90(float p_time, Matrix4& p_transform)
 MxResult Act3Actor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 {
 	if (!p_actor->GetUserNavFlag() && p_bool) {
-		if (p_actor->GetState()) {
+		if (p_actor->GetActorFlags()) {
 			return FAILURE;
 		}
 
@@ -96,7 +96,7 @@ MxResult Act3Actor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 		roi->FUN_100a58f0(local2world);
 		roi->VTable0x14();
 
-		p_actor->SetState(c_bit2 | c_bit9);
+		p_actor->SetActorFlags(c_bit2 | c_noCollide);
 	}
 
 	return SUCCESS;
@@ -108,7 +108,7 @@ Act3Cop::Act3Cop()
 {
 	m_unk0x20 = -1.0f;
 	m_world = NULL;
-	SetState(c_disable);
+	SetActorFlags(c_disable);
 }
 
 // FUNCTION: LEGO1 0x1003ff70
@@ -154,7 +154,7 @@ void Act3Cop::ParseAction(char* p_extra)
 }
 
 // STUB: LEGO1 0x100401f0
-void Act3Cop::VTable0x70(float p_time)
+void Act3Cop::UpdateState(float p_time)
 {
 	// TODO
 }
@@ -194,7 +194,7 @@ Act3Brickster::Act3Brickster()
 	m_unk0x24 = 0.0f;
 	m_unk0x54 = 0;
 
-	SetState(c_disable);
+	SetActorFlags(c_disable);
 	m_unk0x58 = 0;
 
 	m_unk0x3c.Clear();
@@ -227,7 +227,7 @@ void Act3Brickster::ParseAction(char* p_extra)
 }
 
 // STUB: LEGO1 0x10041050
-void Act3Brickster::VTable0x70(float p_time)
+void Act3Brickster::UpdateState(float p_time)
 {
 	// TODO
 }
@@ -315,7 +315,7 @@ MxResult Act3Shark::FUN_10042ce0(Act3Ammo* p_ammo)
 }
 
 // STUB: LEGO1 0x10042d40
-void Act3Shark::VTable0x70(float p_time)
+void Act3Shark::UpdateState(float p_time)
 {
 	// TODO
 }

--- a/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
@@ -159,7 +159,7 @@ MxResult Act3Ammo::FUN_10053cb0(LegoPathController* p_p, LegoPathBoundary* p_bou
 	m_unk0x19c = p_unk0x19c;
 	m_unk0x7c = 0.0f;
 	m_lastTime = -1.0f;
-	m_state = 1;
+	m_actorFlags = 1;
 	return SUCCESS;
 }
 
@@ -186,13 +186,13 @@ MxResult Act3Ammo::FUN_10053d30(LegoPathController* p_p, MxFloat p_unk0x19c)
 	m_unk0x19c = p_unk0x19c;
 	m_unk0x7c = 0.0f;
 	m_lastTime = -1.0f;
-	m_state = 1;
+	m_actorFlags = 1;
 	return SUCCESS;
 }
 
 // STUB: LEGO1 0x10054050
 // STUB: BETA10 0x1001e362
-void Act3Ammo::VTable0x70(float p_time)
+void Act3Ammo::UpdateState(float p_time)
 {
 	// TODO
 }

--- a/LEGO1/lego/legoomni/src/actors/ambulance.cpp
+++ b/LEGO1/lego/legoomni/src/actors/ambulance.cpp
@@ -87,9 +87,9 @@ MxResult Ambulance::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10036300
-void Ambulance::VTable0x70(float p_time)
+void Ambulance::UpdateState(float p_time)
 {
-	IslePathActor::VTable0x70(p_time);
+	IslePathActor::UpdateState(p_time);
 
 	if (UserActor() == this) {
 		char buf[200];

--- a/LEGO1/lego/legoomni/src/actors/doors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/doors.cpp
@@ -65,7 +65,7 @@ MxFloat Doors::VTable0xcc(float p_time)
 
 // FUNCTION: LEGO1 0x10066250
 // FUNCTION: BETA10 0x10026a45
-void Doors::VTable0x70(float p_time)
+void Doors::UpdateState(float p_time)
 {
 	assert(m_ltDoor && m_rtDoor);
 
@@ -75,7 +75,7 @@ void Doors::VTable0x70(float p_time)
 	switch (m_unk0x154) {
 	case 0:
 		m_unk0x154 = 1;
-		m_state = 0;
+		m_actorFlags = 0;
 		break;
 	case 1:
 		break;
@@ -108,7 +108,7 @@ void Doors::VTable0x70(float p_time)
 			m_ltDoor->VTable0x14();
 			m_rtDoor->VTable0x14();
 			m_unk0x154 = 1;
-			m_state = 0;
+			m_actorFlags = 0;
 			m_unk0x1f4 = 0;
 		}
 	}

--- a/LEGO1/lego/legoomni/src/actors/dunebuggy.cpp
+++ b/LEGO1/lego/legoomni/src/actors/dunebuggy.cpp
@@ -48,9 +48,9 @@ MxResult DuneBuggy::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10067ec0
-void DuneBuggy::VTable0x70(float p_time)
+void DuneBuggy::UpdateState(float p_time)
 {
-	IslePathActor::VTable0x70(p_time);
+	IslePathActor::UpdateState(p_time);
 
 	char buf[200];
 	float speed = abs(m_worldSpeed);

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -134,7 +134,7 @@ MxLong Helicopter::HandleClick()
 		((Isle*) CurrentWorld())->SetDestLocation(LegoGameState::e_copter);
 		FUN_10015820(TRUE, 0);
 		TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, TRUE);
-		SetState(LegoPathActor::c_disable);
+		SetActorFlags(LegoPathActor::c_disable);
 		PlayMusic(JukeboxScript::c_Jail_Music);
 		break;
 	case LegoGameState::e_act2:
@@ -199,7 +199,7 @@ MxLong Helicopter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				m_state->m_unk0x08 = 1;
 				m_world->RemoveActor(this);
 				InvokeAction(Extra::ActionType::e_start, script, IsleScript::c_HelicopterTakeOff_Anim, NULL);
-				SetState(0);
+				SetActorFlags(0);
 			}
 
 			result = 1;
@@ -214,7 +214,7 @@ MxLong Helicopter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				m_state->m_unk0x08 = 3;
 				m_world->RemoveActor(this);
 				InvokeAction(Extra::ActionType::e_start, script, IsleScript::c_HelicopterLand_Anim, NULL);
-				SetState(LegoPathActor::c_disable);
+				SetActorFlags(LegoPathActor::c_disable);
 			}
 
 			result = 1;
@@ -382,12 +382,12 @@ void Helicopter::VTable0x74(Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x10003ee0
-void Helicopter::VTable0x70(float p_time)
+void Helicopter::UpdateState(float p_time)
 {
 	MxU32 state = m_state->GetUnkown8();
 	switch (state) {
 	default:
-		LegoPathActor::VTable0x70(p_time);
+		LegoPathActor::UpdateState(p_time);
 		return;
 	case 4:
 	case 5:
@@ -419,7 +419,7 @@ void Helicopter::VTable0x70(float p_time)
 			else {
 				((Act3*) m_world)->FUN_10073430();
 			}
-			LegoPathActor::m_state = 4;
+			LegoPathActor::m_actorFlags = 4;
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
@@ -148,7 +148,7 @@ void IslePathActor::Exit()
 			m_previousActor->SetLocation(GetWorldPosition(), GetWorldDirection(), GetWorldUp(), TRUE);
 		}
 
-		m_previousActor->SetState(0);
+		m_previousActor->SetActorFlags(0);
 		GameState()->m_currentArea = LegoGameState::Area::e_unk66;
 	}
 

--- a/LEGO1/lego/legoomni/src/actors/jetski.cpp
+++ b/LEGO1/lego/legoomni/src/actors/jetski.cpp
@@ -49,9 +49,9 @@ MxResult Jetski::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1007e680
-void Jetski::VTable0x70(float p_time)
+void Jetski::UpdateState(float p_time)
 {
-	IslePathActor::VTable0x70(p_time);
+	IslePathActor::UpdateState(p_time);
 
 	char buf[200];
 	float speed = abs(m_worldSpeed);

--- a/LEGO1/lego/legoomni/src/actors/motorcycle.cpp
+++ b/LEGO1/lego/legoomni/src/actors/motorcycle.cpp
@@ -44,9 +44,9 @@ MxResult Motocycle::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x10035ad0
-void Motocycle::VTable0x70(float p_time)
+void Motocycle::UpdateState(float p_time)
 {
-	IslePathActor::VTable0x70(p_time);
+	IslePathActor::UpdateState(p_time);
 
 	if (UserActor() == this) {
 		char buf[200];

--- a/LEGO1/lego/legoomni/src/actors/pizza.cpp
+++ b/LEGO1/lego/legoomni/src/actors/pizza.cpp
@@ -202,7 +202,7 @@ void Pizza::FUN_100382b0()
 
 		m_act1state->m_unk0x018 = 0;
 		m_state->m_unk0x0c = 0;
-		UserActor()->SetState(0);
+		UserActor()->SetActorFlags(0);
 		g_isleFlags |= Isle::c_playMusic;
 		AnimationManager()->EnableCamAnims(TRUE);
 		AnimationManager()->FUN_1005f6d0(TRUE);
@@ -472,7 +472,7 @@ MxLong Pizza::HandleEndAction(MxEndActionNotificationParam& p_param)
 
 			m_state->m_unk0x0c = 4;
 			m_state->SetUnknown0xb0(IsleScript::c_noneIsle);
-			UserActor()->SetState(0);
+			UserActor()->SetActorFlags(0);
 			m_skateBoard->SetUnknown0x160(TRUE);
 			m_world->PlaceActor(m_skateBoard, "int37", 2, 0.5, 3, 0.5);
 

--- a/LEGO1/lego/legoomni/src/actors/towtrack.cpp
+++ b/LEGO1/lego/legoomni/src/actors/towtrack.cpp
@@ -74,9 +74,9 @@ MxResult TowTrack::Create(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x1004cb10
-void TowTrack::VTable0x70(float p_time)
+void TowTrack::UpdateState(float p_time)
 {
-	IslePathActor::VTable0x70(p_time);
+	IslePathActor::UpdateState(p_time);
 
 	if (UserActor() == this) {
 		char buf[200];

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1028,7 +1028,7 @@ MxResult LegoAnimationManager::FUN_100605e0(
 				LegoPathActor* actor = UserActor();
 
 				if (actor != NULL) {
-					actor->SetState(LegoPathActor::c_disable);
+					actor->SetActorFlags(LegoPathActor::c_disable);
 					actor->SetWorldSpeed(0.0f);
 				}
 			}
@@ -1592,7 +1592,7 @@ MxU16 LegoAnimationManager::FUN_10062110(
 {
 	LegoPathActor* actor = (LegoPathActor*) p_roi->GetEntity();
 
-	if (actor != NULL && actor->GetBoundary() == p_boundary && actor->GetState() == 0) {
+	if (actor != NULL && actor->GetBoundary() == p_boundary && actor->GetActorFlags() == 0) {
 		if (GetViewManager()->IsBoundingBoxInFrustum(p_roi->GetWorldBoundingBox())) {
 			Mx3DPointFloat direction(p_roi->GetWorldDirection());
 
@@ -2786,7 +2786,7 @@ void LegoAnimationManager::FUN_100648f0(LegoTranInfo* p_tranInfo, MxLong p_unk0x
 
 		LegoPathActor* actor = UserActor();
 		if (actor != NULL) {
-			actor->SetState(LegoPathActor::c_disable);
+			actor->SetActorFlags(LegoPathActor::c_disable);
 			actor->SetWorldSpeed(0.0f);
 		}
 

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -460,7 +460,7 @@ MxBool LegoAnimMMPresenter::FUN_1004b6d0(MxLong p_time)
 			}
 		}
 
-		actor->SetState(0);
+		actor->SetActorFlags(0);
 	}
 
 	return TRUE;

--- a/LEGO1/lego/legoomni/src/entity/act2brick.cpp
+++ b/LEGO1/lego/legoomni/src/entity/act2brick.cpp
@@ -100,7 +100,7 @@ void Act2Brick::FUN_1007a670(MxMatrix& p_param1, MxMatrix& p_param2, LegoPathBou
 	CurrentWorld()->PlaceActor(this);
 	p_boundary->AddActor(this);
 
-	SetState(LegoPathActor::c_disable);
+	SetActorFlags(LegoPathActor::c_disable);
 	m_roi->FUN_100a58f0(p_param1);
 	m_roi->VTable0x14();
 	m_roi->SetVisibility(TRUE);

--- a/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
@@ -37,7 +37,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 	Vector3* v1 = NULL;
 	Vector3* v2 = NULL;
 
-	if (m_state == 1) {
+	if (m_actorFlags == 1) {
 		if (m_destEdge == LegoPathController::GetControlEdgeA(13)) {
 			m_boundary = (LegoPathBoundary*) m_destEdge->OtherFace(LegoPathController::GetControlBoundaryA(13));
 		}
@@ -45,7 +45,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 			m_boundary = (LegoPathBoundary*) m_destEdge->OtherFace(LegoPathController::GetControlBoundaryA(15));
 		}
 
-		m_state = 0;
+		m_actorFlags = 0;
 		m_unk0x7c = 0;
 
 		if (m_userNavFlag) {
@@ -58,7 +58,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 	}
 	else {
 		if (p_edge == LegoPathController::GetControlEdgeA(12)) {
-			m_state = 1;
+			m_actorFlags = 1;
 
 			if (m_worldSpeed < g_unk0x100da044) {
 				m_worldSpeed = g_unk0x100da044;
@@ -68,7 +68,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 			m_boundary = LegoPathController::GetControlBoundaryA(13);
 		}
 		else if (p_edge == LegoPathController::GetControlEdgeA(14)) {
-			m_state = 1;
+			m_actorFlags = 1;
 
 			if (m_worldSpeed < g_unk0x100da044) {
 				m_worldSpeed = g_unk0x100da044;
@@ -78,7 +78,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 			m_boundary = LegoPathController::GetControlBoundaryA(15);
 		}
 
-		if (m_state == 1) {
+		if (m_actorFlags == 1) {
 			if (m_userNavFlag) {
 				m_unk0xe4 = 0.5f;
 			}
@@ -119,7 +119,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 }
 
 // FUNCTION: LEGO1 0x10081550
-void LegoJetskiRaceActor::VTable0x70(float p_time)
+void LegoJetskiRaceActor::UpdateState(float p_time)
 {
 	if (m_unk0x0c == 0) {
 		const LegoChar* raceState = VariableTable()->GetVariable(g_raceState);
@@ -129,12 +129,12 @@ void LegoJetskiRaceActor::VTable0x70(float p_time)
 			m_unk0x1c = p_time;
 		}
 		else if (!m_userNavFlag) {
-			LegoAnimActor::VTable0x70(m_lastTime + 1.0f);
+			LegoAnimActor::UpdateState(m_lastTime + 1.0f);
 		}
 	}
 
 	if (m_unk0x0c == 1) {
-		LegoAnimActor::VTable0x70(p_time);
+		LegoAnimActor::UpdateState(p_time);
 	}
 }
 

--- a/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
@@ -71,7 +71,7 @@ void LegoAnimActor::VTable0x74(Matrix4& p_transform)
 
 // FUNCTION: LEGO1 0x1001c290
 // FUNCTION: BETA10 0x1003e144
-void LegoAnimActor::VTable0x70(float p_time)
+void LegoAnimActor::UpdateState(float p_time)
 {
 	assert(m_roi);
 
@@ -79,7 +79,7 @@ void LegoAnimActor::VTable0x70(float p_time)
 		m_lastTime = p_time - 1.0f;
 	}
 
-	if (m_state == 0 && !m_userNavFlag && m_worldSpeed <= 0) {
+	if (m_actorFlags == 0 && !m_userNavFlag && m_worldSpeed <= 0) {
 		if (m_curAnim >= 0) {
 			MxMatrix matrix(m_unk0xec);
 			float f;
@@ -90,7 +90,7 @@ void LegoAnimActor::VTable0x70(float p_time)
 		m_lastTime = m_actorTime = p_time;
 	}
 	else {
-		LegoPathActor::VTable0x70(p_time);
+		LegoPathActor::UpdateState(p_time);
 	}
 }
 

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -50,13 +50,13 @@ LegoExtraActor::~LegoExtraActor()
 // FUNCTION: LEGO1 0x1002a720
 MxU32 LegoExtraActor::VTable0x90(float p_time, Matrix4& p_transform)
 {
-	switch (m_state & 0xff) {
+	switch (m_actorFlags & 0xff) {
 	case 0:
 	case 1:
 		return TRUE;
 	case 2:
 		m_scheduledTime = p_time + 2000.0f;
-		m_state = 3;
+		m_actorFlags = 3;
 		m_actorTime += (p_time - m_lastTime) * m_worldSpeed;
 		m_lastTime = p_time;
 		return FALSE;
@@ -95,7 +95,7 @@ MxU32 LegoExtraActor::VTable0x90(float p_time, Matrix4& p_transform)
 			return FALSE;
 		}
 		else {
-			m_state = 0;
+			m_actorFlags = 0;
 			m_scheduledTime = 0.0f;
 			positionRef -= g_unk0x10104c18;
 			m_roi->FUN_100a58f0(p_transform);
@@ -192,7 +192,7 @@ inline void LegoExtraActor::FUN_1002ad8a()
 // FUNCTION: LEGO1 0x1002aba0
 MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 {
-	if (p_actor->GetState() != 0 || m_state != 0) {
+	if (p_actor->GetActorFlags() != 0 || m_actorFlags != 0) {
 		return FAILURE;
 	}
 
@@ -237,7 +237,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 				VTable0xc4();
 				SetWorldSpeed(0);
 				m_whichAnim = 1;
-				m_state = 0x101;
+				m_actorFlags = 0x101;
 			}
 		}
 
@@ -245,7 +245,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			LegoROI* roi = m_roi;
 			SoundManager()->GetCacheSoundManager()->Play("crash5", m_roi->GetName(), FALSE);
 			VTable0xc4();
-			m_state = 0x102;
+			m_actorFlags = 0x102;
 			Mx3DPointFloat dir = p_actor->GetWorldDirection();
 			MxMatrix matrix3 = MxMatrix(roi->GetLocal2World());
 			Vector3 positionRef(matrix3[3]);
@@ -328,18 +328,18 @@ void LegoExtraActor::Restart()
 }
 
 // FUNCTION: LEGO1 0x1002b440
-void LegoExtraActor::VTable0x70(float p_time)
+void LegoExtraActor::UpdateState(float p_time)
 {
 	LegoAnimActorStruct* laas = NULL;
 
 	switch (m_whichAnim) {
 	case 0:
-		LegoAnimActor::VTable0x70(p_time);
+		LegoAnimActor::UpdateState(p_time);
 		break;
 	case 1:
 		if (m_scheduledTime < p_time) {
 			m_whichAnim = 2;
-			m_state = 0x101;
+			m_actorFlags = 0x101;
 			m_scheduledTime = m_assAnim->GetDuration() + p_time;
 			break;
 		}
@@ -350,7 +350,7 @@ void LegoExtraActor::VTable0x70(float p_time)
 	case 2:
 		if (m_scheduledTime < p_time) {
 			m_whichAnim = 0;
-			m_state = 0;
+			m_actorFlags = 0;
 			SetWorldSpeed(m_prevWorldSpeed);
 			m_roi->FUN_100a58f0(m_unk0x18);
 			m_lastTime = p_time;
@@ -452,7 +452,7 @@ MxU32 LegoExtraActor::VTable0x6c(
 		if (plpas.find(*itpa) != plpas.end()) {
 			LegoPathActor* actor = *itpa;
 
-			if (this != actor && !(actor->GetState() & LegoPathActor::c_bit9)) {
+			if (this != actor && !(actor->GetActorFlags() & LegoPathActor::c_noCollide)) {
 				LegoROI* roi = actor->GetROI();
 
 				if ((roi != NULL && roi->GetVisibility()) || actor->GetCameraFlag()) {

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -46,7 +46,7 @@ LegoPathActor::LegoPathActor()
 	m_lastTime = 0;
 	m_unk0x7c = 0;
 	m_userNavFlag = FALSE;
-	m_state = 0;
+	m_actorFlags = 0;
 	m_grec = NULL;
 	m_pathController = NULL;
 	m_collideBox = FALSE;
@@ -235,7 +235,7 @@ MxResult LegoPathActor::VTable0x84(
 // FUNCTION: BETA10 0x100b0520
 MxS32 LegoPathActor::VTable0x8c(float p_time, Matrix4& p_transform)
 {
-	if (m_userNavFlag && m_state == 0) {
+	if (m_userNavFlag && m_actorFlags == 0) {
 		m_lastTime = p_time;
 
 		Mx3DPointFloat p1, p2, p3, p4, p5;
@@ -381,13 +381,13 @@ void LegoPathActor::VTable0x74(Matrix4& p_transform)
 
 // FUNCTION: LEGO1 0x1002e790
 // FUNCTION: BETA10 0x100af208
-void LegoPathActor::VTable0x70(float p_time)
+void LegoPathActor::UpdateState(float p_time)
 {
 	MxMatrix transform;
 	MxU32 b = FALSE;
 
 	while (m_lastTime < p_time) {
-		if (m_state != 0 && !VTable0x90(p_time, transform)) {
+		if (m_actorFlags != 0 && !VTable0x90(p_time, transform)) {
 			return;
 		}
 
@@ -458,7 +458,7 @@ MxU32 LegoPathActor::VTable0x6c(
 		if (plpas.find(*itpa) != plpas.end()) {
 			LegoPathActor* actor = *itpa;
 
-			if (this != actor && !(actor->GetState() & LegoPathActor::c_bit9)) {
+			if (this != actor && !(actor->GetActorFlags() & LegoPathActor::c_noCollide)) {
 				LegoROI* roi = actor->GetROI();
 
 				if (roi != NULL && (roi->GetVisibility() || actor->GetCameraFlag())) {

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -366,8 +366,8 @@ void LegoPathController::FUN_10046970()
 		LegoPathActor* actor = *itpa;
 
 		if (m_actors.find(actor) != m_actors.end()) {
-			if (!((MxU8) actor->GetState() & LegoPathActor::c_disable)) {
-				actor->VTable0x70(time);
+			if (!((MxU8) actor->GetActorFlags() & LegoPathActor::c_disable)) {
+				actor->UpdateState(time);
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -48,14 +48,14 @@ MxS32 LegoRaceActor::VTable0x68(Vector3& p_v1, Vector3& p_v2, Vector3& p_v3)
 MxU32 LegoRaceActor::VTable0x90(float p_time, Matrix4& p_transform)
 {
 	// Note: Code duplication with LegoExtraActor::VTable0x90
-	switch (m_state) {
+	switch (m_actorFlags) {
 	case 0:
 	case 1:
 		return 1;
 
 	case 2:
 		m_unk0x08 = p_time + 2000.0f;
-		m_state = 3;
+		m_actorFlags = 3;
 		m_actorTime += (p_time - m_lastTime) * m_worldSpeed;
 		m_lastTime = p_time;
 		return 0;
@@ -81,7 +81,7 @@ MxU32 LegoRaceActor::VTable0x90(float p_time, Matrix4& p_transform)
 			return 0;
 		}
 		else {
-			m_state = 0;
+			m_actorFlags = 0;
 			m_unk0x08 = 0;
 
 			positionRef -= g_unk0x10102b08;
@@ -98,7 +98,7 @@ MxU32 LegoRaceActor::VTable0x90(float p_time, Matrix4& p_transform)
 MxResult LegoRaceActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 {
 	if (!p_actor->GetUserNavFlag()) {
-		if (p_actor->GetState()) {
+		if (p_actor->GetActorFlags()) {
 			return FAILURE;
 		}
 
@@ -112,7 +112,7 @@ MxResult LegoRaceActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 
 			roi->FUN_100a58f0(matr);
 
-			p_actor->SetState(2);
+			p_actor->SetActorFlags(2);
 		}
 	}
 

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -377,14 +377,14 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 
 // FUNCTION: LEGO1 0x100131f0
 // FUNCTION: BETA10 0x100cb88a
-void LegoRaceCar::VTable0x70(float p_time)
+void LegoRaceCar::UpdateState(float p_time)
 {
 	if (m_userNavFlag && (m_userState == LEGORACECAR_KICK1 || m_userState == LEGORACECAR_KICK2)) {
 		FUN_10012ff0(p_time);
 		return;
 	}
 
-	LegoCarRaceActor::VTable0x70(p_time);
+	LegoCarRaceActor::UpdateState(p_time);
 
 	if (m_userNavFlag && m_userState == LEGORACECAR_UNKNOWN_1) {
 		if (HandleSkeletonKicks(p_time)) {
@@ -438,7 +438,7 @@ MxResult LegoRaceCar::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 {
 	// Note: Code duplication with LegoRaceActor::HitActor
 	if (!p_actor->GetUserNavFlag()) {
-		if (p_actor->GetState()) {
+		if (p_actor->GetActorFlags()) {
 			return FAILURE;
 		}
 
@@ -451,7 +451,7 @@ MxResult LegoRaceCar::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			Vector3(matr[3]) += g_unk0x10102af0;
 			roi->FUN_100a58f0(matr);
 
-			p_actor->SetState(2);
+			p_actor->SetActorFlags(2);
 		}
 
 		if (m_userNavFlag) {
@@ -587,9 +587,9 @@ void LegoJetski::FUN_100136f0(float p_worldSpeed)
 
 // FUNCTION: LEGO1 0x10013740
 // FUNCTION: BETA10 0x100cc0ae
-void LegoJetski::VTable0x70(float p_time)
+void LegoJetski::UpdateState(float p_time)
 {
-	LegoJetskiRaceActor::VTable0x70(p_time);
+	LegoJetskiRaceActor::UpdateState(p_time);
 
 	if (LegoCarRaceActor::m_unk0x0c == 1) {
 		FUN_1005d4b0();

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -113,7 +113,7 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 	Mx3DPointFloat destEdgeUnknownVector;
 	Mx3DPointFloat crossProduct;
 
-	if (m_state == 1) {
+	if (m_actorFlags == 1) {
 		m_boundary = NULL;
 
 		// Not sure where the upper bound of 11 comes from, the underlying array has a size of 16
@@ -126,7 +126,7 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 
 		assert(m_boundary);
 
-		m_state = 0;
+		m_actorFlags = 0;
 		m_unk0x7c = 0;
 
 		if (m_userNavFlag) {
@@ -140,7 +140,7 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 	else {
 		for (MxS32 i = 0; i < 11; i += 2) {
 			if (LegoPathController::GetControlEdgeA(i) == p_edge) {
-				m_state = 1;
+				m_actorFlags = 1;
 
 				if (m_worldSpeed < g_unk0x100f7aec) {
 					m_worldSpeed = g_unk0x100f7aec;
@@ -152,7 +152,7 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 			}
 		}
 
-		if (m_state == 1) {
+		if (m_actorFlags == 1) {
 			if (m_userNavFlag) {
 				m_unk0xe4 = 0.5f;
 			}
@@ -214,7 +214,7 @@ void LegoCarRaceActor::SwitchBoundary(LegoPathBoundary*& p_boundary, LegoUnknown
 
 // FUNCTION: LEGO1 0x10080b70
 // FUNCTION: BETA10 0x100cdbae
-void LegoCarRaceActor::VTable0x70(float p_time)
+void LegoCarRaceActor::UpdateState(float p_time)
 {
 	// m_unk0x0c is not an MxBool, there are places where it is set to 2 or higher
 	if (m_unk0x0c == 0) {
@@ -228,7 +228,7 @@ void LegoCarRaceActor::VTable0x70(float p_time)
 	}
 
 	if (m_unk0x0c == 1) {
-		LegoAnimActor::VTable0x70(p_time);
+		LegoAnimActor::UpdateState(p_time);
 	}
 }
 

--- a/LEGO1/lego/legoomni/src/worlds/act3.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/act3.cpp
@@ -426,7 +426,7 @@ MxLong Act3::Notify(MxParam& p_param)
 					VideoManager()->Get3DManager()->SetFrustrum(45.0f, 0.1f, 125.0f);
 
 					m_brickster->SetWorldSpeed(5.0f);
-					m_brickster->SetState(0);
+					m_brickster->SetActorFlags(0);
 					assert(BackgroundAudioManager());
 
 					action.SetAtomId(*g_jukeboxScript);
@@ -435,11 +435,11 @@ MxLong Act3::Notify(MxParam& p_param)
 					BackgroundAudioManager()->PlayMusic(action, 5, MxPresenter::e_repeating);
 					m_brickster->FUN_100417c0();
 
-					m_cop1->SetState(0);
+					m_cop1->SetActorFlags(0);
 					m_cop1->SetWorldSpeed(2.0f);
 					m_cop1->VTable0xa8();
 
-					m_cop2->SetState(0);
+					m_cop2->SetActorFlags(0);
 					m_cop2->SetWorldSpeed(2.0f);
 					m_cop2->VTable0xa8();
 
@@ -592,9 +592,9 @@ void Act3::GoodEnding(const Matrix4& p_destination)
 {
 	assert(m_cop1 && m_cop2 && m_brickster && m_state);
 
-	m_cop1->SetState(LegoPathActor::c_disable);
-	m_cop2->SetState(LegoPathActor::c_disable);
-	m_brickster->SetState(LegoPathActor::c_disable);
+	m_cop1->SetActorFlags(LegoPathActor::c_disable);
+	m_cop2->SetActorFlags(LegoPathActor::c_disable);
+	m_brickster->SetActorFlags(LegoPathActor::c_disable);
 
 	m_unk0x4220.Clear();
 	m_copter->FUN_10004640(p_destination);

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -586,7 +586,7 @@ void Isle::Enable(MxBool p_enable)
 				FALSE,
 				IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
 			);
-			actor->SetState(0);
+			actor->SetActorFlags(0);
 		}
 		else {
 			FUN_10032620();

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -177,7 +177,7 @@ MxResult LegoAct2::Tickle()
 		m_unk0x10c4 = 1;
 		break;
 	case 1:
-		((LegoPathActor*) m_pepper->GetEntity())->SetState(LegoPathActor::c_disable);
+		((LegoPathActor*) m_pepper->GetEntity())->SetActorFlags(LegoPathActor::c_disable);
 
 		switch (rand() % 3) {
 		case 0:
@@ -336,7 +336,7 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 
 				m_unk0x10c4 = 14;
 				m_unk0x10d0 = 0;
-				((LegoPathActor*) m_pepper->GetEntity())->SetState(LegoPathActor::c_disable);
+				((LegoPathActor*) m_pepper->GetEntity())->SetActorFlags(LegoPathActor::c_disable);
 			}
 			break;
 		case c_notificationTransitioned:
@@ -417,7 +417,7 @@ MxLong LegoAct2::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_unk0x10d0 = 0;
 
 			FUN_10052560(Act2mainScript::c_tra045la_RunAnim, TRUE, TRUE, NULL, NULL, NULL);
-			((LegoPathActor*) m_pepper->GetEntity())->SetState(LegoPathActor::c_disable);
+			((LegoPathActor*) m_pepper->GetEntity())->SetActorFlags(LegoPathActor::c_disable);
 			AnimationManager()->EnableCamAnims(TRUE);
 			AnimationManager()->FUN_1005f6d0(TRUE);
 			AnimationManager()->FUN_100604f0(g_unk0x100f4428, sizeOfArray(g_unk0x100f4428));
@@ -450,7 +450,7 @@ MxLong LegoAct2::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_unk0x10c4 = 13;
 			SpawnBricks();
 			PlayMusic(JukeboxScript::c_BrickHunt);
-			((LegoPathActor*) m_pepper->GetEntity())->SetState(0);
+			((LegoPathActor*) m_pepper->GetEntity())->SetActorFlags(0);
 			break;
 		}
 		case 14:
@@ -602,7 +602,7 @@ MxLong LegoAct2::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 {
 	if (m_unk0x10c4 == 5 && p_param.GetData() == 0x32) {
 		LegoPathActor* actor = (LegoPathActor*) m_pepper->GetEntity();
-		actor->SetState(LegoPathActor::c_disable);
+		actor->SetActorFlags(LegoPathActor::c_disable);
 		actor->SetWorldSpeed(0.0f);
 		FUN_10051900();
 
@@ -630,7 +630,7 @@ MxLong LegoAct2::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 		FUN_10051fa0(p_param.GetData());
 	}
 	else if (m_unk0x10c4 == 10 && p_param.GetData() == 0x165) {
-		((LegoPathActor*) m_pepper->GetEntity())->SetState(LegoPathActor::c_disable);
+		((LegoPathActor*) m_pepper->GetEntity())->SetActorFlags(LegoPathActor::c_disable);
 
 		if (FUN_10052560(Act2mainScript::c_VOhide_PlayWav, FALSE, TRUE, NULL, NULL, NULL) == SUCCESS) {
 			m_unk0x1140 = Act2mainScript::c_VOhide_PlayWav;
@@ -746,7 +746,7 @@ void LegoAct2::FUN_10051960()
 		roi->SetVisibility(FALSE);
 	}
 
-	((LegoPathActor*) m_pepper->GetEntity())->SetState(0);
+	((LegoPathActor*) m_pepper->GetEntity())->SetActorFlags(0);
 }
 
 // FUNCTION: LEGO1 0x100519c0
@@ -937,7 +937,7 @@ MxResult LegoAct2::BadEnding()
 	}
 
 	LegoPathActor* actor = m_unk0x1138;
-	actor->SetState(LegoPathActor::c_disable);
+	actor->SetActorFlags(LegoPathActor::c_disable);
 
 	m_gameState->SetUnknown0x08(104);
 	m_destLocation = LegoGameState::e_infomain;


### PR DESCRIPTION
`VTable0x70` is clearly intended to progress/update the state of the actor, so I named it `UpdateState`. To avoid confusion, I've renamed the `SetState` and `GetState` functions and the `m_state` member to `m_actorFlags`.