### PR TITLE
Implement/match `LegoPlantManager::FUN_10026410`

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
@@ -221,6 +221,7 @@ char* LegoBuildingManager::g_customizeAnimFile = NULL;
 MxS32 g_buildingManagerConfig = 1;
 
 // GLOBAL: LEGO1 0x10104c30
+// GLOBAL: BETA10 0x10209fa0
 LegoBuildingInfo g_buildingInfo[16];
 
 // GLOBAL: LEGO1 0x100f3748
@@ -808,7 +809,7 @@ MxResult LegoBuildingManager::FUN_10030630()
 				for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
 					Mx4DPointFloat* normal = boundary->GetEdgeNormal(j);
 
-					if (position.Dot(normal, &position) + (*normal)[3] < -0.001) {
+					if (position.Dot(normal, &position) + (*normal).index_operator(3) < -0.001) {
 						MxTrace(
 							"Building %d shot location (%g, %g, %g) is not in boundary %s.\n",
 							i,
@@ -825,26 +826,28 @@ MxResult LegoBuildingManager::FUN_10030630()
 				if (g_buildingInfo[i].m_boundary != NULL) {
 					Mx4DPointFloat& unk0x14 = *g_buildingInfo[i].m_boundary->GetUnknown0x14();
 
-					if (position.Dot(&position, &unk0x14) + unk0x14[3] <= 0.001 &&
-						position.Dot(&position, &unk0x14) + unk0x14[3] >= -0.001) {
-						continue;
+					if (position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) > 0.001 ||
+						position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) < -0.001) {
+
+						g_buildingInfo[i].m_y =
+							-((position[0] * unk0x14.index_operator(0) + unk0x14.index_operator(3) +
+							   position[2] * unk0x14.index_operator(2)) /
+							  unk0x14.index_operator(1));
+
+						MxTrace(
+							"Building %d shot location (%g, %g, %g) is not on plane of boundary %s...adjusting to (%g, "
+							"%g, "
+							"%g)\n",
+							i,
+							position[0],
+							position[1],
+							position[2],
+							g_buildingInfo[i].m_boundary->GetName(),
+							position[0],
+							g_buildingInfo[i].m_y,
+							position[2]
+						);
 					}
-
-					g_buildingInfo[i].m_y =
-						-((unk0x14[3] + unk0x14[0] * position[0] + unk0x14[2] * position[2]) / unk0x14[1]);
-
-					MxTrace(
-						"Building %d shot location (%g, %g, %g) is not on plane of boundary %s...adjusting to (%g, %g, "
-						"%g)\n",
-						i,
-						position[0],
-						position[1],
-						position[2],
-						g_buildingInfo[i].m_boundary->GetName(),
-						position[0],
-						g_buildingInfo[i].m_y,
-						position[2]
-					);
 				}
 			}
 			else {

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -140,7 +140,7 @@ MxResult LegoPlantManager::FUN_10026410()
 				for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
 					Mx4DPointFloat* normal = boundary->GetEdgeNormal(j);
 
-					if (position.Dot(normal, &position) + (*normal)[3] < -0.001) {
+					if (position.Dot(normal, &position) + (*normal).index_operator(3) < -0.001) {
 						MxTrace(
 							"Plant %d shot location (%g, %g, %g) is not in boundary %s.\n",
 							i,
@@ -157,25 +157,28 @@ MxResult LegoPlantManager::FUN_10026410()
 				if (g_plantInfo[i].m_boundary != NULL) {
 					Mx4DPointFloat& unk0x14 = *g_plantInfo[i].m_boundary->GetUnknown0x14();
 
-					if (position.Dot(&position, &unk0x14) + unk0x14[3] <= 0.001 &&
-						position.Dot(&position, &unk0x14) + unk0x14[3] >= -0.001) {
-						continue;
+					if (position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) > 0.001 ||
+						position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) < -0.001) {
+
+						g_plantInfo[i].m_y =
+							-((position[0] * unk0x14.index_operator(0) + unk0x14.index_operator(3) +
+							   position[2] * unk0x14.index_operator(2)) /
+							  unk0x14.index_operator(1));
+
+						MxTrace(
+							"Plant %d shot location (%g, %g, %g) is not on plane of boundary %s...adjusting to (%g, "
+							"%g, "
+							"%g)\n",
+							i,
+							position[0],
+							position[1],
+							position[2],
+							g_plantInfo[i].m_boundary->GetName(),
+							position[0],
+							g_plantInfo[i].m_y,
+							position[2]
+						);
 					}
-
-					g_plantInfo[i].m_y =
-						-((unk0x14[3] + unk0x14[0] * position[0] + unk0x14[2] * position[2]) / unk0x14[1]);
-
-					MxTrace(
-						"Plant %d shot location (%g, %g, %g) is not on plane of boundary %s...adjusting to (%g, %g, %g)\n",
-						i,
-						position[0],
-						position[1],
-						position[2],
-						g_plantInfo[i].m_boundary->GetName(),
-						position[0],
-						g_plantInfo[i].m_y,
-						position[2]
-					);
 				}
 			}
 			else {

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -8,6 +8,7 @@
 #include "legoworld.h"
 #include "misc.h"
 #include "misc/legostorage.h"
+#include "mxdebug.h"
 #include "mxmisc.h"
 #include "mxticklemanager.h"
 #include "mxtimer.h"
@@ -54,6 +55,7 @@ MxU32 g_plantAnimationId[4] = {30, 33, 36, 39};
 char* LegoPlantManager::g_customizeAnimFile = NULL;
 
 // GLOBAL: LEGO1 0x10103180
+// GLOBAL: BETA10 0x1020f4c0
 LegoPlantInfo g_plantInfo[81];
 
 // FUNCTION: LEGO1 0x10026220
@@ -115,12 +117,74 @@ void LegoPlantManager::Reset(MxS32 p_worldId)
 	m_unk0x0c = 0;
 }
 
-// STUB: LEGO1 0x10026410
-// STUB: BETA10 0x100c50e9
+// FUNCTION: LEGO1 0x10026410
+// FUNCTION: BETA10 0x100c50e9
 MxResult LegoPlantManager::FUN_10026410()
 {
-	// might be similar to LegoBuildingManager::FUN_10030630()
-	// TODO
+	// similar to LegoBuildingManager::FUN_10030630()
+
+	LegoWorld* world = CurrentWorld();
+
+	if (world == NULL) {
+		return FAILURE;
+	}
+
+	for (MxS32 i = 0; i < sizeOfArray(g_plantInfo); i++) {
+		if (g_plantInfo[i].m_entity != NULL && g_plantInfo[i].m_name != NULL) {
+			g_plantInfo[i].m_boundary = world->FindPathBoundary(g_plantInfo[i].m_name);
+
+			if (g_plantInfo[i].m_boundary != NULL) {
+				Mx3DPointFloat position(g_plantInfo[i].m_x, g_plantInfo[i].m_y, g_plantInfo[i].m_z);
+				LegoPathBoundary* boundary = g_plantInfo[i].m_boundary;
+
+				for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
+					Mx4DPointFloat* normal = boundary->GetEdgeNormal(j);
+
+					if (position.Dot(normal, &position) + (*normal)[3] < -0.001) {
+						MxTrace(
+							"Plant %d shot location (%g, %g, %g) is not in boundary %s.\n",
+							i,
+							position[0],
+							position[1],
+							position[2],
+							boundary->GetName()
+						);
+						g_plantInfo[i].m_boundary = NULL;
+						break;
+					}
+				}
+
+				if (g_plantInfo[i].m_boundary != NULL) {
+					Mx4DPointFloat& unk0x14 = *g_plantInfo[i].m_boundary->GetUnknown0x14();
+
+					if (position.Dot(&position, &unk0x14) + unk0x14[3] <= 0.001 &&
+						position.Dot(&position, &unk0x14) + unk0x14[3] >= -0.001) {
+						continue;
+					}
+
+					g_plantInfo[i].m_y =
+						-((unk0x14[3] + unk0x14[0] * position[0] + unk0x14[2] * position[2]) / unk0x14[1]);
+
+					MxTrace(
+						"Plant %d shot location (%g, %g, %g) is not on plane of boundary %s...adjusting to (%g, %g, %g)\n",
+						i,
+						position[0],
+						position[1],
+						position[2],
+						g_plantInfo[i].m_boundary->GetName(),
+						position[0],
+						g_plantInfo[i].m_y,
+						position[2]
+					);
+				}
+			}
+			else {
+				MxTrace("Plant %d is in boundary %s that does not exist.\n", i, g_plantInfo[i].m_name);
+			}
+		}
+	}
+
+	m_unk0x0c = TRUE;
 	return SUCCESS;
 }
 

--- a/LEGO1/lego/sources/geom/legowegedge.h
+++ b/LEGO1/lego/sources/geom/legowegedge.h
@@ -43,6 +43,7 @@ public:
 	// FUNCTION: BETA10 0x100270c0
 	LegoU32 GetFlag0x10() { return m_flags & c_bit5 ? FALSE : TRUE; }
 
+	// TODO: Other BETA10 reference at 0x1001c9e0, not sure what is going on
 	// FUNCTION: BETA10 0x1001ff80
 	Mx4DPointFloat* GetUnknown0x14() { return &m_unk0x14; }
 

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -76,8 +76,8 @@ public:
 	// FUNCTION: BETA10 0x1004af10
 	float& operator[](int idx) { return m_data[idx]; }
 
-	const float& operator[](int idx) const { return m_data[idx]; }
-
+	// According to the PDB, BETA10 will not link this one if it is never used
+	// const float& operator[](int idx) const { return m_data[idx]; }
 
 	// only used by a couple of BETA10 functions for some unknown reason
 	// FUNCTION: BETA10 0x1001c950

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -78,6 +78,11 @@ public:
 
 	const float& operator[](int idx) const { return m_data[idx]; }
 
+
+	// only used by a couple of BETA10 functions for some unknown reason
+	// FUNCTION: BETA10 0x1001c950
+	float& index_operator(int idx) { return m_data[idx]; }
+
 	// SYNTHETIC: LEGO1 0x10064b20
 	// SYNTHETIC: BETA10 0x10070420
 	// ??4Mx4DPointFloat@@QAEAAV0@ABV0@@Z


### PR DESCRIPTION
Matches down to compiler entropy (and one small issue in `reccmp` which we haven't addressed yet). I also found small BETA10 improvements for `LegoBuildingManager::FUN_10030630`.

I did notice an oddity with `LegoWEGEdge::GetUnknown0x14()` in BETA10, which appears to be defined twice. Not sure what is going on here, opinions are appreciated.