### PR TITLE
Implement `MxDisplaySurface::DrawTransparentRLE`

### DIFF
--- a/LEGO1/omni/include/mxdisplaysurface.h
+++ b/LEGO1/omni/include/mxdisplaysurface.h
@@ -99,14 +99,14 @@ public:
 	LPDIRECTDRAWSURFACE GetDirectDrawSurface2() { return m_ddSurface2; }
 	MxVideoParam& GetVideoParam() { return m_videoParam; }
 
-	void FUN_100bb500(
-		MxU8** p_bitmapData,
-		MxU8** p_surfaceData,
+	void DrawTransparentRLE(
+		MxU8*& p_bitmapData,
+		MxU8*& p_surfaceData,
 		MxU32 p_bitmapSize,
 		MxS32 p_width,
 		MxS32 p_height,
 		MxLong p_pitch,
-		MxU32 p_bpp
+		MxU8 p_bpp
 	);
 
 private:

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -529,7 +529,7 @@ void MxDisplaySurface::VTable0x30(
 		MxU8* surface = (MxU8*) ddsd.lpSurface + p_right + (p_bottom * ddsd.lPitch);
 		if (p_und) {
 			MxS32 size = p_bitmap->GetBmiHeader()->biSizeImage;
-			FUN_100bb500(&data, &surface, size, p_width, p_height, ddsd.lPitch, 8);
+			DrawTransparentRLE(data, surface, size, p_width, p_height, ddsd.lPitch, 8);
 		}
 		else {
 			MxLong stride = -p_width + GetAdjustedStride(p_bitmap);
@@ -555,7 +555,7 @@ void MxDisplaySurface::VTable0x30(
 		MxU8* surface = (MxU8*) ddsd.lpSurface + (2 * p_right) + (p_bottom * ddsd.lPitch);
 		if (p_und) {
 			MxS32 size = p_bitmap->GetBmiHeader()->biSizeImage;
-			FUN_100bb500(&data, &surface, size, p_width, p_height, ddsd.lPitch, 16);
+			DrawTransparentRLE(data, surface, size, p_width, p_height, ddsd.lPitch, 16);
 		}
 		else {
 			MxLong stride = -p_width + GetAdjustedStride(p_bitmap);
@@ -584,19 +584,159 @@ void MxDisplaySurface::VTable0x30(
 	m_ddSurface2->Unlock(ddsd.lpSurface);
 }
 
-// STUB: LEGO1 0x100bb500
-// STUB: BETA10 0x10140cd6
-void MxDisplaySurface::FUN_100bb500(
-	MxU8** p_bitmapData,
-	MxU8** p_surfaceData,
+// FUNCTION: LEGO1 0x100bb500
+// FUNCTION: BETA10 0x10140cd6
+void MxDisplaySurface::DrawTransparentRLE(
+	MxU8*& p_bitmapData,
+	MxU8*& p_surfaceData,
 	MxU32 p_bitmapSize,
 	MxS32 p_width,
 	MxS32 p_height,
 	MxLong p_pitch,
-	MxU32 p_bpp
+	MxU8 p_bpp
 )
 {
-	// TODO
+	/* Assumes partial RLE for the bitmap: only the skipped pixels are compressed.
+	The drawn pixels are uncompressed. The procedure is:
+	1. Read 3 bytes from p_bitmapData. Skip this many pixels on the surface.
+	2. Read 3 bytes from p_bitmapData. Draw this many pixels on the surface.
+	3. Repeat until the end of p_bitmapData is reached. */
+
+	MxU8* end = p_bitmapData + p_bitmapSize;
+	MxU8* surf_copy = p_surfaceData; // unused?
+
+	// The total number of pixels drawn or skipped
+	MxU32 count = 0;
+
+	// Used in both 8 and 16 bit branches
+	MxU32 n_skip;
+	MxU32 n_draw;
+	MxU32 t;
+
+	if (p_bpp == 16) {
+		// DECOMP: why goto?
+		goto sixteen_bit;
+	}
+
+	while (p_bitmapData < end) {
+		n_skip = *p_bitmapData++;
+		t = *p_bitmapData++;
+		n_skip += t << 8;
+		t = *p_bitmapData++;
+		n_skip += t << 16;
+
+		MxS32 row_remainder = p_width - count % p_width;
+		count += n_skip;
+
+		if (n_skip >= row_remainder) {
+			p_surfaceData += row_remainder; // skip the rest of this row
+			n_skip -= row_remainder;
+			p_surfaceData += p_pitch - p_width;            // seek to start of next row
+			p_surfaceData += p_pitch * (n_skip / p_width); // skip entire rows if any
+		}
+
+		// skip any pixels at the start of this row
+		p_surfaceData += n_skip % p_width;
+		if (p_bitmapData >= end) {
+			break;
+		}
+
+		n_draw = *p_bitmapData++;
+		t = *p_bitmapData++;
+		n_draw += t << 8;
+		t = *p_bitmapData++;
+		n_draw += t << 16;
+
+		row_remainder = p_width - count % p_width;
+		count += n_draw;
+
+		if (n_draw >= row_remainder) {
+			memcpy(p_surfaceData, p_bitmapData, row_remainder);
+			p_surfaceData += row_remainder;
+			p_bitmapData += row_remainder;
+
+			n_draw -= row_remainder;
+
+			// seek to start of bitmap on this screen row
+			p_surfaceData += p_pitch - p_width;
+			MxS32 rows = n_draw / p_width;
+
+			for (MxU32 i = 0; i < rows; i++) {
+				memcpy(p_surfaceData, p_bitmapData, p_width);
+				p_bitmapData += p_width;
+				p_surfaceData += p_pitch;
+			}
+		}
+
+		MxS32 tail = n_draw % p_width;
+		memcpy(p_surfaceData, p_bitmapData, tail);
+		p_surfaceData += tail;
+		p_bitmapData += tail;
+	}
+	return;
+
+sixteen_bit:
+	while (p_bitmapData < end) {
+		n_skip = *p_bitmapData++;
+		t = *p_bitmapData++;
+		n_skip += t << 8;
+		t = *p_bitmapData++;
+		n_skip += t << 16;
+
+		MxS32 row_remainder = p_width - count % p_width;
+		count += n_skip;
+
+		if (n_skip >= row_remainder) {
+			p_surfaceData += 2 * row_remainder;
+			n_skip -= row_remainder;
+			p_surfaceData += p_pitch - 2 * p_width;
+			p_surfaceData += p_pitch * (n_skip / p_width);
+		}
+
+		p_surfaceData += 2 * (n_skip % p_width);
+		if (p_bitmapData >= end) {
+			break;
+		}
+
+		n_draw = *p_bitmapData++;
+		t = *p_bitmapData++;
+		n_draw += t << 8;
+		t = *p_bitmapData++;
+		n_draw += t << 16;
+
+		row_remainder = p_width - count % p_width;
+		count += n_draw;
+
+		if (n_draw >= row_remainder) {
+			// memcpy
+			for (MxU32 j = 0; j < row_remainder; j++) {
+				*((MxU16*) p_surfaceData) = m_16bitPal[*p_bitmapData++];
+				p_surfaceData += 2;
+			}
+
+			n_draw -= row_remainder;
+
+			p_surfaceData += p_pitch - 2 * p_width;
+			MxS32 rows = n_draw / p_width;
+
+			for (MxU32 i = 0; i < rows; i++) {
+				// memcpy
+				for (MxS32 j = 0; j < p_width; j++) {
+					*((MxU16*) p_surfaceData) = m_16bitPal[*p_bitmapData++];
+					p_surfaceData += 2;
+				}
+
+				p_surfaceData += p_pitch - 2 * p_width;
+			}
+		}
+
+		MxS32 tail = n_draw % p_width;
+		// memcpy
+		for (MxS32 j = 0; j < tail; j++) {
+			*((MxU16*) p_surfaceData) = m_16bitPal[*p_bitmapData++];
+			p_surfaceData += 2;
+		}
+	}
 }
 
 // STUB: LEGO1 0x100bb850

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -603,14 +603,14 @@ void MxDisplaySurface::DrawTransparentRLE(
 	3. Repeat until the end of p_bitmapData is reached. */
 
 	MxU8* end = p_bitmapData + p_bitmapSize;
-	MxU8* surf_copy = p_surfaceData; // unused?
+	MxU8* surfCopy = p_surfaceData; // unused?
 
 	// The total number of pixels drawn or skipped
 	MxU32 count = 0;
 
 	// Used in both 8 and 16 bit branches
-	MxU32 n_skip;
-	MxU32 n_draw;
+	MxU32 skipCount;
+	MxU32 drawCount;
 	MxU32 t;
 
 	if (p_bpp == 16) {
@@ -619,47 +619,47 @@ void MxDisplaySurface::DrawTransparentRLE(
 	}
 
 	while (p_bitmapData < end) {
-		n_skip = *p_bitmapData++;
+		skipCount = *p_bitmapData++;
 		t = *p_bitmapData++;
-		n_skip += t << 8;
+		skipCount += t << 8;
 		t = *p_bitmapData++;
-		n_skip += t << 16;
+		skipCount += t << 16;
 
-		MxS32 row_remainder = p_width - count % p_width;
-		count += n_skip;
+		MxS32 rowRemainder = p_width - count % p_width;
+		count += skipCount;
 
-		if (n_skip >= row_remainder) {
-			p_surfaceData += row_remainder; // skip the rest of this row
-			n_skip -= row_remainder;
-			p_surfaceData += p_pitch - p_width;            // seek to start of next row
-			p_surfaceData += p_pitch * (n_skip / p_width); // skip entire rows if any
+		if (skipCount >= rowRemainder) {
+			p_surfaceData += rowRemainder; // skip the rest of this row
+			skipCount -= rowRemainder;
+			p_surfaceData += p_pitch - p_width;               // seek to start of next row
+			p_surfaceData += p_pitch * (skipCount / p_width); // skip entire rows if any
 		}
 
 		// skip any pixels at the start of this row
-		p_surfaceData += n_skip % p_width;
+		p_surfaceData += skipCount % p_width;
 		if (p_bitmapData >= end) {
 			break;
 		}
 
-		n_draw = *p_bitmapData++;
+		drawCount = *p_bitmapData++;
 		t = *p_bitmapData++;
-		n_draw += t << 8;
+		drawCount += t << 8;
 		t = *p_bitmapData++;
-		n_draw += t << 16;
+		drawCount += t << 16;
 
-		row_remainder = p_width - count % p_width;
-		count += n_draw;
+		rowRemainder = p_width - count % p_width;
+		count += drawCount;
 
-		if (n_draw >= row_remainder) {
-			memcpy(p_surfaceData, p_bitmapData, row_remainder);
-			p_surfaceData += row_remainder;
-			p_bitmapData += row_remainder;
+		if (drawCount >= rowRemainder) {
+			memcpy(p_surfaceData, p_bitmapData, rowRemainder);
+			p_surfaceData += rowRemainder;
+			p_bitmapData += rowRemainder;
 
-			n_draw -= row_remainder;
+			drawCount -= rowRemainder;
 
 			// seek to start of bitmap on this screen row
 			p_surfaceData += p_pitch - p_width;
-			MxS32 rows = n_draw / p_width;
+			MxS32 rows = drawCount / p_width;
 
 			for (MxU32 i = 0; i < rows; i++) {
 				memcpy(p_surfaceData, p_bitmapData, p_width);
@@ -668,7 +668,7 @@ void MxDisplaySurface::DrawTransparentRLE(
 			}
 		}
 
-		MxS32 tail = n_draw % p_width;
+		MxS32 tail = drawCount % p_width;
 		memcpy(p_surfaceData, p_bitmapData, tail);
 		p_surfaceData += tail;
 		p_bitmapData += tail;
@@ -677,47 +677,47 @@ void MxDisplaySurface::DrawTransparentRLE(
 
 sixteen_bit:
 	while (p_bitmapData < end) {
-		n_skip = *p_bitmapData++;
+		skipCount = *p_bitmapData++;
 		t = *p_bitmapData++;
-		n_skip += t << 8;
+		skipCount += t << 8;
 		t = *p_bitmapData++;
-		n_skip += t << 16;
+		skipCount += t << 16;
 
-		MxS32 row_remainder = p_width - count % p_width;
-		count += n_skip;
+		MxS32 rowRemainder = p_width - count % p_width;
+		count += skipCount;
 
-		if (n_skip >= row_remainder) {
-			p_surfaceData += 2 * row_remainder;
-			n_skip -= row_remainder;
+		if (skipCount >= rowRemainder) {
+			p_surfaceData += 2 * rowRemainder;
+			skipCount -= rowRemainder;
 			p_surfaceData += p_pitch - 2 * p_width;
-			p_surfaceData += p_pitch * (n_skip / p_width);
+			p_surfaceData += p_pitch * (skipCount / p_width);
 		}
 
-		p_surfaceData += 2 * (n_skip % p_width);
+		p_surfaceData += 2 * (skipCount % p_width);
 		if (p_bitmapData >= end) {
 			break;
 		}
 
-		n_draw = *p_bitmapData++;
+		drawCount = *p_bitmapData++;
 		t = *p_bitmapData++;
-		n_draw += t << 8;
+		drawCount += t << 8;
 		t = *p_bitmapData++;
-		n_draw += t << 16;
+		drawCount += t << 16;
 
-		row_remainder = p_width - count % p_width;
-		count += n_draw;
+		rowRemainder = p_width - count % p_width;
+		count += drawCount;
 
-		if (n_draw >= row_remainder) {
+		if (drawCount >= rowRemainder) {
 			// memcpy
-			for (MxU32 j = 0; j < row_remainder; j++) {
+			for (MxU32 j = 0; j < rowRemainder; j++) {
 				*((MxU16*) p_surfaceData) = m_16bitPal[*p_bitmapData++];
 				p_surfaceData += 2;
 			}
 
-			n_draw -= row_remainder;
+			drawCount -= rowRemainder;
 
 			p_surfaceData += p_pitch - 2 * p_width;
-			MxS32 rows = n_draw / p_width;
+			MxS32 rows = drawCount / p_width;
 
 			for (MxU32 i = 0; i < rows; i++) {
 				// memcpy
@@ -730,7 +730,7 @@ sixteen_bit:
 			}
 		}
 
-		MxS32 tail = n_draw % p_width;
+		MxS32 tail = drawCount % p_width;
 		// memcpy
 		for (MxS32 j = 0; j < tail; j++) {
 			*((MxU16*) p_surfaceData) = m_16bitPal[*p_bitmapData++];


### PR DESCRIPTION
I'm not sure this function is ever used. Hopefully not: it's full of bugs!

1. We assume `p_bitmapData` is set to the location where we start drawing pixels, but our range check is based on that pointer plus `p_bitmapSize`. In the caller `VTable0x30`, that parameter is the full size of the bitmap, so we will run off the end unless the full image is drawn.

2. `p_height` is ignored, so I assume a sprite drawn to the bottom of the screen surface will also cause issues.

3. This probably doesn't work well for a bottom-up bitmap.

Do we have any non-standard bitmaps that could be used here? Aren't the transparent images drawn using special palette colors instead of this method?

The match looks pretty good in retail. `stackcmp` shows an effective match[^1] for BETA10. The `goto` is bizarre but it's the best match for the beta. I had the idea that maybe it was a `switch` and they just forgot `case 8`, but no luck.

[^1]: Until I changed the variable names again to fix the ncc error