### PR TITLE
`MxDSBuffer::SkipToData` to 100%

### DIFF
--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -384,6 +384,7 @@ done:
 	m_pIntoBuffer2 = result;
 	return result;
 }
+
 // FUNCTION: LEGO1 0x100c6ec0
 MxU8 MxDSBuffer::ReleaseRef(MxDSChunk*)
 {


### PR DESCRIPTION
Found this rummaging through some old branches and stash files. I can get a beta match for the similar function `MxDSBuffer::FUN_100c6fa0` but only a slight increase on retail. That could be compiler randomness. I'll keep working on it.