### PR TITLE
`MxDSBuffer::ParseChunk` to 100%

### DIFF
--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -83,6 +83,7 @@ public:
 	// FUNCTION: BETA10 0x1012be80
 	MxS32 GetLoopCount() { return m_loopCount; }
 
+	// FUNCTION: BETA10 0x100f27f0
 	void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
 
 	// FUNCTION: BETA10 0x1003db50

--- a/LEGO1/omni/include/mxdsbuffer.h
+++ b/LEGO1/omni/include/mxdsbuffer.h
@@ -11,6 +11,7 @@ class MxStreamChunk;
 class MxDSChunk;
 
 // VTABLE: LEGO1 0x100dcca0
+// VTABLE: BETA10 0x101c2898
 // SIZE 0x34
 class MxDSBuffer : public MxCore {
 public:
@@ -25,6 +26,7 @@ public:
 	~MxDSBuffer() override;
 
 	// FUNCTION: LEGO1 0x100c6500
+	// FUNCTION: BETA10 0x10158510
 	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x101025b8
@@ -87,6 +89,7 @@ public:
 	void SetUnk30(MxDSStreamingAction* p_unk0x30) { m_unk0x30 = p_unk0x30; }
 
 	// SYNTHETIC: LEGO1 0x100c6510
+	// SYNTHETIC: BETA10 0x10158530
 	// MxDSBuffer::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/include/mxdschunk.h
+++ b/LEGO1/omni/include/mxdschunk.h
@@ -12,6 +12,7 @@
 #define DS_CHUNK_BIT16 0x8000
 
 // VTABLE: LEGO1 0x100dc7f8
+// VTABLE: BETA10 0x101c23d0
 // SIZE 0x1c
 class MxDSChunk : public MxCore {
 public:
@@ -19,6 +20,7 @@ public:
 	~MxDSChunk() override;
 
 	// FUNCTION: LEGO1 0x100be0c0
+	// FUNCTION: BETA10 0x10134580
 	const char* ClassName() const override // vtable+0x0c
 	{
 		// STRING: LEGO1 0x10101e6c
@@ -26,6 +28,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100be0d0
+	// FUNCTION: BETA10 0x10134520
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSChunk::ClassName()) || MxCore::IsA(p_name);
@@ -39,14 +42,26 @@ public:
 
 	void SetChunkFlags(MxU16 p_flags) { m_flags = p_flags; }
 	void SetObjectId(undefined4 p_objectid) { m_objectId = p_objectid; }
+
+	// FUNCTION: BETA10 0x101343f0
 	void SetTime(MxLong p_time) { m_time = p_time; }
+
 	void SetLength(MxU32 p_length) { m_length = p_length; }
 	void SetData(MxU8* p_data) { m_data = p_data; }
 
+	// FUNCTION: BETA10 0x1005ab90
 	MxU16 GetChunkFlags() { return m_flags; }
+
+	// FUNCTION: BETA10 0x10159110
 	undefined4 GetObjectId() { return m_objectId; }
+
+	// FUNCTION: BETA10 0x1005ab30
 	MxLong GetTime() { return m_time; }
+
+	// FUNCTION: BETA10 0x1008d000
 	MxU32 GetLength() { return m_length; }
+
+	// FUNCTION: BETA10 0x10056d60
 	MxU8* GetData() { return m_data; }
 
 	void Release()
@@ -57,6 +72,7 @@ public:
 	}
 
 	// SYNTHETIC: LEGO1 0x100be150
+	// SYNTHETIC: BETA10 0x101474c0
 	// MxDSChunk::`scalar deleting destructor'
 
 protected:

--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -258,7 +258,8 @@ MxResult MxDSBuffer::ParseChunk(
 		MxU32 length = p_header->GetLength() + MxDSChunk::GetHeaderSize() + 8;
 		MxDSBuffer* buffer = new MxDSBuffer();
 
-		if (!buffer || buffer->AllocateBuffer(length, e_allocate) || buffer->CalcBytesRemaining((MxU8*) p_data) ||
+		if (!buffer || buffer->AllocateBuffer(length, e_allocate) != SUCCESS ||
+			buffer->CalcBytesRemaining((MxU8*) p_data) != SUCCESS ||
 			(*p_streamingAction = new MxDSStreamingAction((MxDSStreamingAction&) *p_action)) == NULL) {
 			delete buffer;
 			delete p_header;

--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -13,12 +13,13 @@
 DECOMP_SIZE_ASSERT(MxDSBuffer, 0x34);
 
 // FUNCTION: LEGO1 0x100c6470
+// FUNCTION: BETA10 0x10156f00
 MxDSBuffer::MxDSBuffer()
 {
-	m_referenceCount = 0;
 	m_pBuffer = NULL;
 	m_pIntoBuffer = NULL;
 	m_pIntoBuffer2 = NULL;
+	m_referenceCount = 0;
 	m_unk0x14 = 0;
 	m_unk0x18 = 0;
 	m_unk0x1c = 0;
@@ -29,6 +30,7 @@ MxDSBuffer::MxDSBuffer()
 }
 
 // FUNCTION: LEGO1 0x100c6530
+// FUNCTION: BETA10 0x10156ff7
 MxDSBuffer::~MxDSBuffer()
 {
 	assert(m_referenceCount == 0);
@@ -54,6 +56,7 @@ MxDSBuffer::~MxDSBuffer()
 }
 
 // FUNCTION: LEGO1 0x100c6640
+// FUNCTION: BETA10 0x10157146
 MxResult MxDSBuffer::AllocateBuffer(MxU32 p_bufferSize, Type p_mode)
 {
 	MxResult result = FAILURE;
@@ -233,6 +236,7 @@ MxResult MxDSBuffer::StartPresenterFromAction(
 }
 
 // FUNCTION: LEGO1 0x100c6a50
+// FUNCTION: BETA10 0x10157795
 MxResult MxDSBuffer::ParseChunk(
 	MxStreamController* p_controller,
 	MxU32* p_data,
@@ -254,26 +258,18 @@ MxResult MxDSBuffer::ParseChunk(
 		MxU32 length = p_header->GetLength() + MxDSChunk::GetHeaderSize() + 8;
 		MxDSBuffer* buffer = new MxDSBuffer();
 
-		if (buffer && buffer->AllocateBuffer(length, e_allocate) == SUCCESS &&
-			buffer->CalcBytesRemaining((MxU8*) p_data) == SUCCESS) {
-			*p_streamingAction = new MxDSStreamingAction((MxDSStreamingAction&) *p_action);
-
-			if (*p_streamingAction) {
-				MxU16* flags = MxStreamChunk::IntoFlags(buffer->GetBuffer());
-				*flags = p_header->GetChunkFlags() & ~DS_CHUNK_SPLIT;
-
-				delete p_header;
-				(*p_streamingAction)->SetUnknowna0(buffer);
-				goto done;
-			}
-		}
-
-		if (buffer) {
+		if (!buffer || buffer->AllocateBuffer(length, e_allocate) || buffer->CalcBytesRemaining((MxU8*) p_data) ||
+			(*p_streamingAction = new MxDSStreamingAction((MxDSStreamingAction&) *p_action)) == NULL) {
 			delete buffer;
+			delete p_header;
+			return FAILURE;
 		}
+
+		MxU16* flags = MxStreamChunk::IntoFlags(buffer->GetBuffer());
+		*flags = p_header->GetChunkFlags() & ~DS_CHUNK_SPLIT;
 
 		delete p_header;
-		return FAILURE;
+		(*p_streamingAction)->SetUnknowna0(buffer);
 	}
 	else {
 		if (p_header->GetChunkFlags() & DS_CHUNK_END_OF_STREAM) {
@@ -317,7 +313,6 @@ MxResult MxDSBuffer::ParseChunk(
 		}
 	}
 
-done:
 	return result;
 }
 

--- a/LEGO1/omni/src/stream/mxdschunk.cpp
+++ b/LEGO1/omni/src/stream/mxdschunk.cpp
@@ -3,16 +3,18 @@
 DECOMP_SIZE_ASSERT(MxDSChunk, 0x1c);
 
 // FUNCTION: LEGO1 0x100be050
+// FUNCTION: BETA10 0x10147290
 MxDSChunk::MxDSChunk()
 {
-	m_flags = 0;
 	m_data = NULL;
+	m_flags = 0;
 	m_objectId = -1;
 	m_time = 0;
 	m_length = 0;
 }
 
 // FUNCTION: LEGO1 0x100be170
+// FUNCTION: BETA10 0x10147330
 MxDSChunk::~MxDSChunk()
 {
 	if (m_flags & DS_CHUNK_BIT1) {
@@ -21,6 +23,7 @@ MxDSChunk::~MxDSChunk()
 }
 
 // FUNCTION: LEGO1 0x100be1e0
+// FUNCTION: BETA10 0x101473c5
 MxU32 MxDSChunk::GetHeaderSize()
 {
 	return 0x0e;

--- a/LEGO1/omni/src/stream/mxstreamchunk.cpp
+++ b/LEGO1/omni/src/stream/mxstreamchunk.cpp
@@ -57,6 +57,7 @@ MxU32 MxStreamChunk::ReadChunkHeader(MxU8* p_chunkData)
 }
 
 // FUNCTION: LEGO1 0x100c30e0
+// FUNCTION: BETA10 0x10151517
 MxResult MxStreamChunk::SendChunk(MxStreamListMxDSSubscriber& p_subscriberList, MxBool p_append, MxS16 p_obj24val)
 {
 	for (MxStreamListMxDSSubscriber::iterator it = p_subscriberList.begin(); it != p_subscriberList.end(); it++) {
@@ -82,6 +83,7 @@ void MxStreamChunk::SetBuffer(MxDSBuffer* p_buffer)
 }
 
 // FUNCTION: LEGO1 0x100c3180
+// FUNCTION: BETA10 0x101515f1
 MxU16* MxStreamChunk::IntoFlags(MxU8* p_buffer)
 {
 	return (MxU16*) (p_buffer + 0x08);


### PR DESCRIPTION
Not a full beta match because the beta does not call `MxDSStreamingAction::FUN_100cd2d0`. It does almost the same thing but like this:

```cpp
if (m_unk0x30->GetDuration() != -1) {
    m_unk0x30->SetLoopCount(m_unk0x30->GetLoopCount() - 1);
    m_unk0x30->SetUnknowna8toDuration()
}
```

Filled in some other beta addrs and fixed member set order in `MxDSBuffer` and `MxDSChunk` constructors.
