### PR TITLE
Match `MxDiskStreamController::FUN_100c7db0`

### DIFF
--- a/LEGO1/omni/include/mxdiskstreamcontroller.h
+++ b/LEGO1/omni/include/mxdiskstreamcontroller.h
@@ -92,6 +92,9 @@ private:
 // List<MxDSBuffer *>::~List<MxDSBuffer *>
 
 // TEMPLATE: LEGO1 0x100c7ef0
-// list<MxNextActionDataStart *>::insert
+// list<MxNextActionDataStart *,allocator<MxNextActionDataStart *> >::insert
+
+// TEMPLATE: BETA10 0x10150e60
+// MxUtilityList<MxNextActionDataStart *>::PushBack
 
 #endif // MXDISKSTREAMCONTROLLER_H

--- a/LEGO1/omni/include/mxutilitylist.h
+++ b/LEGO1/omni/include/mxutilitylist.h
@@ -20,7 +20,7 @@ public:
 	}
 
 	// Note: does not take a reference
-	void PushBack(T p_obj) { push_back(p_obj); }
+	void PushBack(T p_obj) { this->push_back(p_obj); }
 };
 
 #endif // MXUTILITYLIST_H

--- a/LEGO1/omni/include/mxutilitylist.h
+++ b/LEGO1/omni/include/mxutilitylist.h
@@ -18,6 +18,9 @@ public:
 		this->pop_front();
 		return TRUE;
 	}
+
+	// Note: does not take a reference
+	void PushBack(T p_obj) { push_back(p_obj); }
 };
 
 #endif // MXUTILITYLIST_H

--- a/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
@@ -248,27 +248,31 @@ MxResult MxDiskStreamController::FUN_100c7d10()
 }
 
 // FUNCTION: LEGO1 0x100c7db0
+// FUNCTION: BETA10 0x101551d0
 MxDSStreamingAction* MxDiskStreamController::FUN_100c7db0()
 {
 	AUTOLOCK(m_criticalSection);
 
 	for (MxNextActionDataStartList::iterator it = m_nextActionList.begin(); it != m_nextActionList.end(); it++) {
 		MxNextActionDataStart* data = *it;
+
 		for (MxDSObjectList::iterator it2 = m_list0x64.begin(); it2 != m_list0x64.end(); it2++) {
 			MxDSStreamingAction* streamingAction = (MxDSStreamingAction*) *it2;
+
 			if (streamingAction->GetObjectId() == data->GetObjectId() &&
 				streamingAction->GetUnknown24() == data->GetUnknown24() &&
 				streamingAction->GetBufferOffset() == data->GetData()) {
 				m_nextActionList.erase(it);
 
 				data->SetData(m_provider->GetFileSize() + data->GetData());
-				m_nextActionList.push_back(data);
+				m_nextActionList.PushBack(data);
 
 				m_list0x64.erase(it2);
 				return streamingAction;
 			}
 		}
 	}
+
 	return NULL;
 }
 


### PR DESCRIPTION
BETA10 revealed they had a `PushBack` proxy function on the `MxUtilityList` - this finally allows `MxDiskStreamController::FUN_100c7db0` to match to 100%.

Based on the alpha we know that they initially used their own STL-like structures and later migrated to using the STL. I'm assuming they kept their own classes, slapped the corresponding STL class as a base on them, forwarded some functions and called it a day.