### PR TITLE
Fix `Vector2`/`Vector3` order

### DIFF
--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -86,6 +86,8 @@ public:
 	MxBool GetUnknown0x10IsSet(MxU8 p_flag) { return m_unk0x10 & p_flag; }
 	MxBool GetFlagsIsSet(MxU8 p_flag) { return m_flags & p_flag; }
 	MxU8 GetFlags() { return m_flags; }
+
+	// FUNCTION: BETA10 0x10049db0
 	MxFloat GetWorldSpeed() { return m_worldSpeed; }
 
 	// FUNCTION: BETA10 0x1000f2f0

--- a/LEGO1/lego/legoomni/src/actors/act2actor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act2actor.cpp
@@ -311,7 +311,7 @@ void Act2Actor::Animate(float p_time)
 				local30 -= local60;
 				local30.Unitize();
 
-				MxFloat dotproduct = local18.Dot(&local30, &local18);
+				MxFloat dotproduct = local18.Dot(local30, local18);
 
 				if (dotproduct >= 0.0) {
 					const MxFloat* pepperWorldPosition = roiPepper->GetWorldPosition();
@@ -613,9 +613,9 @@ MxU32 Act2Actor::FUN_10019700(MxFloat p_param)
 	col2 = col3;
 	col2 -= m_unk0x4c->GetROI()->GetWorldPosition();
 	col2.Unitize();
-	col0.EqualsCross(&col1, &col2);
+	col0.EqualsCross(col1, col2);
 	col0.Unitize();
-	col1.EqualsCross(&col2, &col0);
+	col1.EqualsCross(col2, col0);
 
 	assert(!m_cameraFlag);
 

--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -238,7 +238,7 @@ void Act3Cop::ParseAction(char* p_extra)
 
 			for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
 				Mx4DPointFloat* edgeNormal = boundary->GetEdgeNormal(j);
-				if (point.Dot(edgeNormal, &point) + edgeNormal->index_operator(3) < -0.001) {
+				if (point.Dot(*edgeNormal, point) + edgeNormal->index_operator(3) < -0.001) {
 					MxTrace("Bad Act3 cop destination %d\n", i);
 					break;
 				}
@@ -246,8 +246,8 @@ void Act3Cop::ParseAction(char* p_extra)
 
 			Mx4DPointFloat* boundary0x14 = boundary->GetUnknown0x14();
 
-			if (point.Dot(&point, boundary0x14) + boundary0x14->index_operator(3) <= 0.001 &&
-				point.Dot(&point, boundary0x14) + boundary0x14->index_operator(3) >= -0.001) {
+			if (point.Dot(point, *boundary0x14) + boundary0x14->index_operator(3) <= 0.001 &&
+				point.Dot(point, *boundary0x14) + boundary0x14->index_operator(3) >= -0.001) {
 				continue;
 			}
 
@@ -496,9 +496,9 @@ MxResult Act3Cop::FUN_10040360()
 		v3 = v4;
 		v3 -= vecUnk;
 		v3.Unitize();
-		v1.EqualsCross(&v2, &v3);
+		v1.EqualsCross(v2, v3);
 		v1.Unitize();
-		v2.EqualsCross(&v3, &v1);
+		v2.EqualsCross(v3, v1);
 
 		VTable0x9c();
 	}
@@ -628,9 +628,9 @@ void Act3Brickster::Animate(float p_time)
 			localc = local20;
 			localc -= m_pInfo->m_position;
 			localc.Unitize();
-			local14.EqualsCross(&local28, &localc);
+			local14.EqualsCross(local28, localc);
 			local14.Unitize();
-			local28.EqualsCross(&localc, &local14);
+			local28.EqualsCross(localc, local14);
 
 			assert(!m_cameraFlag);
 
@@ -675,9 +675,9 @@ void Act3Brickster::Animate(float p_time)
 
 			local80 -= m_unk0x3c;
 			local80.Unitize();
-			local88.EqualsCross(&local9c, &local80);
+			local88.EqualsCross(local9c, local80);
 			local88.Unitize();
-			local9c.EqualsCross(&local80, &local88);
+			local9c.EqualsCross(local80, local88);
 
 			assert(!m_cameraFlag);
 
@@ -991,9 +991,9 @@ MxResult Act3Brickster::FUN_100417c0()
 		v3 = v4;
 		v3 -= vecUnk;
 		v3.Unitize();
-		v1.EqualsCross(&v2, &v3);
+		v1.EqualsCross(v2, v3);
 		v1.Unitize();
-		v2.EqualsCross(&v3, &v1);
+		v2.EqualsCross(v3, v1);
 
 		VTable0x9c();
 
@@ -1087,7 +1087,7 @@ MxS32 Act3Brickster::FUN_10042300()
 						local18 = local64[local1c];
 						local18 -= local38;
 
-						if (maxE == NULL || (local18.Dot(&local94, &local18) < 0.0f && local78 < local98)) {
+						if (maxE == NULL || (local18.Dot(local94, local18) < 0.0f && local78 < local98)) {
 							maxE = e;
 							m_boundary = boundaries[i];
 							local78 = local98;

--- a/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
@@ -227,12 +227,12 @@ MxResult Act3Ammo::FUN_10053db0(float p_param1, const Matrix4& p_param2)
 
 	local14[1] = local14[2] = 0.0f;
 	local14[0] = 1.0f;
-	local3c.EqualsCross(&localc, &local14);
+	local3c.EqualsCross(localc, local14);
 
 	if (local3c.Unitize() != 0) {
 		local14[0] = local14[1] = 0.0f;
 		local14[2] = 1.0f;
-		local3c.EqualsCross(&localc, &local14);
+		local3c.EqualsCross(localc, local14);
 
 		if (local3c.Unitize() != 0) {
 			assert(0);
@@ -240,7 +240,7 @@ MxResult Act3Ammo::FUN_10053db0(float p_param1, const Matrix4& p_param2)
 		}
 	}
 
-	local14.EqualsCross(&local3c, &localc);
+	local14.EqualsCross(local3c, localc);
 	return SUCCESS;
 }
 
@@ -340,17 +340,17 @@ void Act3Ammo::Animate(float p_time)
 				local184 = *m_boundary->GetUnknown0x14();
 				local17c[0] = 1.0f;
 				local17c[1] = local17c[2] = 0.0f;
-				local174.EqualsCross(&local17c, &local184);
+				local174.EqualsCross(local17c, local184);
 				local174.Unitize();
-				local17c.EqualsCross(&local184, &local174);
+				local17c.EqualsCross(local184, local174);
 			}
 			else {
 				local17c = *m_boundary->GetUnknown0x14();
 				local184[0] = 1.0f;
 				local184[1] = local184[2] = 0.0f;
-				local174.EqualsCross(&local17c, &local184);
+				local174.EqualsCross(local17c, local184);
 				local174.Unitize();
-				local184.EqualsCross(&local174, &local17c);
+				local184.EqualsCross(local174, local17c);
 			}
 		}
 

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -251,8 +251,8 @@ MxLong Helicopter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				Mx3DPointFloat v68, va4, up;
 				Mx3DPointFloat v90(0, 1, 0);
 				v68 = m_world->GetCamera()->GetWorldUp();
-				va4.EqualsCross(&v68, &direction);
-				up.EqualsCross(&va4, &v90);
+				va4.EqualsCross(v68, direction);
+				up.EqualsCross(va4, v90);
 
 				if (isPizza) {
 					if (((Act3*) m_world)->ShootPizza(m_pathController, location, direction, up) != SUCCESS) {
@@ -457,9 +457,9 @@ void Helicopter::FUN_100042a0(const Matrix4& p_matrix)
 	vec5[0] = vec5[2] = 0.0f;
 	vec5[1] = -1.0f;
 
-	vec3.EqualsCross(&vec4, &vec5);
+	vec3.EqualsCross(vec4, vec5);
 	vec3.Unitize();
-	vec4.EqualsCross(&vec5, &vec3);
+	vec4.EqualsCross(vec5, vec3);
 	vec6 = vec2;
 
 	local90 = m_unk0x1a8;

--- a/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
@@ -133,7 +133,7 @@ void IslePathActor::Exit()
 			for (j = 0; j < m_boundary->GetNumEdges(); j++) {
 				Mx4DPointFloat& normal = *m_boundary->GetEdgeNormal(j);
 
-				if (local20.Dot(&normal, &local20) + normal[3] < -0.001) {
+				if (local20.Dot(normal, local20) + normal[3] < -0.001) {
 					break;
 				}
 			}
@@ -645,7 +645,7 @@ void IslePathActor::FUN_1001b660()
 	Vector3 up(transform[2]);
 
 	up *= -1.0f;
-	position.EqualsCross(&direction, &up);
+	position.EqualsCross(direction, up);
 	m_roi->FUN_100a58f0(transform);
 	m_roi->VTable0x14();
 }

--- a/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
@@ -550,7 +550,7 @@ void LegoCarBuildAnimPresenter::RotateAroundYAxis(MxFloat p_angle)
 		Mx4DPointFloat newRotation;
 
 		additionalRotation.NormalizeQuaternion();
-		newRotation.EqualsHamiltonProduct(&currentRotation, &additionalRotation);
+		newRotation.EqualsHamiltonProduct(currentRotation, additionalRotation);
 
 		if (newRotation[3] < 0.9999) {
 			rotationKey->FUN_100739a0(TRUE);

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1596,7 +1596,7 @@ MxU16 LegoAnimationManager::FUN_10062110(
 		if (GetViewManager()->IsBoundingBoxInFrustum(p_roi->GetWorldBoundingBox())) {
 			Mx3DPointFloat direction(p_roi->GetWorldDirection());
 
-			if (direction.Dot(&direction, &p_direction) > 0.707) {
+			if (direction.Dot(direction, p_direction) > 0.707) {
 				Mx3DPointFloat position(p_roi->GetWorldPosition());
 
 				position -= p_position;
@@ -2525,7 +2525,7 @@ MxBool LegoAnimationManager::FUN_10064120(LegoLocation::Boundary* p_boundary, Mx
 	for (i = 0; i < numEdges; i++) {
 		e = (LegoUnknown100db7f4*) boundary->GetEdges()[i];
 		e->FUN_1002ddc0(*boundary, vec);
-		float dot = vec.Dot(&direction, &vec);
+		float dot = vec.Dot(direction, vec);
 
 		if (dot > local4c) {
 			local50 = e;

--- a/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
@@ -809,7 +809,7 @@ MxResult LegoBuildingManager::FUN_10030630()
 				for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
 					Mx4DPointFloat* normal = boundary->GetEdgeNormal(j);
 
-					if (position.Dot(normal, &position) + (*normal).index_operator(3) < -0.001) {
+					if (position.Dot(*normal, position) + (*normal).index_operator(3) < -0.001) {
 						MxTrace(
 							"Building %d shot location (%g, %g, %g) is not in boundary %s.\n",
 							i,
@@ -826,8 +826,8 @@ MxResult LegoBuildingManager::FUN_10030630()
 				if (g_buildingInfo[i].m_boundary != NULL) {
 					Mx4DPointFloat& unk0x14 = *g_buildingInfo[i].m_boundary->GetUnknown0x14();
 
-					if (position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) > 0.001 ||
-						position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) < -0.001) {
+					if (position.Dot(position, unk0x14) + unk0x14.index_operator(3) > 0.001 ||
+						position.Dot(position, unk0x14) + unk0x14.index_operator(3) < -0.001) {
 
 						g_buildingInfo[i].m_y =
 							-((position[0] * unk0x14.index_operator(0) + unk0x14.index_operator(3) +

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -145,7 +145,7 @@ MxResult LegoPlantManager::FUN_10026410()
 				for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
 					Mx4DPointFloat* normal = boundary->GetEdgeNormal(j);
 
-					if (position.Dot(normal, &position) + (*normal).index_operator(3) < -0.001) {
+					if (position.Dot(*normal, position) + (*normal).index_operator(3) < -0.001) {
 						MxTrace(
 							"Plant %d shot location (%g, %g, %g) is not in boundary %s.\n",
 							i,
@@ -162,8 +162,8 @@ MxResult LegoPlantManager::FUN_10026410()
 				if (g_plantInfo[i].m_boundary != NULL) {
 					Mx4DPointFloat& unk0x14 = *g_plantInfo[i].m_boundary->GetUnknown0x14();
 
-					if (position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) > 0.001 ||
-						position.Dot(&position, &unk0x14) + unk0x14.index_operator(3) < -0.001) {
+					if (position.Dot(position, unk0x14) + unk0x14.index_operator(3) > 0.001 ||
+						position.Dot(position, unk0x14) + unk0x14.index_operator(3) < -0.001) {
 
 						g_plantInfo[i].m_y =
 							-((position[0] * unk0x14.index_operator(0) + unk0x14.index_operator(3) +

--- a/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legojetskiraceactor.cpp
@@ -90,7 +90,7 @@ MxS32 LegoJetskiRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_
 			LERP3(a, *v1, *v2, m_unk0xe4);
 
 			m_destEdge->FUN_1002ddc0(*m_boundary, bbb);
-			c.EqualsCross(&bbb, m_boundary->GetUnknown0x14());
+			c.EqualsCross(bbb, *m_boundary->GetUnknown0x14());
 			c.Unitize();
 
 			Mx3DPointFloat worldDirection(m_roi->GetWorldDirection());

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -191,9 +191,10 @@ inline void LegoExtraActor::FUN_1002ad8a()
 }
 
 // FUNCTION: LEGO1 0x1002aba0
+// FUNCTION: BETA10 0x1008114a
 MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 {
-	if (p_actor->GetActorState() != c_initial || m_actorState != c_initial) {
+	if (p_actor->GetActorState() != c_initial || GetActorState() != c_initial) {
 		return FAILURE;
 	}
 
@@ -222,7 +223,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			for (MxS32 i = 0; i < m_boundary->GetNumEdges(); i++) {
 				Mx4DPointFloat* normal = m_boundary->GetEdgeNormal(i);
 
-				if (positionRef.Dot(*normal, positionRef) + (*normal)[3] < -0.001) {
+				if (positionRef.Dot(*normal, positionRef) + normal->index_operator(3) < -0.001) {
 					b = TRUE;
 					break;
 				}
@@ -232,41 +233,34 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 				m_roi->FUN_100a58f0(matrix2);
 				m_roi->VTable0x14();
 				FUN_1002ad8a();
+				assert(m_roi);
+				assert(SoundManager()->GetCacheSoundManager());
 				SoundManager()->GetCacheSoundManager()->Play("crash5", m_roi->GetName(), FALSE);
 				m_scheduledTime = Timer()->GetTime() + m_disAnim->GetDuration();
-				m_prevWorldSpeed = m_worldSpeed;
+				m_prevWorldSpeed = GetWorldSpeed();
 				VTable0xc4();
 				SetWorldSpeed(0);
 				m_whichAnim = 1;
-				m_actorState = c_one | c_noCollide;
+				SetActorState(c_one | c_noCollide);
 			}
 		}
 
 		if (b) {
-			LegoROI* roi = m_roi;
+			LegoROI* roi = GetROI();
+			assert(roi);
 			SoundManager()->GetCacheSoundManager()->Play("crash5", m_roi->GetName(), FALSE);
 			VTable0xc4();
-			m_actorState = c_two | c_noCollide;
+			SetActorState(c_two | c_noCollide);
 			Mx3DPointFloat dir = p_actor->GetWorldDirection();
 			MxMatrix matrix3 = MxMatrix(roi->GetLocal2World());
 			Vector3 positionRef(matrix3[3]);
 			positionRef += g_unk0x10104c18;
 			roi->FUN_100a58f0(matrix3);
 
-#ifdef COMPAT_MODE
-			float dotX, dotZ;
-			{
-				Mx3DPointFloat tmp(1.0f, 0, 0);
-				dotX = dir.Dot(dir, tmp);
-				Mx3DPointFloat tmp2(0, 0, 1.0f);
-				dotZ = dir.Dot(dir, tmp2);
-			}
-#else
 			float dotX = dir.Dot(dir, Mx3DPointFloat(1.0f, 0, 0));
 			float dotZ = dir.Dot(dir, Mx3DPointFloat(0, 0, 1.0f));
-#endif
 
-			if (abs(dotZ) < abs(dotX)) {
+			if (fabs(dotZ) < fabs(dotX)) {
 				m_axis = dotX > 0.0 ? e_posz : e_negz;
 			}
 			else {

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -138,7 +138,7 @@ MxResult LegoExtraActor::FUN_1002aae0()
 	Vector3 positionRef(m_unk0xec[3]);
 
 	dirRef *= -1.0f;
-	rightRef.EqualsCross(&upRef, &dirRef);
+	rightRef.EqualsCross(upRef, dirRef);
 
 	if (m_boundary == m_destEdge->m_faceA) {
 		m_boundary = (LegoPathBoundary*) m_destEdge->m_faceB;
@@ -222,7 +222,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			for (MxS32 i = 0; i < m_boundary->GetNumEdges(); i++) {
 				Mx4DPointFloat* normal = m_boundary->GetEdgeNormal(i);
 
-				if (positionRef.Dot(normal, &positionRef) + (*normal)[3] < -0.001) {
+				if (positionRef.Dot(*normal, positionRef) + (*normal)[3] < -0.001) {
 					b = TRUE;
 					break;
 				}
@@ -257,13 +257,13 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			float dotX, dotZ;
 			{
 				Mx3DPointFloat tmp(1.0f, 0, 0);
-				dotX = dir.Dot(&dir, &tmp);
+				dotX = dir.Dot(dir, tmp);
 				Mx3DPointFloat tmp2(0, 0, 1.0f);
-				dotZ = dir.Dot(&dir, &tmp2);
+				dotZ = dir.Dot(dir, tmp2);
 			}
 #else
-			float dotX = dir.Dot(&dir, &Mx3DPointFloat(1.0f, 0, 0));
-			float dotZ = dir.Dot(&dir, &Mx3DPointFloat(0, 0, 1.0f));
+			float dotX = dir.Dot(dir, Mx3DPointFloat(1.0f, 0, 0));
+			float dotZ = dir.Dot(dir, Mx3DPointFloat(0, 0, 1.0f));
 #endif
 
 			if (abs(dotZ) < abs(dotX)) {
@@ -463,9 +463,9 @@ MxU32 LegoExtraActor::VTable0x6c(
 						Mx3DPointFloat local54(p_v1);
 
 						local54 -= local60;
-						float local1c = p_v2.Dot(&p_v2, &p_v2);
-						float local24 = p_v2.Dot(&p_v2, &local54) * 2.0f;
-						float local20 = local54.Dot(&local54, &local54);
+						float local1c = p_v2.Dot(p_v2, p_v2);
+						float local24 = p_v2.Dot(p_v2, local54) * 2.0f;
+						float local20 = local54.Dot(local54, local54);
 
 						if (m_unk0x15 != 0 && local20 < 10.0f) {
 							return 0;

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -142,11 +142,11 @@ MxResult LegoPathActor::VTable0x88(
 		dir *= -1.0f;
 	}
 
-	right.EqualsCross(&up, &dir);
+	right.EqualsCross(up, dir);
 	m_roi->UpdateTransformationRelativeToParent(matrix);
 
 	if (!m_cameraFlag || !m_userNavFlag) {
-		p5.EqualsCross(p_boundary->GetUnknown0x14(), &p3);
+		p5.EqualsCross(*p_boundary->GetUnknown0x14(), p3);
 		p5.Unitize();
 
 		if (VTable0x80(p1, p4, p2, p5) == SUCCESS) {
@@ -208,11 +208,11 @@ MxResult LegoPathActor::VTable0x84(
 		dir *= -1.0f;
 	}
 
-	right.EqualsCross(&up, &dir);
+	right.EqualsCross(up, dir);
 	m_roi->UpdateTransformationRelativeToParent(matrix);
 
 	if (!m_cameraFlag || !m_userNavFlag) {
-		p5.EqualsCross(p_boundary->GetUnknown0x14(), &p3);
+		p5.EqualsCross(*p_boundary->GetUnknown0x14(), p3);
 		p5.Unitize();
 
 		if (VTable0x80(p_p1, p_p4, p2, p5) == SUCCESS) {
@@ -308,9 +308,9 @@ MxS32 LegoPathActor::VTable0x8c(float p_time, Matrix4& p_transform)
 
 			dir = p1;
 			up = *m_boundary->GetUnknown0x14();
-			right.EqualsCross(&up, &dir);
+			right.EqualsCross(up, dir);
 			right.Unitize();
-			dir.EqualsCross(&right, &up);
+			dir.EqualsCross(right, up);
 			pos = p2;
 			return result;
 		}
@@ -636,7 +636,7 @@ MxResult LegoPathActor::VTable0x9c()
 		LERP3(local34, v1, v2, m_unk0xe4);
 
 		m_destEdge->FUN_1002ddc0(*m_boundary, local78);
-		local48.EqualsCross(m_boundary->GetUnknown0x14(), &local78);
+		local48.EqualsCross(*m_boundary->GetUnknown0x14(), local78);
 		local48.Unitize();
 	}
 
@@ -646,10 +646,10 @@ MxResult LegoPathActor::VTable0x9c()
 
 	upRef = *m_boundary->GetUnknown0x14();
 
-	rightRef.EqualsCross(&upRef, &dirRef);
+	rightRef.EqualsCross(upRef, dirRef);
 	rightRef.Unitize();
 
-	dirRef.EqualsCross(&rightRef, &upRef);
+	dirRef.EqualsCross(rightRef, upRef);
 	dirRef.Unitize();
 
 	Mx3DPointFloat localc0(m_unk0xec[3]);

--- a/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
@@ -54,11 +54,11 @@ void LegoPathBoundary::FUN_100575b0(Vector3& p_point1, Vector3& p_point2, LegoPa
 
 		v = p_point1;
 		v -= *ccwV;
-		float dot1 = v.Dot(&v, m_unk0x50);
+		float dot1 = v.Dot(v, *m_unk0x50);
 
 		v = p_point2;
 		v -= *ccwV;
-		float dot2 = v.Dot(&v, m_unk0x50);
+		float dot2 = v.Dot(v, *m_unk0x50);
 
 		if (dot2 > dot1) {
 			for (MxS32 i = 0; i < m_numTriggers; i++) {
@@ -197,7 +197,7 @@ MxU32 LegoPathBoundary::Intersect(
 	for (MxS32 i = 0; i < m_numEdges; i++) {
 		LegoUnknown100db7f4* edge = (LegoUnknown100db7f4*) m_edges[i];
 
-		if (p_point2.Dot(&m_edgeNormals[i], &p_point2) + m_edgeNormals[i][3] <= -1e-07) {
+		if (p_point2.Dot(m_edgeNormals[i], p_point2) + m_edgeNormals[i][3] <= -1e-07) {
 			if (local10 == 0) {
 				local10 = 1;
 				vec = p_point2;
@@ -212,9 +212,9 @@ MxU32 LegoPathBoundary::Intersect(
 				vec /= len;
 			}
 
-			float dot = vec.Dot(&vec, &m_edgeNormals[i]);
+			float dot = vec.Dot(vec, m_edgeNormals[i]);
 			if (dot != 0.0f) {
-				float local34 = (-m_edgeNormals[i][3] - p_point1.Dot(&p_point1, &m_edgeNormals[i])) / dot;
+				float local34 = (-m_edgeNormals[i][3] - p_point1.Dot(p_point1, m_edgeNormals[i])) / dot;
 
 				if (local34 >= -0.001 && local34 <= len && (e == NULL || local34 < localc)) {
 					e = edge;
@@ -242,7 +242,7 @@ MxU32 LegoPathBoundary::Intersect(
 
 		e->FUN_1002ddc0(*this, local70);
 
-		float local58 = local50.Dot(&local50, &local70);
+		float local58 = local50.Dot(local50, local70);
 		LegoUnknown100db7f4* local54 = NULL;
 
 		if (local58 < 0.0f) {
@@ -252,7 +252,7 @@ MxU32 LegoPathBoundary::Intersect(
 				 local88 = (LegoUnknown100db7f4*) local88->GetClockwiseEdge(*this)) {
 				local88->FUN_1002ddc0(*this, local84);
 
-				if (local84.Dot(&local84, &local70) <= 0.9) {
+				if (local84.Dot(local84, local70) <= 0.9) {
 					break;
 				}
 
@@ -260,7 +260,7 @@ MxU32 LegoPathBoundary::Intersect(
 				Mx3DPointFloat locala4(p_point3);
 				locala4 -= *local90;
 
-				float local8c = locala4.Dot(&locala4, &local84);
+				float local8c = locala4.Dot(locala4, local84);
 
 				if (local8c > local58 && local8c < local88->m_unk0x3c) {
 					local54 = local88;
@@ -279,7 +279,7 @@ MxU32 LegoPathBoundary::Intersect(
 					 locala8 = (LegoUnknown100db7f4*) locala8->GetCounterclockwiseEdge(*this)) {
 					locala8->FUN_1002ddc0(*this, localbc);
 
-					if (localbc.Dot(&localbc, &local70) <= 0.9) {
+					if (localbc.Dot(localbc, local70) <= 0.9) {
 						break;
 					}
 
@@ -287,7 +287,7 @@ MxU32 LegoPathBoundary::Intersect(
 					Mx3DPointFloat locald8(p_point3);
 					locald8 -= *localc4;
 
-					float localc0 = locald8.Dot(&locald8, &localbc);
+					float localc0 = locald8.Dot(locald8, localbc);
 
 					if (localc0 < local58 && localc0 >= 0.0f) {
 						local54 = locala8;

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -256,7 +256,7 @@ MxResult LegoPathController::PlaceActor(
 			for (j = 0; j < b.GetNumEdges(); j++) {
 				Mx4DPointFloat normal(*b.GetEdgeNormal(j));
 
-				if (p_position.Dot(&p_position, &normal) + normal[3] < 0.0f) {
+				if (p_position.Dot(p_position, normal) + normal[3] < 0.0f) {
 					break;
 				}
 			}
@@ -282,7 +282,7 @@ MxResult LegoPathController::PlaceActor(
 			Mx3DPointFloat vec;
 
 			if (((LegoUnknown100db7f4*) edge->GetClockwiseEdge(*boundary))->FUN_1002ddc0(*boundary, vec) == SUCCESS &&
-				vec.Dot(&vec, &p_direction) < 0.0f) {
+				vec.Dot(vec, p_direction) < 0.0f) {
 				edge =
 					(LegoUnknown100db7f4*) edge->GetCounterclockwiseEdge(*boundary)->GetCounterclockwiseEdge(*boundary);
 			}
@@ -949,7 +949,7 @@ MxS32 LegoPathController::FUN_1004a240(
 	p_v1 *= p_f1;
 	p_v1 += *p_edge->CWVertex(*p_boundary);
 	p_edge->FUN_1002ddc0(*p_boundary, vec);
-	p_v2.EqualsCross(p_boundary->GetUnknown0x14(), &vec);
+	p_v2.EqualsCross(*p_boundary->GetUnknown0x14(), vec);
 	return 0;
 }
 
@@ -974,14 +974,14 @@ MxResult LegoPathController::FUN_1004a380(
 
 		LegoPathBoundary* b = &m_boundaries[i];
 		Mx4DPointFloat* unk0x14 = b->GetUnknown0x14();
-		float local28 = p_param3[0].Dot(&p_param3[0], unk0x14);
+		float local28 = p_param3[0].Dot(p_param3[0], *unk0x14);
 
 		if (local28 < 0.001 && local28 > -0.001) {
 			continue;
 		}
 
-		float local2c = p_param3[1].Dot(&p_param3[1], unk0x14);
-		float local34 = p_param3[2].Dot(&p_param3[2], unk0x14) + unk0x14->index_operator(3);
+		float local2c = p_param3[1].Dot(p_param3[1], *unk0x14);
+		float local34 = p_param3[2].Dot(p_param3[2], *unk0x14) + unk0x14->index_operator(3);
 		float local3c = local2c * local2c - local34 * local28 * 4.0f;
 
 		if (local3c < -0.001) {
@@ -1022,7 +1022,7 @@ MxResult LegoPathController::FUN_1004a380(
 			for (j = b->GetNumEdges() - 1; j >= 0; j--) {
 				Mx4DPointFloat* local60 = b->GetEdgeNormal(j);
 
-				if (local24.Dot(local60, &local24) + local60->index_operator(3) < -0.001) {
+				if (local24.Dot(*local60, local24) + local60->index_operator(3) < -0.001) {
 					break;
 				}
 			}
@@ -1031,7 +1031,7 @@ MxResult LegoPathController::FUN_1004a380(
 				Mx3DPointFloat local74(p_param1);
 				local74 -= local24;
 
-				if (local74.Dot(&local74, unk0x14) >= 0.0f) {
+				if (local74.Dot(local74, *unk0x14) >= 0.0f) {
 					p_param5 = local38;
 					p_boundary = b;
 					local8 = FALSE;

--- a/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracespecial.cpp
@@ -166,7 +166,7 @@ MxS32 LegoCarRaceActor::VTable0x1c(LegoPathBoundary* p_boundary, LegoEdge* p_edg
 
 			m_destEdge->FUN_1002ddc0(*m_boundary, destEdgeUnknownVector);
 
-			crossProduct.EqualsCross(m_boundary->GetUnknown0x14(), &destEdgeUnknownVector);
+			crossProduct.EqualsCross(*m_boundary->GetUnknown0x14(), destEdgeUnknownVector);
 			crossProduct.Unitize();
 
 			Mx3DPointFloat worldDirection(Vector3(m_roi->GetWorldDirection()));
@@ -260,8 +260,8 @@ MxResult LegoCarRaceActor::VTable0x9c()
 		d->FUN_1002ddc0(*b, point2);
 		m_destEdge->FUN_1002ddc0(*m_boundary, point3);
 
-		point4.EqualsCross(&point2, m_boundary->GetUnknown0x14());
-		point5.EqualsCross(m_boundary->GetUnknown0x14(), &point3);
+		point4.EqualsCross(point2, *m_boundary->GetUnknown0x14());
+		point5.EqualsCross(*m_boundary->GetUnknown0x14(), point3);
 
 		point4.Unitize();
 		point5.Unitize();

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -652,9 +652,9 @@ void LegoAnimPresenter::PutFrame()
 
 					up -= m_currentWorld->GetCamera()->GetWorldLocation();
 					dir /= dirsqr;
-					pos.EqualsCross(&dir, &up);
+					pos.EqualsCross(dir, up);
 					pos.Unitize();
-					up.EqualsCross(&pos, &dir);
+					up.EqualsCross(pos, dir);
 					pos *= possqr;
 					dir *= dirsqr;
 					up *= upsqr;

--- a/LEGO1/lego/legoomni/src/video/legoloopinganimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoloopinganimpresenter.cpp
@@ -68,9 +68,9 @@ void LegoLoopingAnimPresenter::PutFrame()
 
 				up -= m_currentWorld->GetCamera()->GetWorldLocation();
 				dir /= dirsqr;
-				pos.EqualsCross(&dir, &up);
+				pos.EqualsCross(dir, up);
 				pos.Unitize();
-				up.EqualsCross(&pos, &dir);
+				up.EqualsCross(pos, dir);
 				pos *= possqr;
 				dir *= dirsqr;
 				up *= upsqr;

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -327,7 +327,7 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 				local90 *= 1.25f;
 				locala4 += local90;
 				locala4[1] += 0.25;
-				local30.EqualsCross(&localac, &local28);
+				local30.EqualsCross(localac, local28);
 				local30.Unitize();
 
 				Mx3DPointFloat locald4(local2world[2]);
@@ -1155,7 +1155,7 @@ MxResult LegoAct2::FUN_10052560(
 			Vector3 secondColumn(matrix[1]);
 			Vector3 thirdColumn(matrix[2]);
 
-			firstColumn.EqualsCross(&secondColumn, &thirdColumn);
+			firstColumn.EqualsCross(secondColumn, thirdColumn);
 			firstColumn.Unitize();
 
 			MxMatrix* pmatrix = NULL;

--- a/LEGO1/lego/sources/anim/legoanim.cpp
+++ b/LEGO1/lego/sources/anim/legoanim.cpp
@@ -231,10 +231,10 @@ LegoResult LegoAnimScene::FUN_1009f490(LegoFloat p_time, Matrix4& p_matrix)
 	local54 -= localb8;
 
 	if (local54.Unitize() == 0) {
-		local5c.EqualsCross(&local68, &local54);
+		local5c.EqualsCross(local68, local54);
 
 		if (local5c.Unitize() == 0) {
-			local68.EqualsCross(&local54, &local5c);
+			local68.EqualsCross(local54, local5c);
 
 			localcc = p_matrix[3];
 			localcc += localb0[3];

--- a/LEGO1/lego/sources/geom/legowegedge.cpp
+++ b/LEGO1/lego/sources/geom/legowegedge.cpp
@@ -139,10 +139,10 @@ LegoS32 LegoWEGEdge::VTable0x04()
 		Mx3DPointFloat local58;
 		Vector3 local64(&m_edgeNormals[i][0]);
 		edge->FUN_1002ddc0(*this, local58);
-		local64.EqualsCross(&local58, &m_unk0x14);
+		local64.EqualsCross(local58, m_unk0x14);
 
-		m_edgeNormals[i][3] = -local64.Dot(m_edges[i]->m_pointA, &local64);
-		if (m_edgeNormals[i][3] + m_unk0x30.Dot(&m_unk0x30, &local64) < 0.0f) {
+		m_edgeNormals[i][3] = -local64.Dot(*m_edges[i]->m_pointA, local64);
+		if (m_edgeNormals[i][3] + m_unk0x30.Dot(m_unk0x30, local64) < 0.0f) {
 			m_edgeNormals[i] *= -1.0f;
 		}
 
@@ -178,12 +178,12 @@ LegoS32 LegoWEGEdge::VTable0x04()
 			localb8 -= *vTrig1;
 			local80 -= *vTrig1;
 
-			float locala4 = localb8.Dot(m_unk0x50, &localb8);
+			float locala4 = localb8.Dot(*m_unk0x50, localb8);
 			if (local98 < locala4) {
 				local98 = locala4;
 			}
 
-			locala4 = local80.Dot(m_unk0x50, &local80);
+			locala4 = local80.Dot(*m_unk0x50, local80);
 			if (locala4 < local9c) {
 				local9c = locala4;
 			}
@@ -244,7 +244,7 @@ LegoS32 LegoWEGEdge::FUN_1009aea0()
 		local50 = *local8[i - 2];
 		local50 -= *local8[i - 1];
 
-		local24.EqualsCross(&local50, &local3c);
+		local24.EqualsCross(local50, local3c);
 		local28 = local24.LenSquared();
 
 		if (local28 < 0.00001f) {
@@ -255,7 +255,7 @@ LegoS32 LegoWEGEdge::FUN_1009aea0()
 		local24 /= local58;
 
 		if (localc) {
-			float local54 = local24.Dot(&m_unk0x14, &local24);
+			float local54 = local24.Dot(m_unk0x14, local24);
 			if (local54 < 0.98) {
 				delete[] local8;
 				return -2;
@@ -265,7 +265,7 @@ LegoS32 LegoWEGEdge::FUN_1009aea0()
 			m_unk0x14[0] = local24[0];
 			m_unk0x14[1] = local24[1];
 			m_unk0x14[2] = local24[2];
-			m_unk0x14[3] = -local8[i]->Dot(local8[i], &local24);
+			m_unk0x14[3] = -local8[i]->Dot(*local8[i], local24);
 			localc = TRUE;
 		}
 	}

--- a/LEGO1/lego/sources/misc/legounknown.cpp
+++ b/LEGO1/lego/sources/misc/legounknown.cpp
@@ -68,11 +68,11 @@ LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, L
 		return FAILURE;
 	}
 
-	v2.EqualsCross(&p_v, &v4);
+	v2.EqualsCross(p_v, v4);
 	if (v2.Unitize() != 0) {
 		return FAILURE;
 	}
 
-	v3.EqualsCross(&v4, &v2);
+	v3.EqualsCross(v4, v2);
 	return SUCCESS;
 }

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -626,13 +626,13 @@ LegoU32 LegoROI::FUN_100a9410(
 		local38 *= 0.5f;
 
 		local70 = localc0;
-		localc0.SetMatrixProduct(&local70, (float*) m_local2world.GetData());
+		localc0.SetMatrixProduct(local70, (float*) m_local2world.GetData());
 
 		local70 = local9c;
-		local9c.SetMatrixProduct(&local70, (float*) m_local2world.GetData());
+		local9c.SetMatrixProduct(local70, (float*) m_local2world.GetData());
 
 		local70 = local168;
-		local168.SetMatrixProduct(&local70, (float*) m_local2world.GetData());
+		local168.SetMatrixProduct(local70, (float*) m_local2world.GetData());
 
 		p_v3 = m_local2world[3];
 
@@ -641,22 +641,22 @@ LegoU32 LegoROI::FUN_100a9410(
 			local150[i] = m_local2world[i % 3];
 
 			if (i > 2) {
-				local150[i][3] = -local58.Dot(&local58, &local150[i]);
+				local150[i][3] = -local58.Dot(local58, local150[i]);
 			}
 			else {
-				local150[i][3] = -locala8.Dot(&locala8, &local150[i]);
+				local150[i][3] = -locala8.Dot(locala8, local150[i]);
 			}
 
-			if (local150[i][3] + local38.Dot(&local38, &local150[i]) < 0.0f) {
+			if (local150[i][3] + local38.Dot(local38, local150[i]) < 0.0f) {
 				local150[i] *= -1.0f;
 			}
 		}
 
 		for (i = 0; i < 6; i++) {
-			float local50 = p_v2.Dot(&p_v2, &local150[i]);
+			float local50 = p_v2.Dot(p_v2, local150[i]);
 
 			if (local50 >= 0.01 || local50 < -0.01) {
-				local50 = -((local150[i][3] + local4c.Dot(&local4c, &local150[i])) / local50);
+				local50 = -((local150[i][3] + local4c.Dot(local4c, local150[i])) / local50);
 
 				if (local50 >= 0.0f && local50 <= p_f1) {
 					Mx3DPointFloat local17c(p_v2);
@@ -666,7 +666,7 @@ LegoU32 LegoROI::FUN_100a9410(
 					LegoS32 j;
 					for (j = 0; j < 6; j++) {
 						if (i != j && i - j != 3 && j - i != 3) {
-							if (local150[j][3] + local17c.Dot(&local17c, &local150[j]) < 0.0f) {
+							if (local150[j][3] + local17c.Dot(local17c, local150[j]) < 0.0f) {
 								break;
 							}
 						}
@@ -684,9 +684,9 @@ LegoU32 LegoROI::FUN_100a9410(
 		v1 -= GetWorldBoundingSphere().Center();
 
 		float local10 = GetWorldBoundingSphere().Radius();
-		float local8 = p_v2.Dot(&p_v2, &p_v2);
-		float localc = p_v2.Dot(&p_v2, &v1) * 2.0f;
-		float local14 = v1.Dot(&v1, &v1) - (local10 * local10);
+		float local8 = p_v2.Dot(p_v2, p_v2);
+		float localc = p_v2.Dot(p_v2, v1) * 2.0f;
+		float local14 = v1.Dot(v1, v1) - (local10 * local10);
 
 		if (local8 >= 0.001 || local8 <= -0.001) {
 			float local1c = -1.0f;

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -185,7 +185,7 @@ inline long UnknownMx4DPointFloat::FUN_10004520()
 	v2 = m_unk0x00;
 	v2 -= m_unk0x18;
 
-	if (v1.Dot(&v1, &v1) < v2.Dot(&v2, &v2)) {
+	if (v1.Dot(v1, v1) < v2.Dot(v2, v2)) {
 		m_unk0x18 *= -1.0f;
 	}
 
@@ -208,7 +208,7 @@ inline int UnknownMx4DPointFloat::FUN_100040a0(Vector4& p_v, float p_f)
 	}
 	else if (m_unk0x30 == (c_bit1 | c_bit2)) {
 		int i;
-		double d1 = p_v.Dot(&m_unk0x00, &m_unk0x18);
+		double d1 = p_v.Dot(m_unk0x00, m_unk0x18);
 		double a;
 		double b;
 

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -42,28 +42,25 @@ public:
 		m_data[1] -= p_value[1];
 	} // vtable+0x08
 
-	// Those are also overloads in all likelihood,
-	// but we need a type to do that.
-
-	// FUNCTION: LEGO1 0x10002000
-	virtual void MulScalarImpl(float* p_value)
-	{
-		m_data[0] *= *p_value;
-		m_data[1] *= *p_value;
-	} // vtable+0x0c
-
 	// FUNCTION: LEGO1 0x10001fe0
-	virtual void MulVectorImpl(float* p_value)
+	virtual void MulImpl(float* p_value)
 	{
 		m_data[0] *= p_value[0];
 		m_data[1] *= p_value[1];
 	} // vtable+0x10
 
-	// FUNCTION: LEGO1 0x10002020
-	virtual void DivScalarImpl(float* p_value)
+	// FUNCTION: LEGO1 0x10002000
+	virtual void MulImpl(const float& p_value)
 	{
-		m_data[0] /= *p_value;
-		m_data[1] /= *p_value;
+		m_data[0] *= p_value;
+		m_data[1] *= p_value;
+	} // vtable+0x0c
+
+	// FUNCTION: LEGO1 0x10002020
+	virtual void DivImpl(const float& p_value)
+	{
+		m_data[0] /= p_value;
+		m_data[1] /= p_value;
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x10002040
@@ -110,7 +107,7 @@ public:
 		if (sq > 0.0f) {
 			float root = sqrt(sq);
 			if (root > 0.0f) {
-				DivScalarImpl(&root);
+				DivImpl(root);
 				return 0;
 			}
 		}
@@ -135,16 +132,16 @@ private:
 	virtual void Sub(const Vector2& p_other) { SubImpl((float*) p_other.m_data); } // vtable+0x54
 
 	// FUNCTION: LEGO1 0x10002210
-	virtual void Mul(float* p_other) { MulVectorImpl(p_other); } // vtable+0x64
+	virtual void Mul(float* p_other) { MulImpl(p_other); } // vtable+0x64
 
 	// FUNCTION: LEGO1 0x10002220
-	virtual void Mul(Vector2* p_other) { MulVectorImpl(p_other->m_data); } // vtable+0x60
+	virtual void Mul(Vector2* p_other) { MulImpl(p_other->m_data); } // vtable+0x60
 
 	// FUNCTION: LEGO1 0x10002230
-	virtual void Mul(const float& p_value) { MulScalarImpl((float*) &p_value); } // vtable+0x5c
+	virtual void Mul(const float& p_value) { MulImpl(p_value); } // vtable+0x5c
 
 	// FUNCTION: LEGO1 0x10002240
-	virtual void Div(const float& p_value) { DivScalarImpl((float*) &p_value); } // vtable+0x68
+	virtual void Div(const float& p_value) { DivImpl(p_value); } // vtable+0x68
 
 public:
 	// FUNCTION: LEGO1 0x10002250
@@ -279,28 +276,28 @@ public:
 		m_data[2] -= p_value[2];
 	} // vtable+0x08
 
-	// FUNCTION: LEGO1 0x10003b20
-	void MulScalarImpl(float* p_value) override
-	{
-		m_data[0] *= *p_value;
-		m_data[1] *= *p_value;
-		m_data[2] *= *p_value;
-	} // vtable+0x0c
-
 	// FUNCTION: LEGO1 0x10003af0
-	void MulVectorImpl(float* p_value) override
+	void MulImpl(float* p_value) override
 	{
 		m_data[0] *= p_value[0];
 		m_data[1] *= p_value[1];
 		m_data[2] *= p_value[2];
 	} // vtable+0x10
 
-	// FUNCTION: LEGO1 0x10003b50
-	void DivScalarImpl(float* p_value) override
+	// FUNCTION: LEGO1 0x10003b20
+	void MulImpl(const float& p_value) override
 	{
-		m_data[0] /= *p_value;
-		m_data[1] /= *p_value;
-		m_data[2] /= *p_value;
+		m_data[0] *= p_value;
+		m_data[1] *= p_value;
+		m_data[2] *= p_value;
+	} // vtable+0x0c
+
+	// FUNCTION: LEGO1 0x10003b50
+	void DivImpl(const float& p_value) override
+	{
+		m_data[0] /= p_value;
+		m_data[1] /= p_value;
+		m_data[2] /= p_value;
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x10003b80
@@ -392,17 +389,8 @@ public:
 		m_data[3] -= p_value[3];
 	} // vtable+0x08
 
-	// FUNCTION: LEGO1 0x10002970
-	void MulScalarImpl(float* p_value) override
-	{
-		m_data[0] *= *p_value;
-		m_data[1] *= *p_value;
-		m_data[2] *= *p_value;
-		m_data[3] *= *p_value;
-	} // vtable+0x0c
-
 	// FUNCTION: LEGO1 0x10002930
-	void MulVectorImpl(float* p_value) override
+	void MulImpl(float* p_value) override
 	{
 		m_data[0] *= p_value[0];
 		m_data[1] *= p_value[1];
@@ -410,13 +398,22 @@ public:
 		m_data[3] *= p_value[3];
 	} // vtable+0x10
 
-	// FUNCTION: LEGO1 0x100029b0
-	void DivScalarImpl(float* p_value) override
+	// FUNCTION: LEGO1 0x10002970
+	void MulImpl(const float& p_value) override
 	{
-		m_data[0] /= *p_value;
-		m_data[1] /= *p_value;
-		m_data[2] /= *p_value;
-		m_data[3] /= *p_value;
+		m_data[0] *= p_value;
+		m_data[1] *= p_value;
+		m_data[2] *= p_value;
+		m_data[3] *= p_value;
+	} // vtable+0x0c
+
+	// FUNCTION: LEGO1 0x100029b0
+	void DivImpl(const float& p_value) override
+	{
+		m_data[0] /= p_value;
+		m_data[1] /= p_value;
+		m_data[2] /= p_value;
+		m_data[3] /= p_value;
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x100029f0
@@ -464,9 +461,10 @@ inline int Vector4::NormalizeQuaternion()
 		float theta = v[3] * 0.5f;
 		v[3] = cos(theta);
 		magnitude = sin(theta) / sqrt(magnitude);
-		Vector3::MulScalarImpl(&magnitude);
+		Vector3::MulImpl(magnitude);
 		return 0;
 	}
+
 	return -1;
 }
 

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -22,7 +22,7 @@ public:
 	// in reverse order of appearance.
 
 	// FUNCTION: LEGO1 0x10001f80
-	virtual void AddImpl(float* p_value)
+	virtual void AddImpl(const float* p_value)
 	{
 		m_data[0] += p_value[0];
 		m_data[1] += p_value[1];
@@ -36,14 +36,14 @@ public:
 	} // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10001fc0
-	virtual void SubImpl(float* p_value)
+	virtual void SubImpl(const float* p_value)
 	{
 		m_data[0] -= p_value[0];
 		m_data[1] -= p_value[1];
 	} // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10001fe0
-	virtual void MulImpl(float* p_value)
+	virtual void MulImpl(const float* p_value)
 	{
 		m_data[0] *= p_value[0];
 		m_data[1] *= p_value[1];
@@ -64,14 +64,17 @@ public:
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x10002040
-	virtual float DotImpl(float* p_a, float* p_b) const { return p_b[0] * p_a[0] + p_b[1] * p_a[1]; } // vtable+0x18
+	virtual float DotImpl(const float* p_a, const float* p_b) const
+	{
+		return p_b[0] * p_a[0] + p_b[1] * p_a[1];
+	} // vtable+0x18
 
 	// FUNCTION: LEGO1 0x10002060
 	// FUNCTION: BETA10 0x10010c90
 	virtual void SetData(float* p_data) { m_data = p_data; } // vtable+0x1c
 
 	// FUNCTION: LEGO1 0x10002070
-	virtual void EqualsImpl(float* p_data) { memcpy(m_data, p_data, sizeof(float) * 2); } // vtable+0x20
+	virtual void EqualsImpl(const float* p_data) { memcpy(m_data, p_data, sizeof(float) * 2); } // vtable+0x20
 
 	// FUNCTION: LEGO1 0x10002090
 	virtual float* GetData() { return m_data; } // vtable+0x28
@@ -83,17 +86,20 @@ public:
 	virtual void Clear() { memset(m_data, 0, sizeof(float) * 2); } // vtable+0x2c
 
 	// FUNCTION: LEGO1 0x100020d0
-	virtual float Dot(float* p_a, float* p_b) const { return DotImpl(p_a, p_b); } // vtable+0x3c
+	virtual float Dot(const float* p_a, const float* p_b) const { return DotImpl(p_a, p_b); } // vtable+0x3c
 
 	// FUNCTION: LEGO1 0x100020f0
 	// FUNCTION: BETA10 0x100108c0
-	virtual float Dot(Vector2* p_a, Vector2* p_b) const { return DotImpl(p_a->m_data, p_b->m_data); } // vtable+0x38
+	virtual float Dot(const Vector2& p_a, const Vector2& p_b) const
+	{
+		return DotImpl(p_a.m_data, p_b.m_data);
+	} // vtable+0x38
 
 	// FUNCTION: LEGO1 0x10002110
-	virtual float Dot(float* p_a, Vector2* p_b) const { return DotImpl(p_a, p_b->m_data); } // vtable+0x34
+	virtual float Dot(const float* p_a, const Vector2& p_b) const { return DotImpl(p_a, p_b.m_data); } // vtable+0x34
 
 	// FUNCTION: LEGO1 0x10002130
-	virtual float Dot(Vector2* p_a, float* p_b) const { return DotImpl(p_a->m_data, p_b); } // vtable+0x30
+	virtual float Dot(const Vector2& p_a, const float* p_b) const { return DotImpl(p_a.m_data, p_b); } // vtable+0x30
 
 	// FUNCTION: LEGO1 0x10002150
 	virtual float LenSquared() const { return m_data[0] * m_data[0] + m_data[1] * m_data[1]; } // vtable+0x40
@@ -120,22 +126,22 @@ private:
 	virtual void Add(float p_value) { AddImpl(p_value); } // vtable+0x50
 
 	// FUNCTION: LEGO1 0x100021d0
-	virtual void Add(float* p_other) { AddImpl(p_other); } // vtable+0x4c
+	virtual void Add(const float* p_other) { AddImpl(p_other); } // vtable+0x4c
 
 	// FUNCTION: LEGO1 0x100021e0
-	virtual void Add(const Vector2& p_other) { AddImpl((float*) p_other.m_data); } // vtable+0x48
+	virtual void Add(const Vector2& p_other) { AddImpl(p_other.m_data); } // vtable+0x48
 
 	// FUNCTION: LEGO1 0x100021f0
-	virtual void Sub(const float* p_other) { SubImpl((float*) p_other); } // vtable+0x58
+	virtual void Sub(const float* p_other) { SubImpl(p_other); } // vtable+0x58
 
 	// FUNCTION: LEGO1 0x10002200
-	virtual void Sub(const Vector2& p_other) { SubImpl((float*) p_other.m_data); } // vtable+0x54
+	virtual void Sub(const Vector2& p_other) { SubImpl(p_other.m_data); } // vtable+0x54
 
 	// FUNCTION: LEGO1 0x10002210
-	virtual void Mul(float* p_other) { MulImpl(p_other); } // vtable+0x64
+	virtual void Mul(const float* p_other) { MulImpl(p_other); } // vtable+0x64
 
 	// FUNCTION: LEGO1 0x10002220
-	virtual void Mul(Vector2* p_other) { MulImpl(p_other->m_data); } // vtable+0x60
+	virtual void Mul(const Vector2& p_other) { MulImpl(p_other.m_data); } // vtable+0x60
 
 	// FUNCTION: LEGO1 0x10002230
 	virtual void Mul(const float& p_value) { MulImpl(p_value); } // vtable+0x5c
@@ -145,11 +151,11 @@ private:
 
 public:
 	// FUNCTION: LEGO1 0x10002250
-	virtual void SetVector(float* p_other) { EqualsImpl(p_other); } // vtable+0x70
+	virtual void SetVector(const float* p_other) { EqualsImpl(p_other); } // vtable+0x70
 
 	// FUNCTION: LEGO1 0x10002260
 	// FUNCTION: BETA10 0x100110c0
-	virtual void SetVector(const Vector2* p_other) { EqualsImpl(p_other->m_data); } // vtable+0x6c
+	virtual void SetVector(const Vector2& p_other) { EqualsImpl(p_other.m_data); } // vtable+0x6c
 
 	// Note: it's unclear whether Vector3::operator= has been defined explicitly
 	// with the same function body as Vector2& operator=. The BETA indicates that;
@@ -176,7 +182,7 @@ public:
 
 	Vector2& operator=(const Vector2& p_other)
 	{
-		Vector2::SetVector(&p_other);
+		Vector2::SetVector(p_other);
 		return *this;
 	}
 
@@ -187,14 +193,14 @@ public:
 	const float& operator[](int idx) const { return m_data[idx]; }
 
 	void operator+=(float p_value) { Add(p_value); }
-	void operator+=(float* p_other) { Add(p_other); }
+	void operator+=(const float* p_other) { Add(p_other); }
 	void operator+=(const Vector2& p_other) { Add(p_other); }
 
 	void operator-=(const float* p_other) { Sub(p_other); }
 	void operator-=(const Vector2& p_other) { Sub(p_other); }
 
-	void operator*=(float* p_other) { Mul(p_other); }
-	void operator*=(Vector2* p_other) { Mul(p_other); }
+	void operator*=(const float* p_other) { Mul(p_other); }
+	void operator*=(const Vector2& p_other) { Mul(p_other); }
 	void operator*=(const float& p_value) { Mul(p_value); }
 
 	void operator/=(const float& p_value) { Div(p_value); }
@@ -225,7 +231,7 @@ public:
 
 	// FUNCTION: LEGO1 0x10002270
 	// FUNCTION: BETA10 0x10011350
-	virtual void EqualsCrossImpl(float* p_a, float* p_b)
+	virtual void EqualsCrossImpl(const float* p_a, const float* p_b)
 	{
 		m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
 		m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
@@ -234,13 +240,16 @@ public:
 
 	// FUNCTION: LEGO1 0x100022c0
 	// FUNCTION: BETA10 0x10011430
-	virtual void EqualsCross(Vector3* p_a, Vector3* p_b) { EqualsCrossImpl(p_a->m_data, p_b->m_data); } // vtable+0x80
+	virtual void EqualsCross(const Vector3& p_a, const Vector3& p_b)
+	{
+		EqualsCrossImpl(p_a.m_data, p_b.m_data);
+	} // vtable+0x80
 
 	// FUNCTION: LEGO1 0x100022e0
-	virtual void EqualsCross(Vector3* p_a, float* p_b) { EqualsCrossImpl(p_a->m_data, p_b); } // vtable+0x7c
+	virtual void EqualsCross(const Vector3& p_a, const float* p_b) { EqualsCrossImpl(p_a.m_data, p_b); } // vtable+0x7c
 
 	// FUNCTION: LEGO1 0x10002300
-	virtual void EqualsCross(float* p_a, Vector3* p_b) { EqualsCrossImpl(p_a, p_b->m_data); } // vtable+0x78
+	virtual void EqualsCross(const float* p_a, const Vector3& p_b) { EqualsCrossImpl(p_a, p_b.m_data); } // vtable+0x78
 
 	// FUNCTION: LEGO1 0x10003bf0
 	virtual void Fill(const float& p_value)
@@ -253,7 +262,7 @@ public:
 	// Vector2 overrides
 
 	// FUNCTION: LEGO1 0x10003a60
-	void AddImpl(float* p_value) override
+	void AddImpl(const float* p_value) override
 	{
 		m_data[0] += p_value[0];
 		m_data[1] += p_value[1];
@@ -269,7 +278,7 @@ public:
 	} // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10003ac0
-	void SubImpl(float* p_value) override
+	void SubImpl(const float* p_value) override
 	{
 		m_data[0] -= p_value[0];
 		m_data[1] -= p_value[1];
@@ -277,7 +286,7 @@ public:
 	} // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10003af0
-	void MulImpl(float* p_value) override
+	void MulImpl(const float* p_value) override
 	{
 		m_data[0] *= p_value[0];
 		m_data[1] *= p_value[1];
@@ -301,14 +310,14 @@ public:
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x10003b80
-	float DotImpl(float* p_a, float* p_b) const override
+	float DotImpl(const float* p_a, const float* p_b) const override
 	{
 		return p_a[0] * p_b[0] + p_a[2] * p_b[2] + p_a[1] * p_b[1];
 	} // vtable+0x18
 
 	// FUNCTION: LEGO1 0x10003ba0
 	// FUNCTION: BETA10 0x100113f0
-	void EqualsImpl(float* p_data) override { memcpy(m_data, p_data, sizeof(float) * 3); } // vtable+0x20
+	void EqualsImpl(const float* p_data) override { memcpy(m_data, p_data, sizeof(float) * 3); } // vtable+0x20
 
 	// FUNCTION: LEGO1 0x10003bc0
 	// FUNCTION: BETA10 0x100114f0
@@ -346,7 +355,7 @@ public:
 	// in reverse order of appearance.
 
 	// FUNCTION: LEGO1 0x10002a40
-	virtual void SetMatrixProduct(float* p_vec, float* p_mat)
+	virtual void SetMatrixProduct(const float* p_vec, const float* p_mat)
 	{
 		m_data[0] = p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] + p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
 		m_data[1] = p_vec[0] * p_mat[1] + p_vec[1] * p_mat[5] + p_vec[2] * p_mat[9] + p_vec[4] * p_mat[13];
@@ -355,15 +364,18 @@ public:
 	} // vtable+0x8c
 
 	// FUNCTION: LEGO1 0x10002ae0
-	virtual void SetMatrixProduct(Vector4* p_a, float* p_b) { SetMatrixProduct(p_a->m_data, p_b); } // vtable+0x88
+	virtual void SetMatrixProduct(const Vector4& p_a, const float* p_b)
+	{
+		SetMatrixProduct(p_a.m_data, p_b);
+	} // vtable+0x88
 
-	inline virtual int NormalizeQuaternion();                             // vtable+0x90
-	inline virtual int EqualsHamiltonProduct(Vector4* p_a, Vector4* p_b); // vtable+0x94
+	inline virtual int NormalizeQuaternion();                                         // vtable+0x90
+	inline virtual int EqualsHamiltonProduct(const Vector4& p_a, const Vector4& p_b); // vtable+0x94
 
 	// Vector3 overrides
 
 	// FUNCTION: LEGO1 0x10002870
-	void AddImpl(float* p_value) override
+	void AddImpl(const float* p_value) override
 	{
 		m_data[0] += p_value[0];
 		m_data[1] += p_value[1];
@@ -381,7 +393,7 @@ public:
 	} // vtable+0x00
 
 	// FUNCTION: LEGO1 0x100028f0
-	void SubImpl(float* p_value) override
+	void SubImpl(const float* p_value) override
 	{
 		m_data[0] -= p_value[0];
 		m_data[1] -= p_value[1];
@@ -390,7 +402,7 @@ public:
 	} // vtable+0x08
 
 	// FUNCTION: LEGO1 0x10002930
-	void MulImpl(float* p_value) override
+	void MulImpl(const float* p_value) override
 	{
 		m_data[0] *= p_value[0];
 		m_data[1] *= p_value[1];
@@ -417,13 +429,13 @@ public:
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x100029f0
-	float DotImpl(float* p_a, float* p_b) const override
+	float DotImpl(const float* p_a, const float* p_b) const override
 	{
 		return p_a[0] * p_b[0] + p_a[2] * p_b[2] + (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
 	} // vtable+0x18
 
 	// FUNCTION: LEGO1 0x10002a20
-	void EqualsImpl(float* p_data) override { memcpy(m_data, p_data, sizeof(float) * 4); } // vtable+0x20
+	void EqualsImpl(const float* p_data) override { memcpy(m_data, p_data, sizeof(float) * 4); } // vtable+0x20
 
 	// FUNCTION: LEGO1 0x10002b00
 	void Clear() override { memset(m_data, 0, sizeof(float) * 4); } // vtable+0x2c
@@ -468,7 +480,7 @@ inline int Vector4::NormalizeQuaternion()
 	return -1;
 }
 
-inline static float QuaternionProductScalarPart(float* bDat, float* aDat)
+inline static float QuaternionProductScalarPart(const float* bDat, const float* aDat)
 {
 	// We have no indication from the beta that this function exists,
 	// but it helps with the stack layout of Vector4::EqualsHamiltonProduct()
@@ -477,15 +489,15 @@ inline static float QuaternionProductScalarPart(float* bDat, float* aDat)
 
 // FUNCTION: LEGO1 0x10002bf0
 // FUNCTION: BETA10 0x10048c20
-inline int Vector4::EqualsHamiltonProduct(Vector4* p_a, Vector4* p_b)
+inline int Vector4::EqualsHamiltonProduct(const Vector4& p_a, const Vector4& p_b)
 {
-	m_data[3] = QuaternionProductScalarPart(p_a->m_data, p_b->m_data);
+	m_data[3] = QuaternionProductScalarPart(p_a.m_data, p_b.m_data);
 
-	Vector3::EqualsCrossImpl(p_a->m_data, p_b->m_data);
+	Vector3::EqualsCrossImpl(p_a.m_data, p_b.m_data);
 
-	m_data[0] = p_b->m_data[3] * p_a->m_data[0] + p_a->m_data[3] * p_b->m_data[0] + m_data[0];
-	m_data[1] = p_b->m_data[1] * p_a->m_data[3] + p_a->m_data[1] * p_b->m_data[3] + m_data[1];
-	m_data[2] = p_b->m_data[2] * p_a->m_data[3] + p_a->m_data[2] * p_b->m_data[3] + m_data[2];
+	m_data[0] = p_b.m_data[3] * p_a.m_data[0] + p_a.m_data[3] * p_b.m_data[0] + m_data[0];
+	m_data[1] = p_b.m_data[1] * p_a.m_data[3] + p_a.m_data[1] * p_b.m_data[3] + m_data[1];
+	m_data[2] = p_b.m_data[2] * p_a.m_data[3] + p_a.m_data[2] * p_b.m_data[3] + m_data[2];
 
 	return 0;
 }

--- a/LEGO1/viewmanager/viewmanager.cpp
+++ b/LEGO1/viewmanager/viewmanager.cpp
@@ -435,10 +435,10 @@ void ViewManager::UpdateViewTransformations()
 		y = a;
 		y -= b;
 
-		normal.EqualsCross(&x, &y);
+		normal.EqualsCross(x, y);
 		normal.Unitize();
 
-		frustum_planes[i][3] = -normal.Dot(&normal, &a);
+		frustum_planes[i][3] = -normal.Dot(normal, a);
 	}
 
 	flags |= c_bit4;


### PR DESCRIPTION
The overload mechanism for the multiplication implementation is in all likelihood a reference vs pointer. `roadmap` results for the beginning of `Helicopter` and subsequent vector functions:

```
0001:00000e60   0001:00000e60          0  fun  259     Helicopter::Helicopter
0001:00000f70   0001:00000f70          0  fun  3       MxCore::Tickle
0001:00000f80   0001:00000f80          0  fun  29      Vector2::AddImpl
0001:00000fa0   0001:00000fa0          0  fun  28      Vector2::AddImpl
0001:00000fc0   0001:00000fc0          0  fun  29      Vector2::SubImpl
0001:00000fe0   0001:00000fe0          0  fun  29      Vector2::MulImpl
0001:00001000   0001:00001000          0  fun  28      Vector2::MulImpl
0001:00001020   0001:00001020          0  fun  28      Vector2::DivImpl
0001:00001040   0001:00001040          0  fun  23      Vector2::DotImpl
0001:00001060   0001:00001060          0  fun  10      Vector2::SetData
0001:00001070   0001:00001070          0  fun  20      Vector2::EqualsImpl
0001:00001090   0001:00001090          0  fun  4       Vector2::GetData
0001:000010a0   0001:000010a0          0  fun  4       Vector2::GetData
0001:000010b0   0001:000010b0          0  fun  17      Vector2::Clear
0001:000010d0   0001:000010d0          0  fun  18      Vector2::Dot
0001:000010f0   0001:000010f0          0  fun  24      Vector2::Dot
0001:00001110   0001:00001110          0  fun  21      Vector2::Dot
0001:00001130   0001:00001130          0  fun  21      Vector2::Dot
0001:00001150   0001:00001150          0  fun  16      Vector2::LenSquared
0001:00001160   0001:00001160          0  fun  81      Vector2::Unitize
0001:000011c0   0001:000011c0          0  fun  12      Vector2::Add
0001:000011d0   0001:000011d0          0  fun  13      Vector2::Add
0001:000011e0   0001:000011e0          0  fun  16      Vector2::Add
0001:000011f0   0001:000011f0          0  fun  13      Vector2::Sub
0001:00001200   0001:00001200          0  fun  16      Vector2::Sub
0001:00001210   0001:00001210          0  fun  13      Vector2::Mul
0001:00001220   0001:00001220          0  fun  16      Vector2::Mul
0001:00001230   0001:00001230          0  fun  13      Vector2::Mul
0001:00001240   0001:00001240          0  fun  13      Vector2::Div
0001:00001250   0001:00001250          0  fun  13      Vector2::SetVector
0001:00001260   0001:00001260          0  fun  16      Vector2::SetVector
0001:00001270   0001:00001270          0  fun  68      Vector3::EqualsCrossImpl
0001:000012c0   0001:000012c0          0  fun  24      Vector3::EqualsCross
0001:000012e0   0001:000012e0          0  fun  21      Vector3::EqualsCross
0001:00001300   0001:00001300          0  fun  21      Vector3::EqualsCross
```

`Vector4` and `Matrix4` functions appear in odd order after that - still trying to figure that out.