### PR TITLE
Some tweaks to `LegoCharacterManager`

### DIFF
--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -67,7 +67,7 @@ public:
 	void ReleaseActor(const char* p_name);
 	void ReleaseActor(LegoROI* p_roi);
 	void ReleaseAutoROI(LegoROI* p_roi);
-	MxBool FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_textureInfo);
+	MxBool FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_texture);
 	LegoExtraActor* GetExtraActor(const char* p_name);
 	LegoActorInfo* GetActorInfo(const char* p_name);
 	LegoActorInfo* GetActorInfo(LegoROI* p_roi);


### PR DESCRIPTION
- `GetActorROI` used `operator==` and a `const_iterator`. I'm thinking about ways we can identify blocks of these template functions all at once in BETA10 because many have identical structures. (In Ghidra, use Search > For Matching Instructions > Exclude Operands).
- `FindChildROI` has the iterator constructed outside of the loop.
- Beta shows that many functions here have an unnecessary final `else`.
- `FUN_100849a0`: Arg name `p_texture` confirmed by assert.

The next thing I want to try is separating the first entry of `g_actorLODs` from the rest of the list. The loop in `LegoCharacterManager::SwitchColor` suggests that this may be correct in the beta.