### PR TITLE
Add `MXIOINFO::CreateChunk`

### DIFF
--- a/LEGO1/omni/include/mxio.h
+++ b/LEGO1/omni/include/mxio.h
@@ -29,6 +29,7 @@ public:
 	MxU16 Advance(MxU16);
 	MxU16 Descend(MMCKINFO*, const MMCKINFO*, MxU16);
 	MxU16 Ascend(MMCKINFO*, MxU16);
+	MxU16 CreateChunk(MMCKINFO* p_chunkInfo, MxU16 p_create);
 
 	// NOTE: In MXIOINFO, the `hmmio` member of MMIOINFO is used like
 	// an HFILE (int) instead of an HMMIO (WORD).


### PR DESCRIPTION
Another beta-only function that is never called. I have to assume this file was shared with other internal Mindscape tools for writing data.

I got the name for this function (and other things) from the mmio pages on Microsoft's site. https://learn.microsoft.com/en-us/windows/win32/api/mmiscapi/nf-mmiscapi-mmiocreatechunk

I also went through and added the `MMSYSERR_NOERROR` macro (replacing `0`), also referenced in those doc pages.