### PR TITLE
introduce Docker as a compilation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ cmake <path-to-source> -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 If you have a CMake-compatible IDE, it should be pretty straightforward to use this repository, as long as you can use `VCVARS32.BAT` and set the generator to `NMake Makefiles`.
 
+### Docker
+
+Alternatively, we support Docker as a method of compilation. This is ideal for users on Linux and macOS who do not wish to manually configure a Wine environment for compiling this project.
+
+Compilation should be as simple as configuring and running the following command:
+
+```
+docker run -d \
+	-e CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=RelWithDebInfo" \
+	-v <path-to-source>:/isle:rw \
+	-v <build-folder>:/build:rw \
+	ghcr.io/isledecomp/isle:latest
+```
+
+`<path-to-source>` should be replaced with the path to the source code directory (ie: the root of this repository).
+`<build-folder>` should be replaced with the path to the build folder you'd like CMake to use during compilation.
+
+You can pass as many CMake flags as you'd like in the `CMAKE_FLAGS` environment variable, but the default configuration provided in the command is already ideal for building highly-accurate binaries.
+
 ## Usage
 
 The simplest way to use the recompiled binaries is to swap the original executables (`ISLE.EXE`, `LEGO1.DLL`, and `CONFIG.EXE`) in LEGO Island's installation directory for the ones that you've built from this source code. By default, LEGO Island is installed to `C:\Program Files\LEGO Island` on 32-bit operating systems and `C:\Program Files (x86)\LEGO Island` on 64-bit operating systems.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:latest
+
+# Gather dependencies
+RUN dpkg --add-architecture i386
+RUN apt-get update -y
+RUN apt-get install git wine wine64 wine32 wget unzip -y
+
+# Silence debug warnings in wine (creates noise during compile)
+RUN export WINEDEBUG=-all
+
+# Set up the wineprefix
+RUN wine wineboot
+
+# Set up MSVC 4.20 and CMake for Windows
+RUN git clone https://github.com/itsmattkc/MSVC420 ~/.wine/drive_c/msvc
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.26.6/cmake-3.26.6-windows-i386.zip
+RUN unzip cmake-3.26.6-windows-i386.zip -d ~/.wine/drive_c
+RUN mv ~/.wine/drive_c/cmake-3.26.6-windows-i386 ~/.wine/drive_c/cmake
+RUN rm cmake-3.26.6-windows-i386.zip
+
+# Set up entrypoint script to perform the build
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Populate the Windows path inside of the wineprefix
+# TODO: This is in here because writing to the registry seems
+# to fail when performed in the Dockerfile itself; investigate
+wine reg ADD 'HKCU\Environment' /v PATH /d 'C:\msvc\bin;C:\msvc\bin\winnt;C:\cmake\bin;C:\windows\system32' /f
+wine reg ADD 'HKCU\Environment' /v INCLUDE /d 'C:\msvc\include;C:\msvc\mfc\include' /f
+wine reg ADD 'HKCU\Environment' /v LIB /d 'C:\msvc\lib;C:\msvc\mfc\lib' /f
+wine reg ADD 'HKCU\Environment' /v TMP /d 'Z:\build' /f
+wine reg ADD 'HKCU\Environment' /v TEMP /d 'Z:\build' /f
+
+# Configure build with CMake
+wine cmake -B build isle -G "NMake Makefiles" $CMAKE_FLAGS
+
+# Start compiling LEGO Island
+wine cmake --build build
+
+# Unlock directories
+chmod -R 777 isle build


### PR DESCRIPTION
I frequently get asked if it's possible to build the project on Linux and macOS hosts. It always has been possible; many contributors have used and do use a workflow with Wine on non-Windows platforms, but the manual configuration for this setup has never been officially documented and is a bit cumbersome. I've been thinking about ways to address this over the course of the project, but I haven't sat down and fleshed it out until now.

This PR introduces Docker as a method of compilation. I've written a `Dockerfile` and accompanying shell script to create a Docker image that has MSVC 4.20 and CMake pre-configured properly with Wine under Debian. I've already built the image and pushed it to `ghcr.io` under our organization, so all end users have to do to build the project under Linux and macOS hosts is to use our provided `docker run` command, where they can simply pass paths and CMake flags to the container.

Let me know if anyone has any objections or questions!