### PR TITLE
Add smack functions and math globals

### DIFF
--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -639,6 +639,15 @@
 // GLOBAL: LEGO1 0x101028da
 // __OP_POWjmptab
 
+// GLOBAL: LEGO1 0x1010292a
+// __OP_LOG10jmptab
+
+// GLOBAL: LEGO1 0x1010294a
+// __OP_LOGjmptab
+
+// GLOBAL: LEGO1 0x1010296a
+// __OP_EXPjmptab
+
 // GLOBAL: LEGO1 0x101095f8
 // __crtheap
 

--- a/LEGO1/library_smack.h
+++ b/LEGO1/library_smack.h
@@ -12,6 +12,13 @@
 // LIBRARY: BETA10 0x1015fe83
 // _SmackDoFrameToBuffer
 
+// LIBRARY: LEGO1 0x100cea58
+// LIBRARY: BETA10 0x10160e58
+// _SmackDoFrameToVESA
+
+// LIBRARY: LEGO1 0x100cfd90
+// _SmackDoPCM
+
 // LIBRARY: LEGO1 0x100d052c
 // LIBRARY: BETA10 0x1016292c
 // _SmackGetSizeDeltas
@@ -19,5 +26,8 @@
 // LIBRARY: LEGO1 0x100d0543
 // LIBRARY: BETA10 0x10162943
 // _SmackGetRect
+
+// LIBRARY: LEGO1 0x100d0654
+// _SmackRemapTables
 
 #endif


### PR DESCRIPTION
This PR increases the coverage on LEGO1 for some unused functions. Also, the end of `_SmackDoFrameToBuffer` was misdetected, now the match is better. I got some of the matches by importing `smack.lib` into Ghidra (not shared at the moment). Note that `smack.lib` does not use `INT3` to fill unreachable code segments, but an odd alternation of
```asm
xchg ebx, ebx
xchg ecx, ecx
```
which we also see in some parts of LEGO1. I am still quite suprised that the smack code does not match perfectly, but maybe we don't have the correct version? This would be out of the scope of this PR.