### PR TITLE
Refactor surrounding `MxDSChunk` utility functions

### DIFF
--- a/LEGO1/omni/include/mxdsbuffer.h
+++ b/LEGO1/omni/include/mxdsbuffer.h
@@ -68,7 +68,7 @@ public:
 	// FUNCTION: BETA10 0x10148c60
 	MxU8* GetBuffer() { return m_pBuffer; }
 
-	MxU8** GetBufferRef() { return &m_pBuffer; }
+	// FUNCTION: BETA10 0x10164240
 	undefined4 GetUnknown14() { return m_unk0x14; }
 
 	// FUNCTION: BETA10 0x10156420
@@ -85,7 +85,10 @@ public:
 
 	void SetUnknown14(undefined4 p_unk0x14) { m_unk0x14 = p_unk0x14; }
 	void SetUnknown1c(undefined4 p_unk0x1c) { m_unk0x1c = p_unk0x1c; }
+
+	// FUNCTION: BETA10 0x10164260
 	void SetMode(Type p_mode) { m_mode = p_mode; }
+
 	void SetUnk30(MxDSStreamingAction* p_unk0x30) { m_unk0x30 = p_unk0x30; }
 
 	// SYNTHETIC: LEGO1 0x100c6510

--- a/LEGO1/omni/include/mxdschunk.h
+++ b/LEGO1/omni/include/mxdschunk.h
@@ -35,10 +35,12 @@ public:
 	}
 
 	static MxU32 GetHeaderSize();
-	static MxU32* IntoType(MxU8* p_buffer) { return (MxU32*) p_buffer; }
-	static MxU32* IntoLength(MxU8* p_buffer) { return (MxU32*) (p_buffer + 4); }
-	static MxU32 Size(MxU32 p_dataSize) { return (p_dataSize & 1) + p_dataSize + 8; }
-	static MxU8* End(MxU8* p_buffer) { return p_buffer + Size(*IntoLength(p_buffer)); }
+
+	// FUNCTION: BETA10 0x101641f0
+	static MxU32 Size(MxU8* p_buffer) { return (*(MxU32*) (p_buffer + 4) & 1) + *(MxU32*) (p_buffer + 4) + 8; }
+
+	// FUNCTION: BETA10 0x10164220
+	static MxU8* End(MxU8* p_buffer) { return p_buffer + Size(p_buffer); }
 
 	void SetChunkFlags(MxU16 p_flags) { m_flags = p_flags; }
 	void SetObjectId(undefined4 p_objectid) { m_objectId = p_objectid; }

--- a/LEGO1/omni/include/mxdsstreamingaction.h
+++ b/LEGO1/omni/include/mxdsstreamingaction.h
@@ -31,17 +31,39 @@ public:
 	void SetInternalAction(MxDSAction* p_dsAction);
 	void FUN_100cd2d0();
 
+	// FUNCTION: BETA10 0x10156530
 	MxU32 GetUnknown94() { return m_unk0x94; }
+
+	// FUNCTION: BETA10 0x10156380
 	MxS32 GetUnknown9c() { return m_unk0x9c; }
+
+	// FUNCTION: BETA10 0x10156630
 	MxDSBuffer* GetUnknowna0() { return m_unk0xa0; }
+
+	// FUNCTION: BETA10 0x101563d0
 	MxDSBuffer* GetUnknowna4() { return m_unk0xa4; }
+
+	// FUNCTION: BETA10 0x10159190
 	MxLong GetUnknowna8() { return m_unk0xa8; }
+
 	MxDSAction* GetInternalAction() { return m_internalAction; }
+
+	// FUNCTION: BETA10 0x10156580
 	MxU32 GetBufferOffset() { return m_bufferOffset; }
+
+	// FUNCTION: BETA10 0x10156550
 	void SetUnknown94(MxU32 p_unk0x94) { m_unk0x94 = p_unk0x94; }
+
+	// FUNCTION: BETA10 0x101563a0
 	void SetUnknown9c(MxS32 p_unk0x9c) { m_unk0x9c = p_unk0x9c; }
+
+	// FUNCTION: BETA10 0x10156470
 	void SetUnknowna0(MxDSBuffer* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
+
+	// FUNCTION: BETA10 0x101563f0
 	void SetUnknowna4(MxDSBuffer* p_unk0xa4) { m_unk0xa4 = p_unk0xa4; }
+
+	// FUNCTION: BETA10 0x10151150
 	void SetBufferOffset(MxU32 p_bufferOffset) { m_bufferOffset = p_bufferOffset; }
 
 	// FUNCTION: BETA10 0x10156650

--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -491,6 +491,7 @@ MxU8* MxDSBuffer::FUN_100c6fa0(MxU8* p_data)
 }
 
 // FUNCTION: LEGO1 0x100c7090
+// FUNCTION: BETA10 0x1015842d
 MxResult MxDSBuffer::FUN_100c7090(MxDSBuffer* p_buf)
 {
 	MxResult result = FAILURE;

--- a/LEGO1/omni/src/stream/mxstreamchunk.cpp
+++ b/LEGO1/omni/src/stream/mxstreamchunk.cpp
@@ -96,6 +96,7 @@ MxU32* MxStreamChunk::IntoObjectId(MxU8* p_buffer)
 }
 
 // FUNCTION: LEGO1 0x100c31a0
+// FUNCTION: BETA10 0x10151626
 MxLong* MxStreamChunk::IntoTime(MxU8* p_buffer)
 {
 	return (MxLong*) (p_buffer + 0x0e);


### PR DESCRIPTION
Specifically: the functions `IntoType` and `IntoLength` from the `MxDSChunk` header. They seek a pointer into the right place when reading the chunk, but the beta shows they are not used. The `Size` and `End` functions are used, but they are different from what we had.

These two functions are users of the utility functions:
- `MxDiskStreamProvider::FUN_100d1b20` now 100%
- `ReadData` (from `MxRAMStreamProvider`) still 100% but with entropy

I'm not sure why, but this has also caused us to jump from 141 to 432 functions aligned. It may just be chance, but these two runs of functions now line up:

```
0001:0000b110          0  fun  103     MxEntity::~MxEntity
to
0001:00012c40          0  fun  458     LegoJetski::HitActor

and

0001:00016650          0  fun  390     CarRace::HandleClick
to
0001:00016da0          0  fun  215     PizzeriaState::Serialize
```
