### PR TITLE
Beta match `MxDSStreamingAction`

### DIFF
--- a/LEGO1/omni/include/mxdsstreamingaction.h
+++ b/LEGO1/omni/include/mxdsstreamingaction.h
@@ -6,6 +6,7 @@
 class MxDSBuffer;
 
 // VTABLE: LEGO1 0x100dd088
+// VTABLE: BETA10 0x101c2850
 // SIZE 0xb4
 class MxDSStreamingAction : public MxDSAction {
 public:
@@ -14,20 +15,10 @@ public:
 	~MxDSStreamingAction() override;
 
 	MxDSStreamingAction* CopyFrom(MxDSStreamingAction& p_dsStreamingAction);
-	MxDSStreamingAction& operator=(MxDSAction& p_dsAction)
-	{
-		MxDSAction::operator=(p_dsAction);
-		return *this;
-	}
-	MxDSStreamingAction& operator=(MxDSStreamingAction& p_dsStreamingAction)
-	{
-		MxDSAction::operator=(p_dsStreamingAction);
-		return *this;
-	}
 
-	MxBool HasId(MxU32 p_objectId) override; // vtable+34;
+	MxBool HasId(MxU32 p_objectId) override; // vtable+0x34;
 
-	MxResult Init();
+	void Init();
 	void SetInternalAction(MxDSAction* p_dsAction);
 	void FUN_100cd2d0();
 
@@ -70,6 +61,7 @@ public:
 	void ClearUnknowna0() { m_unk0xa0 = NULL; }
 
 	// SYNTHETIC: LEGO1 0x100cd0b0
+	// SYNTHETIC: BETA10 0x101565f0
 	// MxDSStreamingAction::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/src/action/mxdsstreamingaction.cpp
+++ b/LEGO1/omni/src/action/mxdsstreamingaction.cpp
@@ -10,7 +10,7 @@ MxDSStreamingAction::MxDSStreamingAction(MxDSAction& p_dsAction, MxU32 p_offset)
 {
 	Init();
 
-	*(MxDSAction*) this = p_dsAction;
+	MxDSAction::operator=(p_dsAction);
 	m_unk0x94 = p_offset;
 	m_bufferOffset = p_offset;
 }
@@ -63,7 +63,7 @@ void MxDSStreamingAction::Init()
 // FUNCTION: BETA10 0x1015f5b9
 MxDSStreamingAction* MxDSStreamingAction::CopyFrom(MxDSStreamingAction& p_dsStreamingAction)
 {
-	*(MxDSAction*) this = p_dsStreamingAction;
+	MxDSAction::operator=(p_dsStreamingAction);
 	m_unk0x94 = p_dsStreamingAction.m_unk0x94;
 	m_bufferOffset = p_dsStreamingAction.m_bufferOffset;
 	m_unk0x9c = p_dsStreamingAction.m_unk0x9c;

--- a/LEGO1/omni/src/action/mxdsstreamingaction.cpp
+++ b/LEGO1/omni/src/action/mxdsstreamingaction.cpp
@@ -5,25 +5,25 @@
 DECOMP_SIZE_ASSERT(MxDSStreamingAction, 0xb4)
 
 // FUNCTION: LEGO1 0x100cd010
+// FUNCTION: BETA10 0x1015f380
 MxDSStreamingAction::MxDSStreamingAction(MxDSAction& p_dsAction, MxU32 p_offset)
 {
 	Init();
 
-	*this = p_dsAction;
-	this->m_unk0x94 = p_offset;
-	this->m_bufferOffset = p_offset;
+	*(MxDSAction*) this = p_dsAction;
+	m_unk0x94 = p_offset;
+	m_bufferOffset = p_offset;
 }
 
 // FUNCTION: LEGO1 0x100cd090
+// FUNCTION: BETA10 0x101565a0
 MxBool MxDSStreamingAction::HasId(MxU32 p_objectId)
 {
-	if (this->m_internalAction) {
-		return this->m_internalAction->HasId(p_objectId);
-	}
-	return FALSE;
+	return m_internalAction ? m_internalAction->HasId(p_objectId) : FALSE;
 }
 
 // FUNCTION: LEGO1 0x100cd0d0
+// FUNCTION: BETA10 0x101564a0
 MxDSStreamingAction::MxDSStreamingAction(MxDSStreamingAction& p_dsStreamingAction)
 {
 	Init();
@@ -31,68 +31,71 @@ MxDSStreamingAction::MxDSStreamingAction(MxDSStreamingAction& p_dsStreamingActio
 }
 
 // FUNCTION: LEGO1 0x100cd150
+// FUNCTION: BETA10 0x1015f41d
 MxDSStreamingAction::~MxDSStreamingAction()
 {
-	if (this->m_unk0xa0) {
-		delete this->m_unk0xa0;
+	if (m_unk0xa0) {
+		delete m_unk0xa0;
 	}
-	if (this->m_unk0xa4) {
-		delete this->m_unk0xa4;
+	if (m_unk0xa4) {
+		delete m_unk0xa4;
 	}
-	if (this->m_internalAction) {
-		delete this->m_internalAction;
+	if (m_internalAction) {
+		delete m_internalAction;
 	}
 }
 
 // FUNCTION: LEGO1 0x100cd1e0
-MxResult MxDSStreamingAction::Init()
+// FUNCTION: BETA10 0x1015f53c
+void MxDSStreamingAction::Init()
 {
-	this->m_unk0x94 = 0;
-	this->m_bufferOffset = 0;
-	this->m_unk0x9c = 0;
-	this->m_unk0xa0 = NULL;
-	this->m_unk0xa4 = NULL;
-	this->m_unk0xa8 = 0;
-	this->m_unk0xac = 2;
-	this->m_internalAction = NULL;
-	return SUCCESS;
+	m_unk0x94 = 0;
+	m_bufferOffset = 0;
+	m_unk0x9c = 0;
+	m_unk0xa0 = NULL;
+	m_unk0xa4 = NULL;
+	m_unk0xa8 = 0;
+	m_unk0xac = 2;
+	m_internalAction = NULL;
 }
 
 // FUNCTION: LEGO1 0x100cd220
+// FUNCTION: BETA10 0x1015f5b9
 MxDSStreamingAction* MxDSStreamingAction::CopyFrom(MxDSStreamingAction& p_dsStreamingAction)
 {
-	*this = p_dsStreamingAction;
-	this->m_unk0x94 = p_dsStreamingAction.m_unk0x94;
-	this->m_bufferOffset = p_dsStreamingAction.m_bufferOffset;
-	this->m_unk0x9c = p_dsStreamingAction.m_unk0x9c;
-	this->m_unk0xa0 = NULL;
-	this->m_unk0xa4 = NULL;
-	this->m_unk0xac = p_dsStreamingAction.m_unk0xac;
-	this->m_unk0xa8 = p_dsStreamingAction.m_unk0xa8;
+	*(MxDSAction*) this = p_dsStreamingAction;
+	m_unk0x94 = p_dsStreamingAction.m_unk0x94;
+	m_bufferOffset = p_dsStreamingAction.m_bufferOffset;
+	m_unk0x9c = p_dsStreamingAction.m_unk0x9c;
+	m_unk0xa0 = NULL;
+	m_unk0xa4 = NULL;
+	m_unk0xac = p_dsStreamingAction.m_unk0xac;
+	m_unk0xa8 = p_dsStreamingAction.m_unk0xa8;
 	SetInternalAction(p_dsStreamingAction.m_internalAction ? p_dsStreamingAction.m_internalAction->Clone() : NULL);
 
 	return this;
 }
 
 // FUNCTION: LEGO1 0x100cd2a0
+// FUNCTION: BETA10 0x1015f698
 void MxDSStreamingAction::SetInternalAction(MxDSAction* p_dsAction)
 {
-	if (this->m_internalAction) {
-		delete this->m_internalAction;
+	if (m_internalAction) {
+		delete m_internalAction;
 	}
-	this->m_internalAction = p_dsAction;
+	m_internalAction = p_dsAction;
 }
 
 // FUNCTION: LEGO1 0x100cd2d0
 void MxDSStreamingAction::FUN_100cd2d0()
 {
-	if (this->m_duration == -1) {
+	if (m_duration == -1) {
 		return;
 	}
 
-	MxLong duration = this->m_duration / this->m_loopCount;
-	this->m_loopCount--;
+	MxLong duration = m_duration / m_loopCount;
+	m_loopCount--;
 
-	this->m_duration -= duration;
-	this->m_unk0xa8 += duration;
+	m_duration -= duration;
+	m_unk0xa8 += duration;
 }


### PR DESCRIPTION
Removed `this->` and added beta addresses. `Init()` can be void and still use `xor eax, eax` to null out all members.

The beta shows that the `MxDSAction` version of `operator=` is used instead of one from `MxDSStreamingAction`, so I have this as `*(MxDSAction*) this = ...`. Is that syntax okay?