### PR TITLE
`LegoWorld::Add` to 100%

### DIFF
--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -184,7 +184,8 @@ protected:
 // TEMPLATE: LEGO1 0x10020b20
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::iterator::_Dec
 
-// XTEMPLATE LEGO1 0x10020b70
+// TEMPLATE: LEGO1 0x10020b70
+// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::lower_bound
 
 // TEMPLATE: LEGO1 0x10020bb0
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Buynode


### PR DESCRIPTION
Resolves #1322.

The main thing was swapping `!set.empty()` for `set.size() != 0` and pulling an iterator out into its own variable. The rest is just rearranging things around beta doing an early return.

The diff on `AddPath` is from entropy. I'm not sure what's wrong with `Enable` but it looks okay in the beta. I changed `Remove` around but accuracy is still 100%.