### PR TITLE
Implement/match `LegoWorld::ActorExists`

### DIFF
--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -138,6 +138,9 @@ public:
 		MxFloat& p_param5
 	);
 
+	// FUNCTION: BETA10 0x100e0160
+	MxBool ActorExists(LegoPathActor* p_actor) { return m_actors.find(p_actor) == m_actors.end() ? FALSE : TRUE; }
+
 	static MxResult Init();
 	static MxResult Reset();
 

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -101,6 +101,7 @@ public:
 		Vector3& p_direction
 	);
 	void RemoveActor(LegoPathActor* p_actor);
+	MxBool ActorExists(LegoPathActor* p_actor);
 	void FUN_1001fda0(LegoAnimPresenter* p_presenter);
 	void FUN_1001fe90(LegoAnimPresenter* p_presenter);
 	LegoPathBoundary* FindPathBoundary(const char* p_name);

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -334,6 +334,21 @@ void LegoWorld::RemoveActor(LegoPathActor* p_actor)
 	}
 }
 
+// FUNCTION: BETA10 0x100da560
+MxBool LegoWorld::ActorExists(LegoPathActor* p_actor)
+{
+	LegoPathControllerListCursor cursor(&m_list0x68);
+	LegoPathController* controller;
+
+	while (cursor.Next(controller)) {
+		if (controller->ActorExists(p_actor) == TRUE) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
 // FUNCTION: LEGO1 0x1001fda0
 // FUNCTION: BETA10 0x100da621
 void LegoWorld::FUN_1001fda0(LegoAnimPresenter* p_presenter)


### PR DESCRIPTION
This fixes the order of symbols in `LegoWorld` around `LegoWorld::RemoveActor`.

```
0001:0001ea70   0001:0001ea60        -16  fun  249     LegoWorld::PlaceActor
0001:0001eb70   0001:0001eb60        -16  fun  263     LegoWorld::PlaceActor
0001:0001ec80   0001:0001ec70        -16  fun  227     LegoWorld::RemoveActor
0001:0001ed70   0001:0001ed60        -16  fun  45      _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Lbound
0001:0001eda0   0001:0001ed90        -16  fun  225     LegoWorld::FUN_1001fda0
0001:0001ee90   0001:0001ee80        -16  fun  225     LegoWorld::FUN_1001fe90
0001:0001ef80   0001:0001ef70        -16  fun  152     LegoWorld::AddPath
```