### PR TITLE
Refactor diffs in the pipeline, part 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,10 +149,9 @@ jobs:
         curl -fLSs -o ISLEPROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/ISLEPROGRESS.json || echo "" >ISLEPROGRESS-old.json
         curl -fLSs -o LEGO1PROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/LEGO1PROGRESS.json || echo "" >LEGO1PROGRESS-old.json
 
-# Disabled until one build has been created - will fail otherwise        
-#        reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-old.json
-#        reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json
-#        reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json
+        reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-old.json
+        reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json
+        reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json
 
     - name: Test Exports
       shell: bash
@@ -187,7 +186,7 @@ jobs:
     needs: [build, compare]
     runs-on: ubuntu-latest
 #     FIXME: CHANGED TEMPORARILY FOR TESTING PURPOSES, CHANGE BACK
-#     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -215,6 +214,6 @@ jobs:
           ISLEPROGRESS.* \
           LEGO1PROGRESS.*
 
-#        curl -X POST -F key=$UPLOAD_KEY -F 'file=@CONFIGPROGRESS.SVG' https://legoisland.org/progress/
-#        curl -X POST -F key=$UPLOAD_KEY -F 'file=@ISLEPROGRESS.SVG' https://legoisland.org/progress/
-#        curl -X POST -F key=$UPLOAD_KEY -F 'file=@LEGO1PROGRESS.SVG' https://legoisland.org/progress/
+        curl -X POST -F key=$UPLOAD_KEY -F 'file=@CONFIGPROGRESS.SVG' https://legoisland.org/progress/
+        curl -X POST -F key=$UPLOAD_KEY -F 'file=@ISLEPROGRESS.SVG' https://legoisland.org/progress/
+        curl -X POST -F key=$UPLOAD_KEY -F 'file=@LEGO1PROGRESS.SVG' https://legoisland.org/progress/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,21 +137,22 @@ jobs:
     - name: Summarize Accuracy
       shell: bash
       run: |
-        reccmp-reccmp -S CONFIGPROGRESS.SVG --svg-icon assets/config.png --target CONFIG | tee CONFIGPROGRESS.TXT
-        reccmp-reccmp -S ISLEPROGRESS.SVG --svg-icon assets/isle.png --target ISLE | tee ISLEPROGRESS.TXT
-        reccmp-reccmp -S LEGO1PROGRESS.SVG --svg-icon assets/lego1.png --target LEGO1 | tee LEGO1PROGRESS.TXT
+        reccmp-reccmp -S CONFIGPROGRESS.SVG --svg-icon assets/config.png --target CONFIG --json CONFIGPROGRESS.json
+        reccmp-reccmp -S ISLEPROGRESS.SVG --svg-icon assets/isle.png --target ISLE --json ISLEPROGRESS.json
+        reccmp-reccmp -S LEGO1PROGRESS.SVG --svg-icon assets/lego1.png --target LEGO1 --json LEGO1PROGRESS.json
 
     - name: Compare Accuracy With Current Master
       shell: bash
       run: |
         # Compare with current master
-        curl -fLSs -o CONFIGPROGRESS-OLD.TXT https://github.com/isledecomp/isle/releases/download/continuous/CONFIGPROGRESS.TXT || echo "" >CONFIGPROGRESS-OLD.TXT
-        curl -fLSs -o ISLEPROGRESS-OLD.TXT https://github.com/isledecomp/isle/releases/download/continuous/ISLEPROGRESS.TXT || echo "" >ISLEPROGRESS-OLD.TXT
-        curl -fLSs -o LEGO1PROGRESS-OLD.TXT https://github.com/isledecomp/isle/releases/download/continuous/LEGO1PROGRESS.TXT || echo "" >LEGO1PROGRESS-OLD.TXT
+        curl -fLSs -o CONFIGPROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/CONFIGPROGRESS.json || echo "" >CONFIGPROGRESS-old.json
+        curl -fLSs -o ISLEPROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/ISLEPROGRESS.json || echo "" >ISLEPROGRESS-old.json
+        curl -fLSs -o LEGO1PROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/LEGO1PROGRESS.json || echo "" >LEGO1PROGRESS-old.json
 
-        diff -u0 CONFIGPROGRESS-OLD.TXT CONFIGPROGRESS.TXT || true
-        diff -u0 ISLEPROGRESS-OLD.TXT ISLEPROGRESS.TXT || true
-        diff -u0 LEGO1PROGRESS-OLD.TXT LEGO1PROGRESS.TXT || true
+# Disabled until one build has been created - will fail otherwise        
+#        reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-old.json
+#        reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json
+#        reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json
 
     - name: Test Exports
       shell: bash
@@ -185,7 +186,8 @@ jobs:
     name: Upload artifacts
     needs: [build, compare]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}
+#     FIXME: CHANGED TEMPORARILY FOR TESTING PURPOSES, CHANGE BACK
+#     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -203,7 +205,7 @@ jobs:
     - name: Upload Continuous Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        UPLOAD_KEY: ${{ secrets.UPLOAD_KEY }}
+#        UPLOAD_KEY: ${{ secrets.UPLOAD_KEY }}
       run: |
         ./upload.sh \
           build/CONFIG.EXE \
@@ -213,6 +215,6 @@ jobs:
           ISLEPROGRESS.* \
           LEGO1PROGRESS.*
 
-        curl -X POST -F key=$UPLOAD_KEY -F 'file=@CONFIGPROGRESS.SVG' https://legoisland.org/progress/
-        curl -X POST -F key=$UPLOAD_KEY -F 'file=@ISLEPROGRESS.SVG' https://legoisland.org/progress/
-        curl -X POST -F key=$UPLOAD_KEY -F 'file=@LEGO1PROGRESS.SVG' https://legoisland.org/progress/
+#        curl -X POST -F key=$UPLOAD_KEY -F 'file=@CONFIGPROGRESS.SVG' https://legoisland.org/progress/
+#        curl -X POST -F key=$UPLOAD_KEY -F 'file=@ISLEPROGRESS.SVG' https://legoisland.org/progress/
+#        curl -X POST -F key=$UPLOAD_KEY -F 'file=@LEGO1PROGRESS.SVG' https://legoisland.org/progress/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,17 +144,18 @@ jobs:
     - name: Compare Accuracy With Current Master
       shell: bash
       env:
-#        RELEASE_URL: https://github.com/isledecomp/isle/releases/download/continuous
-        RELEASE_URL: https://github.com/jonschz/isle/releases/download/continuous
+        RELEASE_URL: https://github.com/isledecomp/isle/releases/download/continuous
       run: |
-        # Compare with current master
+        # Download the current master state
         curl -fLSs -o CONFIGPROGRESS-old.json $RELEASE_URL/CONFIGPROGRESS.json || echo "" >CONFIGPROGRESS-old.json
         curl -fLSs -o ISLEPROGRESS-old.json $RELEASE_URL/ISLEPROGRESS.json || echo "" >ISLEPROGRESS-old.json
         curl -fLSs -o LEGO1PROGRESS-old.json $RELEASE_URL/LEGO1PROGRESS.json || echo "" >LEGO1PROGRESS-old.json
-        # intentional typo to validate error handling        
-        reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-oldTYPO.json || echo "Current master not found"
-        reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json || echo "Current master not found"
-        reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json || echo "Current master not found"
+        
+        # Compare with current master
+        # Disabled until second PR - nothing to compare against at the moment
+        # reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-old.json || echo "Current master not found"
+        # reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json || echo "Current master not found"
+        # reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json || echo "Current master not found"
 
     - name: Test Exports
       shell: bash
@@ -188,7 +189,6 @@ jobs:
     name: Upload artifacts
     needs: [build, compare]
     runs-on: ubuntu-latest
-#     FIXME: CHANGED TEMPORARILY FOR TESTING PURPOSES, CHANGE BACK
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle' }}
     steps:
     - uses: actions/checkout@v4
@@ -207,7 +207,7 @@ jobs:
     - name: Upload Continuous Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        UPLOAD_KEY: ${{ secrets.UPLOAD_KEY }}
+        UPLOAD_KEY: ${{ secrets.UPLOAD_KEY }}
       run: |
         ./upload.sh \
           build/CONFIG.EXE \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,15 +143,18 @@ jobs:
 
     - name: Compare Accuracy With Current Master
       shell: bash
+      env:
+#        RELEASE_URL: https://github.com/isledecomp/isle/releases/download/continuous
+        RELEASE_URL: https://github.com/jonschz/isle/releases/download/continuous
       run: |
         # Compare with current master
-        curl -fLSs -o CONFIGPROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/CONFIGPROGRESS.json || echo "" >CONFIGPROGRESS-old.json
-        curl -fLSs -o ISLEPROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/ISLEPROGRESS.json || echo "" >ISLEPROGRESS-old.json
-        curl -fLSs -o LEGO1PROGRESS-old.json https://github.com/isledecomp/isle/releases/download/continuous/LEGO1PROGRESS.json || echo "" >LEGO1PROGRESS-old.json
-
-        reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-old.json
-        reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json
-        reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json
+        curl -fLSs -o CONFIGPROGRESS-old.json $RELEASE_URL/CONFIGPROGRESS.json || echo "" >CONFIGPROGRESS-old.json
+        curl -fLSs -o ISLEPROGRESS-old.json $RELEASE_URL/ISLEPROGRESS.json || echo "" >ISLEPROGRESS-old.json
+        curl -fLSs -o LEGO1PROGRESS-old.json $RELEASE_URL/LEGO1PROGRESS.json || echo "" >LEGO1PROGRESS-old.json
+        # intentional typo to validate error handling        
+        reccmp-reccmp --target CONFIG --diff CONFIGPROGRESS-oldTYPO.json || echo "Current master not found"
+        reccmp-reccmp --target ISLE --diff ISLEPROGRESS-old.json || echo "Current master not found"
+        reccmp-reccmp --target LEGO1 --diff LEGO1PROGRESS-old.json || echo "Current master not found"
 
     - name: Test Exports
       shell: bash

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -66,7 +66,7 @@ public:
 
 	RaceState();
 
-	// FUNCTION: LEGO1 0x10016010
+	// // FUNCTION: LEGO1 0x10016010
 	// FUNCTION: BETA10 0x100a9040
 	const char* ClassName() const override // vtable+0x0c
 	{

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -66,7 +66,7 @@ public:
 
 	RaceState();
 
-	// // FUNCTION: LEGO1 0x10016010
+	// FUNCTION: LEGO1 0x10016010
 	// FUNCTION: BETA10 0x100a9040
 	const char* ClassName() const override // vtable+0x0c
 	{


### PR DESCRIPTION
As discussed on https://github.com/isledecomp/reccmp/pull/76, this PR makes the pipeline use JSON diff instead of text output diff to compare the current branch to `master`. I would like to merge this change in two separate PRs - the first one generating a diff output for the second one to compare against.

Here is a successful run on my PR branch: https://github.com/jonschz/isle/actions/runs/12852523439/job/35834652699