### PR TITLE
Some improvements to `LegoGameState`

### DIFF
--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -193,7 +193,7 @@ public:
 	LegoState* GetState(const char* p_stateName);
 	LegoState* CreateState(const char* p_stateName);
 
-	void GetFileSavePath(MxString* p_outPath, MxU8 p_slotn);
+	void GetFileSavePath(MxString* p_outPath, MxS16 p_slotn);
 	void StopArea(Area p_area);
 	void SwitchArea(Area p_area);
 	void Init();

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -135,7 +135,6 @@ public:
 	// SIZE 0x0e
 	struct Username {
 		Username();
-		Username(Username& p_other) { Set(p_other); }
 		void Set(Username& p_other) { memcpy(m_letters, p_other.m_letters, sizeof(m_letters)); }
 
 		MxResult Serialize(LegoStorage* p_storage);

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -252,6 +252,7 @@ void LegoGameState::ResetROI()
 }
 
 // FUNCTION: LEGO1 0x10039980
+// FUNCTION: BETA10 0x100840e4
 MxResult LegoGameState::Save(MxULong p_slot)
 {
 	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
@@ -550,7 +551,8 @@ done:
 }
 
 // FUNCTION: LEGO1 0x1003a170
-void LegoGameState::GetFileSavePath(MxString* p_outPath, MxU8 p_slotn)
+// FUNCTION: BETA10 0x10084b45
+void LegoGameState::GetFileSavePath(MxString* p_outPath, MxS16 p_slotn)
 {
 	char baseForSlot[2] = "0";
 	char path[1024] = "";

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -624,6 +624,7 @@ MxResult LegoGameState::AddPlayer(Username& p_player)
 }
 
 // FUNCTION: LEGO1 0x1003a540
+// FUNCTION: BETA10 0x10084fc4
 void LegoGameState::SwitchPlayer(MxS16 p_playerId)
 {
 	if (p_playerId > 0) {


### PR DESCRIPTION
An attempt to solve #1337. `SwitchPlayer` is 100% but this feels like an entropy match.

The only change in that method is removing the copy constructor for `LegoGameState::Username`. The code looks like this:

```asm
; Username selectedName(m_players[p_playerId]);
; Starting at BETA10 0x10085036

; Set EAX to m_players[p_playerId]
movsx eax, word ptr [ebp + 8]    ; p_playerId
mov ecx, eax
shl eax, 3
sub eax, ecx
add eax, eax
add eax, dword ptr [ebp - 0x54]  ; "this"
add eax, 0x20

; ECX is selectedName
lea ecx, [ebp - 0x40]

; Copy 14 bytes
mov edx, dword ptr [eax]
mov dword ptr [ecx], edx
mov edx, dword ptr [eax + 4]
mov dword ptr [ecx + 4], edx
mov edx, dword ptr [eax + 8]
mov dword ptr [ecx + 8], edx
mov ax, word ptr [eax + 0xc]
mov word ptr [ecx + 0xc], ax

```

Removing the copy constructor generates this asm instead of calling the method. This alone doesn't bump the accuracy in retail, though. Instead, it was changing the param type for `GetFileSavePath` to `MxS16` and adding gotos to `ReadVariable` and `WriteVariable`.

The change to `Username` is the source of all the diff noise. Prior to that, it looked like this:

```
Increased (3):
0x1003a3f0 - LegoGameState::AddPlayer (87.25% -> 100.00%)
0x1003a540 - LegoGameState::SwitchPlayer (76.74% -> 100.00%)
0x1003bbb0 - LegoGameState::GetState (68.57% -> 100.00%)

Decreased (3):
0x10039550 - LegoGameState::LegoGameState (77.27% -> 75.76%)
0x1003c740 - LegoGameState::ScoreItem::Serialize (75.00% -> 73.86%)
0x1003c830 - LegoGameState::History::History (100.00% -> 50.00%)

Compiler entropy (1):
0x1003ba90 - LegoGameState::SetColors (100.00%* -> 100.00%)
```