### PR TITLE
Fix annotations for overloaded functions

### DIFF
--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -125,7 +125,7 @@ private:
 // _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Rrotate
 
 // TEMPLATE: LEGO1 0x1004a7a0
-// ?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z
+// ?_Construct@@YAXPAPAVLegoPathActor@@ABQAV1@@Z
 
 // TEMPLATE: LEGO1 0x10056c20
 // _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::~_Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoA

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -204,7 +204,7 @@ protected:
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::find
 
 // TEMPLATE: LEGO1 0x10022360
-// ?_Construct@@YAXPAPAVLegoPathActor@@ABQAV1@@Z
+// ?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z
 
 // GLOBAL: LEGO1 0x100f11a0
 // _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Nil

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -697,7 +697,7 @@
 // strcpy
 
 // LIBRARY: BETA10 0x100f8a88
-// operator new
+// ??2@YAPAXI@Z
 
 // LIBRARY: BETA10 0x100f9420
 // memcpy


### PR DESCRIPTION
Corrects two annotations for `_Construct` functions and points the `operator new` annotation for `BETA10` at the version that takes one argument.

These would be exposed as diffs when we merge isledecomp/reccmp#76.