### PR TITLE
Match `HistoryBook::ReadyWorld()`

### DIFF
--- a/LEGO1/lego/legoomni/include/historybook.h
+++ b/LEGO1/lego/legoomni/include/historybook.h
@@ -41,8 +41,11 @@ public:
 private:
 	LegoGameState::Area m_destLocation; // 0xf8
 	MxStillPresenter* m_alphabet[26];   // 0xfc
-	MxStillPresenter* m_names[20][7];   // 0x164
-	MxStillPresenter* m_scores[20];     // 0x394
+
+	// variable name verified by BETA10 0x1002bd27
+	MxStillPresenter* m_name[20][7]; // 0x164
+
+	MxStillPresenter* m_scores[20]; // 0x394
 };
 
 #endif // HISTORYBOOK_H

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -163,7 +163,9 @@ public:
 		// FUNCTION: BETA10 0x1002c2b0
 		MxS16 GetCount() { return m_count; }
 
-		ScoreItem* GetScore(MxS16 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
+		// TODO: Not yet correct
+		// FUNCTION: BETA10 0x1002c54
+		ScoreItem* GetScore(MxS32 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
 
 		MxS16 m_count;          // 0x00
 		ScoreItem m_scores[20]; // 0x02

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -208,7 +208,6 @@ public:
 	Act GetLoadedAct() { return m_loadedAct; }
 	Area GetPreviousArea() { return m_previousArea; }
 	Area GetUnknown0x42c() { return m_unk0x42c; }
-	History* GetHistory() { return &m_history; }
 
 	void SetDirty(MxBool p_isDirty) { m_isDirty = p_isDirty; }
 	void SetPreviousArea(Area p_previousArea) { m_previousArea = p_previousArea; }

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -164,7 +164,7 @@ public:
 		MxS16 GetCount() { return m_count; }
 
 		// TODO: Not yet correct
-		// FUNCTION: BETA10 0x1002c54
+		// FUNCTION: BETA10 0x1002c540
 		ScoreItem* GetScore(MxS32 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
 
 		MxS16 m_count;          // 0x00

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -107,9 +107,10 @@ inline void SetColor(MxStillPresenter* p_presenter, MxU8 p_color, MxU8* p_colors
 // FUNCTION: BETA10 0x1002b9b9
 void HistoryBook::ReadyWorld()
 {
+	undefined4 dummy;
+
 	LegoWorld::ReadyWorld();
-	// TODO: No GetHistory() in between for BETA10 - check order / alignment for WriteScoreHistory
-	GameState()->GetHistory()->WriteScoreHistory();
+	GameState()->m_history.WriteScoreHistory();
 
 	char bitmap[] = "A_Bitmap";
 	MxS16 i = 0;
@@ -125,8 +126,8 @@ void HistoryBook::ReadyWorld()
 		{0x76, 0x4c, 0x38}; // yellow - #FFB900, blue - #00548C, red - #CB1220, background - #CECECE, border - #74818B
 	MxS32 scoreY = 0x79;
 
-	for (i = 0; i < GameState()->GetHistory()->GetCount(); i++) {
-		LegoGameState::ScoreItem* score = GameState()->GetHistory()->GetScore(i);
+	for (i = 0; i < GameState()->m_history.GetCount(); i++) {
+		LegoGameState::ScoreItem* score = GameState()->m_history.GetScore(i);
 
 		MxStillPresenter** scorebox = &m_scores[i];
 		*scorebox = scoreboxMaster->Clone();

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -89,33 +89,19 @@ MxLong HistoryBook::Notify(MxParam& p_param)
 	return 0;
 }
 
-inline void SetColor(MxStillPresenter* p_presenter, MxU8 p_color, MxU8* p_colors, MxS32 p_x, MxS32 p_y)
-{
-	if (p_color) {
-		for (MxS32 lax = 0; lax < 4; lax++) {
-			if (p_presenter->GetAlphaMask() != NULL) {
-				memset(NULL, p_colors[p_color - 1], 4);
-			}
-			else {
-				memset(p_presenter->GetBitmap()->GetStart(p_x, p_y + lax), p_colors[p_color - 1], 4);
-			}
-		}
-	}
-}
-
 // FUNCTION: LEGO1 0x100826f0
 // FUNCTION: BETA10 0x1002b9b9
 void HistoryBook::ReadyWorld()
 {
-	undefined4 dummy1;
+	undefined4 dummy1, dummy2, dummy3;
 
 	LegoWorld::ReadyWorld();
 	GameState()->m_history.WriteScoreHistory();
 
 	char bitmap[] = "A_Bitmap";
-	MxS16 i = 0;
+	MxS16 i;
 
-	for (; i < 26; i++) {
+	for (i = 0; i < 26; i++) {
 		m_alphabet[i] = (MxStillPresenter*) Find("MxStillPresenter", bitmap);
 		assert(m_alphabet[i]);
 		bitmap[0]++;
@@ -124,13 +110,13 @@ void HistoryBook::ReadyWorld()
 	MxStillPresenter* scoreboxMaster = (MxStillPresenter*) Find("MxStillPresenter", "ScoreBox");
 	MxU8 scoreColors[3] =
 		{0x76, 0x4c, 0x38}; // yellow - #FFB900, blue - #00548C, red - #CB1220, background - #CECECE, border - #74818B
-	MxS32 scoreY = 0x79;
 
-	for (i = 0; i < GameState()->m_history.GetCount(); i++) {
+	MxS32 scoreY;
+
+	for (i = 0, scoreY = 0x79; i < GameState()->m_history.GetCount(); i++, scoreY += 0x1b) {
 		LegoGameState::ScoreItem* score = GameState()->m_history.GetScore(i);
 
-		MxStillPresenter** scorebox = &m_scores[i];
-		*scorebox = scoreboxMaster->Clone();
+		m_scores[i] = scoreboxMaster->Clone();
 
 		MxS32 scoreX = 0x90;
 		if (i >= 10) {
@@ -141,22 +127,17 @@ void HistoryBook::ReadyWorld()
 			scoreX = 0x158;
 		}
 
-		MxS32 scoreboxX = 1;
-
-		for (MxS32 scoreState = 0; scoreState < 5; scoreState++) {
-			MxS32 scoreboxY = 1;
+		for (MxS32 scoreState = 0, scoreboxX = 1; scoreState < 5; scoreState++, scoreboxX += 5) {
 
 			for (MxS32 scoreBoxColumn = 0, scoreboxY = 1; scoreBoxColumn < 5; scoreBoxColumn++, scoreboxY += 5) {
-				// SetColor(*scorebox, score->m_scores[scoreState][scoreBoxColumn], scoreColors, scoreboxX, scoreboxY);
-				// inline void SetColor(MxStillPresenter* p_presenter, MxU8 p_color, MxU8* p_colors, MxS32 p_x, MxS32 p_y)
 				MxU8 color = score->m_scores[scoreState][scoreBoxColumn];
-				// this->m_scores
+
 				if (color) {
 					for (MxS32 lax = 0; lax < 4; lax++) {
 #ifdef BETA10
 						memset(m_scores[i]->GetBitmapStart(scoreboxX, scoreboxY + lax), scoreColors[color - 1], 4);
 #else
-						if ((*scorebox)->GetAlphaMask() != NULL) {
+						if (m_scores[i]->GetAlphaMask() != NULL) {
 							memset(NULL, scoreColors[color - 1], 4);
 						}
 						else {
@@ -165,17 +146,15 @@ void HistoryBook::ReadyWorld()
 #endif
 					}
 				}
-
-				scoreboxY += 5;
 			}
 
 			scoreState++;
 			scoreboxX += 5;
 		}
 
-		(*scorebox)->Enable(TRUE);
-		(*scorebox)->SetTickleState(MxPresenter::e_repeating);
-		(*scorebox)->SetPosition(scoreX + 0xa1, scoreY);
+		m_scores[i]->Enable(TRUE);
+		m_scores[i]->SetTickleState(MxPresenter::e_repeating);
+		m_scores[i]->SetPosition(scoreX + 0xa1, scoreY);
 
 		for (MxS16 letterIndex = 0; letterIndex < (MxS16) sizeOfArray(m_name[0]);) {
 			MxS16 letter = score->m_name.m_letters[letterIndex];
@@ -194,8 +173,6 @@ void HistoryBook::ReadyWorld()
 			m_name[i][j]->SetPosition(scoreX, scoreY);
 			scoreX += 0x17;
 		}
-
-		scoreY += 0x1b; // TODO: wrong place in BETA10, skipped at loop start
 	}
 
 #ifndef BETA10

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -103,9 +103,11 @@ void HistoryBook::ReadyWorld()
 	MxS16 i;
 
 	for (i = 0; i < 26; i++) {
-		m_alphabet[i] = (MxStillPresenter*) Find("MxStillPresenter", bitmap);
-		assert(m_alphabet[i]);
-		bitmap[0]++;
+		if (i < 26) {
+			m_alphabet[i] = (MxStillPresenter*) Find("MxStillPresenter", bitmap);
+			assert(m_alphabet[i]);
+			bitmap[0]++;
+		}
 	}
 
 	MxStillPresenter* scoreboxMaster = (MxStillPresenter*) Find("MxStillPresenter", "ScoreBox");

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -129,11 +129,10 @@ void HistoryBook::ReadyWorld()
 		}
 
 		for (MxS32 scoreState = 0, scoreboxX = 1; scoreState < 5; scoreState++, scoreboxX += 5) {
-
 			for (MxS32 scoreBoxColumn = 0, scoreboxY = 1; scoreBoxColumn < 5; scoreBoxColumn++, scoreboxY += 5) {
 				MxU8 color = score->m_scores[scoreState][scoreBoxColumn];
 
-				if (color) {
+				if (color > 0) {
 					for (MxS32 lax = 0; lax < 4; lax++) {
 #ifdef BETA10
 						memset(m_scores[i]->GetBitmapStart(scoreboxX, scoreboxY + lax), scoreColors[color - 1], 4);
@@ -142,7 +141,11 @@ void HistoryBook::ReadyWorld()
 							memset(NULL, scoreColors[color - 1], 4);
 						}
 						else {
-							memset(m_scores[i]->GetBitmap()->GetStart(scoreboxX, lax + scoreboxY), scoreColors[color - 1], 4);
+							memset(
+								m_scores[i]->GetBitmap()->GetStart(scoreboxX, lax + scoreboxY),
+								scoreColors[color - 1],
+								4
+							);
 						}
 #endif
 					}
@@ -153,11 +156,13 @@ void HistoryBook::ReadyWorld()
 		m_scores[i]->Enable(TRUE);
 		m_scores[i]->SetTickleState(MxPresenter::e_repeating);
 		m_scores[i]->SetPosition(scoreX + 0xa1, scoreY);
+
 #ifdef BETA10
-		for (MxS16 j = 0; score->m_name.m_letters[j] != -1; j++, scoreX += 0x17) {
+		for (MxS16 j = 0; score->m_name.m_letters[j] != -1; j++, scoreX += 0x17)
 #else
-		for (MxS16 j = 0; j < (MxS16) sizeOfArray(m_name[0]) && score->m_name.m_letters[j] != -1; j++, scoreX += 0x17) {
+		for (MxS16 j = 0; j < (MxS16) sizeOfArray(m_name[0]) && score->m_name.m_letters[j] != -1; j++, scoreX += 0x17)
 #endif
+		{
 			m_name[i][j] = m_alphabet[score->m_name.m_letters[j]]->Clone();
 
 			assert(m_name[i][j]);

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -93,9 +93,10 @@ MxLong HistoryBook::Notify(MxParam& p_param)
 // FUNCTION: BETA10 0x1002b9b9
 void HistoryBook::ReadyWorld()
 {
-	undefined2 dummy1 = 0x90, dummy2 = 0x79, dummy3 = 0xc8;//, dummy4 = 0x17, dummy5 = 0x1b;
-
+	undefined2 dummy1 = 0x90, dummy2 = 0x79, dummy3 = 0xc8, dummy4 = 0x17, dummy5 = 0x1b;
+#ifndef BETA10
 	LegoWorld::ReadyWorld();
+#endif
 	GameState()->m_history.WriteScoreHistory();
 
 	char bitmap[] = "A_Bitmap";
@@ -152,17 +153,12 @@ void HistoryBook::ReadyWorld()
 		m_scores[i]->Enable(TRUE);
 		m_scores[i]->SetTickleState(MxPresenter::e_repeating);
 		m_scores[i]->SetPosition(scoreX + 0xa1, scoreY);
-
-		for (MxS16 letterIndex = 0; letterIndex < (MxS16) sizeOfArray(m_name[0]); letterIndex++, scoreX += 0x17) {
-			MxS16 letter = score->m_name.m_letters[letterIndex];
-
-			if (letter == -1) {
-				break;
-			}
-
-			MxS16 j = letterIndex++;
-
-			m_name[i][j] = m_alphabet[letter]->Clone();
+#ifdef BETA10
+		for (MxS16 j = 0; score->m_name.m_letters[j] != -1; j++, scoreX += 0x17) {
+#else
+		for (MxS16 j = 0; j < (MxS16) sizeOfArray(m_name[0]) && score->m_name.m_letters[j] != -1; j++, scoreX += 0x17) {
+#endif
+			m_name[i][j] = m_alphabet[score->m_name.m_letters[j]]->Clone();
 
 			assert(m_name[i][j]);
 			m_name[i][j]->Enable(TRUE);

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -93,7 +93,7 @@ MxLong HistoryBook::Notify(MxParam& p_param)
 // FUNCTION: BETA10 0x1002b9b9
 void HistoryBook::ReadyWorld()
 {
-	undefined4 dummy1, dummy2, dummy3;
+	undefined2 dummy1 = 0x90, dummy2 = 0x79, dummy3 = 0xc8;//, dummy4 = 0x17, dummy5 = 0x1b;
 
 	LegoWorld::ReadyWorld();
 	GameState()->m_history.WriteScoreHistory();
@@ -147,16 +147,13 @@ void HistoryBook::ReadyWorld()
 					}
 				}
 			}
-
-			scoreState++;
-			scoreboxX += 5;
 		}
 
 		m_scores[i]->Enable(TRUE);
 		m_scores[i]->SetTickleState(MxPresenter::e_repeating);
 		m_scores[i]->SetPosition(scoreX + 0xa1, scoreY);
 
-		for (MxS16 letterIndex = 0; letterIndex < (MxS16) sizeOfArray(m_name[0]);) {
+		for (MxS16 letterIndex = 0; letterIndex < (MxS16) sizeOfArray(m_name[0]); letterIndex++, scoreX += 0x17) {
 			MxS16 letter = score->m_name.m_letters[letterIndex];
 
 			if (letter == -1) {
@@ -171,7 +168,6 @@ void HistoryBook::ReadyWorld()
 			m_name[i][j]->Enable(TRUE);
 			m_name[i][j]->SetTickleState(MxPresenter::e_repeating);
 			m_name[i][j]->SetPosition(scoreX, scoreY);
-			scoreX += 0x17;
 		}
 	}
 

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -142,9 +142,10 @@ void HistoryBook::ReadyWorld()
 		}
 
 		MxS32 scoreboxX = 1;
-		MxS32 scoreboxRow = 5;
 
 		for (MxS32 scoreState = 0; scoreState < 5; scoreState++) {
+			MxS32 scoreboxY = 1;
+
 			for (MxS32 scoreBoxColumn = 0, scoreboxY = 1; scoreBoxColumn < 5; scoreBoxColumn++, scoreboxY += 5) {
 				// SetColor(*scorebox, score->m_scores[scoreState][scoreBoxColumn], scoreColors, scoreboxX, scoreboxY);
 				// inline void SetColor(MxStillPresenter* p_presenter, MxU8 p_color, MxU8* p_colors, MxS32 p_x, MxS32 p_y)
@@ -159,11 +160,13 @@ void HistoryBook::ReadyWorld()
 							memset(NULL, scoreColors[color - 1], 4);
 						}
 						else {
-							memset(m_scores[i]->GetBitmap()->GetStart(scoreboxX, scoreboxY + lax), scoreColors[color - 1], 4);
+							memset(m_scores[i]->GetBitmap()->GetStart(scoreboxX, lax + scoreboxY), scoreColors[color - 1], 4);
 						}
 #endif
 					}
 				}
+
+				scoreboxY += 5;
 			}
 
 			scoreState++;
@@ -192,7 +195,7 @@ void HistoryBook::ReadyWorld()
 			scoreX += 0x17;
 		}
 
-		scoreY += 0x1b;
+		scoreY += 0x1b; // TODO: wrong place in BETA10, skipped at loop start
 	}
 
 #ifndef BETA10

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -107,7 +107,7 @@ inline void SetColor(MxStillPresenter* p_presenter, MxU8 p_color, MxU8* p_colors
 // FUNCTION: BETA10 0x1002b9b9
 void HistoryBook::ReadyWorld()
 {
-	undefined4 dummy;
+	undefined4 dummy1;
 
 	LegoWorld::ReadyWorld();
 	GameState()->m_history.WriteScoreHistory();
@@ -143,21 +143,25 @@ void HistoryBook::ReadyWorld()
 
 		MxS32 scoreboxX = 1;
 		MxS32 scoreboxRow = 5;
-		MxS32 scoreState = 0;
 
-		for (; scoreboxRow > 0; scoreboxRow--) {
+		for (MxS32 scoreState = 0; scoreState < 5; scoreState++) {
 			for (MxS32 scoreBoxColumn = 0, scoreboxY = 1; scoreBoxColumn < 5; scoreBoxColumn++, scoreboxY += 5) {
 				// SetColor(*scorebox, score->m_scores[scoreState][scoreBoxColumn], scoreColors, scoreboxX, scoreboxY);
 				// inline void SetColor(MxStillPresenter* p_presenter, MxU8 p_color, MxU8* p_colors, MxS32 p_x, MxS32 p_y)
 				MxU8 color = score->m_scores[scoreState][scoreBoxColumn];
+				// this->m_scores
 				if (color) {
 					for (MxS32 lax = 0; lax < 4; lax++) {
+#ifdef BETA10
+						memset(m_scores[i]->GetBitmapStart(scoreboxX, scoreboxY + lax), scoreColors[color - 1], 4);
+#else
 						if ((*scorebox)->GetAlphaMask() != NULL) {
 							memset(NULL, scoreColors[color - 1], 4);
 						}
 						else {
-							memset((*scorebox)->GetBitmap()->GetStart(scoreboxX, scoreboxY + lax), scoreColors[color - 1], 4);
+							memset(m_scores[i]->GetBitmap()->GetStart(scoreboxX, scoreboxY + lax), scoreColors[color - 1], 4);
 						}
+#endif
 					}
 				}
 			}
@@ -179,8 +183,9 @@ void HistoryBook::ReadyWorld()
 
 			MxS16 j = letterIndex++;
 
-			assert(m_name[i][j]);
 			m_name[i][j] = m_alphabet[letter]->Clone();
+
+			assert(m_name[i][j]);
 			m_name[i][j]->Enable(TRUE);
 			m_name[i][j]->SetTickleState(MxPresenter::e_repeating);
 			m_name[i][j]->SetPosition(scoreX, scoreY);
@@ -190,7 +195,9 @@ void HistoryBook::ReadyWorld()
 		scoreY += 0x1b;
 	}
 
+#ifndef BETA10
 	PlayMusic(JukeboxScript::c_InformationCenter_Music);
+#endif
 }
 
 // FUNCTION: LEGO1 0x10082a10

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -391,7 +391,7 @@ void RegistrationBook::FUN_100778c0()
 void RegistrationBook::ReadyWorld()
 {
 	LegoGameState* gameState = GameState();
-	gameState->GetHistory()->WriteScoreHistory();
+	gameState->m_history.WriteScoreHistory();
 	MxS16 i;
 
 	PlayMusic(JukeboxScript::c_InformationCenter_Music);

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -702,6 +702,9 @@
 // LIBRARY: BETA10 0x100f9420
 // memcpy
 
+// LIBRARY: BETA10 0x100faa00
+// memcmp
+
 // LIBRARY: BETA10 0x100fb080
 // _stricmp
 

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -104,6 +104,9 @@ public:
 	MxBitmap* GetBitmap() { return m_frameBitmap; }
 	AlphaMask* GetAlphaMask() { return m_alpha; }
 
+	// FUNCTION: BETA10 0x1002c2e0
+	MxU8* GetBitmapStart(MxS32 p_left, MxS32 p_top) { return m_frameBitmap->GetStart(p_left, p_top); }
+
 	void SetBit0(BOOL p_e) { m_flags.m_bit0 = p_e; }
 	void SetBit1(BOOL p_e) { m_flags.m_bit1 = p_e; }
 	void SetBit2(BOOL p_e) { m_flags.m_bit2 = p_e; }

--- a/reccmp-project.yml
+++ b/reccmp-project.yml
@@ -24,6 +24,7 @@ targets:
         # these classes have been changed by hand to account for changes between LEGO1 and BETA10
         - Act2Actor
         - Act2Brick
+        - HistoryBook
         - LegoAct2
         - LegoCarBuild
         - LegoCarBuildAnimPresenter

--- a/reccmp-project.yml
+++ b/reccmp-project.yml
@@ -34,3 +34,5 @@ targets:
         - 0x100f8ad0
         - 0x100fa200
         - 0x100f9780
+        # memset etc.
+        - 0x100f9570


### PR DESCRIPTION
Closes #1369.

Matches to about 53 % on BETA10, though most of the mismatch comes from incorrect registers / entropy. The structural match isn't perfect, but quite decent.

I got LEGO1 to 91 %. Some of it appears to be entropy, but I can't make the beginning work:
```diff
0x1008271e : mov ecx, 'A_Bitmap' (STRING)
-0x10082723 : -cmp si, 0x1a
0x10082727 : lea edx, [esp + 0x40]
0x1008272b : mov cl, byte ptr [ecx + 8]
0x1008272e : mov dword ptr [edx], eax
0x10082730 : mov dword ptr [edx + 4], ebx
0x10082733 : mov byte ptr [edx + 8], cl
-0x10082736 : -jge 0x25
0x10082738 : lea eax, [esp + 0x40]
0x1008273c : mov ecx, dword ptr [esp + 0x18]
0x10082740 : push eax
0x10082741 : push 'MxStillPresenter' (STRING)
0x10082746 : call LegoWorld::Find(char const *, char const *) (FUNCTION)
```

It looks as if the code does something like
```c++
MxS16 i = 0;
char bitmap[] = "A_Bitmap";

for (; i < 26; i++) {
// [...]
}
```
but that only makes the match worse.