### PR TITLE
BETA10 match `RegistrationBook::ReadyWorld()`

### DIFF
--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -50,6 +50,9 @@ public:
 
 	void SetUnknown0x74(MxU32 p_unk0x74) { m_unk0x74 = p_unk0x74; }
 
+	// FUNCTION: BETA10 0x10031bd0
+	MxBool FirstLetterIsNotNull() { return m_letters[0] != NULL; }
+
 	// SYNTHETIC: LEGO1 0x10071900
 	// InfocenterState::`scalar deleting destructor'
 

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -40,7 +40,10 @@ public:
 	MxS16 GetMaxNameLength() { return sizeOfArray(m_letters); }
 	MxStillPresenter* GetNameLetter(MxS32 p_index) { return m_letters[p_index]; }
 	void SetNameLetter(MxS32 p_index, MxStillPresenter* p_letter) { m_letters[p_index] = p_letter; }
+
+	// FUNCTION: BETA10 0x10031bd0
 	MxBool HasRegistered() { return m_letters[0] != NULL; }
+
 	Playlist& GetExitDialogueAct1() { return m_exitDialogueAct1; }
 	Playlist& GetExitDialogueAct23() { return m_exitDialogueAct23; }
 	Playlist& GetReturnDialogue(LegoGameState::Act p_act) { return m_returnDialogue[p_act]; }
@@ -49,9 +52,6 @@ public:
 	MxU32 GetUnknown0x74() { return m_unk0x74; }
 
 	void SetUnknown0x74(MxU32 p_unk0x74) { m_unk0x74 = p_unk0x74; }
-
-	// FUNCTION: BETA10 0x10031bd0
-	MxBool FirstLetterIsNotNull() { return m_letters[0] != NULL; }
 
 	// SYNTHETIC: LEGO1 0x10071900
 	// InfocenterState::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legomain.h
+++ b/LEGO1/lego/legoomni/include/legomain.h
@@ -168,7 +168,9 @@ public:
 	// FUNCTION: BETA10 0x100e52b0
 	LegoGameState* GetGameState() { return m_gameState; }
 
+	// FUNCTION: BETA10 0x100e5280
 	MxBackgroundAudioManager* GetBackgroundAudioManager() { return m_bkgAudioManager; }
+
 	MxTransitionManager* GetTransitionManager() { return m_transitionManager; }
 	MxDSAction& GetCurrentAction() { return m_action; }
 	LegoCharacterManager* GetCharacterManager() { return m_characterManager; }

--- a/LEGO1/lego/legoomni/include/registrationbook.h
+++ b/LEGO1/lego/legoomni/include/registrationbook.h
@@ -40,7 +40,7 @@ public:
 	MxBool Escape() override;                         // vtable+0x64
 	void Enable(MxBool p_enable) override;            // vtable+0x68
 
-	inline void PlayAction(MxU32 p_objectId);
+	inline static void PlayAction(MxU32 p_objectId);
 
 	// SYNTHETIC: LEGO1 0x10076f30
 	// RegistrationBook::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/src/common/misc.cpp
+++ b/LEGO1/lego/legoomni/src/common/misc.cpp
@@ -212,8 +212,11 @@ MxTransitionManager* TransitionManager()
 }
 
 // FUNCTION: LEGO1 0x10015910
+// FUNCTION: BETA10 0x100e4f4c
 void PlayMusic(JukeboxScript::Script p_objectId)
 {
+	assert(LegoOmni::GetInstance());
+
 	MxDSAction action;
 	action.SetAtomId(*g_jukeboxScript);
 	action.SetObjectId(p_objectId);

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -103,6 +103,8 @@ void HistoryBook::ReadyWorld()
 	MxS16 i;
 
 	for (i = 0; i < 26; i++) {
+		// TODO: This might be an inline function.
+		// See also `RegistrationBook::ReadyWorld()`.
 		if (i < 26) {
 			m_alphabet[i] = (MxStillPresenter*) Find("MxStillPresenter", bitmap);
 			assert(m_alphabet[i]);

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -388,6 +388,7 @@ void RegistrationBook::FUN_100778c0()
 }
 
 // FUNCTION: LEGO1 0x10077cc0
+// FUNCTION: BETA10 0x100f3671
 void RegistrationBook::ReadyWorld()
 {
 	LegoGameState* gameState = GameState();
@@ -399,9 +400,11 @@ void RegistrationBook::ReadyWorld()
 	MxS16 i;
 
 	for (i = 0; i < 26; i++) {
+		// TODO: This might be an inline function.
+		// See also `HistoryBook::ReadyWorld()`.
 		if (i < 26) {
 			m_alphabet[i] = (MxStillPresenter*) Find("MxStillPresenter", letterBuffer);
-
+			assert(m_alphabet[i]);
 			// We need to loop through the entire alphabet,
 			// so increment the first char of the bitmap name
 			letterBuffer[0]++;
@@ -412,7 +415,7 @@ void RegistrationBook::ReadyWorld()
 	char checkmarkBuffer[] = "Check0_Ctl";
 	for (i = 0; i < 10; i++) {
 		m_checkmark[i] = (MxControlPresenter*) Find("MxControlPresenter", checkmarkBuffer);
-
+		assert(m_checkmark[i]);
 		// Just like in the prior letter loop,
 		// we need to increment the fifth char
 		// to get the next checkmark bitmap
@@ -431,6 +434,7 @@ void RegistrationBook::ReadyWorld()
 				// Start building the player names using a two-dimensional array
 				m_name[i][j] = m_alphabet[players[i - 1].m_letters[j]]->Clone();
 
+				assert(m_name[i][j]);
 				// Enable the presenter to actually show the letter in the grid
 				m_name[i][j]->Enable(TRUE);
 

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -454,13 +454,16 @@ void RegistrationBook::ReadyWorld()
 		}
 	}
 
+	// TODO: Remove this one if the function mismatches again
+	(void)0;
+
 #ifdef BETA10
 	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
 	assert(infocenterState);
 
-	if (infocenterState->FirstLetterIsNotNull())
+	if (infocenterState->HasRegistered())
 #else
-	if (m_infocenterState->FirstLetterIsNotNull())
+	if (m_infocenterState->HasRegistered())
 #endif
 	{
 		PlayAction(RegbookScript::c_iic008in_PlayWav);

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -268,6 +268,7 @@ MxLong RegistrationBook::HandleControl(LegoControlManagerNotificationParam& p_pa
 }
 
 // FUNCTION: LEGO1 0x100775c0
+// STUB: BETA10 0x100f32b2
 void RegistrationBook::FUN_100775c0(MxS16 p_playerIndex)
 {
 	if (m_infocenterState->HasRegistered()) {
@@ -391,6 +392,10 @@ void RegistrationBook::FUN_100778c0()
 // FUNCTION: BETA10 0x100f3671
 void RegistrationBook::ReadyWorld()
 {
+	// This function is very fragile and appears to oscillate between two versions on small changes.
+	// This even happens for commenting out `assert()` calls, which shouldn't affect release builds at all.
+	// See https://github.com/isledecomp/isle/pull/1375 for a version that had 100 %.
+
 	LegoGameState* gameState = GameState();
 	gameState->m_history.WriteScoreHistory();
 
@@ -405,6 +410,7 @@ void RegistrationBook::ReadyWorld()
 		if (i < 26) {
 			m_alphabet[i] = (MxStillPresenter*) Find("MxStillPresenter", letterBuffer);
 			assert(m_alphabet[i]);
+
 			// We need to loop through the entire alphabet,
 			// so increment the first char of the bitmap name
 			letterBuffer[0]++;
@@ -416,6 +422,7 @@ void RegistrationBook::ReadyWorld()
 	for (i = 0; i < 10; i++) {
 		m_checkmark[i] = (MxControlPresenter*) Find("MxControlPresenter", checkmarkBuffer);
 		assert(m_checkmark[i]);
+
 		// Just like in the prior letter loop,
 		// we need to increment the fifth char
 		// to get the next checkmark bitmap
@@ -444,7 +451,15 @@ void RegistrationBook::ReadyWorld()
 		}
 	}
 
-	if (m_infocenterState->m_letters[0] != NULL) {
+#ifdef BETA10
+	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
+	assert(infocenterState);
+
+	if (infocenterState->FirstLetterIsNotNull())
+#else
+	if (m_infocenterState->FirstLetterIsNotNull())
+#endif
+	{
 		PlayAction(RegbookScript::c_iic008in_PlayWav);
 
 		LegoROI* infoman = FindROI(g_infoman);
@@ -457,6 +472,7 @@ void RegistrationBook::ReadyWorld()
 	}
 }
 
+// FUNCTION: BETA10 0x100f3424
 inline void RegistrationBook::PlayAction(MxU32 p_objectId)
 {
 	MxDSAction action;

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -32,6 +32,7 @@
 DECOMP_SIZE_ASSERT(RegistrationBook, 0x2d0)
 
 // GLOBAL: LEGO1 0x100d9924
+// GLOBAL: BETA10 0x101bfb3c
 const char* g_infoman = "infoman";
 
 // GLOBAL: LEGO1 0x100f7964
@@ -396,8 +397,10 @@ void RegistrationBook::ReadyWorld()
 	// This even happens for commenting out `assert()` calls, which shouldn't affect release builds at all.
 	// See https://github.com/isledecomp/isle/pull/1375 for a version that had 100 %.
 
+#ifndef BETA10
 	LegoGameState* gameState = GameState();
 	gameState->m_history.WriteScoreHistory();
+#endif
 
 	PlayMusic(JukeboxScript::c_InformationCenter_Music);
 

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -454,9 +454,6 @@ void RegistrationBook::ReadyWorld()
 		}
 	}
 
-	// TODO: Remove this one if the function mismatches again
-	(void)0;
-
 #ifdef BETA10
 	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
 	assert(infocenterState);


### PR DESCRIPTION
As noted on Element, this function is pretty fragile and highly susceptible to small changes. It now closely resembles BETA10, but has gone down from 100 % to 100 % effective relative to `master` - I hope this is due to entropy.

I was also able to track down a few more BETA10 functions and verify the existence of the inline function `RegistrationBook::PlayAction()` (which is actually `static` - maybe it belongs somewhere else? Its BETA10 version is only called  from `RegistrationBook`, though).

One detail I couldn't work:
```diff
0x100f3a90 : push 0x1f4
-0x100f3a95 : -call RegistrationBook::PlayAction (FUNCTION)
+           : +call Thunk of 'RegistrationBook::PlayAction' (FUNCTION)
0x100f3a9a : add esp, 4
```

Not sure how we can declare a non-thunked function in BETA10 that is inlined in LEGO1.