### PR TITLE
Fix some beta annotations

### DIFF
--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -147,9 +147,10 @@ private:
 // _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::erase
 // clang-format on
 
+// clang-format off
 // TEMPLATE: BETA10 0x10131460
-// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *>
-// >::size
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::size
+// clang-format on
 
 // clang-format off
 // TEMPLATE: LEGO1 0x100afc40
@@ -175,9 +176,10 @@ private:
 // _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::_Nil
 // clang-format on
 
+// clang-format off
 // TEMPLATE: BETA10 0x10132170
-// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *>
-// >::begin
+// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::begin
+// clang-format on
 
 // TEMPLATE: BETA10 0x101321d0
 // set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::size

--- a/LEGO1/omni/include/mxpresenterlist.h
+++ b/LEGO1/omni/include/mxpresenterlist.h
@@ -104,9 +104,9 @@ public:
 // MxPtrListCursor<MxPresenter>::MxPtrListCursor<MxPresenter>
 
 // TEMPLATE: BETA10 0x1007d270
-// MxListCursor<MxPresenter>::MxListCursor<MxPresenter>
+// MxListCursor<MxPresenter *>::MxListCursor<MxPresenter *>
 
 // TEMPLATE: BETA10 0x100d9420
-// MxListCursor<MxPresenter>::Prev
+// MxListCursor<MxPresenter *>::Prev
 
 #endif // MXPRESENTERLIST_H

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -172,10 +172,12 @@ private:
 
 // TEMPLATE: BETA10 0x1017ab10
 // map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
+// No symbol generated for this?
 // Two iterators
 
 // TEMPLATE: BETA10 0x1017a040
-// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
+// ?erase@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@QAE?AViterator@?$_Tree@PBDU?$pair@QBDPAVViewLODList@@@@U_Kfn@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@UROINameComparator@@V?$allocato
+// aka map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
 // One iterator
 
 // TEMPLATE: BETA10 0x10178f80


### PR DESCRIPTION
I noticed these were wrong while working on a change for `reccmp`. Two got truncated by `clang-format` and two used the wrong generic type.

`map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase` does not generate a symbol for both of its appearances:

```
(002E64) S_GPROC32: [0001:00124AC0], Cb: 0000002F, Type:             0x2B2E, map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
         Parent: 00000000, End: 00002F30, Next: 00000000
         Debug start: 0000000C, Debug end: 00000028
         Flags: Frame Ptr Present

(004930) S_GPROC32: [0001:00125BA0], Cb: 0000002B, Type:             0x2B5F, map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::erase
         Parent: 00000000, End: 000049EC, Next: 00000000
         Debug start: 0000000C, Debug end: 00000024
         Flags: Frame Ptr Present

S_PUB32: [0001:00125BA0], Flags: 00000000, ?erase@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@QAE?AViterator@?$_Tree@PBDU?$pair@QBDPAVViewLODList@@@@U_Kfn@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@UROINameComparator@@V?$allocato

No match for 0001:00124AC0

```

Maybe because both are generated but only one is currently used in recomp?