### PR TITLE
Tweaks to `LegoRaceCar` and `LegoJetski`

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimactor.h
+++ b/LEGO1/lego/legoomni/include/legoanimactor.h
@@ -96,7 +96,11 @@ protected:
 // Vector<unsigned char *>::~Vector<unsigned char *>
 
 // TEMPLATE: LEGO1 0x1001c7c0
+// TEMPLATE: BETA10 0x1000fb40
 // vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::size
+
+// TEMPLATE: BETA10 0x1000fb90
+// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::operator[]
 
 // TEMPLATE: LEGO1 0x1001c7e0
 // vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::_Destroy

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -82,6 +82,8 @@ public:
 
 	virtual void FUN_100136f0(float p_worldSpeed);
 
+	static void InitSoundIndices();
+
 	// SYNTHETIC: LEGO1 0x10013e30
 	// LegoJetski::`scalar deleting destructor'
 };
@@ -146,8 +148,7 @@ public:
 	virtual MxU32 HandleSkeletonKicks(float p_param1);
 
 	static void FUN_10012de0();
-	static void FUN_10012e00();
-	static void FUN_10013670();
+	static void InitSoundIndices();
 
 	// SYNTHETIC: LEGO1 0x10014240
 	// LegoRaceCar::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/src/race/carrace.cpp
+++ b/LEGO1/lego/legoomni/src/race/carrace.cpp
@@ -100,7 +100,7 @@ MxResult CarRace::Create(MxDSAction& p_dsAction)
 	m_unk0x148 = -1;
 	m_unk0x14c = -1;
 
-	LegoRaceCar::FUN_10012e00();
+	LegoRaceCar::InitSoundIndices();
 
 	MxS32 streamId =
 		DuneBuggy::GetColorOffset(g_strCRCEDGEY0) + (DuneBuggy::GetColorOffset(g_strCRCFRNTY6) * 5 + 15) * 2;

--- a/LEGO1/lego/legoomni/src/race/jetskirace.cpp
+++ b/LEGO1/lego/legoomni/src/race/jetskirace.cpp
@@ -63,7 +63,7 @@ MxResult JetskiRace::Create(MxDSAction& p_dsAction)
 	m_unk0x130.SetTop(317);
 	m_unk0x130.SetRight(543);
 	m_unk0x130.SetBottom(333);
-	LegoRaceCar::FUN_10013670();
+	LegoJetski::InitSoundIndices();
 	InvokeAction(
 		Extra::e_start,
 		m_atomId,

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -13,6 +13,7 @@ DECOMP_SIZE_ASSERT(LegoRaceActor, 0x180)
 
 // Initialized at LEGO1 0x100145a0
 // GLOBAL: LEGO1 0x10102b08
+// GLOBAL: BETA10 0x102114a8
 Mx3DPointFloat LegoRaceActor::g_unk0x10102b08 = Mx3DPointFloat(0.0, 2.0, 0.0);
 
 // FUNCTION: LEGO1 0x100145d0
@@ -101,9 +102,9 @@ MxResult LegoRaceActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 		}
 
 		if (p_bool) {
+			MxMatrix matr;
 			LegoROI* roi = p_actor->GetROI(); // name verified by BETA10 0x100c9fcf
 			assert(roi);
-			MxMatrix matr;
 			matr = roi->GetLocal2World();
 
 			Vector3(matr[3]) += g_unk0x10102b08;


### PR DESCRIPTION
Corrects beta address for `g_skBMap` array.

Moved `MxMatrix` variable init position in `HitActor` functions to match beta. Removed `timeElapsed` variable per the beta.

Renamed global variables related to sounds and timed events. This was partly based on checking the actual files with SIEdit. I didn't check in the actual game so feel free to correct me if I'm wrong here. I'm basing the name `g_playerHitStudsSounds` on the fact that `srt018sl` through `srt029sl` are grunts and pain sounds. In contrast, `srt006sl` is "Eat my bricks buddy!" so this seems like a sound for when Studs hits you instead of you hitting him. Does this mean that the second bool parameter of all the `HitActor` functions tells whether the player is moving at the time of the collision? (As a way to tell who hit who)

Named the `InitSoundIndices` functions for both `LegoRaceCar` and `LegoJetski` 

Removed the `animMap` variable and two string variables in `LegoRaceCar::ParseAction` per the beta. This is still 100%.

I think the accuracy dip in `LegoJetski::HitActor` is from entropy near the `strcmpi` calls.