### PR TITLE
Match simple BETA10 vector calls

### DIFF
--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -30,10 +30,8 @@ public:
 	Mx3DPointFloat(const Vector3& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
 
 	// FUNCTION: LEGO1 0x10003c10
+	// FUNCTION: BETA10 0x100116e0
 	virtual void operator=(const Vector3& p_impl) { EqualsImpl(p_impl.m_data); } // vtable+0x88
-
-	// FUNCTION: BETA10 0x10015240
-	// ??4Mx3DPointFloat@@QAEAAV0@ABV0@@Z
 
 	// FUNCTION: BETA10 0x10013460
 	float& operator[](int idx) { return m_data[idx]; }
@@ -42,6 +40,7 @@ public:
 	const float& operator[](int idx) const { return m_data[idx]; }
 
 	// SYNTHETIC: LEGO1 0x10010c00
+	// SYNTHETIC: BETA10 0x10015240
 	// ??4Mx3DPointFloat@@QAEAAV0@ABV0@@Z
 
 private:

--- a/LEGO1/mxgeometry/mxgeometry4d.h
+++ b/LEGO1/mxgeometry/mxgeometry4d.h
@@ -25,6 +25,7 @@ public:
 	Mx4DPointFloat(const Mx4DPointFloat& p_other) : Vector4(m_elements) { EqualsImpl(p_other.m_data); }
 
 	// FUNCTION: LEGO1 0x10003200
+	// FUNCTION: BETA10 0x10048da0
 	virtual void operator=(const Vector4& p_impl) { EqualsImpl(p_impl.m_data); } // vtable+0x98
 
 	// FUNCTION: BETA10 0x1004af10

--- a/LEGO1/realtime/vector2d.inl.h
+++ b/LEGO1/realtime/vector2d.inl.h
@@ -7,6 +7,7 @@
 #include <memory.h>
 
 // FUNCTION: LEGO1 0x10001f80
+// FUNCTION: BETA10 0x10010a20
 void Vector2::AddImpl(const float* p_value)
 {
 	m_data[0] += p_value[0];
@@ -14,6 +15,7 @@ void Vector2::AddImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10001fa0
+// FUNCTION: BETA10 0x10010a80
 void Vector2::AddImpl(float p_value)
 {
 	m_data[0] += p_value;
@@ -21,6 +23,7 @@ void Vector2::AddImpl(float p_value)
 }
 
 // FUNCTION: LEGO1 0x10001fc0
+// FUNCTION: BETA10 0x10010ad0
 void Vector2::SubImpl(const float* p_value)
 {
 	m_data[0] -= p_value[0];
@@ -28,6 +31,7 @@ void Vector2::SubImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10001fe0
+// FUNCTION: BETA10 0x10010b30
 void Vector2::MulImpl(const float* p_value)
 {
 	m_data[0] *= p_value[0];
@@ -35,6 +39,7 @@ void Vector2::MulImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10002000
+// FUNCTION: BETA10 0x10010b90
 void Vector2::MulImpl(const float& p_value)
 {
 	m_data[0] *= p_value;
@@ -42,6 +47,7 @@ void Vector2::MulImpl(const float& p_value)
 }
 
 // FUNCTION: LEGO1 0x10002020
+// FUNCTION: BETA10 0x10010bf0
 void Vector2::DivImpl(const float& p_value)
 {
 	m_data[0] /= p_value;
@@ -49,6 +55,7 @@ void Vector2::DivImpl(const float& p_value)
 }
 
 // FUNCTION: LEGO1 0x10002040
+// FUNCTION: BETA10 0x10010c50
 float Vector2::DotImpl(const float* p_a, const float* p_b) const
 {
 	return p_b[0] * p_a[0] + p_b[1] * p_a[1];
@@ -62,30 +69,35 @@ void Vector2::SetData(float* p_data)
 }
 
 // FUNCTION: LEGO1 0x10002070
+// FUNCTION: BETA10 0x10010cc0
 void Vector2::EqualsImpl(const float* p_data)
 {
 	memcpy(m_data, p_data, sizeof(float) * 2);
 }
 
 // FUNCTION: LEGO1 0x10002090
+// FUNCTION: BETA10 0x10010d00
 float* Vector2::GetData()
 {
 	return m_data;
 }
 
 // FUNCTION: LEGO1 0x100020a0
+// FUNCTION: BETA10 0x10010d30
 const float* Vector2::GetData() const
 {
 	return m_data;
 }
 
 // FUNCTION: LEGO1 0x100020b0
+// FUNCTION: BETA10 0x10010d60
 void Vector2::Clear()
 {
 	memset(m_data, 0, sizeof(float) * 2);
 }
 
 // FUNCTION: LEGO1 0x100020d0
+// FUNCTION: BETA10 0x10010da0
 float Vector2::Dot(const float* p_a, const float* p_b) const
 {
 	return DotImpl(p_a, p_b);
@@ -99,18 +111,21 @@ float Vector2::Dot(const Vector2& p_a, const Vector2& p_b) const
 }
 
 // FUNCTION: LEGO1 0x10002110
+// FUNCTION: BETA10 0x10010de0
 float Vector2::Dot(const float* p_a, const Vector2& p_b) const
 {
 	return DotImpl(p_a, p_b.m_data);
 }
 
 // FUNCTION: LEGO1 0x10002130
+// FUNCTION: BETA10 0x10010e20
 float Vector2::Dot(const Vector2& p_a, const float* p_b) const
 {
 	return DotImpl(p_a.m_data, p_b);
 }
 
 // FUNCTION: LEGO1 0x10002150
+// FUNCTION: BETA10 0x10010e60
 float Vector2::LenSquared() const
 {
 	return m_data[0] * m_data[0] + m_data[1] * m_data[1];
@@ -134,60 +149,70 @@ int Vector2::Unitize()
 }
 
 // FUNCTION: LEGO1 0x100021c0
+// FUNCTION: BETA10 0x10010eb0
 void Vector2::operator+=(float p_value)
 {
 	AddImpl(p_value);
 }
 
 // FUNCTION: LEGO1 0x100021d0
+// FUNCTION: BETA10 0x10010ee0
 void Vector2::operator+=(const float* p_other)
 {
 	AddImpl(p_other);
 }
 
 // FUNCTION: LEGO1 0x100021e0
+// FUNCTION: BETA10 0x10010f10
 void Vector2::operator+=(const Vector2& p_other)
 {
 	AddImpl(p_other.m_data);
 }
 
 // FUNCTION: LEGO1 0x100021f0
+// FUNCTION: BETA10 0x10010f50
 void Vector2::operator-=(const float* p_other)
 {
 	SubImpl(p_other);
 }
 
 // FUNCTION: LEGO1 0x10002200
+// FUNCTION: BETA10 0x10010f80
 void Vector2::operator-=(const Vector2& p_other)
 {
 	SubImpl(p_other.m_data);
 }
 
 // FUNCTION: LEGO1 0x10002210
+// FUNCTION: BETA10 0x10010fc0
 void Vector2::operator*=(const float* p_other)
 {
 	MulImpl(p_other);
 }
 
 // FUNCTION: LEGO1 0x10002220
+// FUNCTION: BETA10 0x10010ff0
 void Vector2::operator*=(const Vector2& p_other)
 {
 	MulImpl(p_other.m_data);
 }
 
 // FUNCTION: LEGO1 0x10002230
+// FUNCTION: BETA10 0x10011030
 void Vector2::operator*=(const float& p_value)
 {
 	MulImpl(p_value);
 }
 
 // FUNCTION: LEGO1 0x10002240
+// FUNCTION: BETA10 0x10011060
 void Vector2::operator/=(const float& p_value)
 {
 	DivImpl(p_value);
 }
 
 // FUNCTION: LEGO1 0x10002250
+// FUNCTION: BETA10 0x10011090
 void Vector2::operator=(const float* p_other)
 {
 	EqualsImpl(p_other);

--- a/LEGO1/realtime/vector2d.inl.h
+++ b/LEGO1/realtime/vector2d.inl.h
@@ -138,9 +138,9 @@ int Vector2::Unitize()
 	float sq = LenSquared();
 
 	if (sq > 0.0f) {
-		float root = sqrt(sq);
-		if (root > 0.0f) {
-			DivImpl(root);
+		sq = sqrt(sq);
+		if (sq > 0.0f) {
+			DivImpl(sq);
 			return 0;
 		}
 	}

--- a/LEGO1/realtime/vector3d.inl.h
+++ b/LEGO1/realtime/vector3d.inl.h
@@ -20,18 +20,21 @@ void Vector3::EqualsCross(const Vector3& p_a, const Vector3& p_b)
 }
 
 // FUNCTION: LEGO1 0x100022e0
+// FUNCTION: BETA10 0x10011470
 void Vector3::EqualsCross(const Vector3& p_a, const float* p_b)
 {
 	EqualsCrossImpl(p_a.m_data, p_b);
 }
 
 // FUNCTION: LEGO1 0x10002300
+// FUNCTION: BETA10 0x100114b0
 void Vector3::EqualsCross(const float* p_a, const Vector3& p_b)
 {
 	EqualsCrossImpl(p_a, p_b.m_data);
 }
 
 // FUNCTION: LEGO1 0x10003a60
+// FUNCTION: BETA10 0x10011100
 void Vector3::AddImpl(const float* p_value)
 {
 	m_data[0] += p_value[0];
@@ -40,6 +43,7 @@ void Vector3::AddImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10003a90
+// FUNCTION: BETA10 0x10011150
 void Vector3::AddImpl(float p_value)
 {
 	m_data[0] += p_value;
@@ -48,6 +52,7 @@ void Vector3::AddImpl(float p_value)
 }
 
 // FUNCTION: LEGO1 0x10003ac0
+// FUNCTION: BETA10 0x100111c0
 void Vector3::SubImpl(const float* p_value)
 {
 	m_data[0] -= p_value[0];
@@ -56,6 +61,7 @@ void Vector3::SubImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10003af0
+// FUNCTION: BETA10 0x10011210
 void Vector3::MulImpl(const float* p_value)
 {
 	m_data[0] *= p_value[0];
@@ -64,6 +70,7 @@ void Vector3::MulImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10003b20
+// FUNCTION: BETA10 0x10011260
 void Vector3::MulImpl(const float& p_value)
 {
 	m_data[0] *= p_value;
@@ -72,6 +79,7 @@ void Vector3::MulImpl(const float& p_value)
 }
 
 // FUNCTION: LEGO1 0x10003b50
+// FUNCTION: BETA10 0x100112b0
 void Vector3::DivImpl(const float& p_value)
 {
 	m_data[0] /= p_value;
@@ -80,6 +88,7 @@ void Vector3::DivImpl(const float& p_value)
 }
 
 // FUNCTION: LEGO1 0x10003b80
+// FUNCTION: BETA10 0x10011300
 float Vector3::DotImpl(const float* p_a, const float* p_b) const
 {
 	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + p_a[1] * p_b[1];
@@ -107,6 +116,7 @@ float Vector3::LenSquared() const
 }
 
 // FUNCTION: LEGO1 0x10003bf0
+// FUNCTION: BETA10 0x100115a0
 void Vector3::Fill(const float& p_value)
 {
 	m_data[0] = p_value;

--- a/LEGO1/realtime/vector3d.inl.h
+++ b/LEGO1/realtime/vector3d.inl.h
@@ -37,8 +37,7 @@ void Vector3::EqualsCross(const float* p_a, const Vector3& p_b)
 // FUNCTION: BETA10 0x10011100
 void Vector3::AddImpl(const float* p_value)
 {
-	m_data[0] += p_value[0];
-	m_data[1] += p_value[1];
+	Vector2::AddImpl(p_value);
 	m_data[2] += p_value[2];
 }
 
@@ -55,8 +54,7 @@ void Vector3::AddImpl(float p_value)
 // FUNCTION: BETA10 0x100111c0
 void Vector3::SubImpl(const float* p_value)
 {
-	m_data[0] -= p_value[0];
-	m_data[1] -= p_value[1];
+	Vector2::SubImpl(p_value);
 	m_data[2] -= p_value[2];
 }
 
@@ -64,8 +62,7 @@ void Vector3::SubImpl(const float* p_value)
 // FUNCTION: BETA10 0x10011210
 void Vector3::MulImpl(const float* p_value)
 {
-	m_data[0] *= p_value[0];
-	m_data[1] *= p_value[1];
+	Vector2::MulImpl(p_value);
 	m_data[2] *= p_value[2];
 }
 
@@ -73,8 +70,7 @@ void Vector3::MulImpl(const float* p_value)
 // FUNCTION: BETA10 0x10011260
 void Vector3::MulImpl(const float& p_value)
 {
-	m_data[0] *= p_value;
-	m_data[1] *= p_value;
+	Vector2::MulImpl(p_value);
 	m_data[2] *= p_value;
 }
 
@@ -82,8 +78,7 @@ void Vector3::MulImpl(const float& p_value)
 // FUNCTION: BETA10 0x100112b0
 void Vector3::DivImpl(const float& p_value)
 {
-	m_data[0] /= p_value;
-	m_data[1] /= p_value;
+	Vector2::DivImpl(p_value);
 	m_data[2] /= p_value;
 }
 
@@ -91,7 +86,7 @@ void Vector3::DivImpl(const float& p_value)
 // FUNCTION: BETA10 0x10011300
 float Vector3::DotImpl(const float* p_a, const float* p_b) const
 {
-	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + p_a[1] * p_b[1];
+	return p_a[0] * p_b[0] + p_a[1] * p_b[1] + p_a[2] * p_b[2];
 }
 
 // FUNCTION: LEGO1 0x10003ba0

--- a/LEGO1/realtime/vector4d.inl.h
+++ b/LEGO1/realtime/vector4d.inl.h
@@ -10,9 +10,7 @@
 // FUNCTION: BETA10 0x10048500
 void Vector4::AddImpl(const float* p_value)
 {
-	m_data[0] += p_value[0];
-	m_data[1] += p_value[1];
-	m_data[2] += p_value[2];
+	Vector3::AddImpl(p_value);
 	m_data[3] += p_value[3];
 }
 
@@ -30,9 +28,7 @@ void Vector4::AddImpl(float p_value)
 // FUNCTION: BETA10 0x100485e0
 void Vector4::SubImpl(const float* p_value)
 {
-	m_data[0] -= p_value[0];
-	m_data[1] -= p_value[1];
-	m_data[2] -= p_value[2];
+	Vector3::SubImpl(p_value);
 	m_data[3] -= p_value[3];
 }
 
@@ -40,9 +36,7 @@ void Vector4::SubImpl(const float* p_value)
 // FUNCTION: BETA10 0x10048630
 void Vector4::MulImpl(const float* p_value)
 {
-	m_data[0] *= p_value[0];
-	m_data[1] *= p_value[1];
-	m_data[2] *= p_value[2];
+	Vector3::MulImpl(p_value);
 	m_data[3] *= p_value[3];
 }
 
@@ -50,9 +44,7 @@ void Vector4::MulImpl(const float* p_value)
 // FUNCTION: BETA10 0x10048680
 void Vector4::MulImpl(const float& p_value)
 {
-	m_data[0] *= p_value;
-	m_data[1] *= p_value;
-	m_data[2] *= p_value;
+	Vector3::MulImpl(p_value);
 	m_data[3] *= p_value;
 }
 
@@ -60,9 +52,7 @@ void Vector4::MulImpl(const float& p_value)
 // FUNCTION: BETA10 0x100486d0
 void Vector4::DivImpl(const float& p_value)
 {
-	m_data[0] /= p_value;
-	m_data[1] /= p_value;
-	m_data[2] /= p_value;
+	Vector3::DivImpl(p_value);
 	m_data[3] /= p_value;
 }
 

--- a/LEGO1/realtime/vector4d.inl.h
+++ b/LEGO1/realtime/vector4d.inl.h
@@ -7,6 +7,7 @@
 #include <memory.h>
 
 // FUNCTION: LEGO1 0x10002870
+// FUNCTION: BETA10 0x10048500
 void Vector4::AddImpl(const float* p_value)
 {
 	m_data[0] += p_value[0];
@@ -16,6 +17,7 @@ void Vector4::AddImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x100028b0
+// FUNCTION: BETA10 0x10048550
 void Vector4::AddImpl(float p_value)
 {
 	m_data[0] += p_value;
@@ -25,6 +27,7 @@ void Vector4::AddImpl(float p_value)
 }
 
 // FUNCTION: LEGO1 0x100028f0
+// FUNCTION: BETA10 0x100485e0
 void Vector4::SubImpl(const float* p_value)
 {
 	m_data[0] -= p_value[0];
@@ -34,6 +37,7 @@ void Vector4::SubImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10002930
+// FUNCTION: BETA10 0x10048630
 void Vector4::MulImpl(const float* p_value)
 {
 	m_data[0] *= p_value[0];
@@ -43,6 +47,7 @@ void Vector4::MulImpl(const float* p_value)
 }
 
 // FUNCTION: LEGO1 0x10002970
+// FUNCTION: BETA10 0x10048680
 void Vector4::MulImpl(const float& p_value)
 {
 	m_data[0] *= p_value;
@@ -52,6 +57,7 @@ void Vector4::MulImpl(const float& p_value)
 }
 
 // FUNCTION: LEGO1 0x100029b0
+// FUNCTION: BETA10 0x100486d0
 void Vector4::DivImpl(const float& p_value)
 {
 	m_data[0] /= p_value;
@@ -61,18 +67,21 @@ void Vector4::DivImpl(const float& p_value)
 }
 
 // FUNCTION: LEGO1 0x100029f0
+// FUNCTION: BETA10 0x10048720
 float Vector4::DotImpl(const float* p_a, const float* p_b) const
 {
 	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
 }
 
 // FUNCTION: LEGO1 0x10002a20
+// FUNCTION: BETA10 0x100487c0
 void Vector4::EqualsImpl(const float* p_data)
 {
 	memcpy(m_data, p_data, sizeof(float) * 4);
 }
 
 // FUNCTION: LEGO1 0x10002a40
+// FUNCTION: BETA10 0x10048800
 void Vector4::SetMatrixProduct(const float* p_vec, const float* p_mat)
 {
 	m_data[0] = p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] + p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
@@ -82,24 +91,28 @@ void Vector4::SetMatrixProduct(const float* p_vec, const float* p_mat)
 }
 
 // FUNCTION: LEGO1 0x10002ae0
+// FUNCTION: BETA10 0x10048960
 void Vector4::SetMatrixProduct(const Vector4& p_a, const float* p_b)
 {
 	SetMatrixProduct(p_a.m_data, p_b);
 }
 
 // FUNCTION: LEGO1 0x10002b00
+// FUNCTION: BETA10 0x100489a0
 void Vector4::Clear()
 {
 	memset(m_data, 0, sizeof(float) * 4);
 }
 
 // FUNCTION: LEGO1 0x10002b20
+// FUNCTION: BETA10 0x100489e0
 float Vector4::LenSquared() const
 {
 	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2] + m_data[3] * m_data[3];
 }
 
 // FUNCTION: LEGO1 0x10002b40
+// FUNCTION: BETA10 0x10048a60
 void Vector4::Fill(const float& p_value)
 {
 	m_data[0] = p_value;


### PR DESCRIPTION
This completes the vtables of `Vector2,3,4` and `Mx3,4DPointFloat`. There are still a few diffs on BETA10, most of them are likely due to entropy. I have not seen any significant changes on BETA10 or LEGO1 other than the usual entropy.