### PR TITLE
Fix `Matrix4::operator[]` annotation

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -93,7 +93,7 @@ public:
 
 	void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
 	void SetUnknown0x0cTo1() { m_unk0x9c = 1; }
-	void SetUnknown0xa0(MxMatrix* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
+	void SetUnknown0xa0(Matrix4* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
 
 	LegoAnim* GetAnimation() { return m_anim; }
 
@@ -123,7 +123,7 @@ protected:
 	MxU32 m_roiMapSize;           // 0x6c
 	LegoROIList* m_unk0x70;       // 0x70
 	LegoROIList* m_unk0x74;       // 0x74
-	MxMatrix* m_unk0x78;          // 0x78
+	Matrix4* m_unk0x78;           // 0x78
 	MxU32 m_flags;                // 0x7c
 	LegoWorld* m_currentWorld;    // 0x80
 	MxAtomId m_worldAtom;         // 0x84
@@ -136,7 +136,7 @@ protected:
 	undefined m_unk0x97;          // 0x97
 	LegoAnimSubstMap* m_substMap; // 0x98
 	MxS16 m_unk0x9c;              // 0x9c
-	MxMatrix* m_unk0xa0;          // 0xa0
+	Matrix4* m_unk0xa0;           // 0xa0
 
 public:
 	float m_unk0xa4;          // 0xa4

--- a/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
@@ -90,7 +90,7 @@ public:
 	void SetUnknown0xbc(undefined2 p_unk0xbc) { m_unk0xbc = p_unk0xbc; }
 
 	// FUNCTION: BETA10 0x100703b0
-	MxMatrix& GetUnknown0xe0() { return m_unk0xe0; }
+	Matrix4& GetUnknown0xe0() { return m_unk0xe0; }
 
 	MxBool StringEndsOnW(LegoChar* p_param);
 	MxBool StringEndsOnYOrN(const LegoChar* p_string);

--- a/LEGO1/lego/legoomni/include/legopathactor.h
+++ b/LEGO1/lego/legoomni/include/legopathactor.h
@@ -77,8 +77,8 @@ public:
 		float p_srcScale,
 		LegoUnknown100db7f4& p_destEdge,
 		float p_destScale
-	);                                                             // vtable+0x88
-	virtual MxS32 VTable0x8c(float p_time, MxMatrix& p_transform); // vtable+0x8c
+	);                                                            // vtable+0x88
+	virtual MxS32 VTable0x8c(float p_time, Matrix4& p_transform); // vtable+0x8c
 
 	// FUNCTION: LEGO1 0x10002d40
 	virtual MxU32 VTable0x90(float, Matrix4&) { return FALSE; } // vtable+0x90

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -234,7 +234,7 @@ MxResult LegoPathActor::VTable0x84(
 
 // FUNCTION: LEGO1 0x1002e100
 // FUNCTION: BETA10 0x100b0520
-MxS32 LegoPathActor::VTable0x8c(float p_time, MxMatrix& p_transform)
+MxS32 LegoPathActor::VTable0x8c(float p_time, Matrix4& p_transform)
 {
 	if (m_userNavFlag && m_actorState == c_initial) {
 		m_lastTime = p_time;

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -704,7 +704,9 @@ MxResult LegoAnimPresenter::FUN_1006b140(LegoROI* p_roi)
 		return FAILURE;
 	}
 
-	MxMatrix* mn = new MxMatrix();
+	Matrix4* mn = new MxMatrix();
+	assert(mn);
+
 	MxMatrix local58;
 	const Matrix4& local2world = p_roi->GetLocal2World();
 	MxMatrix* local5c;
@@ -725,7 +727,7 @@ MxResult LegoAnimPresenter::FUN_1006b140(LegoROI* p_roi)
 	}
 
 	{
-		((Matrix4*) mn)->Product(local58, local2world);
+		mn->Product(local58, local2world);
 		SetUnknown0xa0(mn);
 		delete[] local5c;
 		SetUnknown0x0cTo1();
@@ -734,7 +736,7 @@ MxResult LegoAnimPresenter::FUN_1006b140(LegoROI* p_roi)
 		MxMatrix localf8;
 
 		localf8.Product(local140, *m_unk0xa0);
-		((Matrix4&) *m_unk0x78) = localf8;
+		*m_unk0x78 = localf8;
 		return SUCCESS;
 	}
 

--- a/LEGO1/lego/sources/misc/legounknown.cpp
+++ b/LEGO1/lego/sources/misc/legounknown.cpp
@@ -37,7 +37,7 @@ void LegoUnknown::FUN_1009a140(
 
 // FUNCTION: LEGO1 0x1009a1e0
 // FUNCTION: BETA10 0x10182d61
-LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, MxMatrix& p_mat, Vector3& p_v, LegoU32 p_und)
+LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, LegoU32 p_und)
 {
 	Vector3 v1(p_mat[3]);
 	Vector3 v2(p_mat[0]);

--- a/LEGO1/lego/sources/misc/legounknown.h
+++ b/LEGO1/lego/sources/misc/legounknown.h
@@ -4,7 +4,7 @@
 #include "legotypes.h"
 #include "mxgeometry/mxgeometry3d.h"
 
-class MxMatrix;
+class Matrix4;
 
 // SIZE 0x50
 class LegoUnknown {
@@ -18,7 +18,7 @@ public:
 		const Vector3& p_point3,
 		const Vector3& p_point4
 	);
-	LegoResult FUN_1009a1e0(float p_f1, MxMatrix& p_mat, Vector3& p_v, LegoU32 p_und);
+	LegoResult FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, LegoU32 p_und);
 
 private:
 	Mx3DPointFloat m_unk0x00[4]; // 0x00

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -736,6 +736,7 @@ TimeROI::TimeROI(Tgl::Renderer* p_renderer, ViewLODList* p_lodList, LegoTime p_t
 }
 
 // FUNCTION: LEGO1 0x100a9b40
+// FUNCTION: BETA10 0x1018bbf0
 void TimeROI::FUN_100a9b40(Matrix4& p_matrix, LegoTime p_time)
 {
 	LegoTime time = p_time - m_time;
@@ -747,7 +748,7 @@ void TimeROI::FUN_100a9b40(Matrix4& p_matrix, LegoTime p_time)
 		Vector3 vec(m_local2world[3]);
 
 		targetPosition -= vec;
-		targetPosition /= time * 0.001;
+		targetPosition /= time / 1000.0;
 
 		FUN_100a5a30(targetPosition);
 	}

--- a/LEGO1/mxgeometry/mxmatrix.h
+++ b/LEGO1/mxgeometry/mxmatrix.h
@@ -22,7 +22,6 @@ public:
 	// FUNCTION: BETA10 0x10010860
 	float* operator[](int idx) { return m_data[idx]; }
 
-	// FUNCTION: BETA10 0x1001c670
 	const float* operator[](int idx) const { return m_data[idx]; }
 
 	// FUNCTION: LEGO1 0x10002850

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -48,6 +48,7 @@ public:
 	inline int BETA_1005a590(Matrix4& p_mat);
 	inline void Swap(int p_d1, int p_d2);
 
+	// FUNCTION: BETA10 0x1001c670
 	float* operator[](int idx) { return m_data[idx]; }
 
 	// FUNCTION: BETA10 0x10017780

--- a/LEGO1/realtime/matrix4d.inl.h
+++ b/LEGO1/realtime/matrix4d.inl.h
@@ -292,8 +292,8 @@ int Matrix4::BETA_1005a590(Matrix4& p_mat)
 {
 	float local5c[4][4];
 	Matrix4 localc(local5c);
+	localc = *this;
 
-	((Matrix4&) localc) = *this;
 	p_mat.SetIdentity();
 
 	for (int i = 0; i < 4; i++) {

--- a/LEGO1/realtime/orientableroi.cpp
+++ b/LEGO1/realtime/orientableroi.cpp
@@ -68,6 +68,7 @@ void OrientableROI::WrappedVTable0x24(const Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x100a50a0
+// FUNCTION: BETA10 0x1016601f
 void OrientableROI::GetLocalTransform(Matrix4& p_transform)
 {
 	MxMatrix mat;


### PR DESCRIPTION
This fixes the BETA annotation of `Matrix4::operator[]`, which was previously annotated as `MxMatrix::operator[] const`. The best place to verify that this is correct is `LegoView1::Create`, since it accesses both a `Matrix4` and `MxMatrix`.

In consequence, several function parameters and members which were previously `MxMatrix` were changed to be of type `Matrix4` instead. Matches of affected functions stay the same. (but plenty of entropy in the code base as usual)