### PR TITLE
Add BETA10 reference to `_aexit_rtn`

### DIFF
--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -774,6 +774,9 @@
 // LIBRARY: BETA10 0x100fbdb0
 // _exit
 
+// GLOBAL: BETA10 0x101faf70
+// _aexit_rtn
+
 // LIBRARY: BETA10 0x10100bf0
 // _CrtDbgReport
 


### PR DESCRIPTION
See https://github.com/isledecomp/reccmp/pull/89#issuecomment-2692662622. Should have no impact at the moment, but will fix/prevent a small regression when the linked PR on `reccmp` is merged.