### PR TITLE
Write entropy report to HTML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,9 +263,9 @@ jobs:
     - name: Aggregate Accuracy
       shell: bash
       run: |
-        reccmp-aggregate --samples $(find build-entropy -type f -name "CONFIGPROGRESS.json") --output CONFIGPROGRESS-agg.json
-        reccmp-aggregate --samples $(find build-entropy -type f -name "ISLEPROGRESS.json") --output ISLEPROGRESS-agg.json
-        reccmp-aggregate --samples $(find build-entropy -type f -name "LEGO1PROGRESS.json") --output LEGO1PROGRESS-agg.json
+        reccmp-aggregate --samples $(find build-entropy -type f -name "CONFIGPROGRESS.json") --output CONFIGPROGRESS-agg.json --html CONFIGPROGRESS-agg.html
+        reccmp-aggregate --samples $(find build-entropy -type f -name "ISLEPROGRESS.json") --output ISLEPROGRESS-agg.json --html ISLEPROGRESS-agg.html
+        reccmp-aggregate --samples $(find build-entropy -type f -name "LEGO1PROGRESS.json") --output LEGO1PROGRESS-agg.json --html LEGO1PROGRESS-agg.html
 
     - name: Compare Aggregate Accuracy With Current Master
       shell: bash


### PR DESCRIPTION
isledecomp/reccmp#94 adds the feature to `reccmp-aggregate` to create an HTML report from the aggregate run. This enables that option in CI so the files will get included in the build artifact.

For each entity we choose the sample that has the highest accuracy score. The new HTML report includes the diff that resulted in that score.