### PR TITLE
`MxDirect3D::D3DSetMode` to 100% (and more)

### DIFF
--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -12,21 +12,24 @@ DECOMP_SIZE_ASSERT(MxDirect3D, 0x894)
 	}
 
 // FUNCTION: LEGO1 0x1009b0a0
+// FUNCTION: BETA10 0x1011b220
 MxDirect3D::MxDirect3D()
 {
-	this->m_pDirect3d = NULL;
-	this->m_pDirect3dDevice = NULL;
-	this->m_bTexturesDisabled = FALSE;
-	this->m_assignedDevice = NULL;
+	m_pDirect3d = NULL;
+	m_pDirect3dDevice = NULL;
+	m_bTexturesDisabled = FALSE;
+	m_currentDeviceInfo = NULL;
 }
 
 // FUNCTION: LEGO1 0x1009b140
+// FUNCTION: BETA10 0x1011b2c3
 MxDirect3D::~MxDirect3D()
 {
 	Destroy();
 }
 
 // FUNCTION: LEGO1 0x1009b1a0
+// FUNCTION: BETA10 0x1011b333
 BOOL MxDirect3D::Create(
 	HWND hWnd,
 	BOOL fullscreen_1,
@@ -40,22 +43,33 @@ BOOL MxDirect3D::Create(
 )
 {
 	BOOL success = FALSE;
-	BOOL ret = MxDirectDraw::Create(
-		hWnd,
-		fullscreen_1,
-		surface_fullscreen,
-		onlySystemMemory,
-		width,
-		height,
-		bpp,
-		pPaletteEntries,
-		paletteEntryCount
-	);
+	assert(m_currentDeviceInfo);
 
-	if (ret && D3DCreate() && D3DSetMode()) {
-		success = TRUE;
+	if (!MxDirectDraw::Create(
+			hWnd,
+			fullscreen_1,
+			surface_fullscreen,
+			onlySystemMemory,
+			width,
+			height,
+			bpp,
+			pPaletteEntries,
+			paletteEntryCount
+		)) {
+		goto done;
 	}
 
+	if (!D3DCreate()) {
+		goto done;
+	}
+
+	if (!D3DSetMode()) {
+		goto done;
+	}
+
+	success = TRUE;
+
+done:
 	if (!success) {
 		FUN_1009d920();
 	}
@@ -64,24 +78,26 @@ BOOL MxDirect3D::Create(
 }
 
 // FUNCTION: LEGO1 0x1009b210
+// FUNCTION: BETA10 0x1011b41d
 void MxDirect3D::Destroy()
 {
 	RELEASE(m_pDirect3dDevice);
 	RELEASE(m_pDirect3d);
 
-	if (this->m_assignedDevice) {
-		delete m_assignedDevice;
-		this->m_assignedDevice = NULL;
+	if (m_currentDeviceInfo) {
+		delete m_currentDeviceInfo;
+		m_currentDeviceInfo = NULL;
 	}
 
-	if (m_pCurrentDeviceModesList) {
-		m_pCurrentDeviceModesList = NULL;
+	if (m_currentDevInfo) {
+		m_currentDevInfo = NULL;
 	}
 
 	MxDirectDraw::Destroy();
 }
 
 // FUNCTION: LEGO1 0x1009b290
+// FUNCTION: BETA10 0x1011b50a
 void MxDirect3D::DestroyButNotDirectDraw()
 {
 	RELEASE(m_pDirect3dDevice);
@@ -90,6 +106,7 @@ void MxDirect3D::DestroyButNotDirectDraw()
 }
 
 // FUNCTION: LEGO1 0x1009b2d0
+// FUNCTION: BETA10 0x1011b592
 BOOL MxDirect3D::D3DCreate()
 {
 	HRESULT result;
@@ -103,46 +120,50 @@ BOOL MxDirect3D::D3DCreate()
 }
 
 // FUNCTION: LEGO1 0x1009b310
+// FUNCTION: BETA10 0x1011b617
 BOOL MxDirect3D::D3DSetMode()
 {
-	if (m_assignedDevice->m_flags & MxAssignedDevice::c_hardwareMode) {
+	assert(m_currentDeviceInfo);
+
+	if (m_currentDeviceInfo->m_flags & MxAssignedDevice::c_hardwareMode) {
 		if (m_bOnlySoftRender) {
 			Error("Failed to place vital surfaces in video memory for hardware driver", DDERR_GENERIC);
 			return FALSE;
 		}
 
-		if (m_assignedDevice->m_desc.dpcTriCaps.dwTextureCaps & D3DPTEXTURECAPS_PERSPECTIVE) {
+		if (m_currentDeviceInfo->m_desc.dpcTriCaps.dwTextureCaps & D3DPTEXTURECAPS_PERSPECTIVE) {
 			m_bTexturesDisabled = FALSE;
 		}
 		else {
 			m_bTexturesDisabled = TRUE;
 		}
 
-		if (!CreateZBuffer(DDSCAPS_VIDEOMEMORY, ZBufferDepth(m_assignedDevice))) {
+		if (!CreateZBuffer(DDSCAPS_VIDEOMEMORY, ZBufferDepth(m_currentDeviceInfo))) {
 			return FALSE;
 		}
 	}
 	else {
-		if (m_assignedDevice->m_desc.dpcTriCaps.dwTextureCaps & D3DPTEXTURECAPS_PERSPECTIVE) {
+		if (m_currentDeviceInfo->m_desc.dpcTriCaps.dwTextureCaps & D3DPTEXTURECAPS_PERSPECTIVE) {
 			m_bTexturesDisabled = FALSE;
 		}
 		else {
 			m_bTexturesDisabled = TRUE;
 		}
 
-		if (!CreateZBuffer(DDSCAPS_SYSTEMMEMORY, ZBufferDepth(m_assignedDevice))) {
+		if (!CreateZBuffer(DDSCAPS_SYSTEMMEMORY, ZBufferDepth(m_currentDeviceInfo))) {
 			return FALSE;
 		}
 	}
 
-	HRESULT result = m_pDirect3d->CreateDevice(m_assignedDevice->m_guid, m_pBackBuffer, &m_pDirect3dDevice);
+	LPDIRECTDRAWSURFACE backBuf = BackBuffer();
+	HRESULT result = m_pDirect3d->CreateDevice(m_currentDeviceInfo->m_guid, backBuf, &m_pDirect3dDevice);
 
 	if (result != DD_OK) {
 		Error("Create D3D device failed", result);
 		return FALSE;
 	}
 
-	DeviceModesInfo::Mode mode = m_currentMode;
+	DeviceModesInfo::Mode mode = *CurrentMode();
 
 	if (IsFullScreen()) {
 		if (!IsSupportedMode(mode.width, mode.height, mode.bitsPerPixel)) {
@@ -151,8 +172,8 @@ BOOL MxDirect3D::D3DSetMode()
 		}
 	}
 
-	LPDIRECTDRAWSURFACE frontBuffer = m_pFrontBuffer;
-	LPDIRECTDRAWSURFACE backBuffer = m_pBackBuffer;
+	LPDIRECTDRAWSURFACE frontBuffer = FrontBuffer();
+	LPDIRECTDRAWSURFACE backBuffer = BackBuffer();
 
 	DDSURFACEDESC desc;
 	memset(&desc, 0, sizeof(desc));
@@ -161,7 +182,7 @@ BOOL MxDirect3D::D3DSetMode()
 	if (backBuffer->Lock(NULL, &desc, DDLOCK_WAIT, NULL) == DD_OK) {
 		unsigned char* surface = (unsigned char*) desc.lpSurface;
 
-		for (int i = mode.height; i > 0; i--) {
+		for (int i = 0; i < mode.height; i++) {
 			memset(surface, 0, mode.width * desc.ddpfPixelFormat.dwRGBBitCount / 8);
 			surface += desc.lPitch;
 		}
@@ -172,14 +193,14 @@ BOOL MxDirect3D::D3DSetMode()
 		OutputDebugString("MxDirect3D::D3DSetMode() back lock failed\n");
 	}
 
-	if (m_bFullScreen) {
+	if (IsFullScreen()) {
 		memset(&desc, 0, sizeof(desc));
 		desc.dwSize = sizeof(desc);
 
 		if (frontBuffer->Lock(NULL, &desc, DDLOCK_WAIT, NULL) == DD_OK) {
 			unsigned char* surface = (unsigned char*) desc.lpSurface;
 
-			for (int i = mode.height; i > 0; i--) {
+			for (int i = 0; i < mode.height; i++) {
 				memset(surface, 0, mode.width * desc.ddpfPixelFormat.dwRGBBitCount / 8);
 				surface += desc.lPitch;
 			}
@@ -195,6 +216,7 @@ BOOL MxDirect3D::D3DSetMode()
 }
 
 // FUNCTION: LEGO1 0x1009b5a0
+// FUNCTION: BETA10 0x1011babb
 int MxDirect3D::ZBufferDepth(MxAssignedDevice* p_assignedDevice)
 {
 	int depth;
@@ -230,10 +252,10 @@ int MxDirect3D::ZBufferDepth(MxAssignedDevice* p_assignedDevice)
 // FUNCTION: BETA10 0x1011bbca
 BOOL MxDirect3D::SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_driver, Direct3DDeviceInfo* p_device)
 {
-	if (m_assignedDevice) {
-		delete m_assignedDevice;
-		m_assignedDevice = NULL;
-		m_pCurrentDeviceModesList = NULL;
+	if (m_currentDeviceInfo) {
+		delete m_currentDeviceInfo;
+		m_currentDeviceInfo = NULL;
+		m_currentDevInfo = NULL;
 	}
 
 	MxAssignedDevice* d = new MxAssignedDevice;
@@ -287,15 +309,15 @@ BOOL MxDirect3D::SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_dri
 						d->m_desc = device.m_HELDesc;
 					}
 
-					m_assignedDevice = d;
-					m_pCurrentDeviceModesList = d->m_deviceInfo;
+					m_currentDeviceInfo = d;
+					m_currentDevInfo = d->m_deviceInfo;
 					break;
 				}
 			}
 		}
 	}
 
-	if (!m_assignedDevice) {
+	if (!m_currentDeviceInfo) {
 		delete d;
 		return FALSE;
 	}

--- a/LEGO1/mxdirectx/mxdirect3d.h
+++ b/LEGO1/mxdirectx/mxdirect3d.h
@@ -9,6 +9,7 @@
 #include <d3d.h>
 
 // VTABLE: LEGO1 0x100db800
+// VTABLE: BETA10 0x101c1af8
 // SIZE 0x894
 class MxDirect3D : public MxDirectDraw {
 public:
@@ -29,9 +30,13 @@ public:
 	void Destroy() override;                 // vtable+0x08
 	void DestroyButNotDirectDraw() override; // vtable+0x0c
 
-	MxAssignedDevice* AssignedDevice() { return this->m_assignedDevice; }
-	IDirect3D2* Direct3D() { return this->m_pDirect3d; }
-	IDirect3DDevice2* Direct3DDevice() { return this->m_pDirect3dDevice; }
+	MxAssignedDevice* AssignedDevice() { return m_currentDeviceInfo; }
+
+	// FUNCTION: BETA10 0x100d8b40
+	IDirect3D2* Direct3D() { return m_pDirect3d; }
+
+	// FUNCTION: BETA10 0x100d8b70
+	IDirect3DDevice2* Direct3DDevice() { return m_pDirect3dDevice; }
 
 	BOOL SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_driver, Direct3DDeviceInfo* p_device);
 
@@ -42,14 +47,19 @@ protected:
 	int ZBufferDepth(MxAssignedDevice* p_assignedDevice);
 
 	// SYNTHETIC: LEGO1 0x1009b120
+	// SYNTHETIC: BETA10 0x1011c0f0
 	// MxDirect3D::`scalar deleting destructor'
 
 private:
-	MxAssignedDevice* m_assignedDevice;  // 0x880
-	IDirect3D2* m_pDirect3d;             // 0x884
-	IDirect3DDevice2* m_pDirect3dDevice; // 0x888
-	BOOL m_bTexturesDisabled;            // 0x88c
-	undefined4 m_unk0x890;               // 0x890
+	MxAssignedDevice* m_currentDeviceInfo; // 0x880
+	IDirect3D2* m_pDirect3d;               // 0x884
+	IDirect3DDevice2* m_pDirect3dDevice;   // 0x888
+	BOOL m_bTexturesDisabled;              // 0x88c
+	undefined4 m_unk0x890;                 // 0x890
 };
+
+// GLOBAL: LEGO1 0x100dd1b0
+// GLOBAL: BETA10 0x101c2de8
+// IID_IDirect3D2
 
 #endif // MXDIRECT3D_H

--- a/LEGO1/mxdirectx/mxdirectdraw.h
+++ b/LEGO1/mxdirectx/mxdirectdraw.h
@@ -7,6 +7,7 @@
 #include <windows.h>
 
 // VTABLE: LEGO1 0x100db818
+// VTABLE: BETA10 0x101c1b10
 // SIZE 0x880
 class MxDirectDraw {
 public:
@@ -32,10 +33,20 @@ public:
 	virtual void DestroyButNotDirectDraw(); // vtable+0x0c
 
 	IDirectDraw* DirectDraw() { return m_pDirectDraw; }
+
+	// FUNCTION: BETA10 0x100d8ab0
 	IDirectDrawSurface* FrontBuffer() { return m_pFrontBuffer; }
+
+	// FUNCTION: BETA10 0x100d8ae0
 	IDirectDrawSurface* BackBuffer() { return m_pBackBuffer; }
+
+	// FUNCTION: BETA10 0x100d8b10
 	IDirectDrawClipper* Clipper() { return m_pClipper; }
 
+	// FUNCTION: BETA10 0x1011c190
+	DeviceModesInfo::Mode* CurrentMode() { return &m_currentMode; }
+
+	// FUNCTION: BETA10 0x1011c170
 	BOOL IsFullScreen() { return m_bFullScreen; }
 
 	BOOL IsSupportedMode(int width, int height, int bpp);
@@ -72,6 +83,7 @@ protected:
 	void FUN_1009d920();
 
 	// SYNTHETIC: LEGO1 0x1009d510
+	// SYNTHETIC: BETA10 0x10122f80
 	// MxDirectDraw::`scalar deleting destructor'
 
 protected:
@@ -102,7 +114,7 @@ protected:
 	void* m_pErrorHandlerArg;                   // 0x864
 	void* m_pFatalErrorHandlerArg;              // 0x868
 	int m_pauseCount;                           // 0x86c
-	DeviceModesInfo* m_pCurrentDeviceModesList; // 0x870
+	DeviceModesInfo* m_currentDevInfo;          // 0x870
 	DeviceModesInfo::Mode m_currentMode;        // 0x874
 };
 

--- a/LEGO1/mxdirectx/mxdirectxinfo.h
+++ b/LEGO1/mxdirectx/mxdirectxinfo.h
@@ -10,6 +10,7 @@
 struct DeviceModesInfo {
 	// SIZE 0x0c
 	struct Mode {
+		// FUNCTION: BETA10 0x10122fc0
 		int operator==(const Mode& p_mode) const
 		{
 			return ((width == p_mode.width) && (height == p_mode.height) && (bitsPerPixel == p_mode.bitsPerPixel));


### PR DESCRIPTION
Beta addrs for `MxDirectDraw` and `MxDirect3D`, removing `this->`, general tweaks, etc.

Despite all that, the only real increase is in `MxDirect3D::D3DSetMode`, now 100%. It doesn't fully match the beta. For example:

```diff
; if (m_currentDeviceInfo->m_flags & MxAssignedDevice::c_hardwareMode)
-mov eax, dword ptr [eax + 0x10]
-shl eax, 0x1f
-and eax, 0x80000000
-xor ecx, ecx
-and ecx, 0x80000000
-cmp eax, ecx
+test byte ptr [eax + 0x10], 1
```

Maybe a bitfield?

Asserts revealed two member names: the very similar `m_currentDeviceInfo` and `m_currentDevInfo`.
