### PR TITLE
Match `MxControlPresenter::HasTickleStatePassed`

### DIFF
--- a/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
@@ -296,9 +296,14 @@ void MxControlPresenter::Enable(MxBool p_enable)
 // FUNCTION: LEGO1 0x100448a0
 MxBool MxControlPresenter::HasTickleStatePassed(TickleState p_tickleState)
 {
-	MxCompositePresenterList::iterator it = m_list.begin();
-	for (MxS16 i = m_unk0x4e; i > 0; i--, it++) {
-	}
+	MxCompositePresenterList::const_iterator it = m_list.begin();
+
+#ifdef COMPAT_MODE
+	advance(it, m_unk0x4e);
+#else
+	// Uses forward iterator logic instead of bidrectional for some reason.
+	_Advance(it, m_unk0x4e, forward_iterator_tag());
+#endif
 
 	return (*it)->HasTickleStatePassed(p_tickleState);
 }


### PR DESCRIPTION
The only way to get this to match is to have an inline function like `advance` (with that exact interface). However, standard STL `advance` doesn't work because of the bidirectional nature of the list iterator; it will decrement the iterator if `n` is negative. But this is not part of the original assembly.

Defining a new (template) method like `advance` separately would work, but doesn't make a whole lot of sense in the context of that class with the required interface so I used a direct call to internal `_Advance` with the `forward_iterator` tag instead. Maybe they defined a function like that in the global scope like other template functions in `mxutilities.h`? Or they had a diferent version of the STL?