### PR TITLE
Match `LegoAnimPresenterSetCompare` comparison

### DIFF
--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -21,7 +21,7 @@ struct LegoPathActorSetCompare {
 };
 
 struct LegoAnimPresenterSetCompare {
-	MxBool operator()(const LegoAnimPresenter* p_lhs, const LegoAnimPresenter* p_rhs) const
+	MxU32 operator()(const LegoAnimPresenter* p_lhs, const LegoAnimPresenter* p_rhs) const
 	{
 		return (COMPARE_POINTER_TYPE) p_lhs < (COMPARE_POINTER_TYPE) p_rhs;
 	}


### PR DESCRIPTION
Matches `_Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::insert`