### PR TITLE
Match `MxStreamController::RemoveSubscriber`

### DIFF
--- a/LEGO1/omni/src/stream/mxstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxstreamcontroller.cpp
@@ -87,7 +87,7 @@ void MxStreamController::AddSubscriber(MxDSSubscriber* p_subscriber)
 // FUNCTION: BETA10 0x1014e7b4
 void MxStreamController::RemoveSubscriber(MxDSSubscriber* p_subscriber)
 {
-	m_subscribers.Remove(p_subscriber);
+	m_subscribers.remove(p_subscriber);
 }
 
 // FUNCTION: LEGO1 0x100c1690


### PR DESCRIPTION
Doesn't use the `Remove` proxy function for some reason in retail