### PR TITLE
`MxControlPresenter::FUN_10044270` to 100%?

### DIFF
--- a/LEGO1/lego/legoomni/include/mxcontrolpresenter.h
+++ b/LEGO1/lego/legoomni/include/mxcontrolpresenter.h
@@ -5,7 +5,6 @@
 #include "mxcompositepresenter.h"
 
 class LegoControlManagerNotificationParam;
-class MxVideoPresenter;
 
 // VTABLE: LEGO1 0x100d7b88
 // VTABLE: BETA10 0x101bf5d0
@@ -48,18 +47,18 @@ public:
 	virtual void VTable0x6c(MxS16 p_unk0x4e);                        // vtable+0x6c
 
 	MxBool FUN_10044480(LegoControlManagerNotificationParam* p_param, MxPresenter* p_presenter);
-	MxBool FUN_10044270(MxS32 p_x, MxS32 p_y, MxVideoPresenter* p_presenter);
+	MxBool FUN_10044270(MxS32 p_x, MxS32 p_y, MxPresenter* p_presenter);
 
 	MxS16 GetUnknown0x4e() { return m_unk0x4e; }
 
 private:
-	undefined2 m_unk0x4c; // 0x4c
-	MxS16 m_unk0x4e;      // 0x4e
-	MxBool m_unk0x50;     // 0x50
-	undefined2 m_unk0x52; // 0x52
-	undefined2 m_unk0x54; // 0x54
-	undefined2 m_unk0x56; // 0x56
-	MxS16* m_unk0x58;     // 0x58
+	MxS16 m_unk0x4c;  // 0x4c
+	MxS16 m_unk0x4e;  // 0x4e
+	MxBool m_unk0x50; // 0x50
+	MxS16 m_unk0x52;  // 0x52
+	MxS16 m_unk0x54;  // 0x54
+	MxS16 m_unk0x56;  // 0x56
+	MxS16* m_states;  // 0x58
 };
 
 // SYNTHETIC: LEGO1 0x100440f0

--- a/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
+++ b/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
@@ -144,12 +144,13 @@ void LegoControlManager::FUN_100293c0(MxU32 p_objectId, const char* p_atom, MxS1
 }
 
 // FUNCTION: LEGO1 0x100294e0
+// FUNCTION: BETA10 0x1007c92f
 MxControlPresenter* LegoControlManager::FUN_100294e0(MxS32 p_x, MxS32 p_y)
 {
 	if (m_presenterList) {
 		MxPresenterListCursor cursor(m_presenterList);
 		MxPresenter* control;
-		MxVideoPresenter* presenter = (MxVideoPresenter*) VideoManager()->GetPresenterAt(p_x, p_y);
+		MxPresenter* presenter = VideoManager()->GetPresenterAt(p_x, p_y);
 
 		if (presenter) {
 			while (cursor.Next(control)) {

--- a/LEGO1/omni/src/common/mxutilities.cpp
+++ b/LEGO1/omni/src/common/mxutilities.cpp
@@ -81,6 +81,7 @@ void MakeSourceName(char* p_output, const char* p_input)
 }
 
 // FUNCTION: LEGO1 0x100b7050
+// FUNCTION: BETA10 0x10136c19
 MxBool KeyValueStringParse(char* p_output, const char* p_command, const char* p_string)
 {
 	MxBool didMatch = FALSE;
@@ -92,7 +93,8 @@ MxBool KeyValueStringParse(char* p_output, const char* p_command, const char* p_
 	assert(string);
 	strcpy(string, p_string);
 
-	for (char* token = strtok(string, ", \t\r\n:"); token; token = strtok(NULL, ", \t\r\n:")) {
+	const char* delim = ", \t\r\n:";
+	for (char* token = strtok(string, delim); token; token = strtok(NULL, delim)) {
 		len -= (strlen(token) + 1);
 
 		if (strcmpi(token, p_command) == 0) {
@@ -116,6 +118,7 @@ MxBool KeyValueStringParse(char* p_output, const char* p_command, const char* p_
 }
 
 // FUNCTION: LEGO1 0x100b7170
+// FUNCTION: BETA10 0x10136e12
 MxBool ContainsPresenter(MxCompositePresenterList& p_presenterList, MxPresenter* p_presenter)
 {
 	for (MxCompositePresenterList::iterator it = p_presenterList.begin(); it != p_presenterList.end(); it++) {


### PR DESCRIPTION
Resolves #1344. The best I can get with a lot of entropy samples is 95.51%. But here's the main diff:

```diff
mov eax, dword ptr [ebx + 0x18]
cmp dword ptr [edi + 0x18], eax
-jge 0x119
+jge 0x11b
+mov eax, dword ptr [ebx]
+mov ecx, ebx
+call dword ptr [eax + 0x7c]
+test al, al
+je 0x10c
mov ebp, dword ptr [edi]
-mov ecx, edi
-call dword ptr [ebp + 0x7c]
-test al, al
-je 0x10a
mov ecx, edi
call dword ptr [ebp + 0x84]
```

That looks fine to me. Easier to see it side by side. The jump diffs are caused by using different registers.
```
mov eax, dword ptr [ebx + 0x18]
cmp dword ptr [edi + 0x18], eax
jge 0x119                        ; jge 0x11b
mov ebp, dword ptr [edi]         ; mov eax, dword ptr [ebx]
mov ecx, edi                     ; mov ecx, ebx
call dword ptr [ebp + 0x7c]      ; call dword ptr [eax + 0x7c]
test al, al                      ; test al, al
je 0x10a                         ; je 0x10c
mov ecx, edi
call dword ptr [ebp + 0x84]
```

**Changes:**

- The beta makes a copy of the `p_presenter` parameter, so I took that to mean it is a cast from `MxPresenter*` and updated the callers.
- The assert checks for `MxStillPresenter`, a subclass of `MxVideoPresenter`, so we now use that.
- Beta instructions showed where `undefined2` members of `MxControlPresenter` should be `MxS16`.
- The beta uses the helper function `GetBitmapStart()` in place of `GetBitmap()->GetStart()`. Using it drops retail accuracy, so I left it as is. (The late addition of the alpha mask in retail might explain this diff.)
- Named the member `m_states` based on the assert for `numStates` in `ParseExtra`.
- I needed this cast to get close to 100%.
  ```cpp
  if (m_states[i] == (MxS16) *start)
  ```
  I tried to see whether `m_states` should be `MxU16` instead. Making that change fixes this but breaks other things.
- Used ternary assignment where it helped.
- Improved beta match for `MxUtilities::KeyValueStringParse` and `MxControlPresenter::ParseExtra`. Both stay at 100% in retail.