### PR TITLE
Fix `AlphaMask` functions

### DIFF
--- a/LEGO1/omni/include/mxbitmap.h
+++ b/LEGO1/omni/include/mxbitmap.h
@@ -115,7 +115,7 @@ public:
 	MxLong GetDataSize() const { return AlignToFourByte(m_bmiHeader->biWidth) * GetBmiHeightAbs(); }
 
 	// FUNCTION: BETA10 0x1002c4b0
-	MxBool IsTopDown()
+	MxBool IsTopDown() const
 	{
 		if (m_bmiHeader->biCompression == BI_RGB_TOPDOWN) {
 			return TRUE;
@@ -130,7 +130,7 @@ public:
 						   : -p_bitmap->AlignToFourByte(p_bitmap->GetBmiWidth()))
 
 	// FUNCTION: BETA10 0x1002c320
-	MxU8* GetStart(MxS32 p_left, MxS32 p_top)
+	MxU8* GetStart(MxS32 p_left, MxS32 p_top) const
 	{
 		if (m_bmiHeader->biCompression == BI_RGB) {
 			return m_data + p_left +


### PR DESCRIPTION
Resolves #1424. I wrote up the issue expecting it to sit for a while and then figured it out pretty quickly. As it turns out, we _did_ already have the utility function we needed (`GetStart`) from the beta.

`IsHit` and the bitmap constructor can both hit 100% in an entropy build.