### PR TITLE
Add getters to `MxVideoPresenter::AlphaMask`

### DIFF
--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -48,10 +48,13 @@ public:
 	virtual MxBool VTable0x7c() { return m_frameBitmap != NULL || m_alpha != NULL; } // vtable+0x7c
 
 	// FUNCTION: LEGO1 0x1000c7e0
-	virtual MxS32 GetWidth() { return m_alpha ? m_alpha->m_width : m_frameBitmap->GetBmiWidth(); } // vtable+0x80
+	virtual MxS32 GetWidth() { return m_alpha ? m_alpha->GetWidth() : m_frameBitmap->GetBmiWidth(); } // vtable+0x80
 
 	// FUNCTION: LEGO1 0x1000c800
-	virtual MxS32 GetHeight() { return m_alpha ? m_alpha->m_height : m_frameBitmap->GetBmiHeightAbs(); } // vtable+0x84
+	virtual MxS32 GetHeight()
+	{
+		return m_alpha ? m_alpha->GetHeight() : m_frameBitmap->GetBmiHeightAbs();
+	} // vtable+0x84
 
 	// FUNCTION: BETA10 0x100551b0
 	static const char* HandlerClassName()
@@ -85,19 +88,24 @@ public:
 
 	// VTABLE: LEGO1 0x100dc2bc
 	// SIZE 0x0c
-	struct AlphaMask {
-		MxU8* m_bitmask;
-		MxU16 m_width;
-		MxU16 m_height;
-
+	class AlphaMask {
+	public:
 		AlphaMask(const MxBitmap&);
 		AlphaMask(const AlphaMask&);
 		virtual ~AlphaMask();
 
 		MxS32 IsHit(MxU32 p_x, MxU32 p_y);
 
+		MxS32 GetWidth() const { return m_width; }
+		MxS32 GetHeight() const { return m_height; }
+
 		// SYNTHETIC: LEGO1 0x100b2650
 		// MxVideoPresenter::AlphaMask::`scalar deleting destructor'
+
+	private:
+		MxU8* m_bitmask; // 0x00
+		MxU16 m_width;   // 0x04
+		MxU16 m_height;  // 0x08
 	};
 
 	inline MxS32 PrepareRects(RECT& p_rectDest, RECT& p_rectSrc);


### PR DESCRIPTION
Resolves #1388.

Results of a 256-build entropy run below. (I removed the `_Tree` template functions.) GH won't let me attach the HTML report here but you can find it on the branch on my fork. I checked the decreased functions and they all look fine.
```
Increased (22):
0x1000c7e0 - MxVideoPresenter::GetWidth (60.00% -> 100.00%)
0x1000c800 - MxVideoPresenter::GetHeight (61.54% -> 100.00%)
0x10025450 - LegoCarBuild::FUN_10025450 (96.51% -> 97.09%)
0x1002aba0 - LegoExtraActor::HitActor (89.30% -> 89.52%)
0x1002b980 - LegoExtraActor::VTable0x6c (98.57% -> 100.00%*)
0x10031820 - Isle::Enable (99.80% -> 100.00%)
0x10040360 - Act3Cop::FUN_10040360 (90.64% -> 91.18%)
0x10041050 - Act3Brickster::Animate (98.38% -> 98.57%)
0x10048310 - LegoPathController::FUN_10048310 (89.75% -> 89.89%)
0x10054050 - Act3Ammo::Animate (95.18% -> 95.32%)
0x10066250 - Doors::Animate (93.26% -> 100.00%*)
0x10070d10 - Infocenter::FUN_10070d10 (88.46% -> 100.00%*)
0x10074a60 - Hospital::ReadyWorld (91.16% -> 98.58%)
0x100b2a70 - MxVideoPresenter::PutFrame (85.25% -> 86.18%)

Decreased (15):
0x10002bf0 - Vector4::EqualsHamiltonProduct (100.00%* -> 92.50%)
0x1002edd0 - LegoPathActor::FUN_1002edd0 (62.39% -> 60.79%)
0x1003e050 - FUN_1003e050 (100.00%* -> 99.47%)
0x10045c20 - LegoPathController::PlaceActor(class LegoPathActor *, char const *, int, float, int, float) (100.00% -> 96.14%)
0x1004a380 - LegoPathController::FUN_1004a380 (100.00% -> 99.31%)
0x1004b450 - LegoAnimMMPresenter::FUN_1004b450 (100.00% -> 92.41%)
0x100605e0 - LegoAnimationManager::FUN_100605e0 (100.00%* -> 99.67%)
0x10061010 - LegoAnimationManager::FUN_10061010 (54.37% -> 51.46%)
0x10062e20 - LegoAnimationManager::FUN_10062e20 (100.00% -> 98.83%)
0x100674b0 - LegoWorldPresenter::FUN_100674b0 (95.92% -> 95.04%)
0x1007f6b0 - LegoModelPresenter::CreateROI (100.00% -> 97.71%)
0x10081840 - LegoCarRaceActor::VTable0x6c (100.00%* -> 94.98%)
```