### PR TITLE
Beta match and cleanup of `MxDS*` classes

### DIFF
--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -47,17 +47,17 @@ public:
 		return !strcmp(p_name, MxDSAction::ClassName()) || MxDSObject::IsA(p_name);
 	}
 
-	undefined4 VTable0x14() override;                            // vtable+0x14;
-	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
-	virtual MxLong GetDuration();                                // vtable+0x24;
-	virtual void SetDuration(MxLong p_duration);                 // vtable+0x28;
-	virtual MxDSAction* Clone();                                 // vtable+0x2c;
-	virtual void MergeFrom(MxDSAction& p_dsAction);              // vtable+0x30;
-	virtual MxBool HasId(MxU32 p_objectId);                      // vtable+0x34;
-	virtual void SetUnknown90(MxLong p_unk0x90);                 // vtable+0x38;
-	virtual MxLong GetUnknown90();                               // vtable+0x3c;
-	virtual MxLong GetElapsedTime();                             // vtable+0x40;
+	undefined4 VTable0x14() override;                            // vtable+0x14
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c
+	virtual MxLong GetDuration();                                // vtable+0x24
+	virtual void SetDuration(MxLong p_duration);                 // vtable+0x28
+	virtual MxDSAction* Clone();                                 // vtable+0x2c
+	virtual void MergeFrom(MxDSAction& p_dsAction);              // vtable+0x30
+	virtual MxBool HasId(MxU32 p_objectId);                      // vtable+0x34
+	virtual void SetUnknown90(MxLong p_unk0x90);                 // vtable+0x38
+	virtual MxLong GetUnknown90();                               // vtable+0x3c
+	virtual MxLong GetElapsedTime();                             // vtable+0x40
 
 	void AppendExtra(MxU16 p_extraLength, const char* p_extraData);
 

--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -47,17 +47,17 @@ public:
 		return !strcmp(p_name, MxDSAction::ClassName()) || MxDSObject::IsA(p_name);
 	}
 
-	undefined4 VTable0x14() override;                            // vtable+14;
-	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
-	virtual MxLong GetDuration();                                // vtable+24;
-	virtual void SetDuration(MxLong p_duration);                 // vtable+28;
-	virtual MxDSAction* Clone();                                 // vtable+2c;
-	virtual void MergeFrom(MxDSAction& p_dsAction);              // vtable+30;
-	virtual MxBool HasId(MxU32 p_objectId);                      // vtable+34;
-	virtual void SetUnknown90(MxLong p_unk0x90);                 // vtable+38;
-	virtual MxLong GetUnknown90();                               // vtable+3c;
-	virtual MxLong GetElapsedTime();                             // vtable+40;
+	undefined4 VTable0x14() override;                            // vtable+0x14;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
+	virtual MxLong GetDuration();                                // vtable+0x24;
+	virtual void SetDuration(MxLong p_duration);                 // vtable+0x28;
+	virtual MxDSAction* Clone();                                 // vtable+0x2c;
+	virtual void MergeFrom(MxDSAction& p_dsAction);              // vtable+0x30;
+	virtual MxBool HasId(MxU32 p_objectId);                      // vtable+0x34;
+	virtual void SetUnknown90(MxLong p_unk0x90);                 // vtable+0x38;
+	virtual MxLong GetUnknown90();                               // vtable+0x3c;
+	virtual MxLong GetElapsedTime();                             // vtable+0x40;
 
 	void AppendExtra(MxU16 p_extraLength, const char* p_extraData);
 

--- a/LEGO1/omni/include/mxdsactionlist.h
+++ b/LEGO1/omni/include/mxdsactionlist.h
@@ -29,6 +29,7 @@ public:
 	} // vtable+0x14
 
 	// FUNCTION: LEGO1 0x100c9cb0
+	// FUNCTION: BETA10 0x1015add0
 	static void Destroy(MxDSAction* p_action) { delete p_action; }
 
 	// SYNTHETIC: LEGO1 0x100c9dc0
@@ -138,5 +139,8 @@ public:
 
 // TEMPLATE: BETA10 0x1015bd90
 // MxList<MxDSAction *>::DeleteAll
+
+// TEMPLATE: BETA10 0x1015be20
+// MxListCursor<MxDSAction *>::HasMatch
 
 #endif // MXDSACTIONLIST_H

--- a/LEGO1/omni/include/mxdsanim.h
+++ b/LEGO1/omni/include/mxdsanim.h
@@ -30,7 +30,7 @@ public:
 		return !strcmp(p_name, MxDSAnim::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override; // vtable+0x2c;
+	MxDSAction* Clone() override; // vtable+0x2c
 
 	// SYNTHETIC: LEGO1 0x100c9180
 	// SYNTHETIC: BETA10 0x1015d910

--- a/LEGO1/omni/include/mxdsanim.h
+++ b/LEGO1/omni/include/mxdsanim.h
@@ -9,6 +9,7 @@
 class MxDSAnim : public MxDSMediaAction {
 public:
 	MxDSAnim();
+	MxDSAnim(MxDSAnim& p_dsAnim);
 	~MxDSAnim() override;
 
 	void CopyFrom(MxDSAnim& p_dsAnim);
@@ -23,14 +24,16 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c9070
+	// FUNCTION: BETA10 0x1015d8b0
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSAnim::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override; // vtable+2c;
+	MxDSAction* Clone() override; // vtable+0x2c;
 
 	// SYNTHETIC: LEGO1 0x100c9180
+	// SYNTHETIC: BETA10 0x1015d910
 	// MxDSAnim::`scalar deleting destructor'
 };
 

--- a/LEGO1/omni/include/mxdsevent.h
+++ b/LEGO1/omni/include/mxdsevent.h
@@ -8,6 +8,7 @@
 class MxDSEvent : public MxDSMediaAction {
 public:
 	MxDSEvent();
+	MxDSEvent(MxDSEvent& p_dsEvent);
 	~MxDSEvent() override;
 
 	void CopyFrom(MxDSEvent& p_dsEvent);
@@ -22,14 +23,16 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c9670
+	// FUNCTION: BETA10 0x1015da30
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSEvent::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override; // vtable+2c;
+	MxDSAction* Clone() override; // vtable+0x2c;
 
 	// SYNTHETIC: LEGO1 0x100c9780
+	// SYNTHETIC: BETA10 0x1015da90
 	// MxDSEvent::`scalar deleting destructor'
 };
 

--- a/LEGO1/omni/include/mxdsevent.h
+++ b/LEGO1/omni/include/mxdsevent.h
@@ -29,7 +29,7 @@ public:
 		return !strcmp(p_name, MxDSEvent::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override; // vtable+0x2c;
+	MxDSAction* Clone() override; // vtable+0x2c
 
 	// SYNTHETIC: LEGO1 0x100c9780
 	// SYNTHETIC: BETA10 0x1015da90

--- a/LEGO1/omni/include/mxdsmediaaction.h
+++ b/LEGO1/omni/include/mxdsmediaaction.h
@@ -10,10 +10,10 @@
 class MxDSMediaAction : public MxDSAction {
 public:
 	MxDSMediaAction();
+	MxDSMediaAction(MxDSMediaAction& p_dsMediaAction);
 	~MxDSMediaAction() override;
 
 	void CopyFrom(MxDSMediaAction& p_dsMediaAction);
-	MxDSMediaAction(MxDSMediaAction& p_dsMediaAction);
 	MxDSMediaAction& operator=(MxDSMediaAction& p_dsMediaAction);
 
 	// FUNCTION: LEGO1 0x100c8be0
@@ -35,10 +35,10 @@ public:
 	// SYNTHETIC: BETA10 0x1015d810
 	// MxDSMediaAction::`scalar deleting destructor'
 
-	undefined4 VTable0x14() override;                            // vtable+14;
-	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
-	MxDSAction* Clone() override;                                // vtable+2c;
+	undefined4 VTable0x14() override;                            // vtable+0x14;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
+	MxDSAction* Clone() override;                                // vtable+0x2c;
 
 	void CopyMediaSrcPath(const char* p_mediaSrcPath);
 

--- a/LEGO1/omni/include/mxdsmediaaction.h
+++ b/LEGO1/omni/include/mxdsmediaaction.h
@@ -35,10 +35,10 @@ public:
 	// SYNTHETIC: BETA10 0x1015d810
 	// MxDSMediaAction::`scalar deleting destructor'
 
-	undefined4 VTable0x14() override;                            // vtable+0x14;
-	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
-	MxDSAction* Clone() override;                                // vtable+0x2c;
+	undefined4 VTable0x14() override;                            // vtable+0x14
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c
+	MxDSAction* Clone() override;                                // vtable+0x2c
 
 	void CopyMediaSrcPath(const char* p_mediaSrcPath);
 

--- a/LEGO1/omni/include/mxdsmultiaction.h
+++ b/LEGO1/omni/include/mxdsmultiaction.h
@@ -31,14 +31,14 @@ public:
 		return !strcmp(p_name, MxDSMultiAction::ClassName()) || MxDSAction::IsA(p_name);
 	}
 
-	undefined4 VTable0x14() override;                            // vtable+0x14;
-	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
-	void SetAtomId(MxAtomId p_atomId) override;                  // vtable+0x20;
-	MxDSAction* Clone() override;                                // vtable+0x2c;
-	void MergeFrom(MxDSAction& p_dsAction) override;             // vtable+0x30;
-	MxBool HasId(MxU32 p_objectId) override;                     // vtable+0x34;
-	void SetUnknown90(MxLong p_unk0x90) override;                // vtable+0x38;
+	undefined4 VTable0x14() override;                            // vtable+0x14
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c
+	void SetAtomId(MxAtomId p_atomId) override;                  // vtable+0x20
+	MxDSAction* Clone() override;                                // vtable+0x2c
+	void MergeFrom(MxDSAction& p_dsAction) override;             // vtable+0x30
+	MxBool HasId(MxU32 p_objectId) override;                     // vtable+0x34
+	void SetUnknown90(MxLong p_unk0x90) override;                // vtable+0x38
 
 	// FUNCTION: BETA10 0x1004e180
 	MxDSActionList* GetActionList() const { return m_actionList; }

--- a/LEGO1/omni/include/mxdsmultiaction.h
+++ b/LEGO1/omni/include/mxdsmultiaction.h
@@ -10,6 +10,7 @@
 class MxDSMultiAction : public MxDSAction {
 public:
 	MxDSMultiAction();
+	MxDSMultiAction(MxDSMultiAction& p_dsMultiAction);
 	~MxDSMultiAction() override;
 
 	void CopyFrom(MxDSMultiAction& p_dsMultiAction);
@@ -24,29 +25,31 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c9f60
+	// FUNCTION: BETA10 0x1015b1b0
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSMultiAction::ClassName()) || MxDSAction::IsA(p_name);
 	}
 
-	undefined4 VTable0x14() override;                            // vtable+14;
-	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
-	void SetAtomId(MxAtomId p_atomId) override;                  // vtable+20;
-	MxDSAction* Clone() override;                                // vtable+2c;
-	void MergeFrom(MxDSAction& p_dsAction) override;             // vtable+30;
-	MxBool HasId(MxU32 p_objectId) override;                     // vtable+34;
-	void SetUnknown90(MxLong p_unk0x90) override;                // vtable+38;
+	undefined4 VTable0x14() override;                            // vtable+0x14;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
+	void SetAtomId(MxAtomId p_atomId) override;                  // vtable+0x20;
+	MxDSAction* Clone() override;                                // vtable+0x2c;
+	void MergeFrom(MxDSAction& p_dsAction) override;             // vtable+0x30;
+	MxBool HasId(MxU32 p_objectId) override;                     // vtable+0x34;
+	void SetUnknown90(MxLong p_unk0x90) override;                // vtable+0x38;
 
 	// FUNCTION: BETA10 0x1004e180
-	MxDSActionList* GetActionList() const { return m_actions; }
+	MxDSActionList* GetActionList() const { return m_actionList; }
 
 	// SYNTHETIC: LEGO1 0x100ca040
+	// SYNTHETIC: BETA10 0x1015b210
 	// MxDSMultiAction::`scalar deleting destructor'
 
 protected:
-	MxU32 m_sizeOnDisk;        // 0x94
-	MxDSActionList* m_actions; // 0x98
+	MxU32 m_sizeOnDisk;           // 0x94
+	MxDSActionList* m_actionList; // 0x98
 };
 
 // SYNTHETIC: LEGO1 0x1004ad10

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -62,16 +62,16 @@ public:
 	MxBool IsA(const char* p_name) const override
 	{
 		return !strcmp(p_name, MxDSObject::ClassName()) || MxCore::IsA(p_name);
-	} // vtable+0x10;
+	} // vtable+0x10
 
-	virtual undefined4 VTable0x14();                            // vtable+0x14;
-	virtual MxU32 GetSizeOnDisk();                              // vtable+0x18;
-	virtual void Deserialize(MxU8*& p_source, MxS16 p_unk0x24); // vtable+0x1c;
+	virtual undefined4 VTable0x14();                            // vtable+0x14
+	virtual MxU32 GetSizeOnDisk();                              // vtable+0x18
+	virtual void Deserialize(MxU8*& p_source, MxS16 p_unk0x24); // vtable+0x1c
 
 	// FUNCTION: ISLE 0x401c40
 	// FUNCTION: LEGO1 0x10005530
 	// FUNCTION: BETA10 0x100152e0
-	virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+0x20;
+	virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+0x20
 
 	// FUNCTION: BETA10 0x1012ef90
 	Type GetType() const { return (Type) m_type; }

--- a/LEGO1/omni/include/mxdsobject.h
+++ b/LEGO1/omni/include/mxdsobject.h
@@ -55,23 +55,23 @@ public:
 
 	// FUNCTION: LEGO1 0x100bf730
 	// FUNCTION: BETA10 0x1012bdd0
-	const char* ClassName() const override { return "MxDSObject"; } // vtable+0c
+	const char* ClassName() const override { return "MxDSObject"; } // vtable+0x0c
 
 	// FUNCTION: LEGO1 0x100bf740
 	// FUNCTION: BETA10 0x1012bd70
 	MxBool IsA(const char* p_name) const override
 	{
 		return !strcmp(p_name, MxDSObject::ClassName()) || MxCore::IsA(p_name);
-	} // vtable+10;
+	} // vtable+0x10;
 
-	virtual undefined4 VTable0x14();                            // vtable+14;
-	virtual MxU32 GetSizeOnDisk();                              // vtable+18;
-	virtual void Deserialize(MxU8*& p_source, MxS16 p_unk0x24); // vtable+1c;
+	virtual undefined4 VTable0x14();                            // vtable+0x14;
+	virtual MxU32 GetSizeOnDisk();                              // vtable+0x18;
+	virtual void Deserialize(MxU8*& p_source, MxS16 p_unk0x24); // vtable+0x1c;
 
 	// FUNCTION: ISLE 0x401c40
 	// FUNCTION: LEGO1 0x10005530
 	// FUNCTION: BETA10 0x100152e0
-	virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+20;
+	virtual void SetAtomId(MxAtomId p_atomId) { m_atomId = p_atomId; } // vtable+0x20;
 
 	// FUNCTION: BETA10 0x1012ef90
 	Type GetType() const { return (Type) m_type; }

--- a/LEGO1/omni/include/mxdsobjectaction.h
+++ b/LEGO1/omni/include/mxdsobjectaction.h
@@ -29,8 +29,8 @@ public:
 		return !strcmp(p_name, MxDSObjectAction::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override;                              // vtable+0x2c;
-	virtual void CopyFrom(MxDSObjectAction& p_dsObjectAction); // vtable+0x44;
+	MxDSAction* Clone() override;                              // vtable+0x2c
+	virtual void CopyFrom(MxDSObjectAction& p_dsObjectAction); // vtable+0x44
 
 	// SYNTHETIC: LEGO1 0x100c8a00
 	// SYNTHETIC: BETA10 0x1015c720

--- a/LEGO1/omni/include/mxdsobjectaction.h
+++ b/LEGO1/omni/include/mxdsobjectaction.h
@@ -9,6 +9,7 @@
 class MxDSObjectAction : public MxDSMediaAction {
 public:
 	MxDSObjectAction();
+	MxDSObjectAction(MxDSObjectAction& p_dsObjectAction);
 	~MxDSObjectAction() override;
 
 	MxDSObjectAction& operator=(MxDSObjectAction& p_dsObjectAction);
@@ -22,15 +23,17 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c88f0
+	// FUNCTION: BETA10 0x1015c640
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSObjectAction::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override;                              // vtable+2c;
-	virtual void CopyFrom(MxDSObjectAction& p_dsObjectAction); // vtable+44;
+	MxDSAction* Clone() override;                              // vtable+0x2c;
+	virtual void CopyFrom(MxDSObjectAction& p_dsObjectAction); // vtable+0x44;
 
 	// SYNTHETIC: LEGO1 0x100c8a00
+	// SYNTHETIC: BETA10 0x1015c720
 	// MxDSObjectAction::`scalar deleting destructor'
 };
 

--- a/LEGO1/omni/include/mxdsparallelaction.h
+++ b/LEGO1/omni/include/mxdsparallelaction.h
@@ -30,13 +30,13 @@ public:
 		return !strcmp(p_name, MxDSParallelAction::ClassName()) || MxDSMultiAction::IsA(p_name);
 	}
 
-	MxLong GetDuration() override; // vtable+0x24;
+	MxLong GetDuration() override; // vtable+0x24
 
 	// FUNCTION: LEGO1 0x100caef0
 	// FUNCTION: BETA10 0x1015b370
 	void SetDuration(MxLong p_duration) override { m_duration = p_duration; } // vtable+0x28
 
-	MxDSAction* Clone() override; // vtable+0x2c;
+	MxDSAction* Clone() override; // vtable+0x2c
 
 	// SYNTHETIC: LEGO1 0x100cb020
 	// SYNTHETIC: BETA10 0x1015b420

--- a/LEGO1/omni/include/mxdsparallelaction.h
+++ b/LEGO1/omni/include/mxdsparallelaction.h
@@ -9,6 +9,7 @@
 class MxDSParallelAction : public MxDSMultiAction {
 public:
 	MxDSParallelAction();
+	MxDSParallelAction(MxDSParallelAction& p_dsParallelAction);
 	~MxDSParallelAction() override;
 
 	void CopyFrom(MxDSParallelAction& p_dsParallelAction);
@@ -23,20 +24,23 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100caf10
+	// FUNCTION: BETA10 0x1015b3c0
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSParallelAction::ClassName()) || MxDSMultiAction::IsA(p_name);
 	}
 
-	// SYNTHETIC: LEGO1 0x100cb020
-	// MxDSParallelAction::`scalar deleting destructor'
-
-	MxLong GetDuration() override; // vtable+24;
+	MxLong GetDuration() override; // vtable+0x24;
 
 	// FUNCTION: LEGO1 0x100caef0
+	// FUNCTION: BETA10 0x1015b370
 	void SetDuration(MxLong p_duration) override { m_duration = p_duration; } // vtable+0x28
 
-	MxDSAction* Clone() override; // vtable+2c;
+	MxDSAction* Clone() override; // vtable+0x2c;
+
+	// SYNTHETIC: LEGO1 0x100cb020
+	// SYNTHETIC: BETA10 0x1015b420
+	// MxDSParallelAction::`scalar deleting destructor'
 };
 
 #endif // MXDSPARALLELACTION_H

--- a/LEGO1/omni/include/mxdsselectaction.h
+++ b/LEGO1/omni/include/mxdsselectaction.h
@@ -11,6 +11,7 @@
 class MxDSSelectAction : public MxDSParallelAction {
 public:
 	MxDSSelectAction();
+	MxDSSelectAction(MxDSSelectAction& p_dsSelectAction);
 	~MxDSSelectAction() override;
 
 	void CopyFrom(MxDSSelectAction& p_dsSelectAction);
@@ -25,16 +26,18 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100cb700
+	// FUNCTION: BETA10 0x1015b480
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(p_name);
 	}
 
-	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
-	MxDSAction* Clone() override;                                // vtable+2c;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
+	MxDSAction* Clone() override;                                // vtable+0x2c;
 
 	// SYNTHETIC: LEGO1 0x100cb840
+	// SYNTHETIC: BETA10 0x1015b4e0
 	// MxDSSelectAction::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/include/mxdsselectaction.h
+++ b/LEGO1/omni/include/mxdsselectaction.h
@@ -32,9 +32,9 @@ public:
 		return !strcmp(p_name, MxDSSelectAction::ClassName()) || MxDSParallelAction::IsA(p_name);
 	}
 
-	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
-	MxDSAction* Clone() override;                                // vtable+0x2c;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c
+	MxDSAction* Clone() override;                                // vtable+0x2c
 
 	// SYNTHETIC: LEGO1 0x100cb840
 	// SYNTHETIC: BETA10 0x1015b4e0

--- a/LEGO1/omni/include/mxdsserialaction.h
+++ b/LEGO1/omni/include/mxdsserialaction.h
@@ -10,6 +10,7 @@
 class MxDSSerialAction : public MxDSMultiAction {
 public:
 	MxDSSerialAction();
+	MxDSSerialAction(MxDSSerialAction& p_dsSerialAction);
 	~MxDSSerialAction() override;
 
 	void CopyFrom(MxDSSerialAction& p_dsSerialAction);
@@ -24,22 +25,24 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100caae0
+	// FUNCTION: BETA10 0x1015b2d0
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSerialAction::ClassName()) || MxDSMultiAction::IsA(p_name);
 	}
 
-	MxLong GetDuration() override;                // vtable+24;
-	void SetDuration(MxLong p_duration) override; // vtable+28;
-	MxDSAction* Clone() override;                 // vtable+2c;
+	MxLong GetDuration() override;                // vtable+0x24;
+	void SetDuration(MxLong p_duration) override; // vtable+0x28;
+	MxDSAction* Clone() override;                 // vtable+0x2c;
 
 	// SYNTHETIC: LEGO1 0x100cabf0
+	// SYNTHETIC: BETA10 0x1015b330
 	// MxDSSerialAction::`scalar deleting destructor'
 
 private:
-	MxDSActionListCursor* m_cursor;
-	undefined4 m_unk0xa0;
-	undefined4 m_unk0xa4;
+	MxDSActionListCursor* m_cursor; // 0x9c
+	undefined4 m_unk0xa0;           // 0xa0
+	undefined4 m_unk0xa4;           // 0xa4
 };
 
 #endif // MXDSSERIALACTION_H

--- a/LEGO1/omni/include/mxdsserialaction.h
+++ b/LEGO1/omni/include/mxdsserialaction.h
@@ -31,9 +31,9 @@ public:
 		return !strcmp(p_name, MxDSSerialAction::ClassName()) || MxDSMultiAction::IsA(p_name);
 	}
 
-	MxLong GetDuration() override;                // vtable+0x24;
-	void SetDuration(MxLong p_duration) override; // vtable+0x28;
-	MxDSAction* Clone() override;                 // vtable+0x2c;
+	MxLong GetDuration() override;                // vtable+0x24
+	void SetDuration(MxLong p_duration) override; // vtable+0x28
+	MxDSAction* Clone() override;                 // vtable+0x2c
 
 	// SYNTHETIC: LEGO1 0x100cabf0
 	// SYNTHETIC: BETA10 0x1015b330

--- a/LEGO1/omni/include/mxdssound.h
+++ b/LEGO1/omni/include/mxdssound.h
@@ -9,6 +9,7 @@
 class MxDSSound : public MxDSMediaAction {
 public:
 	MxDSSound();
+	MxDSSound(MxDSSound& p_dsSound);
 	~MxDSSound() override;
 
 	void CopyFrom(MxDSSound& p_dsSound);
@@ -23,19 +24,21 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c9340
+	// FUNCTION: BETA10 0x1015d970
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSSound::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxU32 GetSizeOnDisk() override;                              // vtable+18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+1c;
-	MxDSAction* Clone() override;                                // vtable+2c;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
+	MxDSAction* Clone() override;                                // vtable+0x2c;
 
 	// FUNCTION: BETA10 0x1008d060
 	MxS32 GetVolume() const { return m_volume; }
 
 	// SYNTHETIC: LEGO1 0x100c9450
+	// SYNTHETIC: BETA10 0x1015d9d0
 	// MxDSSound::`scalar deleting destructor'
 
 private:

--- a/LEGO1/omni/include/mxdssound.h
+++ b/LEGO1/omni/include/mxdssound.h
@@ -30,9 +30,9 @@ public:
 		return !strcmp(p_name, MxDSSound::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxU32 GetSizeOnDisk() override;                              // vtable+0x18;
-	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c;
-	MxDSAction* Clone() override;                                // vtable+0x2c;
+	MxU32 GetSizeOnDisk() override;                              // vtable+0x18
+	void Deserialize(MxU8*& p_source, MxS16 p_unk0x24) override; // vtable+0x1c
+	MxDSAction* Clone() override;                                // vtable+0x2c
 
 	// FUNCTION: BETA10 0x1008d060
 	MxS32 GetVolume() const { return m_volume; }

--- a/LEGO1/omni/include/mxdsstill.h
+++ b/LEGO1/omni/include/mxdsstill.h
@@ -9,6 +9,7 @@
 class MxDSStill : public MxDSMediaAction {
 public:
 	MxDSStill();
+	MxDSStill(MxDSStill& p_dsStill);
 	~MxDSStill() override;
 
 	void CopyFrom(MxDSStill& p_dsStill);
@@ -23,14 +24,16 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100c9940
+	// FUNCTION: BETA10 0x1015daf0
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, MxDSStill::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override; // vtable+2c;
+	MxDSAction* Clone() override; // vtable+0x2c;
 
 	// SYNTHETIC: LEGO1 0x100c9a50
+	// SYNTHETIC: BETA10 0x1015db50
 	// MxDSStill::`scalar deleting destructor'
 };
 

--- a/LEGO1/omni/include/mxdsstill.h
+++ b/LEGO1/omni/include/mxdsstill.h
@@ -30,7 +30,7 @@ public:
 		return !strcmp(p_name, MxDSStill::ClassName()) || MxDSMediaAction::IsA(p_name);
 	}
 
-	MxDSAction* Clone() override; // vtable+0x2c;
+	MxDSAction* Clone() override; // vtable+0x2c
 
 	// SYNTHETIC: LEGO1 0x100c9a50
 	// SYNTHETIC: BETA10 0x1015db50

--- a/LEGO1/omni/include/mxdsstreamingaction.h
+++ b/LEGO1/omni/include/mxdsstreamingaction.h
@@ -16,7 +16,7 @@ public:
 
 	MxDSStreamingAction* CopyFrom(MxDSStreamingAction& p_dsStreamingAction);
 
-	MxBool HasId(MxU32 p_objectId) override; // vtable+0x34;
+	MxBool HasId(MxU32 p_objectId) override; // vtable+0x34
 
 	void Init();
 	void SetInternalAction(MxDSAction* p_dsAction);

--- a/LEGO1/omni/src/action/mxdsanim.cpp
+++ b/LEGO1/omni/src/action/mxdsanim.cpp
@@ -6,20 +6,29 @@ DECOMP_SIZE_ASSERT(MxDSAnim, 0xb8)
 // FUNCTION: BETA10 0x1015cd71
 MxDSAnim::MxDSAnim()
 {
-	this->SetType(e_anim);
+	m_type = e_anim;
 }
 
 // FUNCTION: LEGO1 0x100c91a0
+// FUNCTION: BETA10 0x1015cde9
 MxDSAnim::~MxDSAnim()
 {
 }
 
 // FUNCTION: LEGO1 0x100c91f0
+// FUNCTION: BETA10 0x1015ce51
 void MxDSAnim::CopyFrom(MxDSAnim& p_dsAnim)
 {
 }
 
+// FUNCTION: BETA10 0x1015ce69
+MxDSAnim::MxDSAnim(MxDSAnim& p_dsAnim) : MxDSMediaAction(p_dsAnim)
+{
+	CopyFrom(p_dsAnim);
+}
+
 // FUNCTION: LEGO1 0x100c9200
+// FUNCTION: BETA10 0x1015ceea
 MxDSAnim& MxDSAnim::operator=(MxDSAnim& p_dsAnim)
 {
 	if (this == &p_dsAnim) {
@@ -27,11 +36,12 @@ MxDSAnim& MxDSAnim::operator=(MxDSAnim& p_dsAnim)
 	}
 
 	MxDSMediaAction::operator=(p_dsAnim);
-	this->CopyFrom(p_dsAnim);
+	CopyFrom(p_dsAnim);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100c9230
+// FUNCTION: BETA10 0x1015cf31
 MxDSAction* MxDSAnim::Clone()
 {
 	MxDSAnim* clone = new MxDSAnim();

--- a/LEGO1/omni/src/action/mxdsevent.cpp
+++ b/LEGO1/omni/src/action/mxdsevent.cpp
@@ -6,20 +6,29 @@ DECOMP_SIZE_ASSERT(MxDSEvent, 0xb8)
 // FUNCTION: BETA10 0x1015d2e5
 MxDSEvent::MxDSEvent()
 {
-	this->SetType(e_event);
+	m_type = e_event;
 }
 
 // FUNCTION: LEGO1 0x100c97a0
+// FUNCTION: BETA10 0x1015d35d
 MxDSEvent::~MxDSEvent()
 {
 }
 
 // FUNCTION: LEGO1 0x100c97f0
+// FUNCTION: BETA10 0x1015d3c5
 void MxDSEvent::CopyFrom(MxDSEvent& p_dsEvent)
 {
 }
 
+// FUNCTION: BETA10 0x1015d3dd
+MxDSEvent::MxDSEvent(MxDSEvent& p_dsEvent) : MxDSMediaAction(p_dsEvent)
+{
+	CopyFrom(p_dsEvent);
+}
+
 // FUNCTION: LEGO1 0x100c9800
+// FUNCTION: BETA10 0x1015d45e
 MxDSEvent& MxDSEvent::operator=(MxDSEvent& p_dsEvent)
 {
 	if (this == &p_dsEvent) {
@@ -27,11 +36,12 @@ MxDSEvent& MxDSEvent::operator=(MxDSEvent& p_dsEvent)
 	}
 
 	MxDSMediaAction::operator=(p_dsEvent);
-	this->CopyFrom(p_dsEvent);
+	CopyFrom(p_dsEvent);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100c9830
+// FUNCTION: BETA10 0x1015d4a5
 MxDSAction* MxDSEvent::Clone()
 {
 	MxDSEvent* clone = new MxDSEvent();

--- a/LEGO1/omni/src/action/mxdsmediaaction.cpp
+++ b/LEGO1/omni/src/action/mxdsmediaaction.cpp
@@ -87,8 +87,9 @@ void MxDSMediaAction::CopyMediaSrcPath(const char* p_mediaSrcPath)
 		if (m_mediaSrcPath) {
 			strcpy(m_mediaSrcPath, p_mediaSrcPath);
 		}
-
-		MxTrace("MxDSMediaAction: name allocation failed: %s.\n", p_mediaSrcPath);
+		else {
+			MxTrace("MxDSMediaAction: name allocation failed: %s.\n", p_mediaSrcPath);
+		}
 	}
 	else {
 		m_mediaSrcPath = NULL;

--- a/LEGO1/omni/src/action/mxdsobjectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsobjectaction.cpp
@@ -6,20 +6,29 @@ DECOMP_SIZE_ASSERT(MxDSObjectAction, 0xb8)
 // FUNCTION: BETA10 0x1015c3b0
 MxDSObjectAction::MxDSObjectAction()
 {
-	this->SetType(e_objectAction);
+	m_type = e_objectAction;
 }
 
 // FUNCTION: LEGO1 0x100c8a20
+// FUNCTION: BETA10 0x1015c428
 MxDSObjectAction::~MxDSObjectAction()
 {
 }
 
 // FUNCTION: LEGO1 0x100c8a70
+// FUNCTION: BETA10 0x1015c490
 void MxDSObjectAction::CopyFrom(MxDSObjectAction& p_dsObjectAction)
 {
 }
 
+// FUNCTION: BETA10 0x1015c4a8
+MxDSObjectAction::MxDSObjectAction(MxDSObjectAction& p_dsObjectAction) : MxDSMediaAction(p_dsObjectAction)
+{
+	CopyFrom(p_dsObjectAction);
+}
+
 // FUNCTION: LEGO1 0x100c8a80
+// FUNCTION: BETA10 0x1015c529
 MxDSObjectAction& MxDSObjectAction::operator=(MxDSObjectAction& p_dsObjectAction)
 {
 	if (this == &p_dsObjectAction) {
@@ -27,11 +36,12 @@ MxDSObjectAction& MxDSObjectAction::operator=(MxDSObjectAction& p_dsObjectAction
 	}
 
 	MxDSMediaAction::operator=(p_dsObjectAction);
-	this->CopyFrom(p_dsObjectAction);
+	CopyFrom(p_dsObjectAction);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100c8ab0
+// FUNCTION: BETA10 0x1015c573
 MxDSAction* MxDSObjectAction::Clone()
 {
 	MxDSObjectAction* clone = new MxDSObjectAction();

--- a/LEGO1/omni/src/action/mxdsparallelaction.cpp
+++ b/LEGO1/omni/src/action/mxdsparallelaction.cpp
@@ -8,20 +8,29 @@ DECOMP_SIZE_ASSERT(MxDSParallelAction, 0x9c)
 // FUNCTION: BETA10 0x1015a14d
 MxDSParallelAction::MxDSParallelAction()
 {
-	this->SetType(e_parallelAction);
+	m_type = e_parallelAction;
 }
 
 // FUNCTION: LEGO1 0x100cb040
+// FUNCTION: BETA10 0x1015a1c5
 MxDSParallelAction::~MxDSParallelAction()
 {
 }
 
 // FUNCTION: LEGO1 0x100cb090
+// FUNCTION: BETA10 0x1015a22d
 void MxDSParallelAction::CopyFrom(MxDSParallelAction& p_dsParallelAction)
 {
 }
 
+// FUNCTION: BETA10 0x1015a245
+MxDSParallelAction::MxDSParallelAction(MxDSParallelAction& p_dsParallelAction) : MxDSMultiAction(p_dsParallelAction)
+{
+	CopyFrom(p_dsParallelAction);
+}
+
 // FUNCTION: LEGO1 0x100cb0a0
+// FUNCTION: BETA10 0x1015a2c6
 MxDSParallelAction& MxDSParallelAction::operator=(MxDSParallelAction& p_dsParallelAction)
 {
 	if (this == &p_dsParallelAction) {
@@ -29,11 +38,12 @@ MxDSParallelAction& MxDSParallelAction::operator=(MxDSParallelAction& p_dsParall
 	}
 
 	MxDSMultiAction::operator=(p_dsParallelAction);
-	this->CopyFrom(p_dsParallelAction);
+	CopyFrom(p_dsParallelAction);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100cb0d0
+// FUNCTION: BETA10 0x1015a30d
 MxDSAction* MxDSParallelAction::Clone()
 {
 	MxDSParallelAction* clone = new MxDSParallelAction();
@@ -46,13 +56,14 @@ MxDSAction* MxDSParallelAction::Clone()
 }
 
 // FUNCTION: LEGO1 0x100cb160
+// FUNCTION: BETA10 0x1015a3b7
 MxLong MxDSParallelAction::GetDuration()
 {
-	if (this->m_duration) {
-		return this->m_duration;
+	if (m_duration) {
+		return m_duration;
 	}
 
-	MxDSActionListCursor cursor(this->m_actions);
+	MxDSActionListCursor cursor(m_actionList);
 	MxDSAction* action;
 
 	while (cursor.Next(action)) {
@@ -62,7 +73,7 @@ MxLong MxDSParallelAction::GetDuration()
 
 		MxLong duration = action->GetDuration();
 		if (duration == -1) {
-			this->m_duration = -1;
+			m_duration = -1;
 			break;
 		}
 
@@ -79,18 +90,18 @@ MxLong MxDSParallelAction::GetDuration()
 		}
 
 		if (duration == -1) {
-			this->m_duration = -1;
+			m_duration = -1;
 			break;
 		}
 
-		if (this->m_duration < duration) {
-			this->m_duration = duration;
+		if (m_duration < duration) {
+			m_duration = duration;
 		}
 	}
 
-	if (this->IsBit3()) {
-		this->m_duration *= this->m_loopCount;
+	if (IsBit3()) {
+		m_duration *= m_loopCount;
 	}
 
-	return this->m_duration;
+	return m_duration;
 }

--- a/LEGO1/omni/src/action/mxdssound.cpp
+++ b/LEGO1/omni/src/action/mxdssound.cpp
@@ -1,30 +1,37 @@
 #include "mxdssound.h"
 
-#include "mxutilities.h"
-
 DECOMP_SIZE_ASSERT(MxDSSound, 0xc0)
 
 // FUNCTION: LEGO1 0x100c92c0
 // FUNCTION: BETA10 0x1015cfdb
 MxDSSound::MxDSSound()
 {
-	this->m_volume = 0x4f;
-	this->SetType(e_sound);
+	m_type = e_sound;
+	m_volume = 0x4f;
 }
 
 // FUNCTION: LEGO1 0x100c9470
+// FUNCTION: BETA10 0x1015d060
 MxDSSound::~MxDSSound()
 {
 }
 
 // FUNCTION: LEGO1 0x100c94c0
+// FUNCTION: BETA10 0x1015d0c8
 void MxDSSound::CopyFrom(MxDSSound& p_dsSound)
 {
-	this->SetType(p_dsSound.GetType());
-	this->m_volume = p_dsSound.m_volume;
+	m_type = p_dsSound.m_type;
+	m_volume = p_dsSound.m_volume;
+}
+
+// FUNCTION: BETA10 0x1015d100
+MxDSSound::MxDSSound(MxDSSound& p_dsSound) : MxDSMediaAction(p_dsSound)
+{
+	CopyFrom(p_dsSound);
 }
 
 // FUNCTION: LEGO1 0x100c94e0
+// FUNCTION: BETA10 0x1015d181
 MxDSSound& MxDSSound::operator=(MxDSSound& p_dsSound)
 {
 	if (this == &p_dsSound) {
@@ -32,11 +39,12 @@ MxDSSound& MxDSSound::operator=(MxDSSound& p_dsSound)
 	}
 
 	MxDSMediaAction::operator=(p_dsSound);
-	this->CopyFrom(p_dsSound);
+	CopyFrom(p_dsSound);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100c9510
+// FUNCTION: BETA10 0x1015d1c8
 MxDSAction* MxDSSound::Clone()
 {
 	MxDSSound* clone = new MxDSSound();
@@ -49,18 +57,21 @@ MxDSAction* MxDSSound::Clone()
 }
 
 // FUNCTION: LEGO1 0x100c95a0
+// FUNCTION: BETA10 0x1015d272
 void MxDSSound::Deserialize(MxU8*& p_source, MxS16 p_unk0x24)
 {
 	MxDSMediaAction::Deserialize(p_source, p_unk0x24);
-
-	GetScalar(p_source, this->m_volume);
+	m_volume = *(MxS32*) p_source;
+	p_source += sizeof(m_volume);
 }
 
 // FUNCTION: LEGO1 0x100c95d0
+// FUNCTION: BETA10 0x1015d2b0
 MxU32 MxDSSound::GetSizeOnDisk()
 {
 	MxU32 totalSizeOnDisk = MxDSMediaAction::GetSizeOnDisk();
+	totalSizeOnDisk += sizeof(m_volume);
 
-	this->m_sizeOnDisk = sizeof(this->m_volume);
-	return totalSizeOnDisk + 4;
+	m_sizeOnDisk = sizeof(m_volume);
+	return totalSizeOnDisk;
 }

--- a/LEGO1/omni/src/action/mxdsstill.cpp
+++ b/LEGO1/omni/src/action/mxdsstill.cpp
@@ -6,20 +6,29 @@ DECOMP_SIZE_ASSERT(MxDSStill, 0xb8)
 // FUNCTION: BETA10 0x1015d54f
 MxDSStill::MxDSStill()
 {
-	this->SetType(e_still);
+	m_type = e_still;
 }
 
 // FUNCTION: LEGO1 0x100c9a70
+// FUNCTION: BETA10 0x1015d5c7
 MxDSStill::~MxDSStill()
 {
 }
 
 // FUNCTION: LEGO1 0x100c9ac0
+// FUNCTION: BETA10 0x1015d62f
 void MxDSStill::CopyFrom(MxDSStill& p_dsStill)
 {
 }
 
+// FUNCTION: BETA10 0x1015d647
+MxDSStill::MxDSStill(MxDSStill& p_dsStill) : MxDSMediaAction(p_dsStill)
+{
+	CopyFrom(p_dsStill);
+}
+
 // FUNCTION: LEGO1 0x100c9ad0
+// FUNCTION: BETA10 0x1015d6c8
 MxDSStill& MxDSStill::operator=(MxDSStill& p_dsStill)
 {
 	if (this == &p_dsStill) {
@@ -27,11 +36,12 @@ MxDSStill& MxDSStill::operator=(MxDSStill& p_dsStill)
 	}
 
 	MxDSMediaAction::operator=(p_dsStill);
-	this->CopyFrom(p_dsStill);
+	CopyFrom(p_dsStill);
 	return *this;
 }
 
 // FUNCTION: LEGO1 0x100c9b00
+// FUNCTION: BETA10 0x1015d70f
 MxDSAction* MxDSStill::Clone()
 {
 	MxDSStill* clone = new MxDSStill();


### PR DESCRIPTION
- Added beta addrs for (hopefully) all functions.
- Removed `this->`.
- All vtable offsets use our preferred format `// vtable+0x__` instead of `// vtable+__`.
- Copy constructor added for all classes (unused in and removed from retail)
- `SetType` removed from each constructor, per the beta
- Renamed `m_actions` to `m_actionList` to match beta assert

I excluded some beta matches that (for now) decreased retail.