### PR TITLE
Some beta addrs for `Tgl` and `TglImpl`

### DIFF
--- a/LEGO1/tgl/d3drm/camera.cpp
+++ b/LEGO1/tgl/d3drm/camera.cpp
@@ -6,6 +6,7 @@ DECOMP_SIZE_ASSERT(Camera, 0x04);
 DECOMP_SIZE_ASSERT(CameraImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a36f0
+// FUNCTION: BETA10 0x1016f2e0
 void* CameraImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/device.cpp
+++ b/LEGO1/tgl/d3drm/device.cpp
@@ -5,6 +5,7 @@
 using namespace TglImpl;
 
 // FUNCTION: LEGO1 0x100a2bf0
+// FUNCTION: BETA10 0x1016ddf0
 void* DeviceImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/group.cpp
+++ b/LEGO1/tgl/d3drm/group.cpp
@@ -3,6 +3,7 @@
 using namespace TglImpl;
 
 // FUNCTION: LEGO1 0x100a31d0
+// FUNCTION: BETA10 0x1016a480
 void* GroupImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -43,9 +43,13 @@ class TextureImpl;
 class MeshBuilderImpl;
 
 // VTABLE: LEGO1 0x100db910
+// VTABLE: BETA10 0x101c30d8
 class RendererImpl : public Renderer {
 public:
+	// FUNCTION: BETA10 0x10169a20
 	RendererImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x10169d20
 	~RendererImpl() override { Destroy(); }
 
 	void* ImplementationDataPtr() override;
@@ -102,6 +106,7 @@ private:
 
 extern IDirect3DRM2* g_pD3DRM;
 
+// FUNCTION: BETA10 0x1016dd20
 inline void RendererDestroy(IDirect3DRM2* pRenderer)
 {
 	int refCount = pRenderer->Release();
@@ -111,6 +116,7 @@ inline void RendererDestroy(IDirect3DRM2* pRenderer)
 }
 
 // Inlined only
+// FUNCTION: BETA10 0x1016dce0
 void RendererImpl::Destroy()
 {
 	if (m_data) {
@@ -120,9 +126,13 @@ void RendererImpl::Destroy()
 }
 
 // VTABLE: LEGO1 0x100db988
+// VTABLE: BETA10 0x101c31f0
 class DeviceImpl : public Device {
 public:
+	// FUNCTION: BETA10 0x1016b2e0
 	DeviceImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016dd80
 	~DeviceImpl() override
 	{
 		if (m_data) {
@@ -158,9 +168,13 @@ private:
 };
 
 // VTABLE: LEGO1 0x100db9e8
+// VTABLE: BETA10 0x101c3220
 class ViewImpl : public View {
 public:
+	// FUNCTION: BETA10 0x1016b360
 	ViewImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016e5d0
 	~ViewImpl() override
 	{
 		if (m_data) {
@@ -211,9 +225,13 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dbad8
+// VTABLE: BETA10 0x101c3260
 class CameraImpl : public Camera {
 public:
+	// FUNCTION: BETA10 0x1016b3e0
 	CameraImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016f200
 	~CameraImpl() override
 	{
 		if (m_data) {
@@ -236,9 +254,13 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dbaf8
+// VTABLE: BETA10 0x101c31e0
 class LightImpl : public Light {
 public:
+	// FUNCTION: BETA10 0x1016b260
 	LightImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016c7e0
 	~LightImpl() override
 	{
 		if (m_data) {
@@ -262,9 +284,13 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dbb88
+// VTABLE: BETA10 0x101c3340
 class MeshImpl : public Mesh {
 public:
+	// FUNCTION: BETA10 0x1016f970
 	MeshImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x10170460
 	~MeshImpl() override
 	{
 		if (m_data) {
@@ -305,9 +331,13 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dba68
+// VTABLE: BETA10 0x101c3150
 class GroupImpl : public Group {
 public:
+	// FUNCTION: BETA10 0x1016a240
 	GroupImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016a410
 	~GroupImpl() override
 	{
 		if (m_data) {
@@ -346,9 +376,13 @@ private:
 };
 
 // VTABLE: LEGO1 0x100dbb18
+// VTABLE: BETA10 0x101c3270
 class MeshBuilderImpl : public MeshBuilder {
 public:
+	// FUNCTION: BETA10 0x1016b460
 	MeshBuilderImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016f5c0
 	~MeshBuilderImpl() override
 	{
 		if (m_data) {
@@ -419,9 +453,13 @@ public:
 };
 
 // VTABLE: LEGO1 0x100dbb48
+// VTABLE: BETA10 0x101c31c0
 class TextureImpl : public Texture {
 public:
+	// FUNCTION: BETA10 0x1016b1e0
 	TextureImpl() : m_data(0) {}
+
+	// FUNCTION: BETA10 0x1016c2d0
 	~TextureImpl() override
 	{
 		if (m_data) {
@@ -519,30 +557,39 @@ inline D3DRMMATRIX4D* Translate(FloatMatrix4& tglMatrix4x4, D3DRMMATRIX4D& rD3DR
 }
 
 // SYNTHETIC: LEGO1 0x100a16d0
+// SYNTHETIC: BETA10 0x10169aa0
 // TglImpl::RendererImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a22c0
+// SYNTHETIC: BETA10 0x1016b700
 // TglImpl::DeviceImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a23a0
+// SYNTHETIC: BETA10 0x1016b810
 // TglImpl::ViewImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a2480
+// SYNTHETIC: BETA10 0x1016a2c0
 // TglImpl::GroupImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a2560
+// SYNTHETIC: BETA10 0x1016b920
 // TglImpl::CameraImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a2640
+// SYNTHETIC: BETA10 0x1016b5f0
 // TglImpl::LightImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a2720
+// SYNTHETIC: BETA10 0x1016ba30
 // TglImpl::MeshBuilderImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a2800
+// SYNTHETIC: BETA10 0x1016b4e0
 // TglImpl::TextureImpl::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100a3d80
+// SYNTHETIC: BETA10 0x1016fa90
 // TglImpl::MeshImpl::`scalar deleting destructor'
 
 // GLOBAL: LEGO1 0x100dd1e0

--- a/LEGO1/tgl/d3drm/light.cpp
+++ b/LEGO1/tgl/d3drm/light.cpp
@@ -6,6 +6,7 @@ DECOMP_SIZE_ASSERT(Light, 0x04);
 DECOMP_SIZE_ASSERT(LightImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a3770
+// FUNCTION: BETA10 0x1016c9f0
 void* LightImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/mesh.cpp
+++ b/LEGO1/tgl/d3drm/mesh.cpp
@@ -8,6 +8,7 @@ DECOMP_SIZE_ASSERT(Mesh, 0x04);
 DECOMP_SIZE_ASSERT(MeshImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a3ed0
+// FUNCTION: BETA10 0x101704d0
 void* MeshImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/meshbuilder.cpp
+++ b/LEGO1/tgl/d3drm/meshbuilder.cpp
@@ -6,6 +6,7 @@ DECOMP_SIZE_ASSERT(MeshBuilder, 0x04);
 DECOMP_SIZE_ASSERT(MeshBuilderImpl, 0x08);
 
 // FUNCTION: LEGO1 0x100a3830
+// FUNCTION: BETA10 0x1016f630
 void* MeshBuilderImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -304,6 +304,7 @@ Result RendererImpl::SetTextureDefaultColorCount(unsigned long colorCount)
 }
 
 // FUNCTION: LEGO1 0x100a22b0
+// FUNCTION: BETA10 0x1016b050
 void* RendererImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/texture.cpp
+++ b/LEGO1/tgl/d3drm/texture.cpp
@@ -224,6 +224,7 @@ Result TextureImpl::SetPalette(int entryCount, PaletteEntry* pEntries)
 }
 
 // FUNCTION: LEGO1 0x100a3d70
+// FUNCTION: BETA10 0x1016c760
 void* TextureImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/d3drm/view.cpp
+++ b/LEGO1/tgl/d3drm/view.cpp
@@ -122,6 +122,7 @@ inline IDirect3DRMFrame* ViewportGetLightFrame(IDirect3DRMViewport* pViewport)
 }
 
 // FUNCTION: LEGO1 0x100a2d80
+// FUNCTION: BETA10 0x1016e640
 void* ViewImpl::ImplementationDataPtr()
 {
 	return reinterpret_cast<void*>(&m_data);

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -81,6 +81,7 @@ enum Result {
 	Success = 1
 };
 
+// FUNCTION: BETA10 0x10169c60
 inline int Succeeded(Result result)
 {
 	return (result == Success);
@@ -99,18 +100,25 @@ class Texture;
 class MeshBuilder;
 
 // VTABLE: LEGO1 0x100db980
+// VTABLE: BETA10 0x101c3148
 class Object {
 public:
 	// FUNCTION: LEGO1 0x100a2240
+	// FUNCTION: BETA10 0x10169c90
 	virtual ~Object() {}
 
 	virtual void* ImplementationDataPtr() = 0;
 
+	// SYNTHETIC: BETA10 0x10169b50
+	// Tgl::Object::Object
+
 	// SYNTHETIC: LEGO1 0x100a2250
+	// SYNTHETIC: BETA10 0x10169cb0
 	// Tgl::Object::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100db948
+// VTABLE: BETA10 0x101c3110
 class Renderer : public Object {
 public:
 	// vtable+0x08
@@ -147,16 +155,22 @@ public:
 	// vtable+0x30
 	virtual Result SetTextureDefaultColorCount(unsigned long) = 0;
 
+	// SYNTHETIC: BETA10 0x10169ae0
+	// Tgl::Renderer::Renderer
+
 	// SYNTHETIC: LEGO1 0x100a1770
+	// SYNTHETIC: BETA10 0x10169b80
 	// Tgl::Renderer::~Renderer
 
 	// SYNTHETIC: LEGO1 0x100a17c0
+	// SYNTHETIC: BETA10 0x10169be0
 	// Tgl::Renderer::`scalar deleting destructor'
 };
 
 Renderer* CreateRenderer();
 
 // VTABLE: LEGO1 0x100db9b8
+// VTABLE: BETA10 0x101c32b0
 class Device : public Object {
 public:
 	// vtable+0x08
@@ -174,14 +188,20 @@ public:
 	virtual void HandleActivate(WORD) = 0;
 	virtual void HandlePaint(HDC) = 0;
 
+	// SYNTHETIC: BETA10 0x1016b740
+	// Tgl::Device::Device
+
 	// SYNTHETIC: LEGO1 0x100a2350
+	// SYNTHETIC: BETA10 0x1016b7b0
 	// Tgl::Device::~Device
 
 	// SYNTHETIC: LEGO1 0x100a28e0
+	// SYNTHETIC: BETA10 0x1016bbc0
 	// Tgl::Device::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dba28
+// VTABLE: BETA10 0x101c32e0
 class View : public Object {
 public:
 	virtual Result Add(const Light*) = 0;
@@ -234,44 +254,59 @@ public:
 		int& rPickedGroupCount
 	) = 0;
 
+	// SYNTHETIC: BETA10 0x1016b850
+	// Tgl::View::View
+
 	// SYNTHETIC: LEGO1 0x100a2430
+	// SYNTHETIC: BETA10 0x1016b8c0
 	// Tgl::View::~View
 
 	// SYNTHETIC: LEGO1 0x100a2950
+	// SYNTHETIC: BETA10 0x1016bc00
 	// Tgl::View::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbae8
+// VTABLE: BETA10 0x101c3320
 class Camera : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
 
+	// SYNTHETIC: BETA10 0x1016b960
+	// Tgl::Camera::Camera
+
 	// SYNTHETIC: LEGO1 0x100a25f0
+	// SYNTHETIC: BETA10 0x1016b9d0
 	// Tgl::Camera::~Camera
 
 	// SYNTHETIC: LEGO1 0x100a2a30
+	// SYNTHETIC: BETA10 0x1016bc40
 	// Tgl::Camera::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbb08
+// VTABLE: BETA10 0x101c32a0
 class Light : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
 	virtual Result SetColor(float r, float g, float b) = 0;
 
+	// SYNTHETIC: BETA10 0x1016b630
+	// Tgl::Light::Light
+
 	// SYNTHETIC: LEGO1 0x100a26d0
+	// SYNTHETIC: BETA10 0x1016b6a0
 	// Tgl::Light::~Light
 
 	// SYNTHETIC: LEGO1 0x100a2aa0
+	// SYNTHETIC: BETA10 0x1016bb80
 	// Tgl::Light::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbbb0
+// VTABLE: BETA10 0x101c3360
 class Mesh : public Object {
 public:
-	// SYNTHETIC: LEGO1 0x100a3e10
-	// Tgl::Mesh::~Mesh
-
 	virtual Result SetColor(float r, float g, float b, float a) = 0;
 	virtual Result SetTexture(const Texture*) = 0;
 	virtual Result GetTexture(Texture*&) = 0;
@@ -285,11 +320,20 @@ public:
 	// Just get another Group pointing to the same underlying data
 	virtual Mesh* ShallowClone(MeshBuilder*) = 0;
 
+	// SYNTHETIC: BETA10 0x1016fad0
+	// Tgl::Mesh::Mesh
+
+	// SYNTHETIC: LEGO1 0x100a3e10
+	// SYNTHETIC: BETA10 0x1016fb40
+	// Tgl::Mesh::~Mesh
+
 	// SYNTHETIC: LEGO1 0x100a3e60
+	// SYNTHETIC: BETA10 0x1016fbe0
 	// Tgl::Mesh::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbaa0
+// VTABLE: BETA10 0x101c3188
 class Group : public Object {
 public:
 	virtual Result SetTransformation(FloatMatrix4&) = 0;
@@ -307,10 +351,15 @@ public:
 	// to have been replaced by something else in the shipped code.
 	virtual Result Bounds(D3DVECTOR*, D3DVECTOR*) = 0;
 
+	// SYNTHETIC: BETA10 0x1016a300
+	// Tgl::Group::Group
+
 	// SYNTHETIC: LEGO1 0x100a2510
+	// SYNTHETIC: BETA10 0x1016a370
 	// Tgl::Group::~Group
 
 	// SYNTHETIC: LEGO1 0x100a29c0
+	// SYNTHETIC: BETA10 0x1016a3d0
 	// Tgl::Group::`scalar deleting destructor'
 };
 
@@ -318,6 +367,7 @@ public:
 // was not in the leaked Tgl code. My suspicion is that it's
 // some kind of builder class for creating meshes.
 // VTABLE: LEGO1 0x100dbb30
+// VTABLE: BETA10 0x101c3330
 class MeshBuilder : public Object {
 public:
 	virtual Mesh* CreateMesh(
@@ -333,14 +383,20 @@ public:
 	virtual Result GetBoundingBox(float min[3], float max[3]) const = 0;
 	virtual MeshBuilder* Clone() = 0;
 
+	// SYNTHETIC: BETA10 0x1016ba70
+	// Tgl::MeshBuilder::MeshBuilder
+
 	// SYNTHETIC: LEGO1 0x100a27b0
+	// SYNTHETIC: BETA10 0x1016bae0
 	// Tgl::MeshBuilder::~MeshBuilder
 
 	// SYNTHETIC: LEGO1 0x100a2b10
+	// SYNTHETIC: BETA10 0x1016bc80
 	// Tgl::MeshBuilder::`scalar deleting destructor'
 };
 
 // VTABLE: LEGO1 0x100dbb68
+// VTABLE: BETA10 0x101c3280
 class Texture : public Object {
 public:
 	// vtable+0x08
@@ -359,10 +415,15 @@ public:
 	) = 0;
 	virtual Result SetPalette(int entryCount, PaletteEntry* pEntries) = 0;
 
+	// SYNTHETIC: BETA10 0x1016b520
+	// Tgl::Texture::Texture
+
 	// SYNTHETIC: LEGO1 0x100a2890
+	// SYNTHETIC: BETA10 0x1016b590
 	// Tgl::Texture::~Texture
 
 	// SYNTHETIC: LEGO1 0x100a2b80
+	// SYNTHETIC: BETA10 0x1016bb40
 	// Tgl::Texture::`scalar deleting destructor'
 };
 


### PR DESCRIPTION
Adding `BETA10` addresses for vtables and some functions from the `Tgl` and `TglImpl` classes. This is intended as a starting point for comparing the 96 source with the beta. It's also provides data for the ghidra scripts to import.

In `TglImpl` I only marked the scalar destructor and the `ImplementationDataPtr` from each class. `Mesh` and `MeshBuilder` both have one fewer virtual method.