### PR TITLE
Add all `TglImpl::ImplementationData` methods

### DIFF
--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -105,6 +105,15 @@ public:
 	inline Result Create();
 	inline void Destroy();
 	inline Result CreateLight(LightType type, float r, float g, float b, LightImpl& rLight);
+	inline Result CreateView(
+		const DeviceImpl& rDevice,
+		const CameraImpl& rCamera,
+		unsigned long x,
+		unsigned long y,
+		unsigned long width,
+		unsigned long height,
+		ViewImpl& rView
+	);
 
 private:
 	RendererDataType m_data;
@@ -233,8 +242,9 @@ public:
 
 	typedef IDirect3DRMViewport* ViewDataType;
 
-	// FUNCTION: BETA10 0x101711c0
 	const ViewDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x101711c0
 	ViewDataType& ImplementationData() { return m_data; }
 
 	void SetImplementationData(IDirect3DRMViewport* viewport) { m_data = viewport; }
@@ -782,6 +792,9 @@ inline D3DRMLIGHTTYPE Translate(LightType tglLightType)
 // SYNTHETIC: LEGO1 0x100a3d80
 // SYNTHETIC: BETA10 0x1016fa90
 // TglImpl::MeshImpl::`scalar deleting destructor'
+
+// SYNTHETIC: BETA10 0x10169960
+// ViewportAppData::`scalar deleting destructor'
 
 // GLOBAL: LEGO1 0x100dd1e0
 // IID_IDirect3DRMMeshBuilder

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -114,6 +114,7 @@ public:
 		unsigned long height,
 		ViewImpl& rView
 	);
+	inline Result CreateMeshBuilder(MeshBuilderImpl& rMesh);
 
 private:
 	RendererDataType m_data;
@@ -411,10 +412,9 @@ public:
 
 	typedef MeshData* MeshDataType;
 
-	// FUNCTION: BETA10 0x10170420
 	const MeshDataType& ImplementationData() const { return m_data; }
 
-	// FUNCTION: BETA10 0x10170440
+	// FUNCTION: BETA10 0x10171b70
 	MeshDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
@@ -532,7 +532,10 @@ public:
 
 	typedef IDirect3DRMMesh* MeshBuilderDataType;
 
+	// FUNCTION: BETA10 0x10170420
 	const MeshBuilderDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x10170440
 	MeshBuilderDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -418,6 +418,7 @@ public:
 	MeshDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
+	inline Mesh* DeepClone(const MeshBuilderImpl& rMesh);
 
 	friend class RendererImpl;
 

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -128,6 +128,8 @@ public:
 		int paletteEntryCount,
 		const PaletteEntry* pEntries
 	);
+	inline Result CreateDevice(const DeviceDirect3DCreateData& rCreateData, DeviceImpl& rDevice);
+	inline Result CreateDevice(const DeviceDirectDrawCreateData& rCreateData, DeviceImpl& rDevice);
 
 private:
 	RendererDataType m_data;
@@ -186,7 +188,7 @@ public:
 	// FUNCTION: BETA10 0x101708e0
 	const DeviceDataType& ImplementationData() const { return m_data; }
 
-	// FUNCTION: BETA10 0x100d95
+	// FUNCTION: BETA10 0x100d9540
 	DeviceDataType& ImplementationData() { return m_data; }
 
 	void SetImplementationData(IDirect3DRMDevice2* device) { m_data = device; }

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -99,6 +99,7 @@ public:
 
 	const RendererDataType& ImplementationData() const { return m_data; }
 
+	// FUNCTION: BETA10 0x10174c10
 	RendererDataType& ImplementationData() { return m_data; }
 
 public:
@@ -115,6 +116,18 @@ public:
 		ViewImpl& rView
 	);
 	inline Result CreateMeshBuilder(MeshBuilderImpl& rMesh);
+	inline Result CreateCamera(CameraImpl& rCamera);
+	inline Result CreateTexture(TextureImpl& rTexture);
+	inline Result CreateTexture(
+		TextureImpl& rTexture,
+		int width,
+		int height,
+		int bitsPerTexel,
+		const void* pTexels,
+		int texelsArePersistent,
+		int paletteEntryCount,
+		const PaletteEntry* pEntries
+	);
 
 private:
 	RendererDataType m_data;

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -95,7 +95,11 @@ public:
 		return m_data->CreateTextureFromSurface(pSurface, pTexture2);
 	}
 
-	IDirect3DRM2* ImplementationData() const { return m_data; }
+	typedef IDirect3DRM2* RendererDataType;
+
+	const RendererDataType& ImplementationData() const { return m_data; }
+
+	RendererDataType& ImplementationData() { return m_data; }
 
 public:
 	inline Result Create();
@@ -103,7 +107,7 @@ public:
 	inline Result CreateLight(LightType type, float r, float g, float b, LightImpl& rLight);
 
 private:
-	IDirect3DRM2* m_data;
+	RendererDataType m_data;
 };
 
 extern IDirect3DRM2* g_pD3DRM;
@@ -154,7 +158,14 @@ public:
 	void HandleActivate(WORD) override;
 	void HandlePaint(HDC) override;
 
-	IDirect3DRMDevice2* ImplementationData() const { return m_data; }
+	typedef IDirect3DRMDevice2* DeviceDataType;
+
+	// FUNCTION: BETA10 0x101708e0
+	const DeviceDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x100d95
+	DeviceDataType& ImplementationData() { return m_data; }
+
 	void SetImplementationData(IDirect3DRMDevice2* device) { m_data = device; }
 
 	inline void Destroy();
@@ -162,7 +173,7 @@ public:
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMDevice2* m_data;
+	DeviceDataType m_data;
 };
 
 // FUNCTION: BETA10 0x101708c0
@@ -220,7 +231,12 @@ public:
 		int& rPickedGroupCount
 	) override;
 
-	IDirect3DRMViewport* ImplementationData() const { return m_data; }
+	typedef IDirect3DRMViewport* ViewDataType;
+
+	// FUNCTION: BETA10 0x101711c0
+	const ViewDataType& ImplementationData() const { return m_data; }
+	ViewDataType& ImplementationData() { return m_data; }
+
 	void SetImplementationData(IDirect3DRMViewport* viewport) { m_data = viewport; }
 
 	static Result ViewportCreateAppData(IDirect3DRM2*, IDirect3DRMViewport*, IDirect3DRMFrame2*);
@@ -242,7 +258,7 @@ public:
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMViewport* m_data;
+	ViewDataType m_data;
 };
 
 // FUNCTION: BETA10 0x101711a0
@@ -275,14 +291,20 @@ public:
 	// vtable+0x08
 	Result SetTransformation(FloatMatrix4&) override;
 
-	IDirect3DRMFrame2* ImplementationData() const { return m_data; }
+	typedef IDirect3DRMFrame2* CameraDataType;
+
+	// FUNCTION: BETA10 0x10170960
+	const CameraDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x10170980
+	CameraDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
 
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMFrame2* m_data;
+	CameraDataType m_data;
 };
 
 // FUNCTION: BETA10 0x10170940
@@ -318,7 +340,10 @@ public:
 
 	typedef IDirect3DRMFrame2* LightDataType;
 
+	// FUNCTION: BETA10 0x10171b90
 	const LightDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x10171240
 	LightDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
@@ -376,7 +401,10 @@ public:
 
 	typedef MeshData* MeshDataType;
 
+	// FUNCTION: BETA10 0x10170420
 	const MeshDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x10170440
 	MeshDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
@@ -433,14 +461,20 @@ public:
 	// vtable+0x30
 	Result Bounds(D3DVECTOR* p_min, D3DVECTOR* p_max) override;
 
-	IDirect3DRMFrame2* ImplementationData() const { return m_data; }
+	typedef IDirect3DRMFrame2* GroupDataType;
+
+	// FUNCTION: BETA10 0x1016fc20
+	const GroupDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x1016fce0
+	GroupDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
 
 	friend class RendererImpl;
 
 private:
-	IDirect3DRMFrame2* m_data;
+	GroupDataType m_data;
 };
 
 // FUNCTION: BETA10 0x1016c2b0
@@ -486,7 +520,10 @@ public:
 	// vtable+0x10
 	MeshBuilder* Clone() override;
 
-	IDirect3DRMMesh* ImplementationData() const { return m_data; }
+	typedef IDirect3DRMMesh* MeshBuilderDataType;
+
+	const MeshBuilderDataType& ImplementationData() const { return m_data; }
+	MeshBuilderDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
 
@@ -505,7 +542,7 @@ private:
 		ShadingModel shadingModel
 	);
 
-	IDirect3DRMMesh* m_data;
+	MeshBuilderDataType m_data;
 };
 
 // FUNCTION: BETA10 0x10170390
@@ -574,7 +611,14 @@ public:
 	) override;
 	Result SetPalette(int entryCount, PaletteEntry* entries) override;
 
-	IDirect3DRMTexture* ImplementationData() const { return m_data; }
+	typedef IDirect3DRMTexture* TextureDataType;
+
+	// FUNCTION: BETA10 0x1016fd60
+	const TextureDataType& ImplementationData() const { return m_data; }
+
+	// FUNCTION: BETA10 0x1016fe20
+	TextureDataType& ImplementationData() { return m_data; }
+
 	void SetImplementation(IDirect3DRMTexture* pData) { m_data = pData; }
 
 	inline void Destroy();
@@ -584,7 +628,7 @@ public:
 	static Result SetImage(IDirect3DRMTexture* pSelf, TglD3DRMIMAGE* pImage);
 
 private:
-	IDirect3DRMTexture* m_data;
+	TextureDataType m_data;
 };
 
 // FUNCTION: BETA10 0x1016fd40

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -279,14 +279,33 @@ Light* RendererImpl::CreateLight(LightType type, float r, float g, float b)
 	return pLightImpl;
 }
 
+// FUNCTION: BETA10 0x1016d8e0
+inline Result RendererCreateMeshBuilder(IDirect3DRM2* pD3DRM, IDirect3DRMMesh*& rpMesh)
+{
+	return ResultVal(pD3DRM->CreateMesh(&rpMesh));
+}
+
+// FUNCTION: BETA10 0x1016d850
+inline Result RendererImpl::CreateMeshBuilder(MeshBuilderImpl& rMesh)
+{
+	assert(m_data);
+	assert(!rMesh.ImplementationData());
+
+	return RendererCreateMeshBuilder(m_data, rMesh.ImplementationData());
+}
+
 // FUNCTION: LEGO1 0x100a1e90
+// FUNCTION: BETA10 0x1016abf0
 MeshBuilder* RendererImpl::CreateMeshBuilder()
 {
+	assert(m_data);
 	MeshBuilderImpl* meshBuilder = new MeshBuilderImpl();
-	if (FAILED(m_data->CreateMesh(&meshBuilder->m_data))) {
+
+	if (!CreateMeshBuilder(*static_cast<MeshBuilderImpl*>(meshBuilder))) {
 		delete meshBuilder;
 		meshBuilder = NULL;
 	}
+
 	return meshBuilder;
 }
 

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -88,7 +88,7 @@ inline Result RendererCreateDevice(
 
 	if (Succeeded(result)) {
 		if (rCreateData.m_pBackBuffer) {
-			// GLOBAL: LEGO1 0x10101040
+			// LEGO1 0x10101040
 			// GLOBAL: BETA10 0x102055f4
 			static int g_setBufferCount = 1;
 			if (g_setBufferCount) {


### PR DESCRIPTION
The 9 classes now use a `DataType` typedef as in the 96 code.

To get all the methods to appear, I added more abstraction functions in `RendererImpl` and `MeshImpl`. That resulted in:

```
0x100a1900 - TglImpl::RendererImpl::CreateDevice(struct Tgl::DeviceDirectDrawCreateData const &) (68.60% -> 98.88%)
0x100a1a00 - TglImpl::RendererImpl::CreateView (77.73% -> 100.00%)
0x100a1f50 - TglImpl::RendererImpl::CreateTexture(int, int, int, void const *, int, int, struct Tgl::PaletteEntry const *) (79.70% -> 100.00%)
0x100a20d0 - TglImpl::RendererImpl::CreateTexture(void) (92.06% -> 100.00%)
0x100a4030 - TglImpl::MeshImpl::DeepClone (46.92% -> 100.00%)
```

`CreateDevice` is 99% because reccmp doesn't pick up the static variable. The function where it lives gets inlined so we can't match it with our current mechanism.

The beta asserts use `pMesh` or `rMesh` to refer to both `MeshImpl` and `MeshBuilderImpl`, so it's not obvious at first glance. But I'm pretty sure these addresses are right.