### PR TITLE
Fix definition of WriteRegisterSettings()

### DIFF
--- a/CONFIG/config.h
+++ b/CONFIG/config.h
@@ -42,7 +42,7 @@ public:
 	DWORD GetConditionalDeviceRenderBitDepth() const;
 	DWORD GetDeviceRenderBitStatus() const;
 	BOOL AdjustDisplayBitDepthBasedOnRenderStatus();
-	void CConfigApp::WriteRegisterSettings() const;
+	void WriteRegisterSettings() const;
 
 	//{{AFX_MSG(CConfigApp)
 	// NOTE - the ClassWizard will add and remove member functions here.


### PR DESCRIPTION
I couldn't find a way to get this working on Linux so hoping this is the correct fix.