### PR TITLE
pin container base image registry and debian version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM docker.io/library/debian:stable-slim
 
 # Gather dependencies
 RUN dpkg --add-architecture i386


### PR DESCRIPTION
This PR pins the registry, and pins the base image of the container file to use debian (stable, slim). Tested working with the provided build instructions in the readme.