### PR TITLE
Match `DecodeSS2`

### DIFF
--- a/LEGO1/omni/src/video/flic.cpp
+++ b/LEGO1/omni/src/video/flic.cpp
@@ -368,7 +368,7 @@ void DecodeSS2(LPBITMAPINFOHEADER p_bitmapHeader, BYTE* p_pixelData, BYTE* p_dat
 	union {
 		BYTE* byte;
 		WORD* word;
-	 } data = { p_data };
+	} data = {p_data};
 
 	// The first word in the data following the chunk header contains the number of lines in the chunk.
 	// The line count does not include skipped lines.


### PR DESCRIPTION
I have significantly improved `DecodeSS2`, but it isn't perfect yet. Would appreciate if someone else took a look.

A lot of `// LINE` annotations are used, based on [this PR](https://github.com/isledecomp/reccmp/pull/107). They aren't technically needed anymore since the structure matches, but it might still be handy to keep them around (maybe as a reference?) ~The CI currently fails because of these annotations~.

Most of the code matches, there are only two parts I couldn't get quite right. The rest comes down to the stack order / variable names.

Closes #1427.