### PR TITLE
Rename FUN_1009d0d0 into GetBestDevice

### DIFF
--- a/CONFIG/config.cpp
+++ b/CONFIG/config.cpp
@@ -236,7 +236,7 @@ BOOL CConfigApp::ReadRegisterSettings()
 	if (tmp != 0) {
 		is_modified = TRUE;
 		m_device_enumerator->FUN_1009d210();
-		tmp = m_device_enumerator->FUN_1009d0d0();
+		tmp = m_device_enumerator->GetBestDevice();
 		m_device_enumerator->GetDevice(tmp, m_driver, m_device);
 	}
 	if (!ReadRegInt("Display Bit Depth", &m_display_bit_depth)) {

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -119,7 +119,7 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 
 	if (deviceNum < 0) {
 		deviceEnumerate.FUN_1009d210();
-		deviceNum = deviceEnumerate.FUN_1009d0d0();
+		deviceNum = deviceEnumerate.GetBestDevice();
 		deviceNum = deviceEnumerate.GetDevice(deviceNum, driver, device);
 	}
 

--- a/LEGO1/mxdirectx/legodxinfo.cpp
+++ b/LEGO1/mxdirectx/legodxinfo.cpp
@@ -158,7 +158,7 @@ int LegoDeviceEnumerate::BETA_1011cc65(int p_idx, char* p_buffer)
 // FUNCTION: CONFIG 0x00402860
 // FUNCTION: LEGO1 0x1009d0d0
 // FUNCTION: BETA10 0x1011cdb4
-int LegoDeviceEnumerate::FUN_1009d0d0()
+int LegoDeviceEnumerate::GetBestDevice()
 {
 	if (!IsInitialized()) {
 		return -1;

--- a/LEGO1/mxdirectx/legodxinfo.h
+++ b/LEGO1/mxdirectx/legodxinfo.h
@@ -14,7 +14,7 @@ public:
 	int GetDevice(int p_deviceNum, MxDriver*& p_driver, Direct3DDeviceInfo*& p_device);
 	int FormatDeviceName(char* p_buffer, const MxDriver* p_ddInfo, const Direct3DDeviceInfo* p_d3dInfo) const;
 	int BETA_1011cc65(int p_idx, char* p_buffer);
-	int FUN_1009d0d0();
+	int GetBestDevice();
 	static int SupportsMMX();
 	static int SupportsCPUID();
 	int FUN_1009d210();


### PR DESCRIPTION
Gets any hardware device that can output an image, or a software rendere, the software rendere will be color if the CPU has MMX else a black and white software render is picked.

There may well be some logic errors here since it only gets a software render if it's ONLY capable of color OR monochrome but the API seems to allow for multiple flags.