### PR TITLE
Rename F2bit0 to LacksLightSupport

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -218,7 +218,7 @@ void IsleApp::SetupVideoFlags(
 	m_videoParam.Flags().SetFullScreen(fullScreen);
 	m_videoParam.Flags().SetFlipSurfaces(flipSurfaces);
 	m_videoParam.Flags().SetBackBuffers(!backBuffers);
-	m_videoParam.Flags().SetF2bit0(!param_6);
+	m_videoParam.Flags().SetLacksLightSupport(!param_6);
 	m_videoParam.Flags().SetF1bit7(param_7);
 	m_videoParam.Flags().SetWideViewAngle(wideViewAngle);
 	m_videoParam.Flags().SetF2bit1(1);

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1303,7 +1303,7 @@ void LegoBackgroundColor::ToggleSkyColor()
 // FUNCTION: BETA10 0x10086984
 void LegoBackgroundColor::SetLightColor(float p_r, float p_g, float p_b)
 {
-	if (!VideoManager()->GetVideoParam().Flags().GetF2bit0()) {
+	if (!VideoManager()->GetVideoParam().Flags().GetLacksLightSupport()) {
 		// TODO: Computed constants based on what?
 		p_r *= 1. / 0.23;
 		p_g *= 1. / 0.63;

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -126,13 +126,13 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	m_direct3d->SetDevice(deviceEnumerate, driver, device);
 
 	if (!driver->m_ddCaps.dwCaps2 && driver->m_ddCaps.dwSVBRops[7] != 2) {
-		p_videoParam.Flags().SetF2bit0(TRUE);
+		p_videoParam.Flags().SetLacksLightSupport(TRUE);
 	}
 	else {
-		p_videoParam.Flags().SetF2bit0(FALSE);
+		p_videoParam.Flags().SetLacksLightSupport(FALSE);
 	}
 
-	ViewROI::SetUnk101013d8(p_videoParam.Flags().GetF2bit0() == FALSE);
+	ViewROI::SetUnk101013d8(p_videoParam.Flags().GetLacksLightSupport() == FALSE);
 
 	if (!m_direct3d->Create(
 			hwnd,

--- a/LEGO1/omni/include/mxvideoparamflags.h
+++ b/LEGO1/omni/include/mxvideoparamflags.h
@@ -31,7 +31,7 @@ public:
 	void SetF1bit7(MxBool p_e) { m_flags1.m_bit7 = p_e; }
 
 	// FUNCTION: BETA10 0x100d81b0
-	void SetF2bit0(MxBool p_e) { m_flags2.m_bit0 = p_e; }
+	void SetLacksLightSupport(MxBool p_e) { m_flags2.m_bit0 = p_e; }
 
 	// inlined in ISLE
 	void SetF2bit1(MxBool p_e) { m_flags2.m_bit1 = p_e; }
@@ -55,7 +55,7 @@ public:
 	MxBool GetWideViewAngle() { return m_flags1.m_bit6; }
 
 	// FUNCTION: BETA10 0x100886b0
-	MxBool GetF2bit0() { return m_flags2.m_bit0; }
+	MxBool GetLacksLightSupport() { return m_flags2.m_bit0; }
 
 	// FUNCTION: BETA10 0x10142050
 	MxBool GetF2bit1() { return m_flags2.m_bit1; }


### PR DESCRIPTION
A better name for the flag. It's one of the most common places for the miniwin directx implementation to die so I have been starting at this very bit of code for to many times to live with this name any longer.