### PR TITLE
Rename FUN_10018980 into SetShootAnimMap

### DIFF
--- a/LEGO1/lego/legoomni/include/act2actor.h
+++ b/LEGO1/lego/legoomni/include/act2actor.h
@@ -37,7 +37,7 @@ public:
 	MxResult VTable0x9c() override;                     // vtable+0x9c
 	MxS32 VTable0xa0() override;                        // vtable+0xa0
 
-	void FUN_10018980();
+	void SetShootAnimMap();
 	void FUN_10019250(MxFloat p_speed, MxFloat p_param2);
 	void FUN_10019520();
 	void FUN_10019560();

--- a/LEGO1/lego/legoomni/src/actors/act2actor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act2actor.cpp
@@ -142,7 +142,7 @@ void Act2Actor::SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2)
 
 // FUNCTION: LEGO1 0x10018980
 // FUNCTION: BETA10 0x1000c963
-void Act2Actor::FUN_10018980()
+void Act2Actor::SetShootAnimMap()
 {
 	for (MxS32 i = 0; i < m_animMaps.size(); i++) {
 		if (m_animMaps[i]->GetUnknown0x00() == -1.0f) {

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -1222,6 +1222,6 @@ MxResult LegoAct2::FUN_10052800()
 	ap->FUN_1006d680(m_unk0x1138, -1.0f);
 
 	actor->SetWorldSpeed(0.0f);
-	m_unk0x1138->FUN_10018980();
+	m_unk0x1138->SetShootAnimMap();
 	return SUCCESS;
 }


### PR DESCRIPTION
Renames the animation map with GetUnknown0x00() == -1.0f as the "shoot" animation and stores it in m_shootAnim. Ensures that a valid shoot animation was found. Retrieves the "xarrow" sound from the sound manager and assigns it to m_unk0x38, unless the BETA10 flag is set, in which case it uses the "bcrash" sound instead. Sets sound attenuation distances depending on the build, and in non-BETA10 builds, makes the ROI visible.