### PR TITLE
Use argument file for `reccmp-aggregate` samples

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -172,9 +172,12 @@ jobs:
     - name: Aggregate Accuracy
       shell: bash
       run: |
-        reccmp-aggregate --samples $(find build-entropy -type f -name "CONFIGPROGRESS*.json") --output CONFIGPROGRESS-agg.json --html CONFIGPROGRESS-agg.html
-        reccmp-aggregate --samples $(find build-entropy -type f -name "ISLEPROGRESS*.json") --output ISLEPROGRESS-agg.json --html ISLEPROGRESS-agg.html
-        reccmp-aggregate --samples $(find build-entropy -type f -name "LEGO1PROGRESS*.json") --output LEGO1PROGRESS-agg.json --html LEGO1PROGRESS-agg.html
+        find build-entropy -type f -name "CONFIGPROGRESS*.json" > configsamples.txt
+        find build-entropy -type f -name "ISLEPROGRESS*.json" > islesamples.txt
+        find build-entropy -type f -name "LEGO1PROGRESS*.json" > lego1samples.txt
+        reccmp-aggregate --samples @configsamples.txt --output CONFIGPROGRESS-agg.json --html CONFIGPROGRESS-agg.html
+        reccmp-aggregate --samples @islesamples.txt --output ISLEPROGRESS-agg.json --html ISLEPROGRESS-agg.html
+        reccmp-aggregate --samples @lego1samples.txt --output LEGO1PROGRESS-agg.json --html LEGO1PROGRESS-agg.html
 
     - name: Compare Aggregate Accuracy With Current Master
       shell: bash


### PR DESCRIPTION
#1505 reminded me that I never added this. With this we can run 1024 sample entropy runs.