### PR TITLE
Rename functions and parameters in OrientableROI

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/act2actor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act2actor.cpp
@@ -611,8 +611,8 @@ MxU32 Act2Actor::FUN_10019700(MxFloat p_param)
 
 	MxMatrix matrix = m_roi->GetLocal2World();
 	matrix[3][1] += 1.0f;
-	brickstrROI->FUN_100a58f0(matrix);
-	brickstrROI->VTable0x14();
+	brickstrROI->SetLocal2World(matrix);
+	brickstrROI->WrappedUpdateWorldData();
 
 	Vector3 col0(matrix[0]);
 	Vector3 col1(matrix[1]);

--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -138,8 +138,8 @@ MxU32 Act3Actor::VTable0x90(float p_time, Matrix4& p_transform)
 			m_unk0x1c = 0;
 
 			positionRef -= g_unk0x10104ef0;
-			m_roi->FUN_100a58f0(p_transform);
-			m_roi->VTable0x14();
+			m_roi->SetLocal2World(p_transform);
+			m_roi->WrappedUpdateWorldData();
 			return TRUE;
 		}
 	}
@@ -163,8 +163,8 @@ MxResult Act3Actor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 
 		Vector3(local2world[3]) += g_unk0x10104ef0;
 
-		roi->FUN_100a58f0(local2world);
-		roi->VTable0x14();
+		roi->SetLocal2World(local2world);
+		roi->WrappedUpdateWorldData();
 
 		p_actor->SetActorState(c_two | c_noCollide);
 	}

--- a/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
@@ -271,8 +271,8 @@ void Act3Ammo::Animate(float p_time)
 			positionRef.Clear();
 			transform.RotateX(0.6);
 			positionRef = position;
-			m_roi->FUN_100a58f0(transform);
-			m_roi->VTable0x14();
+			m_roi->SetLocal2World(transform);
+			m_roi->WrappedUpdateWorldData();
 			return;
 		}
 		else {
@@ -280,8 +280,8 @@ void Act3Ammo::Animate(float p_time)
 			m_unk0x158 = 0;
 
 			positionRef -= g_unk0x10104f08;
-			m_roi->FUN_100a58f0(transform);
-			m_roi->VTable0x14();
+			m_roi->SetLocal2World(transform);
+			m_roi->WrappedUpdateWorldData();
 			return;
 		}
 	}
@@ -363,8 +363,8 @@ void Act3Ammo::Animate(float p_time)
 
 	MxMatrix localb0(local104);
 	local104.Product(local60, localb0);
-	m_roi->FUN_100a58f0(local104);
-	m_roi->VTable0x14();
+	m_roi->SetLocal2World(local104);
+	m_roi->WrappedUpdateWorldData();
 
 	if (m_BADuration <= m_unk0x7c) {
 		m_worldSpeed = 0.0f;

--- a/LEGO1/lego/legoomni/src/actors/doors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/doors.cpp
@@ -89,24 +89,24 @@ void Doors::Animate(float p_time)
 			local10.Clear();
 			local58.RotateY(-local8);
 			local10 = m_ltDoorLocal[3];
-			m_ltDoor->FUN_100a58f0(local58);
-			m_ltDoor->VTable0x14();
+			m_ltDoor->SetLocal2World(local58);
+			m_ltDoor->WrappedUpdateWorldData();
 
 			local58 = m_rtDoorLocal;
 			local10.Clear();
 			local58.RotateY(local8);
 			local10 = m_rtDoorLocal[3];
-			m_rtDoor->FUN_100a58f0(local58);
-			m_rtDoor->VTable0x14();
+			m_rtDoor->SetLocal2World(local58);
+			m_rtDoor->WrappedUpdateWorldData();
 
 			m_unk0x1f4 = local8;
 		}
 
 		if (m_unk0x158 + g_unk0x100d8e84 < p_time) {
-			m_ltDoor->FUN_100a58f0(m_ltDoorLocal);
-			m_rtDoor->FUN_100a58f0(m_rtDoorLocal);
-			m_ltDoor->VTable0x14();
-			m_rtDoor->VTable0x14();
+			m_ltDoor->SetLocal2World(m_ltDoorLocal);
+			m_rtDoor->SetLocal2World(m_rtDoorLocal);
+			m_ltDoor->WrappedUpdateWorldData();
+			m_rtDoor->WrappedUpdateWorldData();
 			m_unk0x154 = 1;
 			m_actorState = c_initial;
 			m_unk0x1f4 = 0;

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -391,8 +391,8 @@ void Helicopter::VTable0x74(Matrix4& p_transform)
 		FUN_10010c30();
 	}
 	else {
-		m_roi->FUN_100a58f0(p_transform);
-		m_roi->VTable0x14();
+		m_roi->SetLocal2World(p_transform);
+		m_roi->WrappedUpdateWorldData();
 		if (m_cameraFlag) {
 			FUN_10010c30();
 		}

--- a/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
+++ b/LEGO1/lego/legoomni/src/actors/islepathactor.cpp
@@ -630,7 +630,7 @@ void IslePathActor::VTable0xec(MxMatrix p_transform, LegoPathBoundary* p_boundar
 		m_world->Add(this);
 	}
 
-	m_roi->FUN_100a58f0(p_transform);
+	m_roi->SetLocal2World(p_transform);
 	if (m_cameraFlag) {
 		FUN_1003eda0();
 		FUN_10010c30();
@@ -648,6 +648,6 @@ void IslePathActor::FUN_1001b660()
 
 	up *= -1.0f;
 	position.EqualsCross(direction, up);
-	m_roi->FUN_100a58f0(transform);
-	m_roi->VTable0x14();
+	m_roi->SetLocal2World(transform);
+	m_roi->WrappedUpdateWorldData();
 }

--- a/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
@@ -318,7 +318,7 @@ void LegoCarBuild::FUN_10022f30()
 void LegoCarBuild::VTable0x6c()
 {
 	m_unk0x178 = m_unk0x1c0;
-	m_unk0x110->WrappedSetLocalTransform(m_unk0x178);
+	m_unk0x110->WrappedSetLocal2WorldWithWorldDataUpdate(m_unk0x178);
 	m_unk0x2a4 = Vector4(m_unk0x110->GetWorldPosition());
 
 	VTable0x70();
@@ -406,7 +406,7 @@ void LegoCarBuild::FUN_10023130(MxLong p_x, MxLong p_y)
 			local78[3][2] = m_unk0x178[3][2] + local18[2];
 			local78[3][3] = 1.0;
 
-			m_unk0x110->WrappedSetLocalTransform(local78);
+			m_unk0x110->WrappedSetLocal2WorldWithWorldDataUpdate(local78);
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
@@ -267,7 +267,7 @@ void LegoCarBuildAnimPresenter::StreamingTickle()
 
 	CalcLocalTransform(cameraPosition, dirVec, upVec, localTransform);
 
-	videoManagerROI->WrappedSetLocalTransform(localTransform);
+	videoManagerROI->WrappedSetLocal2WorldWithWorldDataUpdate(localTransform);
 	lego3dview->Moved(*videoManagerROI);
 	videoManager->Get3DManager()->SetFrustrum(fov, 0.1, 250.0);
 

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -2808,7 +2808,7 @@ void LegoAnimationManager::FUN_100648f0(LegoTranInfo* p_tranInfo, MxLong p_unk0x
 
 		Mx3DPointFloat vec;
 		vec.Clear();
-		viewROI->FUN_100a5a30(vec);
+		viewROI->SetWorldVelocity(vec);
 	}
 }
 
@@ -2841,7 +2841,7 @@ void LegoAnimationManager::FUN_10064b50(MxLong p_time)
 
 		LegoROI* viewROI = VideoManager()->GetViewROI();
 
-		viewROI->WrappedSetLocalTransform(mat);
+		viewROI->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 		VideoManager()->Get3DManager()->Moved(*viewROI);
 		SoundManager()->UpdateListener(
 			viewROI->GetWorldPosition(),

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -364,7 +364,7 @@ MxBool LegoAnimMMPresenter::FUN_1004b5b0(MxLong p_time)
 				LegoROI* roi = m_roiMap[i];
 
 				if (roi != NULL) {
-					roi->WrappedSetLocalTransform(m_unk0x68[i]);
+					roi->WrappedSetLocal2WorldWithWorldDataUpdate(m_unk0x68[i]);
 				}
 			}
 		}
@@ -450,7 +450,7 @@ MxBool LegoAnimMMPresenter::FUN_1004b6d0(MxLong p_time)
 			}
 
 			if (und != 0) {
-				viewROI->WrappedSetLocalTransform(m_tranInfo->m_unk0x2c);
+				viewROI->WrappedSetLocal2WorldWithWorldDataUpdate(m_tranInfo->m_unk0x2c);
 				VideoManager()->Get3DManager()->Moved(*viewROI);
 				m_world->PlaceActor(actor);
 			}

--- a/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legocharactermanager.cpp
@@ -551,7 +551,7 @@ LegoROI* LegoCharacterManager::CreateActorROI(const char* p_key)
 			Mx3DPointFloat(g_actorLODs[i + 1].m_up),
 			mat
 		);
-		childROI->WrappedSetLocalTransform(mat);
+		childROI->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 
 		if (g_actorLODs[i + 1].m_flags & LegoActorLOD::c_flag1 && (i != 0 || part.m_unk0x00[part.m_unk0x08] != 0)) {
 
@@ -577,7 +577,7 @@ LegoROI* LegoCharacterManager::CreateActorROI(const char* p_key)
 		Mx3DPointFloat(g_actorLODs[c_topLOD].m_up),
 		mat
 	);
-	roi->WrappedSetLocalTransform(mat);
+	roi->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 
 	info->m_roi = roi;
 	success = TRUE;
@@ -1066,7 +1066,7 @@ MxResult LegoCharacterManager::FUN_10085870(LegoROI* p_roi)
 
 		p_roi->SetUnknown0x80(boundingBox);
 
-		p_roi->VTable0x14();
+		p_roi->WrappedUpdateWorldData();
 
 		result = SUCCESS;
 	}

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -215,7 +215,7 @@ void LegoGameState::SetActor(MxU8 p_actorId)
 	newActor->SetROI(roi, FALSE, FALSE);
 
 	if (oldActor) {
-		newActor->GetROI()->FUN_100a58f0(oldActor->GetROI()->GetLocal2World());
+		newActor->GetROI()->SetLocal2World(oldActor->GetROI()->GetLocal2World());
 		newActor->SetBoundary(oldActor->GetBoundary());
 		delete oldActor;
 	}

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -666,8 +666,8 @@ MxResult LegoPlantManager::Tickle()
 
 			SET3(locald8[3], localec);
 
-			entry->m_roi->FUN_100a58f0(locald8);
-			entry->m_roi->VTable0x14();
+			entry->m_roi->SetLocal2World(locald8);
+			entry->m_roi->WrappedUpdateWorldData();
 
 			if (entry->m_time < time) {
 				LegoPlantInfo* info = GetInfo(entry->m_entity);

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -86,7 +86,7 @@ void RotateY(LegoROI* p_roi, MxFloat p_angle)
 		mat[i][2] = (local2world[i][2] * fcos) - (local2world[i][0] * fsin);
 	}
 
-	p_roi->WrappedSetLocalTransform(mat);
+	p_roi->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 }
 
 // FUNCTION: LEGO1 0x1003de80
@@ -218,7 +218,7 @@ void FUN_1003e050(LegoAnimPresenter* p_presenter)
 	LegoROI* roi = video->GetViewROI();
 	Lego3DView* view = video->Get3DManager()->GetLego3DView();
 
-	roi->WrappedSetLocalTransform(viewMatrix);
+	roi->WrappedSetLocal2WorldWithWorldDataUpdate(viewMatrix);
 	view->Moved(*roi);
 	FUN_1003eda0();
 	video->Get3DManager()->SetFrustrum(cam, 0.1, 250.0);
@@ -480,7 +480,7 @@ void FUN_1003eda0()
 
 	LegoROI* viewROI = VideoManager()->GetViewROI();
 	if (viewROI) {
-		viewROI->FUN_100a5a30(vec);
+		viewROI->SetWorldVelocity(vec);
 		SoundManager()->UpdateListener(
 			viewROI->GetWorldPosition(),
 			viewROI->GetWorldDirection(),

--- a/LEGO1/lego/legoomni/src/entity/act2brick.cpp
+++ b/LEGO1/lego/legoomni/src/entity/act2brick.cpp
@@ -108,8 +108,8 @@ void Act2Brick::FUN_1007a670(MxMatrix& p_param1, MxMatrix& p_param2, LegoPathBou
 	p_boundary->AddActor(this);
 
 	SetActorState(c_disabled);
-	m_roi->FUN_100a58f0(p_param1);
-	m_roi->VTable0x14();
+	m_roi->SetLocal2World(p_param1);
+	m_roi->WrappedUpdateWorldData();
 	m_roi->SetVisibility(TRUE);
 }
 
@@ -147,8 +147,8 @@ MxResult Act2Brick::Tickle()
 		VPV3(local2world[3], local2world[3], m_unk0x168);
 	}
 
-	m_roi->FUN_100a58f0(local2world);
-	m_roi->VTable0x14();
+	m_roi->SetLocal2World(local2world);
+	m_roi->WrappedUpdateWorldData();
 	return SUCCESS;
 }
 

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -172,7 +172,7 @@ void LegoCameraController::FUN_100123e0(const Matrix4& p_transform, MxU32 p_und)
 			}
 
 			((TimeROI*) pov)->FUN_100a9b40(mat, Timer()->GetTime());
-			pov->WrappedSetLocalTransform(mat);
+			pov->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 			m_lego3DView->Moved(*pov);
 
 			SoundManager()->UpdateListener(

--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -442,8 +442,8 @@ MxResult LegoNavController::UpdateLocation(const char* p_location)
 			Mx3DPointFloat vec;
 			vec.Clear();
 
-			viewROI->FUN_100a5a30(vec);
-			viewROI->WrappedSetLocalTransform(mat);
+			viewROI->SetWorldVelocity(vec);
+			viewROI->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 			VideoManager()->Get3DManager()->Moved(*viewROI);
 
 			SoundManager()->UpdateListener(
@@ -480,8 +480,8 @@ MxResult LegoNavController::UpdateLocation(MxU32 p_location)
 		Mx3DPointFloat vec;
 		vec.Clear();
 
-		viewROI->FUN_100a5a30(vec);
-		viewROI->WrappedSetLocalTransform(mat);
+		viewROI->SetWorldVelocity(vec);
+		viewROI->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 		VideoManager()->Get3DManager()->Moved(*viewROI);
 
 		SoundManager()->UpdateListener(
@@ -930,7 +930,7 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 					MxMatrix mat;
 					mat.SetIdentity();
 					mat.RotateX(0.2618f);
-					roi->WrappedVTable0x24(mat);
+					roi->WrappedUpdateWorldDataWithTransform(mat);
 					break;
 				}
 				case 'J': {
@@ -938,7 +938,7 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 					MxMatrix mat;
 					mat.SetIdentity();
 					mat.RotateZ(0.2618f);
-					roi->WrappedVTable0x24(mat);
+					roi->WrappedUpdateWorldDataWithTransform(mat);
 					break;
 				}
 				case 'K': {
@@ -946,7 +946,7 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 					LegoROI* roi = LegoOmni::GetInstance()->GetVideoManager()->GetViewROI();
 					mat.SetIdentity();
 					mat.RotateZ(-0.2618f);
-					roi->WrappedVTable0x24(mat);
+					roi->WrappedUpdateWorldDataWithTransform(mat);
 					break;
 				}
 				case 'L':
@@ -957,7 +957,7 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 					MxMatrix mat;
 					mat.SetIdentity();
 					mat.RotateX(-0.2618f);
-					roi->WrappedVTable0x24(mat);
+					roi->WrappedUpdateWorldDataWithTransform(mat);
 					break;
 				}
 				case 'N':

--- a/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
@@ -154,7 +154,7 @@ MxResult LegoPointOfViewController::Tickle()
 
 			CalcLocalTransform(newPos, newDir, pov->GetWorldUp(), mat);
 			((TimeROI*) pov)->FUN_100a9b40(mat, Timer()->GetTime());
-			pov->WrappedSetLocalTransform(mat);
+			pov->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 			m_lego3DView->Moved(*pov);
 
 			SoundManager()->UpdateListener(
@@ -171,7 +171,7 @@ MxResult LegoPointOfViewController::Tickle()
 				Mx3DPointFloat vel;
 
 				vel.Clear();
-				pov->FUN_100a5a30(vel);
+				pov->SetWorldVelocity(vel);
 
 				SoundManager()->UpdateListener(
 					pov->GetWorldPosition(),
@@ -210,7 +210,7 @@ void LegoPointOfViewController::SetEntity(LegoEntity* p_entity)
 			mat
 		);
 
-		pov->WrappedSetLocalTransform(mat);
+		pov->WrappedSetLocal2WorldWithWorldDataUpdate(mat);
 	}
 	else {
 		TickleManager()->RegisterClient(this, 10);

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -98,7 +98,7 @@ MxU32 LegoExtraActor::VTable0x90(float p_time, Matrix4& p_transform)
 			m_actorState = c_initial;
 			m_scheduledTime = 0.0f;
 			positionRef -= g_unk0x10104c18;
-			m_roi->FUN_100a58f0(p_transform);
+			m_roi->SetLocal2World(p_transform);
 			return TRUE;
 		}
 	}
@@ -229,8 +229,8 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			}
 
 			if (!b) {
-				m_roi->FUN_100a58f0(matrix2);
-				m_roi->VTable0x14();
+				m_roi->SetLocal2World(matrix2);
+				m_roi->WrappedUpdateWorldData();
 				FUN_1002ad8a();
 				assert(m_roi);
 				assert(SoundManager()->GetCacheSoundManager());
@@ -254,7 +254,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			MxMatrix matrix3 = MxMatrix(roi->GetLocal2World());
 			Vector3 positionRef(matrix3[3]);
 			positionRef += g_unk0x10104c18;
-			roi->FUN_100a58f0(matrix3);
+			roi->SetLocal2World(matrix3);
 
 			float dotX = dir.Dot(dir, Mx3DPointFloat(1.0f, 0, 0));
 			float dotZ = dir.Dot(dir, Mx3DPointFloat(0, 0, 1.0f));
@@ -346,7 +346,7 @@ void LegoExtraActor::Animate(float p_time)
 			m_whichAnim = 0;
 			m_actorState = c_initial;
 			SetWorldSpeed(m_prevWorldSpeed);
-			m_roi->FUN_100a58f0(m_unk0x18);
+			m_roi->SetLocal2World(m_unk0x18);
 			m_lastTime = p_time;
 			break;
 		}

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -382,12 +382,12 @@ MxS32 LegoPathActor::VTable0x8c(float p_time, Matrix4& p_transform)
 void LegoPathActor::VTable0x74(Matrix4& p_transform)
 {
 	if (m_userNavFlag) {
-		m_roi->WrappedSetLocalTransform(p_transform);
+		m_roi->WrappedSetLocal2WorldWithWorldDataUpdate(p_transform);
 		FUN_10010c30();
 	}
 	else {
-		m_roi->WrappedSetLocalTransform(p_transform);
-		m_roi->VTable0x14();
+		m_roi->WrappedSetLocal2WorldWithWorldDataUpdate(p_transform);
+		m_roi->WrappedUpdateWorldData();
 
 		if (m_cameraFlag) {
 			FUN_10010c30();
@@ -731,11 +731,11 @@ void LegoPathActor::VTable0xa4(MxBool& p_und1, MxS32& p_und2)
 void LegoPathActor::VTable0xa8()
 {
 	m_lastTime = Timer()->GetTime();
-	m_roi->FUN_100a58f0(m_unk0xec);
-	m_roi->VTable0x14();
+	m_roi->SetLocal2World(m_unk0xec);
+	m_roi->WrappedUpdateWorldData();
 
 	if (m_userNavFlag) {
-		m_roi->WrappedSetLocalTransform(m_unk0xec);
+		m_roi->WrappedSetLocal2WorldWithWorldDataUpdate(m_unk0xec);
 		FUN_10010c30();
 	}
 }

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -84,7 +84,7 @@ MxU32 LegoRaceActor::VTable0x90(float p_time, Matrix4& p_transform)
 			m_unk0x08 = 0;
 
 			positionRef -= g_unk0x10102b08;
-			m_roi->FUN_100a58f0(p_transform);
+			m_roi->SetLocal2World(p_transform);
 			return TRUE;
 		}
 	}
@@ -109,7 +109,7 @@ MxResult LegoRaceActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 
 			Vector3(matr[3]) += g_unk0x10102b08;
 
-			roi->FUN_100a58f0(matr);
+			roi->SetLocal2World(matr);
 
 			p_actor->SetActorState(c_two);
 		}

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -343,7 +343,7 @@ void LegoRaceCar::FUN_10012ff0(float p_param)
 				r->GetCameraController()->FUN_100123e0(transformationMatrix, 0);
 			}
 
-			m_roi->FUN_100a58f0(transformationMatrix);
+			m_roi->SetLocal2World(transformationMatrix);
 		}
 	}
 }
@@ -469,7 +469,7 @@ MxResult LegoRaceCar::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			matr = roi->GetLocal2World();
 
 			Vector3(matr[3]) += g_unk0x10102af0;
-			roi->FUN_100a58f0(matr);
+			roi->SetLocal2World(matr);
 
 			p_actor->SetActorState(c_two);
 		}
@@ -683,7 +683,7 @@ MxResult LegoJetski::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			matr = roi->GetLocal2World();
 
 			Vector3(matr[3]) += g_unk0x10102af0;
-			roi->FUN_100a58f0(matr);
+			roi->SetLocal2World(matr);
 
 			p_actor->SetActorState(c_two);
 		}

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -659,8 +659,8 @@ void LegoAnimPresenter::PutFrame()
 					dir *= dirsqr;
 					up *= upsqr;
 
-					m_unk0x8c[i]->FUN_100a58f0(mat);
-					m_unk0x8c[i]->VTable0x14();
+					m_unk0x8c[i]->SetLocal2World(mat);
+					m_unk0x8c[i]->WrappedUpdateWorldData();
 				}
 			}
 		}
@@ -689,7 +689,7 @@ MxResult LegoAnimPresenter::FUN_1006afc0(MxMatrix*& p_matrix, float p_und)
 		if (m_roiMap[i] != NULL) {
 			mat = p_matrix[i];
 			p_matrix[i] = m_roiMap[i]->GetLocal2World();
-			m_roiMap[i]->FUN_100a58f0(mat);
+			m_roiMap[i]->SetLocal2World(mat);
 		}
 	}
 

--- a/LEGO1/lego/legoomni/src/video/legoloopinganimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoloopinganimpresenter.cpp
@@ -75,8 +75,8 @@ void LegoLoopingAnimPresenter::PutFrame()
 				dir *= dirsqr;
 				up *= upsqr;
 
-				m_unk0x8c[i]->FUN_100a58f0(mat);
-				m_unk0x8c[i]->VTable0x14();
+				m_unk0x8c[i]->SetLocal2World(mat);
+				m_unk0x8c[i]->WrappedUpdateWorldData();
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -200,7 +200,7 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	pLODList->Release();
 
 	CalcLocalTransform(posVec, dirVec, upVec, outMatrix);
-	m_viewROI->WrappedSetLocalTransform(outMatrix);
+	m_viewROI->WrappedSetLocal2WorldWithWorldDataUpdate(outMatrix);
 
 	m_3dManager->Add(*m_viewROI);
 	m_3dManager->SetPointOfView(*m_viewROI);

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -502,8 +502,8 @@ void LegoAct2::ReadyWorld()
 
 	MxMatrix local2world = roi->GetLocal2World();
 	local2world[3][0] -= 1.5;
-	roi->FUN_100a58f0(local2world);
-	roi->VTable0x14();
+	roi->SetLocal2World(local2world);
+	roi->WrappedUpdateWorldData();
 
 	roi = FindROI("Block02");
 	sphere = roi->GetBoundingSphere();
@@ -688,8 +688,8 @@ void LegoAct2::FUN_100517b0()
 	local2world[3][1] += 1.5;
 
 	LegoROI* roi = brick.GetROI();
-	roi->FUN_100a58f0(local2world);
-	roi->VTable0x14();
+	roi->SetLocal2World(local2world);
+	roi->WrappedUpdateWorldData();
 	brick.PlayWhistleSound();
 	m_nextBrick++;
 }
@@ -828,9 +828,9 @@ void LegoAct2::SpawnBricks()
 	}
 
 	SET3(local2world[3], location);
-	roi->FUN_100a58f0(local2world);
+	roi->SetLocal2World(local2world);
 	roi->SetVisibility(TRUE);
-	roi->VTable0x14();
+	roi->WrappedUpdateWorldData();
 	entity = roi->GetEntity();
 	brick->PlayWhistleSound();
 	m_nextBrick++;
@@ -852,9 +852,9 @@ void LegoAct2::SpawnBricks()
 	}
 
 	SET3(local2world[3], location);
-	roi->FUN_100a58f0(local2world);
+	roi->SetLocal2World(local2world);
 	roi->SetVisibility(TRUE);
-	roi->VTable0x14();
+	roi->WrappedUpdateWorldData();
 	entity = roi->GetEntity();
 	brick->PlayWhistleSound();
 	m_nextBrick++;
@@ -876,9 +876,9 @@ void LegoAct2::SpawnBricks()
 	}
 
 	SET3(local2world[3], location);
-	roi->FUN_100a58f0(local2world);
+	roi->SetLocal2World(local2world);
 	roi->SetVisibility(TRUE);
-	roi->VTable0x14();
+	roi->WrappedUpdateWorldData();
 	entity = roi->GetEntity();
 	brick->PlayWhistleSound();
 	m_nextBrick++;
@@ -914,9 +914,9 @@ void LegoAct2::SpawnBricks()
 	}
 
 	SET3(local2world[3], location);
-	roi->FUN_100a58f0(local2world);
+	roi->SetLocal2World(local2world);
 	roi->SetVisibility(TRUE);
-	roi->VTable0x14();
+	roi->WrappedUpdateWorldData();
 	entity = roi->GetEntity();
 	brick->PlayWhistleSound();
 	m_nextBrick++;

--- a/LEGO1/lego/sources/roi/legoroi.cpp
+++ b/LEGO1/lego/sources/roi/legoroi.cpp
@@ -393,7 +393,7 @@ LegoResult LegoROI::FUN_100a8da0(LegoTreeNode* p_node, const Matrix4& p_matrix, 
 	if (roi != NULL) {
 		FUN_100a8cb0(data, p_time, mat);
 		roi->m_local2world.Product(mat, p_matrix);
-		roi->VTable0x1c();
+		roi->UpdateWorldData();
 
 		LegoBool und = data->FUN_100a0990(p_time);
 		roi->SetVisibility(und);
@@ -421,7 +421,7 @@ void LegoROI::FUN_100a8e80(LegoTreeNode* p_node, Matrix4& p_matrix, LegoTime p_t
 	LegoROI* roi = p_roiMap[data->GetUnknown0x20()];
 	if (roi != NULL) {
 		roi->m_local2world.Product(mat, p_matrix);
-		roi->VTable0x1c();
+		roi->UpdateWorldData();
 
 		LegoBool und = data->FUN_100a0990(p_time);
 		roi->SetVisibility(und);
@@ -750,7 +750,7 @@ void TimeROI::FUN_100a9b40(Matrix4& p_matrix, LegoTime p_time)
 		targetPosition -= vec;
 		targetPosition /= time / 1000.0;
 
-		FUN_100a5a30(targetPosition);
+		SetWorldVelocity(targetPosition);
 	}
 }
 

--- a/LEGO1/realtime/orientableroi.cpp
+++ b/LEGO1/realtime/orientableroi.cpp
@@ -17,15 +17,15 @@ OrientableROI::OrientableROI()
 	IDENTMAT4(m_local2world);
 
 	m_parentROI = NULL;
-	ToggleUnknown0xd8(TRUE);
+	SetNeedsWorldDataUpdate(TRUE);
 }
 
 // Maybe an overload based on MxMatrix type
 // FUNCTION: LEGO1 0x100a46a0
 // FUNCTION: BETA10 0x10165268
-void OrientableROI::WrappedSetLocalTransform(const Matrix4& p_transform)
+void OrientableROI::WrappedSetLocal2WorldWithWorldDataUpdate(const Matrix4& p_local2world)
 {
-	SetLocalTransform(p_transform);
+	SetLocal2WorldWithWorldDataUpdate(p_local2world);
 }
 
 // FUNCTION: LEGO1 0x100a46b0
@@ -57,14 +57,14 @@ void OrientableROI::UpdateTransformationRelativeToParent(const Matrix4& p_transf
 		}
 	}
 
-	UpdateWorldData(mat);
+	UpdateWorldDataWithTransformAndChildren(mat);
 }
 
 // Maybe an overload based on MxMatrix type
 // FUNCTION: LEGO1 0x100a5090
-void OrientableROI::WrappedVTable0x24(const Matrix4& p_transform)
+void OrientableROI::WrappedUpdateWorldDataWithTransform(const Matrix4& p_transform)
 {
-	VTable0x24(p_transform);
+	UpdateWorldDataWithTransform(p_transform);
 }
 
 // FUNCTION: LEGO1 0x100a50a0
@@ -101,21 +101,21 @@ void OrientableROI::GetLocalTransform(Matrix4& p_transform)
 
 // FUNCTION: LEGO1 0x100a58f0
 // FUNCTION: BETA10 0x10167b77
-void OrientableROI::FUN_100a58f0(const Matrix4& p_transform)
+void OrientableROI::SetLocal2World(const Matrix4& p_local2world)
 {
-	m_local2world = p_transform;
-	ToggleUnknown0xd8(TRUE);
+	m_local2world = p_local2world;
+	SetNeedsWorldDataUpdate(TRUE);
 }
 
 // FUNCTION: LEGO1 0x100a5910
-void OrientableROI::VTable0x1c()
+void OrientableROI::UpdateWorldData()
 {
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();
 }
 
 // FUNCTION: LEGO1 0x100a5930
-void OrientableROI::SetLocalTransform(const Matrix4& p_transform)
+void OrientableROI::SetLocal2WorldWithWorldDataUpdate(const Matrix4& p_transform)
 {
 	m_local2world = p_transform;
 	UpdateWorldBoundingVolumes();
@@ -123,7 +123,7 @@ void OrientableROI::SetLocalTransform(const Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x100a5960
-void OrientableROI::VTable0x24(const Matrix4& p_transform)
+void OrientableROI::UpdateWorldDataWithTransform(const Matrix4& p_transform)
 {
 	MxMatrix l_matrix(m_local2world);
 	m_local2world.Product(p_transform, l_matrix);
@@ -132,7 +132,7 @@ void OrientableROI::VTable0x24(const Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x100a59b0
-void OrientableROI::UpdateWorldData(const Matrix4& p_transform)
+void OrientableROI::UpdateWorldDataWithTransformAndChildren(const Matrix4& p_transform)
 {
 	MxMatrix l_matrix(m_local2world);
 	m_local2world.Product(l_matrix, p_transform);
@@ -143,13 +143,13 @@ void OrientableROI::UpdateWorldData(const Matrix4& p_transform)
 	if (comp) {
 		for (CompoundObject::iterator iter = comp->begin(); !(iter == comp->end()); iter++) {
 			ROI* child = *iter;
-			static_cast<OrientableROI*>(child)->UpdateWorldData(p_transform);
+			static_cast<OrientableROI*>(child)->UpdateWorldDataWithTransformAndChildren(p_transform);
 		}
 	}
 }
 
 // FUNCTION: LEGO1 0x100a5a30
-void OrientableROI::FUN_100a5a30(const Vector3& p_world_velocity)
+void OrientableROI::SetWorldVelocity(const Vector3& p_world_velocity)
 {
 	m_world_velocity = p_world_velocity;
 }

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -23,21 +23,21 @@ public:
 	const BoundingSphere& GetWorldBoundingSphere() const override; // vtable+0x10
 
 	// FUNCTION: LEGO1 0x100a5db0
-	virtual void VTable0x14() { VTable0x1c(); } // vtable+0x14
+	virtual void WrappedUpdateWorldData() { UpdateWorldData(); } // vtable+0x14
 
-	virtual void UpdateWorldBoundingVolumes() = 0;              // vtable+0x18
-	virtual void VTable0x1c();                                  // vtable+0x1c
-	virtual void SetLocalTransform(const Matrix4& p_transform); // vtable+0x20
-	virtual void VTable0x24(const Matrix4& p_transform);        // vtable+0x24
-	virtual void UpdateWorldData(const Matrix4& p_transform);   // vtable+0x28
-	virtual void UpdateWorldVelocity();                         // vtable+0x2c
+	virtual void UpdateWorldBoundingVolumes() = 0;                                    // vtable+0x18
+	virtual void UpdateWorldData();                                                   // vtable+0x1c
+	virtual void SetLocal2WorldWithWorldDataUpdate(const Matrix4& p_local2world);     // vtable+0x20
+	virtual void UpdateWorldDataWithTransform(const Matrix4& p_transform);            // vtable+0x24
+	virtual void UpdateWorldDataWithTransformAndChildren(const Matrix4& p_transform); // vtable+0x28
+	virtual void UpdateWorldVelocity();                                               // vtable+0x2c
 
-	void WrappedSetLocalTransform(const Matrix4& p_transform);
+	void WrappedSetLocal2WorldWithWorldDataUpdate(const Matrix4& p_local2world);
 	void UpdateTransformationRelativeToParent(const Matrix4& p_transform);
-	void WrappedVTable0x24(const Matrix4& p_transform);
+	void WrappedUpdateWorldDataWithTransform(const Matrix4& p_transform);
 	void GetLocalTransform(Matrix4& p_transform);
-	void FUN_100a58f0(const Matrix4& p_transform);
-	void FUN_100a5a30(const Vector3& p_world_velocity);
+	void SetLocal2World(const Matrix4& p_local2world);
+	void SetWorldVelocity(const Vector3& p_world_velocity);
 
 	// FUNCTION: BETA10 0x1000fbf0
 	const Matrix4& GetLocal2World() const { return m_local2world; }
@@ -57,9 +57,9 @@ public:
 	void SetParentROI(OrientableROI* p_parentROI) { m_parentROI = p_parentROI; }
 
 	// FUNCTION: BETA10 0x10168800
-	void ToggleUnknown0xd8(BOOL p_enable)
+	void SetNeedsWorldDataUpdate(BOOL p_needsWorldDataUpdate)
 	{
-		if (p_enable) {
+		if (p_needsWorldDataUpdate) {
 			m_unk0xd8 |= c_bit1 | c_bit2;
 		}
 		else {

--- a/LEGO1/viewmanager/viewroi.cpp
+++ b/LEGO1/viewmanager/viewroi.cpp
@@ -28,9 +28,9 @@ const Tgl::Group* ViewROI::GetGeometry() const
 }
 
 // FUNCTION: LEGO1 0x100a9ee0
-void ViewROI::UpdateWorldData(const Matrix4& parent2world)
+void ViewROI::UpdateWorldDataWithTransformAndChildren(const Matrix4& parent2world)
 {
-	OrientableROI::UpdateWorldData(parent2world);
+	OrientableROI::UpdateWorldDataWithTransformAndChildren(parent2world);
 
 	if (geometry) {
 		Tgl::FloatMatrix4 matrix;
@@ -42,9 +42,9 @@ void ViewROI::UpdateWorldData(const Matrix4& parent2world)
 }
 
 // FUNCTION: LEGO1 0x100a9fc0
-void ViewROI::VTable0x24(const Matrix4& p_transform)
+void ViewROI::UpdateWorldDataWithTransform(const Matrix4& p_transform)
 {
-	OrientableROI::VTable0x24(p_transform);
+	OrientableROI::UpdateWorldDataWithTransform(p_transform);
 	if (geometry) {
 		Tgl::FloatMatrix4 matrix;
 		Matrix4 in(matrix);
@@ -54,9 +54,9 @@ void ViewROI::VTable0x24(const Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x100aa0a0
-void ViewROI::SetLocalTransform(const Matrix4& p_transform)
+void ViewROI::SetLocal2WorldWithWorldDataUpdate(const Matrix4& p_transform)
 {
-	OrientableROI::SetLocalTransform(p_transform);
+	OrientableROI::SetLocal2WorldWithWorldDataUpdate(p_transform);
 	if (geometry) {
 		Tgl::FloatMatrix4 matrix;
 		Matrix4 in(matrix);
@@ -66,9 +66,9 @@ void ViewROI::SetLocalTransform(const Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x100aa180
-void ViewROI::VTable0x1c()
+void ViewROI::UpdateWorldData()
 {
-	OrientableROI::VTable0x1c();
+	OrientableROI::UpdateWorldData();
 	if (geometry) {
 		Tgl::FloatMatrix4 matrix;
 		Matrix4 in(matrix);

--- a/LEGO1/viewmanager/viewroi.h
+++ b/LEGO1/viewmanager/viewroi.h
@@ -49,12 +49,12 @@ public:
 		}
 	}
 
-	float IntrinsicImportance() const override;                  // vtable+0x04
-	void VTable0x1c() override;                                  // vtable+0x1c
-	void SetLocalTransform(const Matrix4& p_transform) override; // vtable+0x20
-	void VTable0x24(const Matrix4& p_transform) override;        // vtable+0x24
-	virtual Tgl::Group* GetGeometry();                           // vtable+0x30
-	virtual const Tgl::Group* GetGeometry() const;               // vtable+0x34
+	float IntrinsicImportance() const override;                                  // vtable+0x04
+	void UpdateWorldData() override;                                             // vtable+0x1c
+	void SetLocal2WorldWithWorldDataUpdate(const Matrix4& p_transform) override; // vtable+0x20
+	void UpdateWorldDataWithTransform(const Matrix4& p_transform) override;      // vtable+0x24
+	virtual Tgl::Group* GetGeometry();                                           // vtable+0x30
+	virtual const Tgl::Group* GetGeometry() const;                               // vtable+0x34
 
 	int GetUnknown0xe0() { return m_unk0xe0; }
 	void SetUnknown0xe0(int p_unk0xe0) { m_unk0xe0 = p_unk0xe0; }
@@ -62,7 +62,7 @@ public:
 	static unsigned char SetLightSupport(unsigned char p_lightSupport);
 
 protected:
-	void UpdateWorldData(const Matrix4& parent2world) override; // vtable+0x28
+	void UpdateWorldDataWithTransformAndChildren(const Matrix4& parent2world) override; // vtable+0x28
 
 	Tgl::Group* geometry; // 0xdc
 	int m_unk0xe0;        // 0xe0


### PR DESCRIPTION
Gave all unnamed functions in `OrientableROI` understandable names based on what they do, how and where they are called and other similar functions in `OrientableROI`.

Also renamed some previously named functions in `OrientableROI` in case the previous names conflicted with the new names or where misleading.

Reasons for each renaming:

- `OrientableROI::VTable0x14` -> `OrientableROI::WrappedUpdateWorldData`: 
The function wraps `OrientableROI::VTable0x1c` and i renamed that to `OrientableROI::UpdateWorldData` so i named this like other wrapping methods in `OrientableROI`

- `OrientableROI::VTable0x1c` -> `OrientableROI::UpdateWorldData`: 
The function does the same as the function that was previously named `OrientableROI::UpdateWorldData` but without taking a "parent" transform or updating child transforms so i made this function the base name and renamed the other methods to show what extra work they do

- `OrientableROI::SetLocalTransform` -> `OrientableROI::SetLocal2WorldWithWorldDataUpdate`:
The function name was misleading because "LocalTransform" could mean one of two things, either "local2world" or "local2parent". Since the function updates the former i named it as such.
Since there is another function that only updates the `local2world` transform, i also renamed this function to show that it also updates the world data

- `OrientableROI::Vtable0x24` -> `OrientableROI::UpdateWorldDataWithTransform`:
The function does the same as the function that is now named `OrientableROI::UpdateWorldData` but also takes a transform to apply

- `OrientableROI::UpdateWorldData` -> `OrientableROI::UpdateWorldDataWithTransformAndChildren`:
The function does the same as the function that is now named  `OrientableROI::UpdateWorldDataWithTransform` but also applies that transform to the ROIs Children

- `OrientableROI::WrappedSetLocalTransform` -> `OrientableROI::WrappedSetLocal2WorldWithWorldDataUpdate`:
`OrientableROI::SetLocalTransform` got renamed

- `OrientableROI::WrappedVTable0x24` -> `OrientableROI::WrappedUpdateWorldDataWithTransform`:
`OrientableROI::VTable0x24` got renamed

- `OrientableROI::FUN_100a58f0` -> `OrientableROI::SetLocal2World`:
The function does the same as the function that was previously named `OrientableROI::SetLocalTransform` but without updating the world data like that function does

- `OrientableROI::FUN_100a5a30` -> `OrientableROI::SetWorldVelocity`:
The only thing the function does is setting the world velocity

- `OrientableROI::ToggleUnknown0xd8` -> `OrientableROI::SetNeedsWorldDataUpdate`:
This rename is speculative but the function is only called in two places, `OrientableROI::OrientableROI`, which does not update the world data and the specific `OrientableROI::SetLocal2World` variant does not update the world data.
It is weird, that this flag is never read, but almost every context that calls `OrientableROI::SetLocal2World` also immediately calls `OrientableROI::UpdateWorldData` in some form so that might just be unnecessary.

Some notes:

- `OrientableROI::m_unk0xd8` appears to only be storing a `needsWorldDataUpdate` Flag so it could be renamed as such. I did not rename it because it bit fiddling in addition to storing the flag that i am not sure why it exists.

- Many of the functions do similar things as other functions but add functionality.
 Could it be possible that those functions were originally calling each other but got inlined to produce what looks like a lot of duplicated code? 
I don't know enough about decompilation to tell if it is that or if it is just how the code is.

- I am not sure about the true purpose of the `p_transform` parameter for the `UpdateWorldData` methods because it is used in different ways in different contexts so i didn't rename it.
