### PR TITLE
Match Tgl `MeshImpl` and `GroupImpl` functions

### DIFF
--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -436,6 +436,9 @@ public:
 
 	inline void Destroy();
 	inline Mesh* DeepClone(const MeshBuilderImpl& rMesh);
+	inline Result GetTexture(TextureImpl** ppTexture);
+	inline Result SetTexture(const TextureImpl* pTexture);
+	inline Mesh* ShallowClone(const MeshBuilderImpl& rMesh);
 
 	friend class RendererImpl;
 
@@ -498,6 +501,12 @@ public:
 	GroupDataType& ImplementationData() { return m_data; }
 
 	inline void Destroy();
+	inline Result SetTexture(const TextureImpl* pTexture);
+	inline Result GetTexture(TextureImpl** ppTexture);
+	inline Result Add(const GroupImpl& rGroup);
+	inline Result Add(const MeshBuilderImpl& rMesh);
+	inline Result Remove(const GroupImpl& rGroup);
+	inline Result Remove(const MeshBuilderImpl& rMesh);
 
 	friend class RendererImpl;
 
@@ -677,6 +686,18 @@ void TextureImpl::Destroy()
 	}
 }
 
+// Used by both Mesh and MeshBuilder
+// FUNCTION: BETA10 0x10170270
+inline Result MeshSetTextureMappingMode(MeshImpl::MeshData* pMesh, TextureMappingMode mode)
+{
+	if (mode == PerspectiveCorrect) {
+		return ResultVal(pMesh->groupMesh->SetGroupMapping(pMesh->groupIndex, D3DRMMAP_PERSPCORRECT));
+	}
+	else {
+		return ResultVal(pMesh->groupMesh->SetGroupMapping(pMesh->groupIndex, 0));
+	}
+}
+
 // Translation helpers
 // FUNCTION: BETA10 0x1016fc40
 inline D3DRMRENDERQUALITY Translate(ShadingModel tglShadingModel)
@@ -728,6 +749,7 @@ inline D3DRMPROJECTIONTYPE Translate(ProjectionType tglProjectionType)
 // Yes this function serves no purpose, originally they intended it to
 // convert from doubles to floats but ended up using floats throughout
 // the software stack.
+// FUNCTION: BETA10 0x1016fa10
 inline D3DRMMATRIX4D* Translate(FloatMatrix4& tglMatrix4x4, D3DRMMATRIX4D& rD3DRMMatrix4x4)
 {
 	for (int i = 0; i < (sizeof(rD3DRMMatrix4x4) / sizeof(rD3DRMMatrix4x4[0])); i++) {
@@ -778,6 +800,26 @@ inline D3DRMLIGHTTYPE Translate(LightType tglLightType)
 	return lightType;
 }
 
+// FUNCTION: BETA10 0x101702e0
+inline D3DRMMATERIALMODE Translate(MaterialMode mode)
+{
+	D3DRMMATERIALMODE d3dMode;
+	switch (mode) {
+	case FromParent:
+		d3dMode = D3DRMMATERIAL_FROMPARENT;
+		break;
+	case FromFrame:
+		d3dMode = D3DRMMATERIAL_FROMFRAME;
+		break;
+	case FromMesh:
+		d3dMode = D3DRMMATERIAL_FROMMESH;
+		break;
+	}
+	return d3dMode;
+}
+
+} /* namespace TglImpl */
+
 // SYNTHETIC: LEGO1 0x100a16d0
 // SYNTHETIC: BETA10 0x10169aa0
 // TglImpl::RendererImpl::`scalar deleting destructor'
@@ -819,7 +861,5 @@ inline D3DRMLIGHTTYPE Translate(LightType tglLightType)
 
 // GLOBAL: LEGO1 0x100dd1e0
 // IID_IDirect3DRMMeshBuilder
-
-} /* namespace TglImpl */
 
 #endif

--- a/LEGO1/tgl/d3drm/meshbuilder.cpp
+++ b/LEGO1/tgl/d3drm/meshbuilder.cpp
@@ -45,16 +45,6 @@ Mesh* MeshBuilderImpl::CreateMesh(
 	return pMeshImpl;
 }
 
-inline Result MeshSetTextureMappingMode(MeshImpl::MeshData* pMesh, TextureMappingMode mode)
-{
-	if (mode == PerspectiveCorrect) {
-		return ResultVal(pMesh->groupMesh->SetGroupMapping(pMesh->groupIndex, D3DRMMAP_PERSPCORRECT));
-	}
-	else {
-		return ResultVal(pMesh->groupMesh->SetGroupMapping(pMesh->groupIndex, 0));
-	}
-}
-
 inline Result CreateMesh(
 	IDirect3DRMMesh* pD3DRM,
 	unsigned long faceCount,


### PR DESCRIPTION
This time we have functions from the similar `MeshImpl` and `GroupImpl` classes:

```
0x100a31e0 - TglImpl::GroupImpl::SetTransformation (45.16% -> 100.00%)
0x100a3240 - TglImpl::GroupImpl::SetColor (74.36% -> 100.00%)
0x100a33c0 - TglImpl::GroupImpl::SetMaterialMode (50.00% -> 100.00%)
0x100a34b0 - TglImpl::GroupImpl::RemoveAll (93.55% -> 100.00%)
0x100a3540 - TglImpl::GroupImpl::Bounds (75.89% -> 100.00%)
0x100a3ee0 - TglImpl::MeshImpl::SetColor (60.00% -> 100.00%)
0x100a3f80 - TglImpl::MeshImpl::SetTextureMappingMode (69.23% -> 100.00%)
0x100a4240 - TglImpl::MeshImpl::ShallowClone (52.78% -> 100.00%)
```

`Bounds` and `ShallowClone` need some encouragement from the entropy build. The latter is not in the beta, but I got to 100% by imitating `DeepClone`.

These two are nearly perfect, but I had to use an intermediate variable that isn't there in retail:

```
0x100a32e0 - TglImpl::GroupImpl::GetTexture (75.36% -> 96.05%)
0x100a4330 - TglImpl::MeshImpl::GetTexture (76.39% -> 96.20%)
```

Maybe someone can figure out what's missing.