### PR TITLE
Fix ambiguous matches in BETA10

### DIFF
--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -182,7 +182,7 @@ private:
 // _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::lower_bound
 
 // TEMPLATE: BETA10 0x10082b90
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::const_iterator::operator++
+// ??Econst_iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AV01@H@Z
 
 // TEMPLATE: BETA10 0x10082ee0
 // set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::end
@@ -191,13 +191,13 @@ private:
 // _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::const_iterator::operator*
 
 // TEMPLATE: BETA10 0x10021dc0
-// Set<LegoPathActor *,LegoPathActorSetCompare>::Set<LegoPathActor *,LegoPathActorSetCompare>
+// ??0?$Set@PAVLegoPathActor@@ULegoPathActorSetCompare@@@@QAE@ABV0@@Z
 
 // TEMPLATE: BETA10 0x100202d0
 // set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::begin
 
 // TEMPLATE: BETA10 0x10020030
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::const_iterator::operator++
+// ??Econst_iterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AV01@H@Z
 
 // TEMPLATE: BETA10 0x100203d0
 // set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::end

--- a/LEGO1/mxdirectx/mxdirectxinfo.h
+++ b/LEGO1/mxdirectx/mxdirectxinfo.h
@@ -168,12 +168,12 @@ struct MxDriver {
 // TEMPLATE: CONFIG 0x401b00
 // TEMPLATE: LEGO1 0x1009c400
 // TEMPLATE: BETA10 0x1011fad0
-// list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::insert
+// ?insert@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QAE?AViterator@1@V21@ABUDirect3DDeviceInfo@@@Z
 
 // TEMPLATE: CONFIG 0x401b60
 // TEMPLATE: LEGO1 0x1009c460
 // TEMPLATE: BETA10 0x1011f9a0
-// list<MxDisplayMode,allocator<MxDisplayMode> >::insert
+// ?insert@?$list@UMxDisplayMode@@V?$allocator@UMxDisplayMode@@@@@@QAE?AViterator@1@V21@ABUMxDisplayMode@@@Z
 
 // SYNTHETIC: CONFIG 0x402be0
 // SYNTHETIC: LEGO1 0x1009d450
@@ -248,34 +248,38 @@ protected:
 // list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::iterator::operator*
 
 // TEMPLATE: BETA10 0x1011c200
-// list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::iterator::operator++
+// ??Eiterator@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QAE?AV01@H@Z
 
 // TEMPLATE: BETA10 0x1011c290
-// list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::begin
+// ?begin@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QAE?AViterator@1@XZ
+// Note: could also be
+// ?begin@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QBE?AVconst_iterator@1@XZ
 
 // TEMPLATE: BETA10 0x1011c300
-// list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::end
+// ?end@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QAE?AViterator@1@XZ
+// Note: could also be
+// ?end@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QBE?AVconst_iterator@1@XZ
 
 // TEMPLATE: BETA10 0x1011c4d0
 // list<MxDriver,allocator<MxDriver> >::iterator::operator*
 
 // TEMPLATE: BETA10 0x1011c520
-// list<MxDriver,allocator<MxDriver> >::iterator::operator++
+// ??Eiterator@?$list@UMxDriver@@V?$allocator@UMxDriver@@@@@@QAE?AV01@H@Z
 
 // TEMPLATE: BETA10 0x1011c560
-// list<MxDriver,allocator<MxDriver> >::iterator::operator++
+// ??Eiterator@?$list@UMxDriver@@V?$allocator@UMxDriver@@@@@@QAEAAV01@XZ
 
 // TEMPLATE: BETA10 0x1011c590
 // list<MxDriver,allocator<MxDriver> >::_Acc::_Next
 
 // TEMPLATE: BETA10 0x1011c5b0
-// list<MxDriver,allocator<MxDriver> >::begin
+// ?begin@?$list@UMxDriver@@V?$allocator@UMxDriver@@@@@@QAE?AViterator@1@XZ
 
 // TEMPLATE: BETA10 0x1011c5f0
 // list<MxDriver,allocator<MxDriver> >::iterator::iterator
 
 // TEMPLATE: BETA10 0x1011c620
-// list<MxDriver,allocator<MxDriver> >::end
+// ?end@?$list@UMxDriver@@V?$allocator@UMxDriver@@@@@@QAE?AViterator@1@XZ
 
 // TEMPLATE: BETA10 0x1011c690
 // ??9@YAHABViterator@?$list@UMxDriver@@V?$allocator@UMxDriver@@@@@@0@Z
@@ -290,10 +294,10 @@ protected:
 // list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::size
 
 // TEMPLATE: BETA10 0x1011d3e0
-// list<Direct3DDeviceInfo,allocator<Direct3DDeviceInfo> >::erase
+// ?erase@?$list@UDirect3DDeviceInfo@@V?$allocator@UDirect3DDeviceInfo@@@@@@QAE?AViterator@1@V21@@Z
 
 // TEMPLATE: BETA10 0x1011d570
-// list<MxDriver,allocator<MxDriver> >::erase
+// ?erase@?$list@UMxDriver@@V?$allocator@UMxDriver@@@@@@QAE?AViterator@1@V21@@Z
 
 // TEMPLATE: BETA10 0x1011d6a0
 // list<MxDriver,allocator<MxDriver> >::_Freenode

--- a/LEGO1/omni/include/mxatom.h
+++ b/LEGO1/omni/include/mxatom.h
@@ -144,7 +144,7 @@ private:
 // clang-format off
 // TEMPLATE: LEGO1 0x100af7e0
 // TEMPLATE: BETA10 0x10131210
-// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::erase
+// ?erase@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@QAE?AViterator@1@V21@0@Z
 // clang-format on
 
 // clang-format off
@@ -178,7 +178,9 @@ private:
 
 // clang-format off
 // TEMPLATE: BETA10 0x10132170
-// _Tree<MxAtom *,MxAtom *,set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >::_Kfn,MxAtomCompare,allocator<MxAtom *> >::begin
+// ?begin@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@QAE?AViterator@1@XZ
+// Note: could also be
+// ?begin@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@QBE?AVconst_iterator@1@XZ
 // clang-format on
 
 // TEMPLATE: BETA10 0x101321d0

--- a/LEGO1/omni/include/mxparam.h
+++ b/LEGO1/omni/include/mxparam.h
@@ -14,7 +14,7 @@ public:
 };
 
 // SYNTHETIC: BETA10 0x10013710
-// MxParam::MxParam
+// ??0MxParam@@QAE@XZ
 
 // SYNTHETIC: ISLE 0x401540
 // SYNTHETIC: LEGO1 0x10010370

--- a/LEGO1/omni/include/mxpresenterlist.h
+++ b/LEGO1/omni/include/mxpresenterlist.h
@@ -107,6 +107,6 @@ public:
 // MxListCursor<MxPresenter *>::MxListCursor<MxPresenter *>
 
 // TEMPLATE: BETA10 0x100d9420
-// MxListCursor<MxPresenter *>::Prev
+// ?Prev@?$MxListCursor@PAVMxPresenter@@@@QAEEAAPAVMxPresenter@@@Z
 
 #endif // MXPRESENTERLIST_H

--- a/LEGO1/omni/include/mxstreamer.h
+++ b/LEGO1/omni/include/mxstreamer.h
@@ -134,7 +134,7 @@ private:
 // list<MxStreamController *,allocator<MxStreamController *> >::end
 
 // TEMPLATE: BETA10 0x101461b0
-// list<MxStreamController *,allocator<MxStreamController *> >::iterator::operator++
+// ??Eiterator@?$list@PAVMxStreamController@@V?$allocator@PAVMxStreamController@@@@@@QAE?AV01@H@Z
 
 // SYNTHETIC: LEGO1 0x100b9120
 // SYNTHETIC: BETA10 0x101466e0

--- a/LEGO1/omni/src/video/flic.cpp
+++ b/LEGO1/omni/src/video/flic.cpp
@@ -364,10 +364,10 @@ void DecodeSS2(LPBITMAPINFOHEADER p_bitmapHeader, BYTE* p_pixelData, BYTE* p_dat
 	// LINE: BETA10 0x1013e643
 	short xmax = xofs + width - 1;
 
-	// LINE: BETA10 0x1013e652
 	union {
 		BYTE* byte;
 		WORD* word;
+		// LINE: BETA10 0x1013e652
 	} data = {p_data};
 
 	// The first word in the data following the chunk header contains the number of lines in the chunk.

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -128,7 +128,7 @@ private:
 
 // TEMPLATE: LEGO1 0x100a7960
 // TEMPLATE: BETA10 0x1017ab40
-// _Tree<char const *,pair<char const * const,ViewLODList *>,map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::_Kfn,ROINameComparator,allocator<ViewLODList *> >::erase
+// ?erase@?$_Tree@PBDU?$pair@QBDPAVViewLODList@@@@U_Kfn@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@QAE?AViterator@1@V21@0@Z
 
 // TEMPLATE: LEGO1 0x100a7db0
 // TEMPLATE: BETA10 0x1017aca0
@@ -156,7 +156,7 @@ private:
 // map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::begin
 
 // TEMPLATE: BETA10 0x10179070
-// map<char const *,ViewLODList *,ROINameComparator,allocator<ViewLODList *> >::end
+// ?end@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@QAE?AViterator@?$_Tree@PBDU?$pair@QBDPAVViewLODList@@@@U_Kfn@?$map@PBDPAVViewLODList@@UROINameComparator@@V?$allocator@PAVViewLODList@@@@@@UROINameComparator@@V?$allocator@
 
 // TEMPLATE: BETA10 0x10179250
 // pair<char const * const,ViewLODList *>::pair<char const * const,ViewLODList *>


### PR DESCRIPTION
Gets rid of all _Ambiguous match_ warnings in BETA10. There is no diff in the match %. I checked every entry whether the other match might be more correct, and I added comments in a few places that were truly ambiguous (i.e. no diff for either case).