### PR TITLE
Fix type cast in `MxControlPresenter::FUN_10044270`

### DIFF
--- a/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
@@ -77,7 +77,7 @@ void MxControlPresenter::EndAction()
 MxBool MxControlPresenter::FUN_10044270(MxS32 p_x, MxS32 p_y, MxPresenter* p_presenter)
 {
 	assert(p_presenter);
-	MxStillPresenter* presenter = (MxStillPresenter*) p_presenter;
+	MxVideoPresenter* presenter = (MxVideoPresenter*) p_presenter;
 
 	if (m_unk0x4c == 3) {
 		MxStillPresenter* map = (MxStillPresenter*) m_list.front();


### PR DESCRIPTION
This needs to be a `MxVideoPresenter`, since FMVs can also be clicked on and the function will trigger for `MxSmkPresenter`. This does not change accuracy. The first branch that comes below it is meant specifically for `MxStillPresenter`. 