### PR TITLE
Match `Helicopter::FUN_100042a0`

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -455,7 +455,9 @@ void Helicopter::FUN_100042a0(const Matrix4& p_matrix)
 	Vector3 vec3(m_unk0x1a8[0]); // locala8  // esp+0x20
 	Vector3 vec4(m_unk0x1a8[1]); // localb8  // esp+0x10
 	Vector3 vec5(m_unk0x1a8[2]); // EDI
-	Vector3 vec6((const float*)m_unk0x1a8[3]); // locala0  // esp+0x28
+
+	// the typecast makes this function match for unknown reasons
+	Vector3 vec6((const float*) m_unk0x1a8[3]); // locala0  // esp+0x28
 
 	m_world->GetCameraController()->FUN_100123b0(local48);
 	m_unk0x1a8.SetIdentity();

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -455,7 +455,7 @@ void Helicopter::FUN_100042a0(const Matrix4& p_matrix)
 	Vector3 vec3(m_unk0x1a8[0]); // locala8  // esp+0x20
 	Vector3 vec4(m_unk0x1a8[1]); // localb8  // esp+0x10
 	Vector3 vec5(m_unk0x1a8[2]); // EDI
-	Vector3 vec6(m_unk0x1a8[3]); // locala0  // esp+0x28
+	Vector3 vec6((const float*)m_unk0x1a8[3]); // locala0  // esp+0x28
 
 	m_world->GetCameraController()->FUN_100123b0(local48);
 	m_unk0x1a8.SetIdentity();


### PR DESCRIPTION
To be honest, I have no idea why this worked, but it's up to 100 % effective. No obvious other pattern had such a good outcome.

Fixes #1317.