### PR TITLE
Assertion in MxTransitionManager::StartTransition is beta10-only

### DIFF
--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -93,7 +93,9 @@ MxResult MxTransitionManager::StartTransition(
 	MxBool p_playMusicInAnim
 )
 {
+#ifdef BETA10
 	assert(m_mode == e_idle);
+#endif
 
 	if (m_mode == e_idle) {
 		if (!p_playMusicInAnim) {


### PR DESCRIPTION
This fixes an assertion error, triggered by the following actions:
1. Start the game
2. Skip intro (probably optional)
3. Turn left to the elevator room
4. Enter the elevator
5. Press the (I) button