### PR TITLE
Clear unknowns in legocharactermanager

### DIFF
--- a/LEGO1/lego/legoomni/include/legocharactermanager.h
+++ b/LEGO1/lego/legoomni/include/legocharactermanager.h
@@ -76,7 +76,7 @@ public:
 	void ReleaseActor(const char* p_name);
 	void ReleaseActor(LegoROI* p_roi);
 	void ReleaseAutoROI(LegoROI* p_roi);
-	MxBool FUN_100849a0(LegoROI* p_roi, LegoTextureInfo* p_texture);
+	MxBool SetHeadTexture(LegoROI* p_roi, LegoTextureInfo* p_texture);
 	LegoExtraActor* GetExtraActor(const char* p_name);
 	LegoActorInfo* GetActorInfo(const char* p_name);
 	LegoActorInfo* GetActorInfo(LegoROI* p_roi);
@@ -89,7 +89,7 @@ public:
 	MxU32 GetSoundId(LegoROI* p_roi, MxBool p_und);
 	MxU8 GetMood(LegoROI* p_roi);
 	LegoROI* CreateAutoROI(const char* p_name, const char* p_lodName, MxBool p_createEntity);
-	MxResult FUN_10085870(LegoROI* p_roi);
+	MxResult UpdateBoundingSphereAndBox(LegoROI* p_roi);
 	LegoROI* FUN_10085a80(const char* p_name, const char* p_lodName, MxBool p_createEntity);
 
 	static const char* GetCustomizeAnimFile() { return g_customizeAnimFile; }

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -400,7 +400,7 @@ MxBool LegoPlantManager::SwitchColor(LegoEntity* p_entity)
 
 	roi->SetLODList(lodList);
 	lodList->Release();
-	CharacterManager()->FUN_10085870(roi);
+	CharacterManager()->UpdateBoundingSphereAndBox(roi);
 	return TRUE;
 }
 
@@ -429,7 +429,7 @@ MxBool LegoPlantManager::SwitchVariant(LegoEntity* p_entity)
 
 	roi->SetLODList(lodList);
 	lodList->Release();
-	CharacterManager()->FUN_10085870(roi);
+	CharacterManager()->UpdateBoundingSphereAndBox(roi);
 
 	if (info->m_move != 0 && info->m_move >= g_maxMove[info->m_variant]) {
 		info->m_move = g_maxMove[info->m_variant] - 1;

--- a/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
@@ -66,7 +66,7 @@ void LegoPhonemePresenter::StartingTickle()
 			if (!cursor.Find(phoneme)) {
 				LegoTextureInfo* textureInfo = TextureContainer()->GetCached(m_textureInfo);
 
-				CharacterManager()->FUN_100849a0(entityROI, textureInfo);
+				CharacterManager()->SetHeadTexture(entityROI, textureInfo);
 
 				phoneme->VTable0x0c(m_textureInfo);
 				phoneme->VTable0x14(textureInfo);
@@ -147,7 +147,7 @@ void LegoPhonemePresenter::EndAction()
 				}
 
 				if (roi != NULL) {
-					CharacterManager()->FUN_100849a0(roi, NULL);
+					CharacterManager()->SetHeadTexture(roi, NULL);
 				}
 
 				if (!m_unk0x84) {


### PR DESCRIPTION
With this almost all unknowns in `legocharactermanager.cpp` are now named.

I noticed the pattern where it matches different rois to another one (e.g. the each claw to their respective arm) and used the constants. If this is not wanted (here) I can remove it or extract it into a separate patch.