### PR TITLE
Clear unknowns/numbers in `Hospital` and `HospitalState`

### DIFF
--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -101,7 +101,7 @@ private:
 	HospitalScript::Script m_currentAction; // 0x10c
 	MxStillPresenter* m_copLedBitmap;       // 0x110
 	MxStillPresenter* m_pizzaLedBitmap;     // 0x114
-	undefined m_unk0x118;                   // 0x118
+	MxBool m_flashingLeds;                  // 0x118
 	MxLong m_copLedAnimTimer;               // 0x11c
 	MxLong m_pizzaLedAnimTimer;             // 0x120
 	MxLong m_time;                          // 0x124

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -95,9 +95,9 @@ private:
 
 	MxS16 m_currentActorId;                 // 0xf8
 	LegoGameState::Area m_destLocation;     // 0xfc
-	undefined2 m_unk0x100;                  // 0x100
+	MxU16 m_interactionMode;                // 0x100
 	HospitalState* m_hospitalState;         // 0x104
-	undefined2 m_unk0x108;                  // 0x108
+	MxU16 m_setWithCurrentAction;           // 0x108
 	HospitalScript::Script m_currentAction; // 0x10c
 	MxStillPresenter* m_copLedBitmap;       // 0x110
 	MxStillPresenter* m_pizzaLedBitmap;     // 0x114

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -16,6 +16,24 @@ class MxStillPresenter;
 // SIZE 0x18
 class HospitalState : public LegoState {
 public:
+	enum {
+		e_exitToClose = 0,
+		e_newState = 1,
+		e_unknown3 = 3,
+		e_unknown4 = 4,
+		e_introduction = 5,
+		e_explainQuestShort = 6,
+		e_explainQuest = 7,
+		e_waitAcceptingQuest = 8,
+		e_beforeEnteringAmbulance = 9,
+		e_unknown10 = 10, // Can never be reached
+		e_unknown11 = 11, // Can only be reached via e_unknown10
+		e_afterAcceptingQuest = 12,
+		e_exitImmediately = 13,
+		e_exitToFront = 14,
+		e_exitToInfocenter = 15,
+	};
+
 	HospitalState();
 	~HospitalState() override {}
 

--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -40,13 +40,13 @@ public:
 
 	// TODO: Most likely getters/setters are not used according to BETA.
 
-	undefined4 m_unk0x08; // 0x08
-	MxS16 m_unk0x0c;      // 0x0c
-	MxS16 m_unk0x0e;      // 0x0e
-	MxS16 m_unk0x10;      // 0x10
-	MxS16 m_unk0x12;      // 0x12
-	MxS16 m_unk0x14;      // 0x14
-	MxS16 m_unk0x16;      // 0x16
+	MxS32 m_state;       // 0x08
+	MxS16 m_stateActor;  // 0x0c
+	MxS16 m_statePepper; // 0x0e
+	MxS16 m_stateMama;   // 0x10
+	MxS16 m_statePapa;   // 0x12
+	MxS16 m_stateNick;   // 0x14
+	MxS16 m_stateLaura;  // 0x16
 };
 
 // VTABLE: LEGO1 0x100d9730

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -43,7 +43,7 @@ Hospital::Hospital()
 	m_currentAction = HospitalScript::c__StartUp;
 	m_copLedBitmap = NULL;
 	m_pizzaLedBitmap = NULL;
-	m_unk0x118 = 0;
+	m_flashingLeds = 0;
 	m_copLedAnimTimer = 0;
 	m_pizzaLedAnimTimer = 0;
 	m_unk0x128 = 0;
@@ -250,7 +250,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 
 		m_currentAction = HospitalScript::c_hho006cl_RunAnim;
 		m_unk0x108 = 1;
-		m_unk0x118 = 1;
+		m_flashingLeds = 1;
 		g_unk0x100f7918 = 0;
 		break;
 	case 6:
@@ -643,7 +643,7 @@ MxResult Hospital::Tickle()
 
 	MxLong time = Timer()->GetTime();
 
-	if (m_unk0x118 != 0) {
+	if (m_flashingLeds != 0) {
 		if (time - m_copLedAnimTimer > 300) {
 			m_copLedAnimTimer = time;
 			g_copLedEnabled = !g_copLedEnabled;

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -61,7 +61,7 @@ Hospital::~Hospital()
 	ControlManager()->Unregister(this);
 	TickleManager()->UnregisterClient(this);
 
-	m_hospitalState->m_state = 3;
+	m_hospitalState->m_state = HospitalState::e_unknown3;
 
 	NotificationManager()->Unregister(this);
 	g_animationSkipCounter = 3;
@@ -81,13 +81,13 @@ MxResult Hospital::Create(MxDSAction& p_dsAction)
 	m_hospitalState = (HospitalState*) GameState()->GetState("HospitalState");
 	if (!m_hospitalState) {
 		m_hospitalState = (HospitalState*) GameState()->CreateState("HospitalState");
-		m_hospitalState->m_state = 1;
+		m_hospitalState->m_state = HospitalState::e_newState;
 	}
-	else if (m_hospitalState->m_state == 4) {
-		m_hospitalState->m_state = 4;
+	else if (m_hospitalState->m_state == HospitalState::e_unknown4) {
+		m_hospitalState->m_state = HospitalState::e_unknown4;
 	}
 	else {
-		m_hospitalState->m_state = 3;
+		m_hospitalState->m_state = HospitalState::e_unknown3;
 	}
 
 	GameState()->m_currentArea = LegoGameState::e_hospital;
@@ -197,7 +197,7 @@ void Hospital::ReadyWorld()
 			HospitalScript::c_hho007p1_RunAnim
 		};
 
-		m_hospitalState->m_state = 5;
+		m_hospitalState->m_state = HospitalState::e_introduction;
 
 		PlayAction(hospitalScript[m_hospitalState->m_stateActor]);
 		m_currentAction = hospitalScript[m_hospitalState->m_stateActor];
@@ -207,7 +207,7 @@ void Hospital::ReadyWorld()
 		m_interactionMode = 1;
 		m_time = Timer()->GetTime();
 
-		m_hospitalState->m_state = 6;
+		m_hospitalState->m_state = HospitalState::e_explainQuestShort;
 
 		PlayAction(HospitalScript::c_hho003cl_RunAnim);
 		m_currentAction = HospitalScript::c_hho003cl_RunAnim;
@@ -244,8 +244,8 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 	m_setWithCurrentAction = 0;
 
 	switch (m_hospitalState->m_state) {
-	case 5:
-		m_hospitalState->m_state = 7;
+	case HospitalState::e_introduction:
+		m_hospitalState->m_state = HospitalState::e_explainQuest;
 		PlayAction(HospitalScript::c_hho006cl_RunAnim);
 
 		m_currentAction = HospitalScript::c_hho006cl_RunAnim;
@@ -253,30 +253,30 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 		m_flashingLeds = 1;
 		g_animationSkipCounter = 0;
 		break;
-	case 6:
+	case HospitalState::e_explainQuestShort:
 		m_time = Timer()->GetTime();
 		m_interactionMode = 1;
 		break;
-	case 7:
-	case 10:
-		m_hospitalState->m_state = 8;
+	case HospitalState::e_explainQuest:
+	case HospitalState::e_unknown10:
+		m_hospitalState->m_state = HospitalState::e_waitAcceptingQuest;
 		m_interactionMode = 1;
 		m_time = Timer()->GetTime();
 		break;
-	case 11:
+	case HospitalState::e_unknown11:
 		switch (m_currentActorId) {
 		case LegoActor::c_pepper:
 			switch (m_hospitalState->m_statePepper) {
 			case 0:
 			case 1:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho017cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho017cl_RunAnim;
 				m_setWithCurrentAction = 1;
 				break;
 			default:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho018cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho018cl_RunAnim;
@@ -288,14 +288,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			switch (m_hospitalState->m_stateMama) {
 			case 0:
 			case 1:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho019cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho019cl_RunAnim;
 				m_setWithCurrentAction = 1;
 				break;
 			default:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho020cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho020cl_RunAnim;
@@ -307,14 +307,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			switch (m_hospitalState->m_statePapa) {
 			case 0:
 			case 1:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho023cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho023cl_RunAnim;
 				m_setWithCurrentAction = 1;
 				break;
 			default:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho024cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho024cl_RunAnim;
@@ -326,14 +326,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			switch (m_hospitalState->m_stateNick) {
 			case 0:
 			case 1:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho021cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho021cl_RunAnim;
 				m_setWithCurrentAction = 1;
 				break;
 			default:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hhoa22cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hhoa22cl_RunAnim;
@@ -345,14 +345,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			switch (m_hospitalState->m_stateLaura) {
 			case 0:
 			case 1:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho025cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho025cl_RunAnim;
 				m_setWithCurrentAction = 1;
 				break;
 			default:
-				m_hospitalState->m_state = 12;
+				m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 				PlayAction(HospitalScript::c_hho026cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho026cl_RunAnim;
@@ -362,11 +362,11 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			break;
 		}
 		break;
-	case 12:
-		m_hospitalState->m_state = 9;
+	case HospitalState::e_afterAcceptingQuest:
+		m_hospitalState->m_state = HospitalState::e_beforeEnteringAmbulance;
 		act1State = (Act1State*) GameState()->GetState("Act1State");
 		act1State->SetUnknown18(9);
-	case 14:
+	case HospitalState::e_exitToFront:
 		if (m_unk0x128 == 0) {
 			m_unk0x128 = 1;
 			m_destLocation = LegoGameState::e_unk31;
@@ -375,7 +375,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 		}
 		break;
-	case 15:
+	case HospitalState::e_exitToInfocenter:
 		if (m_unk0x128 == 0) {
 			m_unk0x128 = 1;
 			m_destLocation = LegoGameState::e_infomain;
@@ -409,13 +409,13 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 
 				m_interactionMode = 3;
 
-				if (m_hospitalState->m_state == 6) {
+				if (m_hospitalState->m_state == HospitalState::e_explainQuestShort) {
 					if (m_unk0x128 == 0) {
 						m_unk0x128 = 1;
 
 						TickleManager()->UnregisterClient(this);
 
-						m_hospitalState->m_state = 9;
+						m_hospitalState->m_state = HospitalState::e_beforeEnteringAmbulance;
 						Act1State* act1State = (Act1State*) GameState()->GetState("Act1State");
 						assert(act1State);
 
@@ -430,9 +430,9 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 						TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 					}
 				}
-				else if (m_hospitalState->m_state == 10 || m_hospitalState->m_state == 8) {
-					if (m_hospitalState->m_state == 10) {
-						m_hospitalState->m_state = 11;
+				else if (m_hospitalState->m_state == HospitalState::e_unknown10 || m_hospitalState->m_state == HospitalState::e_waitAcceptingQuest) {
+					if (m_hospitalState->m_state == HospitalState::e_unknown10) {
+						m_hospitalState->m_state = HospitalState::e_unknown11;
 
 						BackgroundAudioManager()->RaiseVolume();
 						DeleteObjects(
@@ -447,14 +447,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							switch (m_hospitalState->m_statePepper) {
 							case 0:
 							case 1:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho017cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho017cl_RunAnim;
 								m_setWithCurrentAction = 1;
 								break;
 							default:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho018cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho018cl_RunAnim;
@@ -466,14 +466,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							switch (m_hospitalState->m_stateMama) {
 							case 0:
 							case 1:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho019cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho019cl_RunAnim;
 								m_setWithCurrentAction = 1;
 								break;
 							default:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho020cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho020cl_RunAnim;
@@ -485,14 +485,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							switch (m_hospitalState->m_stateNick) {
 							case 0:
 							case 1:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho021cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho021cl_RunAnim;
 								m_setWithCurrentAction = 1;
 								break;
 							default:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hhoa22cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hhoa22cl_RunAnim;
@@ -504,14 +504,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							switch (m_hospitalState->m_statePapa) {
 							case 0:
 							case 1:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho023cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho023cl_RunAnim;
 								m_setWithCurrentAction = 1;
 								break;
 							default:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho024cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho024cl_RunAnim;
@@ -523,14 +523,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							switch (m_hospitalState->m_stateLaura) {
 							case 0:
 							case 1:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho025cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho025cl_RunAnim;
 								m_setWithCurrentAction = 1;
 								break;
 							default:
-								m_hospitalState->m_state = 12;
+								m_hospitalState->m_state = HospitalState::e_afterAcceptingQuest;
 								PlayAction(HospitalScript::c_hho026cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho026cl_RunAnim;
@@ -560,7 +560,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
 			if (m_interactionMode == 1) {
-				m_hospitalState->m_state = 14;
+				m_hospitalState->m_state = HospitalState::e_exitToFront;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
@@ -568,7 +568,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			}
 			else if (m_unk0x128 == 0) {
 				m_unk0x128 = 1;
-				m_hospitalState->m_state = 13;
+				m_hospitalState->m_state = HospitalState::e_exitImmediately;
 				m_destLocation = LegoGameState::e_infomain;
 
 				DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
@@ -581,7 +581,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
 			if (m_interactionMode == 1) {
-				m_hospitalState->m_state = 15;
+				m_hospitalState->m_state = HospitalState::e_exitToInfocenter;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
@@ -589,7 +589,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			}
 			else if (m_unk0x128 == 0) {
 				m_unk0x128 = 1;
-				m_hospitalState->m_state = 13;
+				m_hospitalState->m_state = HospitalState::e_exitImmediately;
 				m_destLocation = LegoGameState::e_unk31;
 
 				DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
@@ -664,7 +664,7 @@ MxResult Hospital::Tickle()
 MxBool Hospital::Escape()
 {
 	DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, 999);
-	m_hospitalState->m_state = 0;
+	m_hospitalState->m_state = HospitalState::e_exitToClose;
 
 	m_destLocation = LegoGameState::e_infomain;
 

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -24,7 +24,7 @@ DECOMP_SIZE_ASSERT(Hospital, 0x12c)
 DECOMP_SIZE_ASSERT(HospitalState, 0x18)
 
 // GLOBAL: LEGO1 0x100f7918
-undefined4 g_unk0x100f7918 = 3;
+undefined4 g_animationSkipCounter = 3;
 
 // GLOBAL: LEGO1 0x100f791c
 MxBool g_copLedEnabled = FALSE;
@@ -36,9 +36,9 @@ MxBool g_pizzaLedEnabled = FALSE;
 Hospital::Hospital()
 {
 	m_currentActorId = LegoActor::c_none;
-	m_unk0x100 = 0;
+	m_interactionMode = 0;
 	m_hospitalState = NULL;
-	m_unk0x108 = 0;
+	m_setWithCurrentAction = 0;
 	m_destLocation = LegoGameState::e_undefined;
 	m_currentAction = HospitalScript::c__StartUp;
 	m_copLedBitmap = NULL;
@@ -64,7 +64,7 @@ Hospital::~Hospital()
 	m_hospitalState->m_state = 3;
 
 	NotificationManager()->Unregister(this);
-	g_unk0x100f7918 = 3;
+	g_animationSkipCounter = 3;
 }
 
 // FUNCTION: LEGO1 0x100748c0
@@ -201,17 +201,17 @@ void Hospital::ReadyWorld()
 
 		PlayAction(hospitalScript[m_hospitalState->m_stateActor]);
 		m_currentAction = hospitalScript[m_hospitalState->m_stateActor];
-		m_unk0x108 = 1;
+		m_setWithCurrentAction = 1;
 	}
 	else {
-		m_unk0x100 = 1;
+		m_interactionMode = 1;
 		m_time = Timer()->GetTime();
 
 		m_hospitalState->m_state = 6;
 
 		PlayAction(HospitalScript::c_hho003cl_RunAnim);
 		m_currentAction = HospitalScript::c_hho003cl_RunAnim;
-		m_unk0x108 = 1;
+		m_setWithCurrentAction = 1;
 	}
 
 	FUN_10015820(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
@@ -222,7 +222,7 @@ MxLong Hospital::HandleKeyPress(MxS8 p_key)
 {
 	MxLong result = 0;
 
-	if (p_key == VK_SPACE && g_unk0x100f7918 == 0) {
+	if (p_key == VK_SPACE && g_animationSkipCounter == 0) {
 		DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 		result = 1;
 	}
@@ -241,7 +241,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 		return result;
 	}
 
-	m_unk0x108 = 0;
+	m_setWithCurrentAction = 0;
 
 	switch (m_hospitalState->m_state) {
 	case 5:
@@ -249,18 +249,18 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 		PlayAction(HospitalScript::c_hho006cl_RunAnim);
 
 		m_currentAction = HospitalScript::c_hho006cl_RunAnim;
-		m_unk0x108 = 1;
+		m_setWithCurrentAction = 1;
 		m_flashingLeds = 1;
-		g_unk0x100f7918 = 0;
+		g_animationSkipCounter = 0;
 		break;
 	case 6:
 		m_time = Timer()->GetTime();
-		m_unk0x100 = 1;
+		m_interactionMode = 1;
 		break;
 	case 7:
 	case 10:
 		m_hospitalState->m_state = 8;
-		m_unk0x100 = 1;
+		m_interactionMode = 1;
 		m_time = Timer()->GetTime();
 		break;
 	case 11:
@@ -273,14 +273,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				PlayAction(HospitalScript::c_hho017cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho017cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			default:
 				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho018cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho018cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			}
 			break;
@@ -292,14 +292,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				PlayAction(HospitalScript::c_hho019cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho019cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			default:
 				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho020cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho020cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			}
 			break;
@@ -311,14 +311,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				PlayAction(HospitalScript::c_hho023cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho023cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			default:
 				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho024cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho024cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			}
 			break;
@@ -330,14 +330,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				PlayAction(HospitalScript::c_hho021cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho021cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			default:
 				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hhoa22cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hhoa22cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			}
 			break;
@@ -349,14 +349,14 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				PlayAction(HospitalScript::c_hho025cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho025cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			default:
 				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho026cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho026cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 				break;
 			}
 			break;
@@ -395,7 +395,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 // FUNCTION: BETA10 0x1002d2b1
 MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 {
-	if (m_unk0x100 == 1) {
+	if (m_interactionMode == 1) {
 		LegoROI* roi = PickROI(p_param.GetX(), p_param.GetY());
 		if (roi != NULL) {
 			const LegoChar* roiName = roi->GetName();
@@ -407,7 +407,7 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 			if (!strcmpi("actor_ha", roiName)) {
 				InputManager()->DisableInputProcessing();
 
-				m_unk0x100 = 3;
+				m_interactionMode = 3;
 
 				if (m_hospitalState->m_state == 6) {
 					if (m_unk0x128 == 0) {
@@ -451,14 +451,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								PlayAction(HospitalScript::c_hho017cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho017cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							default:
 								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho018cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho018cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							}
 							break;
@@ -470,14 +470,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								PlayAction(HospitalScript::c_hho019cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho019cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							default:
 								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho020cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho020cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							}
 							break;
@@ -489,14 +489,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								PlayAction(HospitalScript::c_hho021cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho021cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							default:
 								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hhoa22cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hhoa22cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							}
 							break;
@@ -508,14 +508,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								PlayAction(HospitalScript::c_hho023cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho023cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							default:
 								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho024cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho024cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							}
 							break;
@@ -527,14 +527,14 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								PlayAction(HospitalScript::c_hho025cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho025cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							default:
 								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho026cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho026cl_RunAnim;
-								m_unk0x108 = 1;
+								m_setWithCurrentAction = 1;
 								break;
 							}
 							break;
@@ -559,12 +559,12 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			BackgroundAudioManager()->RaiseVolume();
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
-			if (m_unk0x100 == 1) {
+			if (m_interactionMode == 1) {
 				m_hospitalState->m_state = 14;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 			}
 			else if (m_unk0x128 == 0) {
 				m_unk0x128 = 1;
@@ -580,12 +580,12 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 		case HospitalScript::c_Door_Ctl:
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
-			if (m_unk0x100 == 1) {
+			if (m_interactionMode == 1) {
 				m_hospitalState->m_state = 15;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
-				m_unk0x108 = 1;
+				m_setWithCurrentAction = 1;
 			}
 			else if (m_unk0x128 == 0) {
 				m_unk0x128 = 1;
@@ -637,8 +637,8 @@ MxResult Hospital::Tickle()
 		return SUCCESS;
 	}
 
-	if (g_unk0x100f7918 != 0) {
-		g_unk0x100f7918 -= 1;
+	if (g_animationSkipCounter != 0) {
+		g_animationSkipCounter -= 1;
 	}
 
 	MxLong time = Timer()->GetTime();

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -61,7 +61,7 @@ Hospital::~Hospital()
 	ControlManager()->Unregister(this);
 	TickleManager()->UnregisterClient(this);
 
-	m_hospitalState->m_unk0x08 = 3;
+	m_hospitalState->m_state = 3;
 
 	NotificationManager()->Unregister(this);
 	g_unk0x100f7918 = 3;
@@ -81,13 +81,13 @@ MxResult Hospital::Create(MxDSAction& p_dsAction)
 	m_hospitalState = (HospitalState*) GameState()->GetState("HospitalState");
 	if (!m_hospitalState) {
 		m_hospitalState = (HospitalState*) GameState()->CreateState("HospitalState");
-		m_hospitalState->m_unk0x08 = 1;
+		m_hospitalState->m_state = 1;
 	}
-	else if (m_hospitalState->m_unk0x08 == 4) {
-		m_hospitalState->m_unk0x08 = 4;
+	else if (m_hospitalState->m_state == 4) {
+		m_hospitalState->m_state = 4;
 	}
 	else {
-		m_hospitalState->m_unk0x08 = 3;
+		m_hospitalState->m_state = 3;
 	}
 
 	GameState()->m_currentArea = LegoGameState::e_hospital;
@@ -149,65 +149,65 @@ void Hospital::ReadyWorld()
 
 	switch (m_currentActorId) {
 	case LegoActor::c_pepper:
-		m_hospitalState->m_unk0x0c = m_hospitalState->m_unk0x0e;
+		m_hospitalState->m_stateActor = m_hospitalState->m_statePepper;
 
-		if (m_hospitalState->m_unk0x0e < 5) {
-			m_hospitalState->m_unk0x0e += 1;
+		if (m_hospitalState->m_statePepper < 5) {
+			m_hospitalState->m_statePepper += 1;
 		}
 
 		break;
 	case LegoActor::c_mama:
-		m_hospitalState->m_unk0x0c = m_hospitalState->m_unk0x10;
+		m_hospitalState->m_stateActor = m_hospitalState->m_stateMama;
 
-		if (m_hospitalState->m_unk0x10 < 5) {
-			m_hospitalState->m_unk0x10 += 1;
+		if (m_hospitalState->m_stateMama < 5) {
+			m_hospitalState->m_stateMama += 1;
 		}
 
 		break;
 	case LegoActor::c_papa:
-		m_hospitalState->m_unk0x0c = m_hospitalState->m_unk0x12;
+		m_hospitalState->m_stateActor = m_hospitalState->m_statePapa;
 
-		if (m_hospitalState->m_unk0x12 < 5) {
-			m_hospitalState->m_unk0x12 += 1;
+		if (m_hospitalState->m_statePapa < 5) {
+			m_hospitalState->m_statePapa += 1;
 		}
 
 		break;
 	case LegoActor::c_nick:
-		m_hospitalState->m_unk0x0c = m_hospitalState->m_unk0x14;
+		m_hospitalState->m_stateActor = m_hospitalState->m_stateNick;
 
-		if (m_hospitalState->m_unk0x14 < 5) {
-			m_hospitalState->m_unk0x14 += 1;
+		if (m_hospitalState->m_stateNick < 5) {
+			m_hospitalState->m_stateNick += 1;
 		}
 
 		break;
 	case LegoActor::c_laura:
-		m_hospitalState->m_unk0x0c = m_hospitalState->m_unk0x16;
+		m_hospitalState->m_stateActor = m_hospitalState->m_stateLaura;
 
-		if (m_hospitalState->m_unk0x16 < 5) {
-			m_hospitalState->m_unk0x16 += 1;
+		if (m_hospitalState->m_stateLaura < 5) {
+			m_hospitalState->m_stateLaura += 1;
 		}
 
 		break;
 	}
 
-	if (m_hospitalState->m_unk0x0c < 3) {
+	if (m_hospitalState->m_stateActor < 3) {
 		HospitalScript::Script hospitalScript[] = {
 			HospitalScript::c_hho002cl_RunAnim,
 			HospitalScript::c_hho004jk_RunAnim,
 			HospitalScript::c_hho007p1_RunAnim
 		};
 
-		m_hospitalState->m_unk0x08 = 5;
+		m_hospitalState->m_state = 5;
 
-		PlayAction(hospitalScript[m_hospitalState->m_unk0x0c]);
-		m_currentAction = hospitalScript[m_hospitalState->m_unk0x0c];
+		PlayAction(hospitalScript[m_hospitalState->m_stateActor]);
+		m_currentAction = hospitalScript[m_hospitalState->m_stateActor];
 		m_unk0x108 = 1;
 	}
 	else {
 		m_unk0x100 = 1;
 		m_time = Timer()->GetTime();
 
-		m_hospitalState->m_unk0x08 = 6;
+		m_hospitalState->m_state = 6;
 
 		PlayAction(HospitalScript::c_hho003cl_RunAnim);
 		m_currentAction = HospitalScript::c_hho003cl_RunAnim;
@@ -243,9 +243,9 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 
 	m_unk0x108 = 0;
 
-	switch (m_hospitalState->m_unk0x08) {
+	switch (m_hospitalState->m_state) {
 	case 5:
-		m_hospitalState->m_unk0x08 = 7;
+		m_hospitalState->m_state = 7;
 		PlayAction(HospitalScript::c_hho006cl_RunAnim);
 
 		m_currentAction = HospitalScript::c_hho006cl_RunAnim;
@@ -259,24 +259,24 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 		break;
 	case 7:
 	case 10:
-		m_hospitalState->m_unk0x08 = 8;
+		m_hospitalState->m_state = 8;
 		m_unk0x100 = 1;
 		m_time = Timer()->GetTime();
 		break;
 	case 11:
 		switch (m_currentActorId) {
 		case LegoActor::c_pepper:
-			switch (m_hospitalState->m_unk0x0e) {
+			switch (m_hospitalState->m_statePepper) {
 			case 0:
 			case 1:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho017cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho017cl_RunAnim;
 				m_unk0x108 = 1;
 				break;
 			default:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho018cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho018cl_RunAnim;
@@ -285,17 +285,17 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			}
 			break;
 		case LegoActor::c_mama:
-			switch (m_hospitalState->m_unk0x10) {
+			switch (m_hospitalState->m_stateMama) {
 			case 0:
 			case 1:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho019cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho019cl_RunAnim;
 				m_unk0x108 = 1;
 				break;
 			default:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho020cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho020cl_RunAnim;
@@ -304,17 +304,17 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			}
 			break;
 		case LegoActor::c_papa:
-			switch (m_hospitalState->m_unk0x12) {
+			switch (m_hospitalState->m_statePapa) {
 			case 0:
 			case 1:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho023cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho023cl_RunAnim;
 				m_unk0x108 = 1;
 				break;
 			default:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho024cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho024cl_RunAnim;
@@ -323,17 +323,17 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			}
 			break;
 		case LegoActor::c_nick:
-			switch (m_hospitalState->m_unk0x14) {
+			switch (m_hospitalState->m_stateNick) {
 			case 0:
 			case 1:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho021cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho021cl_RunAnim;
 				m_unk0x108 = 1;
 				break;
 			default:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hhoa22cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hhoa22cl_RunAnim;
@@ -342,17 +342,17 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 			}
 			break;
 		case LegoActor::c_laura:
-			switch (m_hospitalState->m_unk0x16) {
+			switch (m_hospitalState->m_stateLaura) {
 			case 0:
 			case 1:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho025cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho025cl_RunAnim;
 				m_unk0x108 = 1;
 				break;
 			default:
-				m_hospitalState->m_unk0x08 = 12;
+				m_hospitalState->m_state = 12;
 				PlayAction(HospitalScript::c_hho026cl_RunAnim);
 
 				m_currentAction = HospitalScript::c_hho026cl_RunAnim;
@@ -363,7 +363,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 		}
 		break;
 	case 12:
-		m_hospitalState->m_unk0x08 = 9;
+		m_hospitalState->m_state = 9;
 		act1State = (Act1State*) GameState()->GetState("Act1State");
 		act1State->SetUnknown18(9);
 	case 14:
@@ -409,13 +409,13 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 
 				m_unk0x100 = 3;
 
-				if (m_hospitalState->m_unk0x08 == 6) {
+				if (m_hospitalState->m_state == 6) {
 					if (m_unk0x128 == 0) {
 						m_unk0x128 = 1;
 
 						TickleManager()->UnregisterClient(this);
 
-						m_hospitalState->m_unk0x08 = 9;
+						m_hospitalState->m_state = 9;
 						Act1State* act1State = (Act1State*) GameState()->GetState("Act1State");
 						assert(act1State);
 
@@ -430,9 +430,9 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 						TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 					}
 				}
-				else if (m_hospitalState->m_unk0x08 == 10 || m_hospitalState->m_unk0x08 == 8) {
-					if (m_hospitalState->m_unk0x08 == 10) {
-						m_hospitalState->m_unk0x08 = 11;
+				else if (m_hospitalState->m_state == 10 || m_hospitalState->m_state == 8) {
+					if (m_hospitalState->m_state == 10) {
+						m_hospitalState->m_state = 11;
 
 						BackgroundAudioManager()->RaiseVolume();
 						DeleteObjects(
@@ -444,17 +444,17 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 					else {
 						switch (m_currentActorId) {
 						case LegoActor::c_pepper:
-							switch (m_hospitalState->m_unk0x0e) {
+							switch (m_hospitalState->m_statePepper) {
 							case 0:
 							case 1:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho017cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho017cl_RunAnim;
 								m_unk0x108 = 1;
 								break;
 							default:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho018cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho018cl_RunAnim;
@@ -463,17 +463,17 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							}
 							break;
 						case LegoActor::c_mama:
-							switch (m_hospitalState->m_unk0x10) {
+							switch (m_hospitalState->m_stateMama) {
 							case 0:
 							case 1:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho019cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho019cl_RunAnim;
 								m_unk0x108 = 1;
 								break;
 							default:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho020cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho020cl_RunAnim;
@@ -482,17 +482,17 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							}
 							break;
 						case LegoActor::c_nick:
-							switch (m_hospitalState->m_unk0x14) {
+							switch (m_hospitalState->m_stateNick) {
 							case 0:
 							case 1:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho021cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho021cl_RunAnim;
 								m_unk0x108 = 1;
 								break;
 							default:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hhoa22cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hhoa22cl_RunAnim;
@@ -501,17 +501,17 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							}
 							break;
 						case LegoActor::c_papa:
-							switch (m_hospitalState->m_unk0x12) {
+							switch (m_hospitalState->m_statePapa) {
 							case 0:
 							case 1:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho023cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho023cl_RunAnim;
 								m_unk0x108 = 1;
 								break;
 							default:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho024cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho024cl_RunAnim;
@@ -520,17 +520,17 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 							}
 							break;
 						case LegoActor::c_laura:
-							switch (m_hospitalState->m_unk0x16) {
+							switch (m_hospitalState->m_stateLaura) {
 							case 0:
 							case 1:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho025cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho025cl_RunAnim;
 								m_unk0x108 = 1;
 								break;
 							default:
-								m_hospitalState->m_unk0x08 = 12;
+								m_hospitalState->m_state = 12;
 								PlayAction(HospitalScript::c_hho026cl_RunAnim);
 
 								m_currentAction = HospitalScript::c_hho026cl_RunAnim;
@@ -560,7 +560,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
 			if (m_unk0x100 == 1) {
-				m_hospitalState->m_unk0x08 = 14;
+				m_hospitalState->m_state = 14;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
@@ -568,7 +568,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			}
 			else if (m_unk0x128 == 0) {
 				m_unk0x128 = 1;
-				m_hospitalState->m_unk0x08 = 13;
+				m_hospitalState->m_state = 13;
 				m_destLocation = LegoGameState::e_infomain;
 
 				DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
@@ -581,7 +581,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
 			if (m_unk0x100 == 1) {
-				m_hospitalState->m_unk0x08 = 15;
+				m_hospitalState->m_state = 15;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
@@ -589,7 +589,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			}
 			else if (m_unk0x128 == 0) {
 				m_unk0x128 = 1;
-				m_hospitalState->m_unk0x08 = 13;
+				m_hospitalState->m_state = 13;
 				m_destLocation = LegoGameState::e_unk31;
 
 				DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
@@ -664,7 +664,7 @@ MxResult Hospital::Tickle()
 MxBool Hospital::Escape()
 {
 	DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, 999);
-	m_hospitalState->m_unk0x08 = 0;
+	m_hospitalState->m_state = 0;
 
 	m_destLocation = LegoGameState::e_infomain;
 
@@ -674,12 +674,12 @@ MxBool Hospital::Escape()
 // FUNCTION: LEGO1 0x10076370
 HospitalState::HospitalState()
 {
-	m_unk0x0c = 0;
-	m_unk0x0e = 0;
-	m_unk0x10 = 0;
-	m_unk0x12 = 0;
-	m_unk0x14 = 0;
-	m_unk0x16 = 0;
+	m_stateActor = 0;
+	m_statePepper = 0;
+	m_stateMama = 0;
+	m_statePapa = 0;
+	m_stateNick = 0;
+	m_stateLaura = 0;
 }
 
 // FUNCTION: LEGO1 0x10076530
@@ -689,20 +689,20 @@ MxResult HospitalState::Serialize(LegoStorage* p_storage)
 	LegoState::Serialize(p_storage);
 
 	if (p_storage->IsWriteMode()) {
-		p_storage->WriteS16(m_unk0x0c);
-		p_storage->WriteS16(m_unk0x0e);
-		p_storage->WriteS16(m_unk0x10);
-		p_storage->WriteS16(m_unk0x12);
-		p_storage->WriteS16(m_unk0x14);
-		p_storage->WriteS16(m_unk0x16);
+		p_storage->WriteS16(m_stateActor);
+		p_storage->WriteS16(m_statePepper);
+		p_storage->WriteS16(m_stateMama);
+		p_storage->WriteS16(m_statePapa);
+		p_storage->WriteS16(m_stateNick);
+		p_storage->WriteS16(m_stateLaura);
 	}
 	else if (p_storage->IsReadMode()) {
-		p_storage->ReadS16(m_unk0x0c);
-		p_storage->ReadS16(m_unk0x0e);
-		p_storage->ReadS16(m_unk0x10);
-		p_storage->ReadS16(m_unk0x12);
-		p_storage->ReadS16(m_unk0x14);
-		p_storage->ReadS16(m_unk0x16);
+		p_storage->ReadS16(m_stateActor);
+		p_storage->ReadS16(m_statePepper);
+		p_storage->ReadS16(m_stateMama);
+		p_storage->ReadS16(m_statePapa);
+		p_storage->ReadS16(m_stateNick);
+		p_storage->ReadS16(m_stateLaura);
 	}
 
 	return SUCCESS;


### PR DESCRIPTION
I've tried to clear unknowns in `Hospital`, and maybe the names are not the best.

For example I'm not really sure about those:
* `m_interactionMode` is weird, as the values seem to be `0`, `1` and `3`. Not sure if those specific values have been used elsewhere.
* `m_setWithCurrentAction` is only set and never read. But it is always (and only) set when an animation is started.
* `g_deleteCounter` just "enables" you to skip the animation with space. Not sure why it is 3 or decremented with each tickle.

If you want I can split this into separate pull requests, depending on the "likeliness" of being correct.

While working on the states I noticed that there the state 10 can never be reached, and because of this 11 is also out of reach. Not sure if this a decompilation artefact or unfinished code. In theory state 4 can never be reached and I'm not sure what the difference is to state 3, which is why those are all `unknown`.