### PR TITLE
Fix Hospital exit bug #1548

### DIFF
--- a/LEGO1/lego/legoomni/include/hospital.h
+++ b/LEGO1/lego/legoomni/include/hospital.h
@@ -30,8 +30,8 @@ public:
 		e_unknown11 = 11, // Can only be reached via e_unknown10
 		e_afterAcceptingQuest = 12,
 		e_exitImmediately = 13,
-		e_exitToFront = 14,
-		e_exitToInfocenter = 15,
+		e_exitToInfocenter = 14,
+		e_exitToFront = 15,
 	};
 
 	HospitalState();

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -560,7 +560,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
 			if (m_interactionMode == 1) {
-				m_hospitalState->m_state = HospitalState::e_exitToFront;
+				m_hospitalState->m_state = HospitalState::e_exitToInfocenter;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;
@@ -581,7 +581,7 @@ MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);
 
 			if (m_interactionMode == 1) {
-				m_hospitalState->m_state = HospitalState::e_exitToInfocenter;
+				m_hospitalState->m_state = HospitalState::e_exitToFront;
 
 				PlayAction(HospitalScript::c_hho016cl_RunAnim);
 				m_currentAction = HospitalScript::c_hho016cl_RunAnim;


### PR DESCRIPTION
It should now send the player to the right place (infocenter or back to the map at the hospital door) if you click either exit after the guy shows you the hat.

See also: isledecomp/reccmp#135