### PR TITLE
Clear unknowns in `PoliceState`

### DIFF
--- a/LEGO1/lego/legoomni/include/police.h
+++ b/LEGO1/lego/legoomni/include/police.h
@@ -38,15 +38,15 @@ public:
 	// SYNTHETIC: LEGO1 0x1005e920
 	// PoliceState::`scalar deleting destructor'
 
-	undefined4 GetUnknown0x0c() { return m_unk0x0c; }
-	void SetUnknown0x0c(undefined4 p_unk0x0c) { m_unk0x0c = p_unk0x0c; }
+	MxS32 GetPlayAnimation() { return m_playAnimation; }
+	void SetPlayAnimation(MxS32 p_playAnimation) { m_playAnimation = p_playAnimation; }
 
-	void FUN_1005ea40();
+	void StartAnimation();
 
 	// TODO: Most likely getters/setters are not used according to BETA.
 
 	PoliceScript::Script m_policeScript; // 0x08
-	undefined4 m_unk0x0c;                // 0x0c
+	MxS32 m_playAnimation;               // 0x0c
 };
 
 // VTABLE: LEGO1 0x100d8a80

--- a/LEGO1/lego/legoomni/src/worlds/police.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/police.cpp
@@ -105,7 +105,7 @@ MxLong Police::HandleControl(LegoControlManagerNotificationParam& p_param)
 		switch (p_param.m_clickedObjectId) {
 		case PoliceScript::c_LeftArrow_Ctl:
 		case PoliceScript::c_RightArrow_Ctl:
-			if (m_policeState->GetUnknown0x0c() == 1) {
+			if (m_policeState->GetPlayAnimation() == 1) {
 				DeleteObjects(&m_atomId, PoliceScript::c_nps001ni_RunAnim, PoliceScript::c_nps002la_RunAnim);
 			}
 
@@ -114,7 +114,7 @@ MxLong Police::HandleControl(LegoControlManagerNotificationParam& p_param)
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Info_Ctl:
-			if (m_policeState->GetUnknown0x0c() == 1) {
+			if (m_policeState->GetPlayAnimation() == 1) {
 				DeleteObjects(&m_atomId, PoliceScript::c_nps001ni_RunAnim, PoliceScript::c_nps002la_RunAnim);
 			}
 
@@ -123,7 +123,7 @@ MxLong Police::HandleControl(LegoControlManagerNotificationParam& p_param)
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Door_Ctl:
-			if (m_policeState->GetUnknown0x0c() == 1) {
+			if (m_policeState->GetPlayAnimation() == 1) {
 				DeleteObjects(&m_atomId, PoliceScript::c_nps001ni_RunAnim, PoliceScript::c_nps002la_RunAnim);
 			}
 
@@ -132,7 +132,7 @@ MxLong Police::HandleControl(LegoControlManagerNotificationParam& p_param)
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 			break;
 		case PoliceScript::c_Donut_Ctl:
-			m_policeState->FUN_1005ea40();
+			m_policeState->StartAnimation();
 		}
 	}
 
@@ -145,8 +145,8 @@ MxLong Police::HandleEndAction(MxEndActionNotificationParam& p_param)
 	MxDSAction* action = p_param.GetAction();
 
 	if (m_radio.Notify(p_param) == 0 && m_atomId == action->GetAtomId()) {
-		if (m_policeState->GetUnknown0x0c() == 1) {
-			m_policeState->SetUnknown0x0c(0);
+		if (m_policeState->GetPlayAnimation() == 1) {
+			m_policeState->SetPlayAnimation(0);
 			return 1;
 		}
 
@@ -161,9 +161,9 @@ MxLong Police::HandleKeyPress(LegoEventNotificationParam& p_param)
 {
 	MxLong result = 0;
 
-	if (p_param.GetKey() == VK_SPACE && m_policeState->GetUnknown0x0c() == 1) {
+	if (p_param.GetKey() == VK_SPACE && m_policeState->GetPlayAnimation() == 1) {
 		DeleteObjects(&m_atomId, PoliceScript::c_nps001ni_RunAnim, PoliceScript::c_nps002la_RunAnim);
-		m_policeState->SetUnknown0x0c(0);
+		m_policeState->SetPlayAnimation(0);
 		return 1;
 	}
 
@@ -197,7 +197,7 @@ MxBool Police::Escape()
 // FUNCTION: LEGO1 0x1005e7c0
 PoliceState::PoliceState()
 {
-	m_unk0x0c = 0;
+	m_playAnimation = 0;
 	m_policeScript = (rand() % 2 == 0) ? PoliceScript::c_nps002la_RunAnim : PoliceScript::c_nps001ni_RunAnim;
 }
 
@@ -218,11 +218,11 @@ MxResult PoliceState::Serialize(LegoStorage* p_storage)
 }
 
 // FUNCTION: LEGO1 0x1005ea40
-void PoliceState::FUN_1005ea40()
+void PoliceState::StartAnimation()
 {
 	PoliceScript::Script policeScript;
 
-	if (m_unk0x0c == 1) {
+	if (m_playAnimation == 1) {
 		return;
 	}
 
@@ -248,5 +248,5 @@ void PoliceState::FUN_1005ea40()
 		Start(&action);
 	}
 
-	m_unk0x0c = 1;
+	m_playAnimation = 1;
 }


### PR DESCRIPTION
While in others (e.g. Hospital) a field like `m_unk0x0c` is used as a state and can have multiple values it appears to be that the police has only two states: Whether an animation is playing or not.

If you want I can use a name like `m_state` and some enum with `e_noAnimation` and `e_playingAnimation`.