### PR TITLE
Add BETA10 assertions in LegoPathController

### DIFF
--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -633,7 +633,6 @@ MxResult LegoPathController::ReadBoundaries(LegoStorage* p_storage)
 		MxU16 s;
 		MxU8 j;
 
-
 		if (p_storage->Read(&numE, sizeof(numE)) != SUCCESS) {
 			return FAILURE;
 		}

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -559,27 +559,32 @@ MxResult LegoPathController::ReadEdges(LegoStorage* p_storage)
 		if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 			return FAILURE;
 		}
+		assert(s < m_numN);
 		edge.m_pointA = &m_nodes[s];
 
 		if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 			return FAILURE;
 		}
+		assert(s < m_numN);
 		edge.m_pointB = &m_nodes[s];
 
 		if (edge.m_flags & LegoOrientedEdge::c_hasFaceA) {
 			if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 				return FAILURE;
 			}
+			assert(s < m_numL);
 			edge.m_faceA = &m_boundaries[s];
 
 			if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 				return FAILURE;
 			}
+			assert(s < m_numE);
 			edge.m_ccwA = &m_edges[s];
 
 			if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 				return FAILURE;
 			}
+			assert(s < m_numE);
 			edge.m_cwA = &m_edges[s];
 		}
 
@@ -587,16 +592,19 @@ MxResult LegoPathController::ReadEdges(LegoStorage* p_storage)
 			if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 				return FAILURE;
 			}
+			assert(s < m_numL);
 			edge.m_faceB = &m_boundaries[s];
 
 			if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 				return FAILURE;
 			}
+			assert(s < m_numE);
 			edge.m_ccwB = &m_edges[s];
 
 			if (p_storage->Read(&s, sizeof(MxU16)) != SUCCESS) {
 				return FAILURE;
 			}
+			assert(s < m_numE);
 			edge.m_cwB = &m_edges[s];
 		}
 
@@ -617,14 +625,20 @@ MxResult LegoPathController::ReadEdges(LegoStorage* p_storage)
 MxResult LegoPathController::ReadBoundaries(LegoStorage* p_storage)
 {
 	for (MxS32 i = 0; i < m_numL; i++) {
+#ifdef BETA10
+		Mx4DPointFloat unused;
+#endif
 		LegoPathBoundary& boundary = m_boundaries[i];
 		MxU8 numE;
 		MxU16 s;
 		MxU8 j;
 
+
 		if (p_storage->Read(&numE, sizeof(numE)) != SUCCESS) {
 			return FAILURE;
 		}
+
+		assert(numE > 2);
 
 		boundary.m_edgeNormals = new Mx4DPointFloat[numE];
 
@@ -635,6 +649,8 @@ MxResult LegoPathController::ReadBoundaries(LegoStorage* p_storage)
 			if (p_storage->Read(&s, sizeof(s)) != SUCCESS) {
 				return FAILURE;
 			}
+
+			assert(s < m_numE);
 
 			edges[j] = &m_edges[s];
 		}
@@ -692,6 +708,8 @@ MxResult LegoPathController::ReadBoundaries(LegoStorage* p_storage)
 				if (p_storage->Read(&s, sizeof(s)) != SUCCESS) {
 					return FAILURE;
 				}
+
+				assert(s < m_numT);
 
 				boundary.m_pathTrigger[j].m_pathStruct = &m_structs[s];
 

--- a/LEGO1/lego/sources/geom/legoweedge.h
+++ b/LEGO1/lego/sources/geom/legoweedge.h
@@ -25,6 +25,7 @@ public:
 	// FUNCTION: BETA10 0x100373f0
 	LegoU32 IsEqual(LegoWEEdge* p_other) { return this == p_other; }
 
+	// FUNCTION: BETA10 0x100bd410
 	void SetEdges(LegoOrientedEdge** p_edges, LegoU8 p_numEdges)
 	{
 		m_edges = p_edges;


### PR DESCRIPTION
Inspired by #1546. These assertions also document that we know the original names. `ReadEdges()` now matches 100 % on BETA10, `ReadBoundaries()` matches structurally.