### PR TITLE
Name `LegoLOD::FUN_100aae20`

### DIFF
--- a/LEGO1/lego/sources/roi/legolod.cpp
+++ b/LEGO1/lego/sources/roi/legolod.cpp
@@ -16,7 +16,7 @@ DECOMP_SIZE_ASSERT(LegoLOD::Mesh, 0x08)
 LPDIRECT3DRMMATERIAL g_unk0x101013d4 = NULL;
 
 // GLOBAL: LEGO1 0x101013dc
-const char* g_unk0x101013dc = "inh";
+const char* g_InhPrefix = "inh";
 
 inline IDirect3DRM2* GetD3DRM(Tgl::Renderer* pRenderer);
 inline BOOL GetMeshData(IDirect3DRMMesh*& mesh, D3DRMGROUPINDEX& index, Tgl::Mesh* pMesh);
@@ -66,7 +66,7 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 	LegoU32(*textureIndices)[3] = NULL;
 	LegoTextureInfo* textureInfo = NULL;
 
-	LegoU32 i, meshUnd1, meshUnd2, tempNumVertsAndNormals;
+	LegoU32 i, indexBackwards, indexForwards, tempNumVertsAndNormals;
 	unsigned char paletteEntries[256];
 
 	if (p_storage->Read(&m_unk0x08, sizeof(undefined4)) != SUCCESS) {
@@ -93,8 +93,8 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 	m_melems = new Mesh[m_numMeshes];
 	memset(m_melems, 0, sizeof(*m_melems) * m_numMeshes);
 
-	meshUnd1 = m_numMeshes - 1;
-	meshUnd2 = 0;
+	indexBackwards = m_numMeshes - 1;
+	indexForwards = 0;
 
 	if (p_storage->Read(&tempNumVertsAndNormals, sizeof(LegoU32)) != SUCCESS) {
 		goto done;
@@ -184,13 +184,13 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 		textureName = mesh->GetTextureName();
 		materialName = mesh->GetMaterialName();
 
-		if (FUN_100aae20(textureName) || FUN_100aae20(materialName)) {
-			meshIndex = meshUnd1;
-			meshUnd1--;
+		if (HasInhPrefix(textureName) || HasInhPrefix(materialName)) {
+			meshIndex = indexBackwards;
+			indexBackwards--;
 		}
 		else {
-			meshIndex = meshUnd2;
-			meshUnd2++;
+			meshIndex = indexForwards;
+			indexForwards++;
 		}
 
 		m_melems[meshIndex].m_tglMesh = m_meshBuilder->CreateMesh(
@@ -265,7 +265,7 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 		}
 	}
 
-	m_meshOffset = meshUnd2;
+	m_meshOffset = indexForwards;
 
 	if (textureVertices != NULL) {
 		delete[] textureVertices;
@@ -377,10 +377,10 @@ LegoResult LegoLOD::GetTextureInfo(LegoTextureInfo*& p_textureInfo)
 }
 
 // FUNCTION: LEGO1 0x100aae20
-LegoBool LegoLOD::FUN_100aae20(const LegoChar* p_name)
+LegoBool LegoLOD::HasInhPrefix(const LegoChar* p_name)
 {
 	if (p_name != NULL) {
-		if (!strnicmp(p_name, g_unk0x101013dc, strlen(g_unk0x101013dc))) {
+		if (!strnicmp(p_name, g_InhPrefix, strlen(g_InhPrefix))) {
 			return TRUE;
 		}
 	}

--- a/LEGO1/lego/sources/roi/legolod.h
+++ b/LEGO1/lego/sources/roi/legolod.h
@@ -35,7 +35,7 @@ public:
 	void ClearMeshOffset();
 	LegoResult GetTextureInfo(LegoTextureInfo*& p_textureInfo);
 
-	static LegoBool FUN_100aae20(const LegoChar* p_name);
+	static LegoBool HasInhPrefix(const LegoChar* p_name);
 
 	// SYNTHETIC: LEGO1 0x100aa430
 	// LegoLOD::`scalar deleting destructor'


### PR DESCRIPTION
Currently the naming is very direct and "not explanatory" as I'm not sure what it also affects.

It appears to me that it sets the mesh offset to set whether the texture/color is inherited (maybe this is what `inh` means) from the parent calls. If you want me to use more explanatory names I can update them here.

E.g. `staticIndex` and `inheritedIndex` instead of just `indexForwards` and `indexBackwards` and `IsInherting` instead of `HasInhPrefix`.