### PR TITLE
Name `m_unk0x21` as `GetUseAlias` in `LegoMesh`

### DIFF
--- a/LEGO1/lego/sources/roi/legolod.cpp
+++ b/LEGO1/lego/sources/roi/legolod.cpp
@@ -211,7 +211,7 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 		m_melems[meshIndex].m_tglMesh->SetShadingModel(shadingModel);
 
 		if (textureName != NULL) {
-			if (mesh->GetUnknown0x21()) {
+			if (mesh->GetUseAlias()) {
 				LegoROI::GetPaletteEntries(textureName, paletteEntries, sizeOfArray(paletteEntries));
 			}
 
@@ -231,7 +231,7 @@ LegoResult LegoLOD::Read(Tgl::Renderer* p_renderer, LegoTextureContainer* p_text
 			LegoFloat blue = 1.0F;
 			LegoFloat alpha = 0.0F;
 
-			if (mesh->GetUnknown0x21()) {
+			if (mesh->GetUseAlias()) {
 				LegoROI::GetRGBAColor(materialName, red, green, blue, alpha);
 			}
 			else {

--- a/LEGO1/lego/sources/shape/legomesh.cpp
+++ b/LEGO1/lego/sources/shape/legomesh.cpp
@@ -15,7 +15,7 @@ LegoMesh::LegoMesh()
 	m_unk0x0d = 0;
 	m_unk0x10 = NULL;
 	m_unk0x20 = 0;
-	m_unk0x21 = FALSE;
+	m_useAlias = FALSE;
 	m_materialName = NULL;
 }
 
@@ -55,7 +55,7 @@ LegoResult LegoMesh::Read(LegoStorage* p_storage)
 	if ((result = p_storage->Read(&m_unk0x20, sizeof(undefined))) != SUCCESS) {
 		return result;
 	}
-	if ((result = p_storage->Read(&m_unk0x21, sizeof(LegoU8))) != SUCCESS) {
+	if ((result = p_storage->Read(&m_useAlias, sizeof(LegoU8))) != SUCCESS) {
 		return result;
 	}
 

--- a/LEGO1/lego/sources/shape/legomesh.h
+++ b/LEGO1/lego/sources/shape/legomesh.h
@@ -56,7 +56,7 @@ public:
 	LegoU8 GetUnknown0x0d() { return m_unk0x0d; }
 	const LegoChar* GetTextureName() { return m_textureName; }
 	const LegoChar* GetMaterialName() { return m_materialName; }
-	LegoBool GetUnknown0x21() { return m_unk0x21; }
+	LegoBool GetUseAlias() { return m_useAlias; }
 	LegoResult Read(LegoStorage* p_storage);
 
 	// SYNTHETIC: LEGO1 0x100d3840
@@ -72,7 +72,7 @@ protected:
 	LegoChar* m_textureName;         // 0x18
 	LegoChar* m_materialName;        // 0x1c
 	undefined m_unk0x20;             // 0x20 - unused
-	LegoBool m_unk0x21;              // 0x21
+	LegoBool m_useAlias;             // 0x21
 };
 
 #endif // __LEGOMESH_H


### PR DESCRIPTION
Not 100% sure what the intent was with `LegoROI::GetPaletteEntries` as there is no "actual" logic. But with respect to the color/material name would is `GetUseAlias` a good description.