### PR TITLE
Fix BETA10 linker settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,12 @@ if(ISLE_BUILD_BETA10)
     OUT_TARGETS beta10_targets
   )
   reccmp_add_target(beta10 ID BETA10)
+
+  # Enable `#ifdef BETA10` conditions
   target_compile_definitions(beta10 PRIVATE BETA10)
+  foreach(tgt IN LISTS beta10_targets)
+    target_compile_definitions(${tgt} PRIVATE BETA10)
+  endforeach()
 endif()
 
 if (ISLE_BUILD_APP)
@@ -600,10 +605,13 @@ if (MSVC_FOR_DECOMP)
     endif()
   endif()
 
+  # Setting the MSVC_RUNTIME_LIBRARY for all libraries as well as `lego1` produces the results
+  # that are most consistent with the LEGO1.DLL and BETA10.DLL originals we have.
+  # Equivalent to target_compile_options(... PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+  set_property(TARGET ${lego1_targets} ${beta10_targets} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   if(TARGET lego1)
     target_link_options(lego1 PRIVATE "/OPT:REF")
-    # Equivalent to target_compile_options(... PRIVATE "/MT$<$<CONFIG:Debug>:d>")
-    set_property(TARGET lego1 ${lego1_targets} ${beta10_targets} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    set_property(TARGET lego1 PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 
   set(CMAKE_CXX_FLAGS "/W3 /GX /D \"WIN32\" /D \"_WINDOWS\"")


### PR DESCRIPTION
As discussed at https://github.com/isledecomp/isle/pull/1569#discussion_r2156457825, I noticed that there are some issues in linking BETA10, leading to a numerous instances of calls into Redistributable DLLs where the original had the functions inlined. Here is a shortened diff on BETA10:
```
New (26):
0x100f8ad0 - strcmp (new -> 100.00%)
0x100f9060 - _assert (new -> 88.66%)
0x100f9420 - memcpy (new -> 100.00%)
0x100f9570 - memset (new -> 100.00%)
0x100f9610 - rand (new -> 96.77%)
0x100f9690 - sprintf (new -> 100.00%)
0x100f9780 - strlen (new -> 100.00%)
0x100f9b90 - _purecall (new -> 100.00%)
0x100f9f60 - strtok (new -> 99.17%)
0x100fa0e0 - atof (new -> 91.84%)
0x100fa200 - strcpy (new -> 100.00%)
0x100faa00 - memcmp (new -> 100.00%)
0x100fad10 - fclose (new -> 100.00%)
0x100fae70 - fprintf (new -> 100.00%)
0x100fb050 - fopen (new -> 94.44%)
0x100fb080 - _stricmp (new -> 90.48%)
0x100fb150 - _spawnl (new -> 100.00%)
0x100fbdb0 - _exit (new -> 100.00%)
0x100fca70 - _amsg_exit (new -> 100.00%)
0x100fe5a0 - abort (new -> 94.74%)
0x100ff82b - __ctrandisp1 (new -> 87.50%)
0x10100bf0 - _CrtDbgReport (new -> 90.69%)
0x1010ab30 - _FF_MSGBANNER (new -> 92.00%)
0x1010ab90 - _NMSG_WRITE (new -> 100.00%)
0x1018ec70 - _strnicmp (new -> 92.16%)
0x1018ed70 - _strupr (new -> 89.44%)

Increased (582):
[...]

Decreased (29):
[...]
```
so the results speak for themselves. I also fixed a minor issue that `#ifdef BETA10` did not work on library code. I checked a few of the decreases, and all those I looked at were entropy.

No regressions on any of the other binaries (according to the CI).