### PR TITLE
Match `LegoGameState::History::WriteScoreHistory()`, clear unknowns

### DIFF
--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -151,6 +151,15 @@ public:
 		MxU8 m_scores[5][5]; // 0x02
 		Username m_name;     // 0x1c
 		MxS16 m_unk0x2a;     // 0x2a
+
+		ScoreItem& operator=(const ScoreItem& p_other)
+		{
+			m_totalScore = p_other.m_totalScore;
+			memcpy(m_scores, p_other.m_scores, sizeof(m_scores));
+			m_name = p_other.m_name;
+			m_unk0x2a = p_other.m_unk0x2a;
+			return *this;
+		}
 	};
 
 	// SIZE 0x372

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -150,7 +150,7 @@ public:
 		MxS16 m_totalScore;  // 0x00
 		MxU8 m_scores[5][5]; // 0x02
 		Username m_name;     // 0x1c
-		MxS16 m_unk0x2a;     // 0x2a
+		MxS16 m_playerId;    // 0x2a
 
 		ScoreItem& operator=(const ScoreItem& p_other);
 	};
@@ -174,7 +174,7 @@ public:
 		MxS16 m_indices[20]; // 0x02
 #endif
 		ScoreItem m_scores[20]; // 0x02 (0x22 for BETA10)
-		MxS16 m_nextPlayerId;       // 0x372 (0x392 for BETA10)
+		MxS16 m_nextPlayerId;   // 0x372 (0x392 for BETA10)
 	};
 
 	LegoGameState();
@@ -249,7 +249,7 @@ private:
 
 public:
 	// Probably m_currentPlayerId
-	MxS16 m_unk0x24;                      // 0x24
+	MxS16 m_currentPlayerId;              // 0x24
 	MxS16 m_playerCount;                  // 0x26
 	Username m_players[9];                // 0x28
 	History m_history;                    // 0xa6

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -160,7 +160,7 @@ public:
 		History();
 		void WriteScoreHistory();
 		MxResult Serialize(LegoStorage* p_storage);
-		ScoreItem* FUN_1003cc90(Username* p_player, MxS16 p_unk0x24, MxS32& p_unk0x2c);
+		ScoreItem* FindPlayerInScoreHistory(Username* p_player, MxS16 p_unk0x24, MxS32& p_unk0x2c);
 
 		// FUNCTION: BETA10 0x1002c2b0
 		MxS16 GetCount() { return m_count; }
@@ -174,7 +174,7 @@ public:
 		MxS16 m_indices[20]; // 0x02
 #endif
 		ScoreItem m_scores[20]; // 0x02 (0x22 for BETA10)
-		MxS16 m_unk0x372;       // 0x372 (0x392 for BETA10)
+		MxS16 m_nextPlayerId;       // 0x372 (0x392 for BETA10)
 	};
 
 	LegoGameState();
@@ -248,6 +248,7 @@ private:
 	// TODO: Most likely getters/setters are not used according to BETA for the following members:
 
 public:
+	// Probably m_currentPlayerId
 	MxS16 m_unk0x24;                      // 0x24
 	MxS16 m_playerCount;                  // 0x26
 	Username m_players[9];                // 0x28

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -167,7 +167,12 @@ public:
 		// FUNCTION: BETA10 0x1002c540
 		ScoreItem* GetScore(MxS32 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
 
-		MxS16 m_count;          // 0x00
+		MxS16 m_count; // 0x00
+// TODO: Enable ifdefs when done
+// #ifdef BETA10
+		MxS16 m_indices[20];
+// #endif
+
 		ScoreItem m_scores[20]; // 0x02
 		MxS16 m_unk0x372;       // 0x372
 	};

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -168,13 +168,11 @@ public:
 		ScoreItem* GetScore(MxS32 p_index) { return p_index >= m_count ? NULL : &m_scores[p_index]; }
 
 		MxS16 m_count; // 0x00
-// TODO: Enable ifdefs when done
-// #ifdef BETA10
-		MxS16 m_indices[20];
-// #endif
-
-		ScoreItem m_scores[20]; // 0x02
-		MxS16 m_unk0x372;       // 0x372
+#ifdef BETA10
+		MxS16 m_indices[20]; // 0x02
+#endif
+		ScoreItem m_scores[20]; // 0x02 (0x22 for BETA10)
+		MxS16 m_unk0x372;       // 0x372 (0x392 for BETA10)
 	};
 
 	LegoGameState();

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -152,14 +152,7 @@ public:
 		Username m_name;     // 0x1c
 		MxS16 m_unk0x2a;     // 0x2a
 
-		ScoreItem& operator=(const ScoreItem& p_other)
-		{
-			m_totalScore = p_other.m_totalScore;
-			memcpy(m_scores, p_other.m_scores, sizeof(m_scores));
-			m_name = p_other.m_name;
-			m_unk0x2a = p_other.m_unk0x2a;
-			return *this;
-		}
+		ScoreItem& operator=(const ScoreItem& p_other);
 	};
 
 	// SIZE 0x372

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1567,32 +1567,32 @@ void LegoGameState::History::WriteScoreHistory()
 
 				// TODO: Possible operator= ?
 
-				tmpItem.m_totalScore = m_scores[j - 1].m_totalScore;
-				memcpy(tmpItem.m_scores, m_scores[j - 1].m_scores, sizeof(tmpItem.m_scores));
-				// LINE: LEGO1 0x1003cbd3
-				tmpItem.m_name = m_scores[j - 1].m_name;
-				tmpItem.m_unk0x2a = m_scores[j - 1].m_unk0x2a;
+				// tmpItem.m_totalScore = m_scores[j - 1].m_totalScore;
+				// memcpy(tmpItem.m_scores, m_scores[j - 1].m_scores, sizeof(tmpItem.m_scores));
+				// // LINE: LEGO1 0x1003cbd3
+				// tmpItem.m_name = m_scores[j - 1].m_name;
+				// tmpItem.m_unk0x2a = m_scores[j - 1].m_unk0x2a;
 
-				m_scores[j - 1].m_totalScore = m_scores[j].m_totalScore;
-				memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
-				// LINE: LEGO1 0x1003cc05
-				m_scores[j - 1].m_name = m_scores[j].m_name;
-				m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+				// m_scores[j - 1].m_totalScore = m_scores[j].m_totalScore;
+				// memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
+				// // LINE: LEGO1 0x1003cc05
+				// m_scores[j - 1].m_name = m_scores[j].m_name;
+				// m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
 
 
-				// LINE: LEGO1 0x1003cc1f
-				m_scores[j - 1].m_totalScore = tmpItem.m_totalScore;
-				memcpy(m_scores[j].m_scores, tmpItem.m_scores, sizeof(m_scores[j].m_scores));
-				m_scores[j].m_name = tmpItem.m_name;
-				m_scores[j].m_unk0x2a = tmpItem.m_unk0x2a;
+				// // LINE: LEGO1 0x1003cc1f
+				// m_scores[j - 1].m_totalScore = tmpItem.m_totalScore;
+				// memcpy(m_scores[j].m_scores, tmpItem.m_scores, sizeof(m_scores[j].m_scores));
+				// m_scores[j].m_name = tmpItem.m_name;
+				// m_scores[j].m_unk0x2a = tmpItem.m_unk0x2a;
 
 				// This version feels like it should be right, but it only produces 68.78 %
 
-				// tmpItem = m_scores[j - 1];
-				// // LINE: LEGO1 0x1003cbf8
-				// m_scores[j - 1] = m_scores[j];
-				// // LINE: LEGO1 0x1003cc24
-				// m_scores[j] = tmpItem;
+				tmpItem = m_scores[j - 1];
+				// LINE: LEGO1 0x1003cbf3
+				m_scores[j - 1] = m_scores[j];
+				// LINE: LEGO1 0x1003cc1f
+				m_scores[j] = tmpItem;
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1441,78 +1441,137 @@ void LegoGameState::History::WriteScoreHistory()
 	MxU8 scores[5][5];
 
 	InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
-	if (state->m_letters[0]) {
-		JetskiRaceState* jetskiRaceState = (JetskiRaceState*) GameState()->GetState("JetskiRaceState");
-		CarRaceState* carRaceState = (CarRaceState*) GameState()->GetState("CarRaceState");
-		TowTrackMissionState* towTrackMissionState =
-			(TowTrackMissionState*) GameState()->GetState("TowTrackMissionState");
-		PizzaMissionState* pizzaMissionState = (PizzaMissionState*) GameState()->GetState("PizzaMissionState");
-		AmbulanceMissionState* ambulanceMissionState =
-			(AmbulanceMissionState*) GameState()->GetState("AmbulanceMissionState");
+	if (!state->m_letters[0]) {
+		return;
+	}
+	JetskiRaceState* jetskiRaceState = (JetskiRaceState*) GameState()->GetState("JetskiRaceState");
+	CarRaceState* carRaceState = (CarRaceState*) GameState()->GetState("CarRaceState");
+	TowTrackMissionState* towTrackMissionState = (TowTrackMissionState*) GameState()->GetState("TowTrackMissionState");
+	PizzaMissionState* pizzaMissionState = (PizzaMissionState*) GameState()->GetState("PizzaMissionState");
+	AmbulanceMissionState* ambulanceMissionState =
+		(AmbulanceMissionState*) GameState()->GetState("AmbulanceMissionState");
 
-		for (MxS32 actor = 1; actor <= 5; actor++) {
-			scores[0][actor - 1] = carRaceState ? carRaceState->GetState(actor)->GetHighScore() : 0;
-			totalScore += scores[0][actor - 1];
+	for (MxS32 actor = 1; actor <= 5; actor++) {
+		scores[0][actor - 1] = carRaceState ? carRaceState->GetState(actor)->GetHighScore() : 0;
+		totalScore += scores[0][actor - 1];
 
-			scores[1][actor - 1] = jetskiRaceState ? jetskiRaceState->GetState(actor)->GetHighScore() : 0;
-			totalScore += scores[1][actor - 1];
+		scores[1][actor - 1] = jetskiRaceState ? jetskiRaceState->GetState(actor)->GetHighScore() : 0;
+		totalScore += scores[1][actor - 1];
 
-			scores[2][actor - 1] = pizzaMissionState ? pizzaMissionState->GetHighScore(actor) : 0;
-			totalScore += scores[2][actor - 1];
+		scores[2][actor - 1] = pizzaMissionState ? pizzaMissionState->GetHighScore(actor) : 0;
+		totalScore += scores[2][actor - 1];
 
-			scores[3][actor - 1] = towTrackMissionState ? towTrackMissionState->GetHighScore(actor) : 0;
-			totalScore += scores[3][actor - 1];
+		scores[3][actor - 1] = towTrackMissionState ? towTrackMissionState->GetHighScore(actor) : 0;
+		totalScore += scores[3][actor - 1];
 
-			scores[4][actor - 1] = ambulanceMissionState ? ambulanceMissionState->GetHighScore(actor) : 0;
-			totalScore += scores[4][actor - 1];
-		}
+		scores[4][actor - 1] = ambulanceMissionState ? ambulanceMissionState->GetHighScore(actor) : 0;
+		totalScore += scores[4][actor - 1];
+	}
 
-		MxS32 unk0x2c;
-		ScoreItem* p_scorehist = FUN_1003cc90(&GameState()->m_players[0], GameState()->m_unk0x24, unk0x2c);
+	MxS32 unk0x2c;
+	ScoreItem* p_scorehist = FUN_1003cc90(&GameState()->m_players[0], GameState()->m_unk0x24, unk0x2c);
 
-		if (p_scorehist != NULL) {
-			p_scorehist->m_totalScore = totalScore;
-			memcpy(p_scorehist->m_scores, scores, sizeof(p_scorehist->m_scores));
-		}
-		else {
-			if (m_count < (MxS16) sizeOfArray(m_scores)) {
-				m_scores[m_count].m_totalScore = totalScore;
-				memcpy(m_scores[m_count].m_scores, scores, sizeof(m_scores[m_count].m_scores));
-				m_scores[m_count].m_name = GameState()->m_players[0];
-				m_scores[m_count].m_unk0x2a = GameState()->m_unk0x24;
-				m_count++;
-			}
-			else if (m_scores[19].m_totalScore <= totalScore) {
-				m_scores[19].m_totalScore = totalScore;
-				memcpy(m_scores[19].m_scores, scores, sizeof(m_scores[19].m_scores));
-				m_scores[19].m_name = GameState()->m_players[0];
-				m_scores[19].m_unk0x2a = GameState()->m_unk0x24;
+	if (!p_scorehist) {
+		MxS32 i;
+		// LINE: BETA10 0x100870ee
+		for (i = 0; i < m_count; i++) {
+			if (totalScore > m_scores[m_indices[i]].m_totalScore) {
+				break;
 			}
 		}
+		// LINE: BETA10 0x1008713f
+		if (i < m_count) {
+			// short sVar2 = m_count >= 20 ? m_indices[19] : m_count++;
 
-		MxU8 tmpScores[5][5];
-		Username tmpPlayer;
-		MxS16 tmpUnk0x2a;
-
-		// TODO: Match bubble sort loops
-		for (MxS32 i = m_count - 1; i > 0; i--) {
-			for (MxS32 j = 1; j <= i; j++) {
-				if (m_scores[j - 1].m_totalScore < m_scores[j].m_totalScore) {
-					memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
-					tmpPlayer = m_scores[j - 1].m_name;
-					tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
-
-					memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
-					m_scores[j - 1].m_name = m_scores[j].m_name;
-					m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
-
-					memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
-					m_scores[j].m_name = tmpPlayer;
-					m_scores[j].m_unk0x2a = tmpUnk0x2a;
-				}
+			MxS32 sVar2;
+			if (m_count < 20) {
+				sVar2 = m_count++;
 			}
+			else {
+				// LINE: BETA10 0x10087171
+				sVar2 = m_indices[19];
+			}
+			unk0x2c = sVar2;
+			// MxS32 count = m_count;
+			for (MxS32 j = m_count - 1; i < j; j--) {
+				m_indices[j - 1] = m_indices[j - 2];
+			}
+			m_indices[i] = sVar2;
+			p_scorehist = (LegoGameState::ScoreItem*) m_scores[unk0x2c].m_scores;
+		}
+		else if (i < 20) {
+			m_indices[m_count] = m_count;
+			p_scorehist = &m_scores[m_count++];
 		}
 	}
+	else if (p_scorehist->m_totalScore != totalScore) {
+		assert(totalScore > p_scorehist->m_totalScore);
+		// TODO: This decomp is likely still very wrong, first draft only.
+		// In particular, something is very confusing with a potential char->short typecast?
+		// But the types in Serialize do make sense.
+		//
+		// Potential explanation: There is another short[5][5] array in the parent type
+
+		for (MxS32 i = unk0x2c; (0 < i && (m_indices[i + -1] < m_indices[i])); i = i + -1) {
+			MxU8 tmp = m_indices[i - 1];
+			m_indices[i - 1] = m_indices[i];
+			m_indices[i] = tmp;
+		}
+	}
+	if (p_scorehist) {
+		p_scorehist->m_totalScore = totalScore;
+		memcpy(p_scorehist->m_scores[0], scores[0], 0x19);
+
+		// TODO: or the other way around
+		p_scorehist->m_name = GameState()->m_players[0];
+		p_scorehist->m_unk0x2a = GameState()->m_unk0x24;
+	}
+
+	// 	if (p_scorehist != NULL) {
+	// 		p_scorehist->m_totalScore = totalScore;
+	// 		memcpy(p_scorehist->m_scores, scores, sizeof(p_scorehist->m_scores));
+	// 	}
+	// 	else {
+	// 		if (m_count < (MxS16) sizeOfArray(m_scores)) {
+	// 			assert(totalScore > p_scorehist->m_totalScore);
+
+	// 			m_scores[m_count].m_totalScore = totalScore;
+	// 			memcpy(m_scores[m_count].m_scores, scores, sizeof(m_scores[m_count].m_scores));
+	// 			m_scores[m_count].m_name = GameState()->m_players[0];
+	// 			m_scores[m_count].m_unk0x2a = GameState()->m_unk0x24;
+	// 			m_count++;
+	// 		}
+	// 		else if (m_scores[19].m_totalScore <= totalScore) {
+	// 			m_scores[19].m_totalScore = totalScore;
+	// 			memcpy(m_scores[19].m_scores, scores, sizeof(m_scores[19].m_scores));
+	// 			m_scores[19].m_name = GameState()->m_players[0];
+	// 			m_scores[19].m_unk0x2a = GameState()->m_unk0x24;
+	// 		}
+	// 	}
+
+	// 	MxU8 tmpScores[5][5];
+	// 	Username tmpPlayer;
+	// 	MxS16 tmpUnk0x2a;
+
+	// 	// TODO: Match bubble sort loops
+	// 	for (MxS32 i = m_count - 1; i > 0; i--) {
+	// 		for (MxS32 j = 1; j <= i; j++) {
+	// 			if (m_scores[j - 1].m_totalScore < m_scores[j].m_totalScore) {
+	// 				memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
+	// 				tmpPlayer = m_scores[j - 1].m_name;
+	// 				tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
+
+	// 				memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
+	// 				m_scores[j - 1].m_name = m_scores[j].m_name;
+	// 				m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+
+	// 				memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
+	// 				m_scores[j].m_name = tmpPlayer;
+	// 				m_scores[j].m_unk0x2a = tmpUnk0x2a;
+	// 			}
+	// 		}
+	// 	}
+	// }
 }
 
 // FUNCTION: LEGO1 0x1003cc90

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1473,6 +1473,8 @@ void LegoGameState::History::WriteScoreHistory()
 	MxS32 unk0x2c;
 	ScoreItem* p_scorehist = FUN_1003cc90(&GameState()->m_players[0], GameState()->m_unk0x24, unk0x2c);
 
+#ifdef BETA10
+
 	if (!p_scorehist) {
 		MxS32 i;
 		// LINE: BETA10 0x100870ee
@@ -1520,51 +1522,54 @@ void LegoGameState::History::WriteScoreHistory()
 		p_scorehist->m_unk0x2a = GameState()->m_unk0x24;
 	}
 
-	// 	if (p_scorehist != NULL) {
-	// 		p_scorehist->m_totalScore = totalScore;
-	// 		memcpy(p_scorehist->m_scores, scores, sizeof(p_scorehist->m_scores));
-	// 	}
-	// 	else {
-	// 		if (m_count < (MxS16) sizeOfArray(m_scores)) {
-	// 			assert(totalScore > p_scorehist->m_totalScore);
+#else
+	// TODO: Improve based on BETA10 if possible
 
-	// 			m_scores[m_count].m_totalScore = totalScore;
-	// 			memcpy(m_scores[m_count].m_scores, scores, sizeof(m_scores[m_count].m_scores));
-	// 			m_scores[m_count].m_name = GameState()->m_players[0];
-	// 			m_scores[m_count].m_unk0x2a = GameState()->m_unk0x24;
-	// 			m_count++;
-	// 		}
-	// 		else if (m_scores[19].m_totalScore <= totalScore) {
-	// 			m_scores[19].m_totalScore = totalScore;
-	// 			memcpy(m_scores[19].m_scores, scores, sizeof(m_scores[19].m_scores));
-	// 			m_scores[19].m_name = GameState()->m_players[0];
-	// 			m_scores[19].m_unk0x2a = GameState()->m_unk0x24;
-	// 		}
-	// 	}
+	if (p_scorehist != NULL) {
+		p_scorehist->m_totalScore = totalScore;
+		memcpy(p_scorehist->m_scores, scores, sizeof(p_scorehist->m_scores));
+	}
+	else {
+		if (m_count < (MxS16) sizeOfArray(m_scores)) {
+			assert(totalScore > p_scorehist->m_totalScore);
 
-	// 	MxU8 tmpScores[5][5];
-	// 	Username tmpPlayer;
-	// 	MxS16 tmpUnk0x2a;
+			m_scores[m_count].m_totalScore = totalScore;
+			memcpy(m_scores[m_count].m_scores, scores, sizeof(m_scores[m_count].m_scores));
+			m_scores[m_count].m_name = GameState()->m_players[0];
+			m_scores[m_count].m_unk0x2a = GameState()->m_unk0x24;
+			m_count++;
+		}
+		else if (m_scores[19].m_totalScore <= totalScore) {
+			m_scores[19].m_totalScore = totalScore;
+			memcpy(m_scores[19].m_scores, scores, sizeof(m_scores[19].m_scores));
+			m_scores[19].m_name = GameState()->m_players[0];
+			m_scores[19].m_unk0x2a = GameState()->m_unk0x24;
+		}
+	}
 
-	// 	// TODO: Match bubble sort loops
-	// 	for (MxS32 i = m_count - 1; i > 0; i--) {
-	// 		for (MxS32 j = 1; j <= i; j++) {
-	// 			if (m_scores[j - 1].m_totalScore < m_scores[j].m_totalScore) {
-	// 				memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
-	// 				tmpPlayer = m_scores[j - 1].m_name;
-	// 				tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
+	MxU8 tmpScores[5][5];
+	Username tmpPlayer;
+	MxS16 tmpUnk0x2a;
 
-	// 				memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
-	// 				m_scores[j - 1].m_name = m_scores[j].m_name;
-	// 				m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+	// TODO: Match bubble sort loops
+	for (MxS32 i = m_count - 1; i > 0; i--) {
+		for (MxS32 j = 1; j <= i; j++) {
+			if (m_scores[j - 1].m_totalScore < m_scores[j].m_totalScore) {
+				memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
+				tmpPlayer = m_scores[j - 1].m_name;
+				tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
 
-	// 				memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
-	// 				m_scores[j].m_name = tmpPlayer;
-	// 				m_scores[j].m_unk0x2a = tmpUnk0x2a;
-	// 			}
-	// 		}
-	// 	}
-	// }
+				memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
+				m_scores[j - 1].m_name = m_scores[j].m_name;
+				m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+
+				memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
+				m_scores[j].m_name = tmpPlayer;
+				m_scores[j].m_unk0x2a = tmpUnk0x2a;
+			}
+		}
+	}
+#endif
 }
 
 // FUNCTION: LEGO1 0x1003cc90

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1547,25 +1547,40 @@ void LegoGameState::History::WriteScoreHistory()
 		}
 	}
 
-	MxU8 tmpScores[5][5];
-	Username tmpPlayer;
-	MxS16 tmpUnk0x2a;
+	// MxU8 tmpScores[5][5];
+	// Username tmpPlayer;
+	// MxS16 tmpUnk0x2a;
+
+	ScoreItem tmpItem;
 
 	// TODO: Match bubble sort loops
-	for (MxS32 i = m_count - 1; i > 0; i--) {
+	for (MxS32 i = m_count - 1; i >= 0; i--) {
 		for (MxS32 j = 1; j <= i; j++) {
-			if (m_scores[j - 1].m_totalScore < m_scores[j].m_totalScore) {
-				memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
-				tmpPlayer = m_scores[j - 1].m_name;
-				tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
+			// TODO: Maybe variables for j and j-1?
+			if (m_scores[j].m_totalScore >= m_scores[j - 1].m_totalScore) {
+				// LINE: LEGO1 0x1003cbc8
+				// experiment: copy manually -> doesn't produce `rep movsd dword ptr`
+				// for (int k = 0; k < 5; k++) {
+				// 	for (int l = 0; l < 5; l++)
+				// 		tmpScores[k][l] = m_scores[j - 1].m_scores[k][l];
+				// }
+				// memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
+				// // LINE: LEGO1 0x1003cbd9
+				// tmpPlayer = m_scores[j - 1].m_name;
+				// tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
 
-				memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
-				m_scores[j - 1].m_name = m_scores[j].m_name;
-				m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+				tmpItem = m_scores[j - 1];
+				// memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
+				// // LINE: LEGO1 0x1003cc05
+				// m_scores[j - 1].m_name = m_scores[j].m_name;
+				// m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+				m_scores[j-1] = m_scores[j];
 
-				memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
-				m_scores[j].m_name = tmpPlayer;
-				m_scores[j].m_unk0x2a = tmpUnk0x2a;
+				m_scores[j] = tmpItem;
+
+				// memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
+				// m_scores[j].m_name = tmpPlayer;
+				// m_scores[j].m_unk0x2a = tmpUnk0x2a;
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1441,9 +1441,11 @@ void LegoGameState::History::WriteScoreHistory()
 	MxU8 scores[5][5];
 
 	InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
+
 	if (!state->m_letters[0]) {
 		return;
 	}
+
 	JetskiRaceState* jetskiRaceState = (JetskiRaceState*) GameState()->GetState("JetskiRaceState");
 	CarRaceState* carRaceState = (CarRaceState*) GameState()->GetState("CarRaceState");
 	TowTrackMissionState* towTrackMissionState = (TowTrackMissionState*) GameState()->GetState("TowTrackMissionState");
@@ -1481,22 +1483,19 @@ void LegoGameState::History::WriteScoreHistory()
 		}
 		// LINE: BETA10 0x1008713f
 		if (i < m_count) {
-			// short sVar2 = m_count >= 20 ? m_indices[19] : m_count++;
-
-			MxS32 sVar2;
 			if (m_count < 20) {
-				sVar2 = m_count++;
+				unk0x2c = m_count++;
 			}
 			else {
-				// LINE: BETA10 0x10087171
-				sVar2 = m_indices[19];
+				unk0x2c = m_indices[19];
 			}
-			unk0x2c = sVar2;
-			// MxS32 count = m_count;
-			for (MxS32 j = m_count - 1; i < j; j--) {
+
+			MxS32 max = m_count - 1;
+			for (MxS32 j = max; i < j; j--) {
 				m_indices[j - 1] = m_indices[j - 2];
 			}
-			m_indices[i] = sVar2;
+
+			m_indices[i] = unk0x2c;
 			p_scorehist = (LegoGameState::ScoreItem*) m_scores[unk0x2c].m_scores;
 		}
 		else if (i < 20) {
@@ -1506,13 +1505,8 @@ void LegoGameState::History::WriteScoreHistory()
 	}
 	else if (p_scorehist->m_totalScore != totalScore) {
 		assert(totalScore > p_scorehist->m_totalScore);
-		// TODO: This decomp is likely still very wrong, first draft only.
-		// In particular, something is very confusing with a potential char->short typecast?
-		// But the types in Serialize do make sense.
-		//
-		// Potential explanation: There is another short[5][5] array in the parent type
 
-		for (MxS32 i = unk0x2c; (0 < i && (m_indices[i + -1] < m_indices[i])); i = i + -1) {
+		for (MxS32 i = unk0x2c; (0 < i && (m_indices[i - 1] < m_indices[i])); i = i - 1) {
 			MxU8 tmp = m_indices[i - 1];
 			m_indices[i - 1] = m_indices[i];
 			m_indices[i] = tmp;
@@ -1520,9 +1514,8 @@ void LegoGameState::History::WriteScoreHistory()
 	}
 	if (p_scorehist) {
 		p_scorehist->m_totalScore = totalScore;
-		memcpy(p_scorehist->m_scores[0], scores[0], 0x19);
+		memcpy(p_scorehist->m_scores[0], scores[0], sizeof(scores));
 
-		// TODO: or the other way around
 		p_scorehist->m_name = GameState()->m_players[0];
 		p_scorehist->m_unk0x2a = GameState()->m_unk0x24;
 	}

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1557,8 +1557,8 @@ void LegoGameState::History::WriteScoreHistory()
 	for (MxS32 i = m_count - 1; i >= 0; i--) {
 		for (MxS32 j = 1; j <= i; j++) {
 			// TODO: Maybe variables for j and j-1?
-			if (m_scores[j].m_totalScore >= m_scores[j - 1].m_totalScore) {
-				// LINE: LEGO1 0x1003cbc8
+			if (m_scores[j].m_totalScore > m_scores[j - 1].m_totalScore) {
+				// // LINE: LEGO1 0x1003cbc8
 				// experiment: copy manually -> doesn't produce `rep movsd dword ptr`
 				// for (int k = 0; k < 5; k++) {
 				// 	for (int l = 0; l < 5; l++)
@@ -1574,8 +1574,9 @@ void LegoGameState::History::WriteScoreHistory()
 				// // LINE: LEGO1 0x1003cc05
 				// m_scores[j - 1].m_name = m_scores[j].m_name;
 				// m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
-				m_scores[j-1] = m_scores[j];
-
+				// LINE: LEGO1 0x1003cbf8
+				m_scores[j - 1] = m_scores[j];
+				// LINE: LEGO1 0x1003cc24
 				m_scores[j] = tmpItem;
 
 				// memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -1564,24 +1564,35 @@ void LegoGameState::History::WriteScoreHistory()
 				// 	for (int l = 0; l < 5; l++)
 				// 		tmpScores[k][l] = m_scores[j - 1].m_scores[k][l];
 				// }
-				// memcpy(tmpScores, m_scores[j - 1].m_scores, sizeof(tmpScores));
-				// // LINE: LEGO1 0x1003cbd9
-				// tmpPlayer = m_scores[j - 1].m_name;
-				// tmpUnk0x2a = m_scores[j - 1].m_unk0x2a;
 
-				tmpItem = m_scores[j - 1];
-				// memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
-				// // LINE: LEGO1 0x1003cc05
-				// m_scores[j - 1].m_name = m_scores[j].m_name;
-				// m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
-				// LINE: LEGO1 0x1003cbf8
-				m_scores[j - 1] = m_scores[j];
-				// LINE: LEGO1 0x1003cc24
-				m_scores[j] = tmpItem;
+				// TODO: Possible operator= ?
 
-				// memcpy(m_scores[j].m_scores, tmpScores, sizeof(m_scores[j].m_scores));
-				// m_scores[j].m_name = tmpPlayer;
-				// m_scores[j].m_unk0x2a = tmpUnk0x2a;
+				tmpItem.m_totalScore = m_scores[j - 1].m_totalScore;
+				memcpy(tmpItem.m_scores, m_scores[j - 1].m_scores, sizeof(tmpItem.m_scores));
+				// LINE: LEGO1 0x1003cbd3
+				tmpItem.m_name = m_scores[j - 1].m_name;
+				tmpItem.m_unk0x2a = m_scores[j - 1].m_unk0x2a;
+
+				m_scores[j - 1].m_totalScore = m_scores[j].m_totalScore;
+				memcpy(m_scores[j - 1].m_scores, m_scores[j].m_scores, sizeof(m_scores[j - 1].m_scores));
+				// LINE: LEGO1 0x1003cc05
+				m_scores[j - 1].m_name = m_scores[j].m_name;
+				m_scores[j - 1].m_unk0x2a = m_scores[j].m_unk0x2a;
+
+
+				// LINE: LEGO1 0x1003cc1f
+				m_scores[j - 1].m_totalScore = tmpItem.m_totalScore;
+				memcpy(m_scores[j].m_scores, tmpItem.m_scores, sizeof(m_scores[j].m_scores));
+				m_scores[j].m_name = tmpItem.m_name;
+				m_scores[j].m_unk0x2a = tmpItem.m_unk0x2a;
+
+				// This version feels like it should be right, but it only produces 68.78 %
+
+				// tmpItem = m_scores[j - 1];
+				// // LINE: LEGO1 0x1003cbf8
+				// m_scores[j - 1] = m_scores[j];
+				// // LINE: LEGO1 0x1003cc24
+				// m_scores[j] = tmpItem;
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -149,7 +149,7 @@ inline LegoGameState::ScoreItem& LegoGameState::ScoreItem::operator=(const Score
 	m_totalScore = p_other.m_totalScore;
 	memcpy(m_scores, p_other.m_scores, sizeof(m_scores));
 	m_name = p_other.m_name;
-	m_unk0x2a = p_other.m_unk0x2a;
+	m_playerId = p_other.m_playerId;
 	return *this;
 }
 
@@ -289,7 +289,7 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	}
 
 	storage.WriteS32(0x1000c);
-	storage.WriteS16(m_unk0x24);
+	storage.WriteS16(m_currentPlayerId);
 	storage.WriteU16(m_currentAct);
 	storage.WriteU8(m_actorId);
 
@@ -384,7 +384,7 @@ MxResult LegoGameState::Load(MxULong p_slot)
 		goto done;
 	}
 
-	storage.ReadS16(m_unk0x24);
+	storage.ReadS16(m_currentPlayerId);
 	storage.ReadS16(actArea);
 
 	SetCurrentAct((Act) actArea);
@@ -627,8 +627,8 @@ MxResult LegoGameState::AddPlayer(Username& p_player)
 
 	m_playerCount++;
 	m_players[0].Set(p_player);
-	m_unk0x24 = m_history.m_nextPlayerId;
-	m_history.m_nextPlayerId = m_unk0x24 + 1;
+	m_currentPlayerId = m_history.m_nextPlayerId;
+	m_history.m_nextPlayerId = m_currentPlayerId + 1;
 	m_history.WriteScoreHistory();
 	SetCurrentAct(e_act1);
 
@@ -1419,7 +1419,7 @@ MxResult LegoGameState::ScoreItem::Serialize(LegoStorage* p_storage)
 		}
 
 		m_name.Serialize(p_storage);
-		p_storage->ReadS16(m_unk0x2a);
+		p_storage->ReadS16(m_playerId);
 	}
 	else if (p_storage->IsWriteMode()) {
 		p_storage->WriteS16(m_totalScore);
@@ -1431,7 +1431,7 @@ MxResult LegoGameState::ScoreItem::Serialize(LegoStorage* p_storage)
 		}
 
 		m_name.Serialize(p_storage);
-		p_storage->WriteS16(m_unk0x2a);
+		p_storage->WriteS16(m_playerId);
 	}
 
 	return SUCCESS;
@@ -1489,7 +1489,7 @@ void LegoGameState::History::WriteScoreHistory()
 
 	MxS32 playerScoreHistoryIndex;
 	ScoreItem* p_scorehist =
-		FindPlayerInScoreHistory(GameState()->m_players, GameState()->m_unk0x24, playerScoreHistoryIndex);
+		FindPlayerInScoreHistory(GameState()->m_players, GameState()->m_currentPlayerId, playerScoreHistoryIndex);
 
 #ifdef BETA10
 	if (!p_scorehist) {
@@ -1535,7 +1535,7 @@ void LegoGameState::History::WriteScoreHistory()
 		p_scorehist->m_totalScore = totalScore;
 		memcpy(p_scorehist->m_scores[0], scores[0], sizeof(scores));
 		p_scorehist->m_name = GameState()->m_players[0];
-		p_scorehist->m_unk0x2a = GameState()->m_unk0x24;
+		p_scorehist->m_playerId = GameState()->m_currentPlayerId;
 	}
 #else
 	if (p_scorehist != NULL) {
@@ -1549,14 +1549,14 @@ void LegoGameState::History::WriteScoreHistory()
 			m_scores[m_count].m_totalScore = totalScore;
 			memcpy(m_scores[m_count].m_scores, scores, sizeof(m_scores[m_count].m_scores));
 			m_scores[m_count].m_name = GameState()->m_players[0];
-			m_scores[m_count].m_unk0x2a = GameState()->m_unk0x24;
+			m_scores[m_count].m_playerId = GameState()->m_currentPlayerId;
 			m_count++;
 		}
 		else if (m_scores[19].m_totalScore <= totalScore) {
 			m_scores[19].m_totalScore = totalScore;
 			memcpy(m_scores[19].m_scores, scores, sizeof(m_scores[19].m_scores));
 			m_scores[19].m_name = GameState()->m_players[0];
-			m_scores[19].m_unk0x2a = GameState()->m_unk0x24;
+			m_scores[19].m_playerId = GameState()->m_currentPlayerId;
 		}
 	}
 
@@ -1584,7 +1584,7 @@ LegoGameState::ScoreItem* LegoGameState::History::FindPlayerInScoreHistory(
 {
 	MxS32 i = 0;
 	for (; i < m_count; i++) {
-		if (!memcmp(p_player, &m_scores[i].m_name, sizeof(*p_player)) && m_scores[i].m_unk0x2a == p_unk0x24) {
+		if (!memcmp(p_player, &m_scores[i].m_name, sizeof(*p_player)) && m_scores[i].m_playerId == p_unk0x24) {
 			break;
 		}
 	}


### PR DESCRIPTION
Closes #1339. I also matched BETA10, which didn't turn out to be very useful due to a major refactor, but it is interesting to see the earlier version. Some unknowns were also renamed where I found the interpretation to be quite clear.