### PR TITLE
Clear unknowns in `Ambulance` and `AmbulanceMissionState`

### DIFF
--- a/LEGO1/lego/legoomni/include/ambulance.h
+++ b/LEGO1/lego/legoomni/include/ambulance.h
@@ -11,6 +11,12 @@ class MxEndActionNotificationParam;
 // SIZE 0x24
 class AmbulanceMissionState : public LegoState {
 public:
+	enum {
+		e_ready = 0,
+		e_enteredAmbulance = 1,
+		e_prepareAmbulance = 2,
+	};
+
 	AmbulanceMissionState();
 
 	// FUNCTION: LEGO1 0x10037440
@@ -125,18 +131,18 @@ public:
 	// SYNTHETIC: LEGO1 0x100376c0
 	// AmbulanceMissionState::`scalar deleting destructor'
 
-	undefined4 m_unk0x08; // 0x08
-	MxLong m_startTime;   // 0x0c
-	MxS16 m_peScore;      // 0x10
-	MxS16 m_maScore;      // 0x12
-	MxS16 m_paScore;      // 0x14
-	MxS16 m_niScore;      // 0x16
-	MxS16 m_laScore;      // 0x18
-	MxS16 m_peHighScore;  // 0x1a
-	MxS16 m_maHighScore;  // 0x1c
-	MxS16 m_paHighScore;  // 0x1e
-	MxS16 m_niHighScore;  // 0x20
-	MxS16 m_laHighScore;  // 0x22
+	MxU32 m_state;       // 0x08
+	MxLong m_startTime;  // 0x0c
+	MxS16 m_peScore;     // 0x10
+	MxS16 m_maScore;     // 0x12
+	MxS16 m_paScore;     // 0x14
+	MxS16 m_niScore;     // 0x16
+	MxS16 m_laScore;     // 0x18
+	MxS16 m_peHighScore; // 0x1a
+	MxS16 m_maHighScore; // 0x1c
+	MxS16 m_paHighScore; // 0x1e
+	MxS16 m_niHighScore; // 0x20
+	MxS16 m_laHighScore; // 0x22
 };
 
 // VTABLE: LEGO1 0x100d71a8
@@ -177,15 +183,21 @@ public:
 	virtual MxLong HandleEndAction(MxEndActionNotificationParam& p_param);         // vtable+0xf4
 
 	void CreateState();
-	void FUN_10036e60();
+	void Init();
 	void ActivateSceneActions();
 	void StopActions();
-	void FUN_10037250();
+	void Reset();
 
 	// SYNTHETIC: LEGO1 0x10036130
 	// Ambulance::`scalar deleting destructor'
 
 private:
+	enum {
+		e_none = 0,
+		e_waiting = 1,
+		e_finished = 3,
+	};
+
 	void PlayAnimation(IsleScript::Script p_objectId);
 	void PlayFinalAnimation(IsleScript::Script p_objectId);
 	void StopAction(IsleScript::Script p_objectId);
@@ -196,9 +208,9 @@ private:
 	AmbulanceMissionState* m_state;     // 0x164
 	MxS16 m_unk0x168;                   // 0x168
 	MxS16 m_actorId;                    // 0x16a
-	MxS16 m_unk0x16c;                   // 0x16c
-	MxS16 m_unk0x16e;                   // 0x16e
-	MxS16 m_unk0x170;                   // 0x170
+	MxS16 m_atPoliceTask;               // 0x16c
+	MxS16 m_atBeachTask;                // 0x16e
+	MxS16 m_taskState;                  // 0x170
 	MxS16 m_unk0x172;                   // 0x172
 	IsleScript::Script m_lastAction;    // 0x174
 	IsleScript::Script m_lastAnimation; // 0x178

--- a/LEGO1/lego/legoomni/src/actors/ambulance.cpp
+++ b/LEGO1/lego/legoomni/src/actors/ambulance.cpp
@@ -37,9 +37,9 @@ Ambulance::Ambulance()
 	m_state = NULL;
 	m_unk0x168 = 0;
 	m_actorId = -1;
-	m_unk0x16c = 0;
-	m_unk0x16e = 0;
-	m_unk0x170 = 0;
+	m_atPoliceTask = 0;
+	m_atBeachTask = 0;
+	m_taskState = Ambulance::e_none;
 	m_lastAction = IsleScript::c_noneIsle;
 	m_unk0x172 = 0;
 	m_lastAnimation = IsleScript::c_noneIsle;
@@ -70,7 +70,7 @@ MxResult Ambulance::Create(MxDSAction& p_dsAction)
 		m_state = (AmbulanceMissionState*) GameState()->GetState("AmbulanceMissionState");
 		if (!m_state) {
 			m_state = new AmbulanceMissionState();
-			m_state->m_unk0x08 = 0;
+			m_state->m_state = AmbulanceMissionState::e_ready;
 			GameState()->RegisterState(m_state);
 		}
 	}
@@ -170,25 +170,25 @@ MxLong Ambulance::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_lastAction = IsleScript::c_noneIsle;
 		}
 		else if (objectId == IsleScript::c_hho027en_RunAnim) {
-			m_state->m_unk0x08 = 1;
+			m_state->m_state = AmbulanceMissionState::e_enteredAmbulance;
 			CurrentWorld()->PlaceActor(UserActor());
 			HandleClick();
 			m_unk0x172 = 0;
 			TickleManager()->RegisterClient(this, 40000);
 		}
 		else if (objectId == IsleScript::c_hpz047pe_RunAnim || objectId == IsleScript::c_hpz048pe_RunAnim || objectId == IsleScript::c_hpz049bd_RunAnim || objectId == IsleScript::c_hpz053pa_RunAnim) {
-			if (m_unk0x170 == 3) {
+			if (m_taskState == Ambulance::e_finished) {
 				PlayAnimation(IsleScript::c_hpz055pa_RunAnim);
-				m_unk0x170 = 0;
+				m_taskState = Ambulance::e_none;
 			}
 			else {
 				PlayAnimation(IsleScript::c_hpz053pa_RunAnim);
 			}
 		}
 		else if (objectId == IsleScript::c_hpz050bd_RunAnim || objectId == IsleScript::c_hpz052ma_RunAnim) {
-			if (m_unk0x170 == 3) {
+			if (m_taskState == Ambulance::e_finished) {
 				PlayAnimation(IsleScript::c_hpz057ma_RunAnim);
-				m_unk0x170 = 0;
+				m_taskState = Ambulance::e_none;
 			}
 			else {
 				PlayAnimation(IsleScript::c_hpz052ma_RunAnim);
@@ -201,18 +201,18 @@ MxLong Ambulance::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_unk0x172 = 0;
 			TickleManager()->RegisterClient(this, 40000);
 
-			if (m_unk0x16c != 0) {
+			if (m_atPoliceTask != 0) {
 				StopActions();
 			}
 		}
 		else if (objectId == IsleScript::c_hps116bd_RunAnim || objectId == IsleScript::c_hps118re_RunAnim) {
-			if (objectId == IsleScript::c_hps116bd_RunAnim && m_unk0x170 != 3) {
+			if (objectId == IsleScript::c_hps116bd_RunAnim && m_taskState != Ambulance::e_finished) {
 				PlayAction(IsleScript::c_Avo923In_PlayWav);
 			}
 
-			if (m_unk0x170 == 3) {
+			if (m_taskState == Ambulance::e_finished) {
 				PlayAnimation(IsleScript::c_hps117bd_RunAnim);
-				m_unk0x170 = 0;
+				m_taskState = Ambulance::e_none;
 			}
 			else {
 				PlayAnimation(IsleScript::c_hps118re_RunAnim);
@@ -225,12 +225,12 @@ MxLong Ambulance::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_unk0x172 = 0;
 			TickleManager()->RegisterClient(this, 40000);
 
-			if (m_unk0x16e != 0) {
+			if (m_atBeachTask != 0) {
 				StopActions();
 			}
 		}
 		else if (objectId == IsleScript::c_hho142cl_RunAnim || objectId == IsleScript::c_hho143cl_RunAnim || objectId == IsleScript::c_hho144cl_RunAnim) {
-			FUN_10037250();
+			Reset();
 		}
 	}
 
@@ -241,18 +241,18 @@ MxLong Ambulance::HandleEndAction(MxEndActionNotificationParam& p_param)
 // FUNCTION: BETA10 0x100230bf
 MxLong Ambulance::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 {
-	if (m_unk0x170 == 1) {
+	if (m_taskState == Ambulance::e_waiting) {
 		LegoROI* roi = PickROI(p_param.GetX(), p_param.GetY());
 
 		if (roi != NULL && !strcmpi(roi->GetName(), "ps-gate")) {
-			m_unk0x170 = 3;
+			m_taskState = Ambulance::e_finished;
 			return 1;
 		}
 
 		roi = PickRootROI(p_param.GetX(), p_param.GetY());
 
 		if (roi != NULL && !strcmpi(roi->GetName(), "gd")) {
-			m_unk0x170 = 3;
+			m_taskState = Ambulance::e_finished;
 			return 1;
 		}
 	}
@@ -270,9 +270,9 @@ MxLong Ambulance::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 	}
 
 	if (p_param.GetTrigger() == LegoPathStruct::c_camAnim && p_param.GetData() == 0x0b) {
-		if (m_unk0x16e != 0) {
-			if (m_unk0x16c != 0) {
-				m_state->m_unk0x08 = 2;
+		if (m_atBeachTask != 0) {
+			if (m_atPoliceTask != 0) {
+				m_state->m_state = AmbulanceMissionState::e_prepareAmbulance;
 
 				if (m_lastAction != IsleScript::c_noneIsle) {
 					InvokeAction(Extra::e_stop, *g_isleScript, m_lastAction, NULL);
@@ -297,7 +297,7 @@ MxLong Ambulance::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 				return 0;
 			}
 
-			if (m_unk0x16e != 0) {
+			if (m_atBeachTask != 0) {
 				if (m_lastAction != IsleScript::c_noneIsle) {
 					InvokeAction(Extra::e_stop, *g_isleScript, m_lastAction, NULL);
 				}
@@ -307,7 +307,7 @@ MxLong Ambulance::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			}
 		}
 
-		if (m_unk0x16c != 0) {
+		if (m_atPoliceTask != 0) {
 			if (m_lastAction != IsleScript::c_noneIsle) {
 				InvokeAction(Extra::e_stop, *g_isleScript, m_lastAction, NULL);
 			}
@@ -315,9 +315,9 @@ MxLong Ambulance::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			PlayAction(IsleScript::c_Avo915In_PlayWav);
 		}
 	}
-	else if (p_param.GetTrigger() == LegoPathStruct::c_s && p_param.GetData() == 0x131 && m_unk0x16e == 0) {
-		m_unk0x16e = 1;
-		m_unk0x170 = 1;
+	else if (p_param.GetTrigger() == LegoPathStruct::c_s && p_param.GetData() == 0x131 && m_atBeachTask == 0) {
+		m_atBeachTask = 1;
+		m_taskState = Ambulance::e_waiting;
 
 		if (m_lastAction != IsleScript::c_noneIsle) {
 			InvokeAction(Extra::e_stop, *g_isleScript, m_lastAction, NULL);
@@ -345,9 +345,9 @@ MxLong Ambulance::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			break;
 		}
 	}
-	else if (p_param.GetTrigger() == LegoPathStruct::c_camAnim && (p_param.GetData() == 0x22 || p_param.GetData() == 0x23 || p_param.GetData() == 0x24) && m_unk0x16c == 0) {
-		m_unk0x16c = 1;
-		m_unk0x170 = 1;
+	else if (p_param.GetTrigger() == LegoPathStruct::c_camAnim && (p_param.GetData() == 0x22 || p_param.GetData() == 0x23 || p_param.GetData() == 0x24) && m_atPoliceTask == 0) {
+		m_atPoliceTask = 1;
+		m_taskState = Ambulance::e_waiting;
 
 		if (m_lastAction != IsleScript::c_noneIsle) {
 			InvokeAction(Extra::e_stop, *g_isleScript, m_lastAction, NULL);
@@ -368,7 +368,7 @@ MxLong Ambulance::HandleClick()
 		return 1;
 	}
 
-	if (m_state->m_unk0x08 == 2) {
+	if (m_state->m_state == AmbulanceMissionState::e_prepareAmbulance) {
 		return 1;
 	}
 
@@ -387,7 +387,7 @@ MxLong Ambulance::HandleClick()
 	InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_AmbulanceDashboard, NULL);
 	ControlManager()->Register(this);
 
-	if (m_state->m_unk0x08 == 1) {
+	if (m_state->m_state == AmbulanceMissionState::e_enteredAmbulance) {
 		SpawnPlayer(LegoGameState::e_hospitalExited, TRUE, 0);
 		m_state->m_startTime = Timer()->GetTime();
 		InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_pns018rd_RunAnim, NULL);
@@ -398,9 +398,9 @@ MxLong Ambulance::HandleClick()
 
 // FUNCTION: LEGO1 0x10036e60
 // FUNCTION: BETA10 0x100236bb
-void Ambulance::FUN_10036e60()
+void Ambulance::Init()
 {
-	m_state->m_unk0x08 = 2;
+	m_state->m_state = AmbulanceMissionState::e_prepareAmbulance;
 	PlayAnimation(IsleScript::c_hho027en_RunAnim);
 	m_lastAction = IsleScript::c_noneIsle;
 	m_lastAnimation = IsleScript::c_noneIsle;
@@ -411,7 +411,7 @@ void Ambulance::Exit()
 {
 	GameState()->m_currentArea = LegoGameState::e_hospitalExterior;
 	StopActions();
-	FUN_10037250();
+	Reset();
 	Leave();
 }
 
@@ -467,11 +467,11 @@ void Ambulance::ActivateSceneActions()
 {
 	PlayMusic(JukeboxScript::c_Hospital_Music);
 
-	if (m_state->m_unk0x08 == 1) {
-		m_state->m_unk0x08 = 0;
+	if (m_state->m_state == AmbulanceMissionState::e_enteredAmbulance) {
+		m_state->m_state = AmbulanceMissionState::e_ready;
 		PlayAction(IsleScript::c_ham033cl_PlayWav);
 	}
-	else if (m_unk0x16c != 0 && m_unk0x16e != 0) {
+	else if (m_atPoliceTask != 0 && m_atBeachTask != 0) {
 		IsleScript::Script objectId;
 
 		switch (rand() % 2) {
@@ -571,14 +571,14 @@ void Ambulance::StopActions()
 }
 
 // FUNCTION: LEGO1 0x10037250
-void Ambulance::FUN_10037250()
+void Ambulance::Reset()
 {
 	StopAction(m_lastAction);
 	BackgroundAudioManager()->RaiseVolume();
 	((Act1State*) GameState()->GetState("Act1State"))->m_unk0x018 = 0;
-	m_state->m_unk0x08 = 0;
-	m_unk0x16e = 0;
-	m_unk0x16c = 0;
+	m_state->m_state = AmbulanceMissionState::e_ready;
+	m_atBeachTask = 0;
+	m_atPoliceTask = 0;
 	g_isleFlags |= Isle::c_playMusic;
 	AnimationManager()->EnableCamAnims(TRUE);
 	AnimationManager()->FUN_1005f6d0(TRUE);
@@ -626,7 +626,7 @@ void Ambulance::PlayAction(IsleScript::Script p_objectId)
 // FUNCTION: LEGO1 0x100373a0
 AmbulanceMissionState::AmbulanceMissionState()
 {
-	m_unk0x08 = 0;
+	m_state = AmbulanceMissionState::e_ready;
 	m_startTime = 0;
 	m_peScore = 0;
 	m_maScore = 0;

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -810,7 +810,7 @@ void Isle::Enable(MxBool p_enable)
 			AnimationManager()->EnableCamAnims(FALSE);
 
 			g_isleFlags &= ~c_playMusic;
-			m_ambulance->FUN_10036e60();
+			m_ambulance->Init();
 			break;
 		case 11:
 			m_act1state->m_unk0x018 = 0;
@@ -1209,7 +1209,7 @@ MxBool Isle::Escape()
 	case 10:
 		if (UserActor() != NULL && !UserActor()->IsA("Ambulance")) {
 			m_ambulance->StopActions();
-			m_ambulance->FUN_10037250();
+			m_ambulance->Reset();
 		}
 		break;
 	}
@@ -1250,7 +1250,7 @@ void Isle::FUN_10033350()
 	if (m_act1state->m_unk0x018 == 10) {
 		if (UserActor() != NULL && !UserActor()->IsA("Ambulance")) {
 			m_ambulance->StopActions();
-			m_ambulance->FUN_10037250();
+			m_ambulance->Reset();
 		}
 	}
 


### PR DESCRIPTION
Only `m_unk0x160`, `m_unk0x168` and `m_unk0x172` aren't named. The first two are nowhere read (at least as far as I can tell) and the other one just delays the music by one tickle. Basically somehow like "it gets set when idling".

Also `m_at*Task` behave like booleans, but are explicitly checked (` != 0` and ` == 0`) even if elsewhere with other non-bools those checks are done "implicitly". If you want I can use `TRUE` and `FALSE` for assignments and replace the equality check with "normal" boolean checks like `if (at*Task)` or `if (!at*Task)`.