### PR TITLE
Fix wrong notification type in `LegoRace::Notify`

### DIFF
--- a/LEGO1/lego/legoomni/include/carrace.h
+++ b/LEGO1/lego/legoomni/include/carrace.h
@@ -52,13 +52,13 @@ public:
 		return !strcmp(p_name, CarRace::ClassName()) || LegoRace::IsA(p_name);
 	}
 
-	MxResult Create(MxDSAction& p_dsAction) override;                   // vtable+0x18
-	void ReadyWorld() override;                                         // vtable+0x50
-	MxBool Escape() override;                                           // vtable+0x64
-	MxLong HandleClick(LegoEventNotificationParam&) override;           // vtable+0x6c
-	MxLong HandlePathStruct(LegoPathStructNotificationParam&) override; // vtable+0x70
-	MxLong HandleEndAction(MxEndActionNotificationParam&) override;     // vtable+0x74
-	MxLong HandleType0Notification(MxNotificationParam&) override;      // vtable+0x78
+	MxResult Create(MxDSAction& p_dsAction) override;                    // vtable+0x18
+	void ReadyWorld() override;                                          // vtable+0x50
+	MxBool Escape() override;                                            // vtable+0x64
+	MxLong HandleControl(LegoControlManagerNotificationParam&) override; // vtable+0x6c
+	MxLong HandlePathStruct(LegoPathStructNotificationParam&) override;  // vtable+0x70
+	MxLong HandleEndAction(MxEndActionNotificationParam&) override;      // vtable+0x74
+	MxLong HandleType0Notification(MxNotificationParam&) override;       // vtable+0x78
 
 	// FUNCTION: BETA10 0x100cd060
 	RaceSkel* GetSkeleton() { return m_skeleton; }

--- a/LEGO1/lego/legoomni/include/jetskirace.h
+++ b/LEGO1/lego/legoomni/include/jetskirace.h
@@ -29,12 +29,12 @@ public:
 		return !strcmp(p_name, JetskiRace::ClassName()) || LegoRace::IsA(p_name);
 	}
 
-	MxResult Create(MxDSAction& p_dsAction) override;                   // vtable+0x18
-	void ReadyWorld() override;                                         // vtable+0x50
-	MxBool Escape() override;                                           // vtable+0x64
-	MxLong HandleClick(LegoEventNotificationParam&) override;           // vtable+0x6c
-	MxLong HandlePathStruct(LegoPathStructNotificationParam&) override; // vtable+0x70
-	MxLong HandleEndAction(MxEndActionNotificationParam&) override;     // vtable+0x74
+	MxResult Create(MxDSAction& p_dsAction) override;                    // vtable+0x18
+	void ReadyWorld() override;                                          // vtable+0x50
+	MxBool Escape() override;                                            // vtable+0x64
+	MxLong HandleControl(LegoControlManagerNotificationParam&) override; // vtable+0x6c
+	MxLong HandlePathStruct(LegoPathStructNotificationParam&) override;  // vtable+0x70
+	MxLong HandleEndAction(MxEndActionNotificationParam&) override;      // vtable+0x74
 
 	void FUN_10016930(MxS32 p_param1, MxS16 p_param2);
 

--- a/LEGO1/lego/legoomni/include/legorace.h
+++ b/LEGO1/lego/legoomni/include/legorace.h
@@ -11,7 +11,7 @@
 #include "mxtypes.h"
 
 class Act1State;
-class LegoEventNotificationParam;
+class LegoControlManagerNotificationParam;
 class LegoPathActor;
 class MxEndActionNotificationParam;
 class MxNotificationParam;
@@ -117,7 +117,7 @@ public:
 
 	MxResult Create(MxDSAction& p_dsAction) override; // vtable+0x18
 
-	virtual MxLong HandleClick(LegoEventNotificationParam&) = 0; // vtable+0x6c
+	virtual MxLong HandleControl(LegoControlManagerNotificationParam&) = 0; // vtable+0x6c
 
 	// FUNCTION: LEGO1 0x10015b70
 	virtual MxLong HandlePathStruct(LegoPathStructNotificationParam&) { return 0; } // vtable+0x70

--- a/LEGO1/lego/legoomni/src/race/carrace.cpp
+++ b/LEGO1/lego/legoomni/src/race/carrace.cpp
@@ -333,12 +333,10 @@ MxLong CarRace::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x10017650
-MxLong CarRace::HandleClick(LegoEventNotificationParam& p_param)
+MxLong CarRace::HandleControl(LegoControlManagerNotificationParam& p_param)
 {
-	LegoControlManagerNotificationParam* param = (LegoControlManagerNotificationParam*) &p_param;
-
-	if (param->m_unk0x28 == 1) {
-		switch (param->m_clickedObjectId) {
+	if (p_param.m_unk0x28 == 1) {
+		switch (p_param.m_clickedObjectId) {
 		case 3:
 			InvokeAction(Extra::e_stop, *g_carraceScript, CarraceScript::c_irtx08ra_PlayWav, NULL);
 			m_act1State->m_unk0x018 = 0;

--- a/LEGO1/lego/legoomni/src/race/jetskirace.cpp
+++ b/LEGO1/lego/legoomni/src/race/jetskirace.cpp
@@ -120,12 +120,12 @@ MxLong JetskiRace::HandleEndAction(MxEndActionNotificationParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x100165a0
-MxLong JetskiRace::HandleClick(LegoEventNotificationParam& p_param)
+MxLong JetskiRace::HandleControl(LegoControlManagerNotificationParam& p_param)
 {
 	MxLong result = 0;
 
-	if (((LegoControlManagerNotificationParam*) &p_param)->m_unk0x28 == 1) {
-		switch (((LegoControlManagerNotificationParam*) &p_param)->m_clickedObjectId) {
+	if (p_param.m_unk0x28 == 1) {
+		switch (p_param.m_clickedObjectId) {
 		case JetraceScript::c_JetskiArms_Ctl:
 			m_act1State->m_unk0x018 = 0;
 			VariableTable()->SetVariable(g_raceState, "");

--- a/LEGO1/lego/legoomni/src/race/legorace.cpp
+++ b/LEGO1/lego/legoomni/src/race/legorace.cpp
@@ -82,8 +82,8 @@ MxLong LegoRace::Notify(MxParam& p_param)
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;
-		case c_notificationClick:
-			result = HandleClick((LegoEventNotificationParam&) p_param);
+		case c_notificationControl:
+			result = HandleControl((LegoControlManagerNotificationParam&) p_param);
 			break;
 		case c_notificationPathStruct:
 			result = HandlePathStruct((LegoPathStructNotificationParam&) p_param);


### PR DESCRIPTION
Fixing this bug: https://github.com/isledecomp/isle-portable/issues/481

`reccmp` didn't catch this, the function was 100%* before but used a wrong value in the switch-case. Something to look at? @disinvite @jonschz 