### PR TITLE
Beta matching `CConfigApp`

### DIFF
--- a/CONFIG/config.h
+++ b/CONFIG/config.h
@@ -14,6 +14,7 @@ struct MxDriver;
 #define currentConfigApp ((CConfigApp*) afxCurrentWinApp)
 
 // VTABLE: CONFIG 0x00406040
+// VTABLE: CONFIGD 0x0040c0a0
 // SIZE 0x108
 class CConfigApp : public CWinApp {
 public:
@@ -74,18 +75,23 @@ public:
 };
 
 // SYNTHETIC: CONFIG 0x00402cd0
+// SYNTHETIC: CONFIGD 0x00408330
 // CConfigApp::`scalar deleting destructor'
 
 // FUNCTION: CONFIG 0x402c20
+// FUNCTION: CONFIGD 0x4068d0
 // CConfigApp::_GetBaseMessageMap
 
 // FUNCTION: CONFIG 0x402c30
+// FUNCTION: CONFIGD 0x4068e5
 // CConfigApp::GetMessageMap
 
 // GLOBAL: CONFIG 0x406008
+// GLOBAL: CONFIGD 0x40c058
 // CConfigApp::messageMap
 
 // GLOBAL: CONFIG 0x406010
+// GLOBAL: CONFIGD 0x40c060
 // CConfigApp::_messageEntries
 
 #endif // !defined(AFX_CONFIG_H)

--- a/reccmp-project.yml
+++ b/reccmp-project.yml
@@ -43,3 +43,8 @@ targets:
     source-root: LEGO1
     hash:
       sha256: dc7e5ed8ec9d96851126a40c4d23755f1783a8df61def44c667dfaa992ac509e
+  CONFIGD:
+    filename: CONFIGD.EXE
+    source-root: .
+    hash:
+      sha256: 9d2b7de2e53eee99cce24a64777a08a7f919a0401a393d9494bce27ef2e24c39

--- a/tools/README.md
+++ b/tools/README.md
@@ -22,6 +22,7 @@ These modules are the most important ones and refer to the English retail versio
 ## BETA v1.0
 
 * `BETA10` -> `LEGO1D.DLL`
+* `CONFIGD` -> `CONFIG.EXE`
 
 The Beta 1.0 version contains a debug build of the game. While it does not have debug symbols, it still has a number of benefits:
 * It is built with less or no optimisation, leading to better decompilations in Ghidra
@@ -31,6 +32,8 @@ The Beta 1.0 version contains a debug build of the game. While it does not have 
 It is therefore advisable to search for the corresponding function in `BETA10` when decompiling a function in `LEGO1`. Finding the correct function can be tricky, but is usually worth it, especially for longer functions.
 
 Unfortunately, some code has been changed after this beta version was created. Therefore, we are not aiming for a perfect binary match of `BETA10`. In case of discrepancies, `LEGO1` (as defined above) is our "gold standard" for matching.
+
+The beta version of the `CONFIG` application has provided some help with matching [MFC handler functions](https://en.wikipedia.org/wiki/Microsoft_Foundation_Class_Library) that are similar to the final version.
 
 ## Pre-Alpha
 


### PR DESCRIPTION
This matches functions from `CConfigApp` in `CONFIG` using the beta 1.0 copy. I renamed that to `CONFIGD` and the annotations use that label.

I can add the checksum to `reccmp-project.yml` if we want it there.

One of the functions appears to degrade, but here is the result of a 256 sample entropy run:

```
New (1):
0x403890 - CConfigApp::WriteRegisterSettings (new -> 100.00%)

Increased (5):
0x402dc0 - CConfigApp::InitInstance (77.92% -> 99.01%)
0x4031b0 - CConfigApp::WriteReg (62.63% -> 100.00%)
0x403430 - CConfigApp::ReadRegisterSettings (88.58% -> 100.00%)
0x403630 - CConfigApp::ValidateSettings (93.90% -> 100.00%)
0x404340 - CMainDialog::OnButtonCancel (78.26% -> 86.96%)
```