### PR TITLE
Match `FUN_1006b140()` and related functions

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -92,7 +92,11 @@ public:
 	const char* GetActionObjectName();
 
 	void SetCurrentWorld(LegoWorld* p_currentWorld) { m_currentWorld = p_currentWorld; }
+
+	// FUNCTION: BETA10 0x1005aad0
 	void SetUnknown0x0cTo1() { m_unk0x9c = 1; }
+
+	// FUNCTION: BETA10 0x1005ab00
 	void SetUnknown0xa0(Matrix4* p_unk0xa0) { m_unk0xa0 = p_unk0xa0; }
 
 	LegoAnim* GetAnimation() { return m_anim; }

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -703,6 +703,9 @@ MxResult LegoAnimPresenter::FUN_1006b140(LegoROI* p_roi)
 	if (p_roi == NULL) {
 		return FAILURE;
 	}
+#ifdef BETA10
+	MxMatrix unused_matrix;
+#endif
 
 	Matrix4* mn = new MxMatrix();
 	assert(mn);

--- a/LEGO1/realtime/matrix4d.inl.h
+++ b/LEGO1/realtime/matrix4d.inl.h
@@ -290,6 +290,8 @@ void Matrix4::RotateZ(const float& p_angle)
 // FUNCTION: BETA10 0x1005a590
 int Matrix4::Invert(Matrix4& p_mat)
 {
+	// Inlined at LEGO1 0x1006b2d3
+
 	float copyData[4][4];
 	Matrix4 copy(copyData);
 	copy = *this;
@@ -312,6 +314,7 @@ int Matrix4::Invert(Matrix4& p_mat)
 		}
 
 		if (copy[i][i] < 0.001f && copy[i][i] > -0.001f) {
+			// FAILURE from mxtypes.h
 			return -1;
 		}
 
@@ -349,6 +352,7 @@ int Matrix4::Invert(Matrix4& p_mat)
 		}
 	}
 
+	// SUCCESS from mxtypes.h
 	return 0;
 }
 

--- a/LEGO1/realtime/matrix4d.inl.h
+++ b/LEGO1/realtime/matrix4d.inl.h
@@ -356,7 +356,7 @@ int Matrix4::Invert(Matrix4& p_mat)
 // FUNCTION: BETA10 0x1005aa20
 void Matrix4::Swap(int p_d1, int p_d2)
 {
-	// TODO: Document entropy build result
+	// This function is affected by entropy even in debug builds
 	int i;
 	float e;
 	for (i = 0; i < 4; i++) {

--- a/LEGO1/realtime/matrix4d.inl.h
+++ b/LEGO1/realtime/matrix4d.inl.h
@@ -353,10 +353,14 @@ int Matrix4::Invert(Matrix4& p_mat)
 }
 
 // FUNCTION: LEGO1 0x1006b500
+// FUNCTION: BETA10 0x1005aa20
 void Matrix4::Swap(int p_d1, int p_d2)
 {
-	for (int i = 0; i < 4; i++) {
-		float e = m_data[p_d1][i];
+	// TODO: Document entropy build result
+	int i;
+	float e;
+	for (i = 0; i < 4; i++) {
+		e = m_data[p_d1][i];
 		m_data[p_d1][i] = m_data[p_d2][i];
 		m_data[p_d2][i] = e;
 	}


### PR DESCRIPTION
Didn't significantly improve the match on `LegoAnimPresenter::FUN_1006b140()`, but I think that function is correct. There is only one minor real diff which is inlined from `Matrix4::Invert()`:
```diff
0x1006b31a : cmp edx, 4
-0x1006b31d : -jge 0x2f
-0x1006b31f : -lea ebx, [edi + edx*4]
+           : +jge 0x34
+           : +mov eax, edx
+           : +mov edx, dword ptr [ebp - 0x48]
+           : +lea ebx, [edx + eax*4]
0x1006b322 : shl ebx, 2
```
However, `Matrix4::Invert()` has a full structural match against BETA10 and I found no trivial changes around the affected location that had an impact on this issue. I think we can close #1357.