### PR TITLE
Remove `GetDriverList` getter

### DIFF
--- a/CONFIG/MainDlg.cpp
+++ b/CONFIG/MainDlg.cpp
@@ -65,7 +65,7 @@ BOOL CMainDialog::OnInitDialog()
 	int device_i = 0;
 	int selected = 0;
 	char device_name[256];
-	const list<MxDriver>& driver_list = enumerator->GetDriverList();
+	const list<MxDriver>& driver_list = enumerator->m_ddInfo;
 	for (list<MxDriver>::const_iterator it_driver = driver_list.begin(); it_driver != driver_list.end(); it_driver++) {
 		const MxDriver& driver = *it_driver;
 		for (list<Direct3DDeviceInfo>::const_iterator it_device = driver.m_devices.begin();

--- a/CONFIG/config.cpp
+++ b/CONFIG/config.cpp
@@ -245,7 +245,7 @@ D3DCOLORMODEL CConfigApp::GetHardwareDeviceColorModel() const
 BOOL CConfigApp::IsPrimaryDriver() const
 {
 	assert(m_driver && m_device_enumerator);
-	return m_driver == &m_device_enumerator->GetDriverList().front();
+	return m_driver == &m_device_enumerator->m_ddInfo.front();
 }
 
 // FUNCTION: CONFIG 0x00403430

--- a/LEGO1/mxdirectx/legodxinfo.cpp
+++ b/LEGO1/mxdirectx/legodxinfo.cpp
@@ -55,7 +55,7 @@ int LegoDeviceEnumerate::ProcessDeviceBytes(int p_deviceNum, GUID& p_guid)
 	GUID4 deviceGuid;
 	memcpy(&deviceGuid, &p_guid, sizeof(GUID4));
 
-	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end(); it++, i++) {
+	for (list<MxDriver>::iterator it = m_ddInfo.begin(); it != m_ddInfo.end(); it++, i++) {
 		if (p_deviceNum >= 0 && p_deviceNum < i) {
 			return -1;
 		}
@@ -90,7 +90,7 @@ int LegoDeviceEnumerate::GetDevice(int p_deviceNum, MxDriver*& p_driver, Direct3
 
 	int i = 0;
 
-	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end(); it++) {
+	for (list<MxDriver>::iterator it = m_ddInfo.begin(); it != m_ddInfo.end(); it++) {
 		p_driver = &*it;
 
 		for (list<Direct3DDeviceInfo>::iterator it2 = p_driver->m_devices.begin(); it2 != p_driver->m_devices.end();
@@ -114,7 +114,7 @@ int LegoDeviceEnumerate::FormatDeviceName(char* p_buffer, const MxDriver* p_ddIn
 	int number = 0;
 	assert(p_ddInfo && p_d3dInfo);
 
-	for (list<MxDriver>::const_iterator it = m_list.begin(); it != m_list.end(); it++, number++) {
+	for (list<MxDriver>::const_iterator it = m_ddInfo.begin(); it != m_ddInfo.end(); it++, number++) {
 		if (&(*it) == p_ddInfo) {
 			GUID4 guid;
 			memcpy(&guid, p_d3dInfo->m_guid, sizeof(GUID4));
@@ -137,7 +137,7 @@ int LegoDeviceEnumerate::BETA_1011cc65(int p_idx, char* p_buffer)
 	int i = 0;
 	int j = 0;
 
-	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end(); it++, i++) {
+	for (list<MxDriver>::iterator it = m_ddInfo.begin(); it != m_ddInfo.end(); it++, i++) {
 		MxDriver& driver = *it;
 		for (list<Direct3DDeviceInfo>::iterator it2 = driver.m_devices.begin(); it2 != driver.m_devices.end(); it2++) {
 
@@ -164,7 +164,7 @@ int LegoDeviceEnumerate::GetBestDevice()
 		return -1;
 	}
 
-	if (m_list.size() == 0) {
+	if (m_ddInfo.size() == 0) {
 		return -1;
 	}
 
@@ -173,7 +173,7 @@ int LegoDeviceEnumerate::GetBestDevice()
 	int k = -1;
 	int cpu_mmx = SupportsMMX();
 
-	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end(); it++, i++) {
+	for (list<MxDriver>::iterator it = m_ddInfo.begin(); it != m_ddInfo.end(); it++, i++) {
 
 		MxDriver& driver = *it;
 		for (list<Direct3DDeviceInfo>::iterator it2 = driver.m_devices.begin(); it2 != driver.m_devices.end(); it2++) {
@@ -297,9 +297,9 @@ int LegoDeviceEnumerate::FUN_1009d210()
 		return -1;
 	}
 
-	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end();) {
+	for (list<MxDriver>::iterator it = m_ddInfo.begin(); it != m_ddInfo.end();) {
 		if (!DriverSupportsRequiredDisplayMode(*it)) {
-			m_list.erase(it++);
+			m_ddInfo.erase(it++);
 			continue;
 		}
 
@@ -315,14 +315,14 @@ int LegoDeviceEnumerate::FUN_1009d210()
 		}
 
 		if (!driver.m_devices.size()) {
-			m_list.erase(it++);
+			m_ddInfo.erase(it++);
 		}
 		else {
 			it++;
 		}
 	}
 
-	if (!m_list.size()) {
+	if (!m_ddInfo.size()) {
 		return -1;
 	}
 
@@ -351,7 +351,7 @@ unsigned char LegoDeviceEnumerate::DriverSupportsRequiredDisplayMode(MxDriver& p
 // FUNCTION: BETA10 0x1011d235
 unsigned char LegoDeviceEnumerate::FUN_1009d3d0(Direct3DDeviceInfo& p_device)
 {
-	if (m_list.size() <= 0) {
+	if (m_ddInfo.size() <= 0) {
 		return FALSE;
 	}
 
@@ -365,7 +365,7 @@ unsigned char LegoDeviceEnumerate::FUN_1009d3d0(Direct3DDeviceInfo& p_device)
 		}
 	}
 
-	MxDriver& front = m_list.front();
+	MxDriver& front = m_ddInfo.front();
 	for (list<Direct3DDeviceInfo>::iterator it = front.m_devices.begin(); it != front.m_devices.end(); it++) {
 		if ((&*it) == &p_device) {
 			return TRUE;

--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -262,7 +262,7 @@ BOOL MxDirect3D::SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_dri
 	assert(d);
 	int i = 0;
 
-	for (list<MxDriver>::iterator it = p_deviceEnumerate.m_list.begin(); it != p_deviceEnumerate.m_list.end();
+	for (list<MxDriver>::iterator it = p_deviceEnumerate.m_ddInfo.begin(); it != p_deviceEnumerate.m_ddInfo.end();
 		 it++, i++) {
 		MxDriver& driver = *it;
 

--- a/LEGO1/mxdirectx/mxdirectxinfo.cpp
+++ b/LEGO1/mxdirectx/mxdirectxinfo.cpp
@@ -197,7 +197,7 @@ MxDeviceEnumerate::~MxDeviceEnumerate()
 BOOL MxDeviceEnumerate::EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName)
 {
 	MxDriver driver(p_guid, p_driverDesc, p_driverName);
-	m_list.push_back(driver);
+	m_ddInfo.push_back(driver);
 
 	// Must be zeroed because held resources are copied by pointer only
 	// and should not be freed at the end of this function
@@ -208,7 +208,7 @@ BOOL MxDeviceEnumerate::EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc
 
 	LPDIRECT3D2 lpDirect3d2 = NULL;
 	LPDIRECTDRAW lpDD = NULL;
-	MxDriver& newDevice = m_list.back();
+	MxDriver& newDevice = m_ddInfo.back();
 	HRESULT result = DirectDrawCreate(newDevice.m_guid, &lpDD, NULL);
 
 	if (result != DD_OK) {
@@ -236,7 +236,7 @@ BOOL MxDeviceEnumerate::EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc
 				}
 				else {
 					if (!newDevice.m_devices.size()) {
-						m_list.pop_back();
+						m_ddInfo.pop_back();
 					}
 				}
 			}
@@ -306,12 +306,12 @@ HRESULT CALLBACK MxDeviceEnumerate::DevicesEnumerateCallback(
 // FUNCTION: BETA10 0x1011e27f
 HRESULT MxDeviceEnumerate::EnumDisplayModesCallback(LPDDSURFACEDESC p_ddsd)
 {
-	assert(m_list.size() > 0);
+	assert(m_ddInfo.size() > 0);
 	assert(p_ddsd);
 
 	// TODO: compat_mode?
 	MxDisplayMode displayMode(p_ddsd->dwWidth, p_ddsd->dwHeight, p_ddsd->ddpfPixelFormat.dwRGBBitCount);
-	m_list.back().m_displayModes.push_back(displayMode);
+	m_ddInfo.back().m_displayModes.push_back(displayMode);
 	return DDENUMRET_OK;
 }
 
@@ -327,7 +327,7 @@ HRESULT MxDeviceEnumerate::EnumDevicesCallback(
 )
 {
 	Direct3DDeviceInfo device(p_guid, p_deviceDesc, p_deviceName, p_HWDesc, p_HELDesc);
-	m_list.back().m_devices.push_back(device);
+	m_ddInfo.back().m_devices.push_back(device);
 	memset(&device, 0, sizeof(device));
 	return DDENUMRET_OK;
 }

--- a/LEGO1/mxdirectx/mxdirectxinfo.h
+++ b/LEGO1/mxdirectx/mxdirectxinfo.h
@@ -218,8 +218,8 @@ public:
 	);
 
 	friend class MxDirect3D;
-
-	const list<MxDriver>& GetDriverList() const { return m_list; }
+	friend class CConfigApp;
+	friend class CMainDialog;
 
 	// SIZE 0x10
 	struct GUID4 {
@@ -240,7 +240,7 @@ public:
 	unsigned char IsInitialized() const { return m_initialized; }
 
 protected:
-	list<MxDriver> m_list;       // 0x04
+	list<MxDriver> m_ddInfo;     // 0x04
 	unsigned char m_initialized; // 0x10
 };
 


### PR DESCRIPTION
`CONFIGD` shows that the list member from `MxDeviceEnumerate` is accessed directly. This removes the now-unused `GetDriverList()` getter and adds the two config classes as friends.

This also renames `m_list` to `m_ddInfo` to match the assert in `EnumDisplayModesCallback`.