### PR TITLE
Improve `FUN_10061010`, other fixes

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -303,4 +303,7 @@ private:
 // TEMPLATE: LEGO1 0x10061750
 // MxListCursor<LegoTranInfo *>::MxListCursor<LegoTranInfo *>
 
+// TEMPLATE: BETA10 0x1004b5d0
+// MxListCursor<LegoTranInfo *>::Next
+
 #endif // LEGOANIMATIONMANAGER_H

--- a/LEGO1/lego/legoomni/include/legotraninfolist.h
+++ b/LEGO1/lego/legoomni/include/legotraninfolist.h
@@ -28,9 +28,11 @@ public:
 // class MxPtrListCursor<LegoTranInfo>
 
 // VTABLE: LEGO1 0x100d8d20
+// VTABLE: BETA10 0x101bad70
 // SIZE 0x10
 class LegoTranInfoListCursor : public MxPtrListCursor<LegoTranInfo> {
 public:
+	// FUNCTION: BETA10 0x100496d0
 	LegoTranInfoListCursor(LegoTranInfoList* p_list) : MxPtrListCursor<LegoTranInfo>(p_list) {}
 };
 
@@ -62,9 +64,14 @@ public:
 // MxPtrList<LegoTranInfo>::`scalar deleting destructor'
 
 // SYNTHETIC: LEGO1 0x100612f0
+// SYNTHETIC: BETA10 0x100498c0
 // LegoTranInfoListCursor::`scalar deleting destructor'
 
+// SYNTHETIC: BETA10 0x10049770
+// MxPtrListCursor<LegoTranInfo>::MxPtrListCursor<LegoTranInfo>
+
 // FUNCTION: LEGO1 0x10061360
+// FUNCTION: BETA10 0x10049910
 // MxPtrListCursor<LegoTranInfo>::~MxPtrListCursor<LegoTranInfo>
 
 // SYNTHETIC: LEGO1 0x100613b0
@@ -77,6 +84,7 @@ public:
 // MxListCursor<LegoTranInfo *>::~MxListCursor<LegoTranInfo *>
 
 // FUNCTION: LEGO1 0x100614e0
+// FUNCTION: BETA10 0x10049ab0
 // LegoTranInfoListCursor::~LegoTranInfoListCursor
 
 #endif // LEGOTRANINFOLIST_H

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -425,6 +425,21 @@ MxBool LegoAnimMMPresenter::FUN_1004b6b0(MxLong p_time)
 // FUNCTION: BETA10 0x1004ce18
 MxBool LegoAnimMMPresenter::FUN_1004b6d0(MxLong p_time)
 {
+#ifdef BETA10
+	switch (m_unk0x58) {
+	case 0:
+		break;
+	case 1:
+		break;
+	case 2:
+		break;
+	case 3:
+		break;
+	case 4:
+		break;
+	}
+#endif
+
 	LegoROI* viewROI = VideoManager()->GetViewROI();
 	LegoPathActor* actor = UserActor();
 
@@ -455,9 +470,13 @@ MxBool LegoAnimMMPresenter::FUN_1004b6d0(MxLong p_time)
 				m_world->PlaceActor(actor);
 			}
 
+#ifdef BETA10
+			actor->VTable0xa8();
+#else
 			if (m_tranInfo->m_unk0x29) {
 				actor->VTable0xa8();
 			}
+#endif
 		}
 
 		actor->SetActorState(LegoPathActor::c_initial);
@@ -491,9 +510,11 @@ void LegoAnimMMPresenter::FUN_1004b840()
 	FUN_1004b6d0(0);
 	EndAction();
 
+#ifndef BETA10
 	if (action != NULL) {
 		Streamer()->FUN_100b98f0(action);
 	}
+#endif
 }
 
 // FUNCTION: LEGO1 0x1004b8b0

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -286,6 +286,7 @@ MxResult LegoWorld::PlaceActor(
 }
 
 // FUNCTION: LEGO1 0x1001fa70
+// FUNCTION: BETA10 0x100da328
 MxResult LegoWorld::PlaceActor(LegoPathActor* p_actor)
 {
 	LegoPathControllerListCursor cursor(&m_pathControllerList);
@@ -301,6 +302,7 @@ MxResult LegoWorld::PlaceActor(LegoPathActor* p_actor)
 }
 
 // FUNCTION: LEGO1 0x1001fb70
+// FUNCTION: BETA10 0x100da3f1
 MxResult LegoWorld::PlaceActor(
 	LegoPathActor* p_actor,
 	LegoAnimPresenter* p_presenter,

--- a/LEGO1/omni/include/mxlist.h
+++ b/LEGO1/omni/include/mxlist.h
@@ -244,11 +244,11 @@ inline MxBool MxListCursor<T>::Next()
 template <class T>
 inline MxBool MxListCursor<T>::Next(T& p_obj)
 {
-	if (!m_match) {
-		m_match = m_list->m_first;
+	if (m_match) {
+		m_match = m_match->GetNext();
 	}
 	else {
-		m_match = m_match->GetNext();
+		m_match = m_list->m_first;
 	}
 
 	if (m_match) {

--- a/LEGO1/realtime/orientableroi.cpp
+++ b/LEGO1/realtime/orientableroi.cpp
@@ -153,6 +153,7 @@ void OrientableROI::UpdateWorldDataWithTransformAndChildren(const Matrix4& p_tra
 }
 
 // FUNCTION: LEGO1 0x100a5a30
+// FUNCTION: BETA10 0x10167d31
 void OrientableROI::SetWorldVelocity(const Vector3& p_world_velocity)
 {
 	m_world_velocity = p_world_velocity;


### PR DESCRIPTION
I tried to match `LegoAnimationManager::FUN_10061010` and got some improvements. I couldn't get one function to inline (specifically `MxListEntry<LegoTranInfo *>::MxListEntry<LegoTranInfo *>` around `LEGO1 0x1006120f`, called from `MxList::Append` -> `MxList::InsertEntry` -> `MxListEntry::MxListEntry`). Not sure if @foxtacles wants to take a look or if we just merge this. #1355 cannot be closed until that issue is fixed, unfortunately. The rest looks like it could match with a different stack layout.