### PR TITLE
Beta match `MxAutoLock` and `MxCriticalSection`

### DIFF
--- a/LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
@@ -98,7 +98,7 @@ void LegoLoadCacheSoundPresenter::DoneTickle()
 // FUNCTION: LEGO1 0x10018700
 MxResult LegoLoadCacheSoundPresenter::PutData()
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_currentTickleState == e_done) {
 		m_cacheSound = SoundManager()->GetCacheSoundManager()->ManageSoundEntry(m_cacheSound);

--- a/LEGO1/lego/legoomni/src/audio/legosoundmanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legosoundmanager.cpp
@@ -46,7 +46,7 @@ MxResult LegoSoundManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 	MxResult result = FAILURE;
 
 	if (MxSoundManager::Create(10, FALSE) == SUCCESS) {
-		m_criticalSection.Enter();
+		ENTER(m_criticalSection);
 		locked = TRUE;
 
 		if (MxOmni::IsSound3D()) {

--- a/LEGO1/lego/legoomni/src/video/legohideanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legohideanimpresenter.cpp
@@ -29,7 +29,7 @@ void LegoHideAnimPresenter::Init()
 // FUNCTION: LEGO1 0x1006da60
 void LegoHideAnimPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_boundaryMap) {
 		delete[] m_boundaryMap;

--- a/LEGO1/lego/legoomni/src/video/legolocomotionanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legolocomotionanimpresenter.cpp
@@ -38,7 +38,7 @@ void LegoLocomotionAnimPresenter::Init()
 // FUNCTION: LEGO1 0x1006d0e0
 void LegoLocomotionAnimPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_unk0xc4) {
 		delete[] m_unk0xc4;

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -33,7 +33,7 @@ void LegoModelPresenter::configureLegoModelPresenter(MxS32 p_modelPresenterConfi
 // FUNCTION: LEGO1 0x1007f670
 void LegoModelPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	m_roi = NULL;
 	m_addedToView = FALSE;
 	m_criticalSection.Leave();

--- a/LEGO1/lego/legoomni/src/video/legopalettepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legopalettepresenter.cpp
@@ -31,7 +31,7 @@ void LegoPalettePresenter::Init()
 // FUNCTION: LEGO1 0x1007a0e0
 void LegoPalettePresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	if (m_palette) {
 		delete m_palette;
 	}

--- a/LEGO1/lego/legoomni/src/video/legopartpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legopartpresenter.cpp
@@ -37,7 +37,7 @@ MxResult LegoPartPresenter::AddToManager()
 // FUNCTION: LEGO1 0x1007c9d0
 void LegoPartPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	VideoManager()->UnregisterPresenter(*this);
 
 	if (m_parts) {

--- a/LEGO1/omni/include/mxautolock.h
+++ b/LEGO1/omni/include/mxautolock.h
@@ -3,15 +3,27 @@
 
 class MxCriticalSection;
 
+#ifdef BETA10
+#define AUTOLOCK(CS) MxAutoLock lock(&CS, __FILE__, __LINE__)
+#else
 #define AUTOLOCK(CS) MxAutoLock lock(&CS)
+#endif
 
 class MxAutoLock {
 public:
+#ifdef BETA10
+	MxAutoLock(MxCriticalSection* p_criticalSection, const char* filename, int line);
+#else
 	MxAutoLock(MxCriticalSection* p_criticalSection);
+#endif
 	~MxAutoLock();
 
 private:
 	MxCriticalSection* m_criticalSection; // 0x00
+
+#ifdef BETA10
+	unsigned long m_currentThreadId; // 0x04
+#endif
 };
 
 #endif // MXAUTOLOCK_H

--- a/LEGO1/omni/include/mxcriticalsection.h
+++ b/LEGO1/omni/include/mxcriticalsection.h
@@ -11,12 +11,23 @@ public:
 
 	static void SetDoMutex();
 
+#ifdef BETA10
+	void Enter(unsigned long p_threadId, const char* filename, int line);
+#else
 	void Enter();
+#endif
 	void Leave();
 
 private:
 	CRITICAL_SECTION m_criticalSection; // 0x00
 	HANDLE m_mutex;                     // 0x18
 };
+
+#ifdef BETA10
+// TODO: Not quite correct yet, the second argument becomes a relocated value
+#define ENTER(criticalSection) criticalSection.Enter(-1, NULL, 0)
+#else
+#define ENTER(criticalSection) criticalSection.Enter()
+#endif
 
 #endif // MXCRITICALSECTION_H

--- a/LEGO1/omni/src/audio/mxaudiomanager.cpp
+++ b/LEGO1/omni/src/audio/mxaudiomanager.cpp
@@ -26,7 +26,7 @@ void MxAudioManager::Init()
 // FUNCTION: LEGO1 0x100b8e00
 void MxAudioManager::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	g_count--;
 	Init();
 	m_criticalSection.Leave();
@@ -43,7 +43,7 @@ MxResult MxAudioManager::Create()
 	MxBool success = FALSE;
 
 	if (MxMediaManager::Create() == SUCCESS) {
-		m_criticalSection.Enter();
+		ENTER(m_criticalSection);
 		success = TRUE;
 		result = SUCCESS;
 		g_count++;
@@ -69,7 +69,7 @@ void MxAudioManager::Destroy()
 // FUNCTION: LEGO1 0x100b8ea0
 void MxAudioManager::SetVolume(MxS32 p_volume)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	m_volume = p_volume;
 	m_criticalSection.Leave();
 }

--- a/LEGO1/omni/src/audio/mxloopingmidipresenter.cpp
+++ b/LEGO1/omni/src/audio/mxloopingmidipresenter.cpp
@@ -39,7 +39,7 @@ void MxLoopingMIDIPresenter::DoneTickle()
 // FUNCTION: LEGO1 0x100c2b00
 MxResult MxLoopingMIDIPresenter::PutData()
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_currentTickleState == e_streaming && m_chunk && !MusicManager()->GetMIDIInitialized()) {
 		SetVolume(((MxDSSound*) m_action)->GetVolume());

--- a/LEGO1/omni/src/audio/mxmidipresenter.cpp
+++ b/LEGO1/omni/src/audio/mxmidipresenter.cpp
@@ -34,7 +34,7 @@ void MxMIDIPresenter::Destroy(MxBool p_fromDestructor)
 		MusicManager()->DeinitializeMIDI();
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_subscriber && m_chunk) {
 		m_subscriber->FreeDataChunk(m_chunk);
@@ -98,7 +98,7 @@ void MxMIDIPresenter::Destroy()
 // FUNCTION: LEGO1 0x100c2970
 MxResult MxMIDIPresenter::PutData()
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_currentTickleState == e_streaming && m_chunk && !MusicManager()->GetMIDIInitialized()) {
 		SetVolume(((MxDSSound*) m_action)->GetVolume());

--- a/LEGO1/omni/src/audio/mxmusicmanager.cpp
+++ b/LEGO1/omni/src/audio/mxmusicmanager.cpp
@@ -53,7 +53,7 @@ void MxMusicManager::Destroy(MxBool p_fromDestructor)
 		TickleManager()->UnregisterClient(this);
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	DeinitializeMIDI();
 	Init();
 	m_criticalSection.Leave();
@@ -146,7 +146,7 @@ MxResult MxMusicManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 
 	if (MxAudioManager::Create() == SUCCESS) {
 		if (p_createThread) {
-			m_criticalSection.Enter();
+			ENTER(m_criticalSection);
 			locked = TRUE;
 			m_thread = new MxTickleThread(this, p_frequencyMS);
 
@@ -183,7 +183,7 @@ void MxMusicManager::Destroy()
 void MxMusicManager::SetVolume(MxS32 p_volume)
 {
 	MxAudioManager::SetVolume(p_volume);
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	SetMIDIVolume();
 	m_criticalSection.Leave();
 }
@@ -191,7 +191,7 @@ void MxMusicManager::SetVolume(MxS32 p_volume)
 // FUNCTION: LEGO1 0x100c0970
 void MxMusicManager::SetMultiplier(MxS32 p_multiplier)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	m_multiplier = p_multiplier;
 	SetMIDIVolume();
 	m_criticalSection.Leave();
@@ -209,7 +209,7 @@ MxResult MxMusicManager::InitializeMIDI(MxU8* p_data, MxS32 p_loopCount)
 {
 	MxResult result = FAILURE;
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (!m_midiInitialized) {
 		MxU32 total = midiOutGetNumDevs();
@@ -278,7 +278,7 @@ done:
 // FUNCTION: LEGO1 0x100c0b20
 void MxMusicManager::DeinitializeMIDI()
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_midiInitialized) {
 		m_midiInitialized = FALSE;

--- a/LEGO1/omni/src/audio/mxmusicpresenter.cpp
+++ b/LEGO1/omni/src/audio/mxmusicpresenter.cpp
@@ -30,7 +30,7 @@ void MxMusicPresenter::Destroy(MxBool p_fromDestructor)
 		MusicManager()->UnregisterPresenter(*this);
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	Init();
 	m_criticalSection.Leave();
 

--- a/LEGO1/omni/src/audio/mxsoundmanager.cpp
+++ b/LEGO1/omni/src/audio/mxsoundmanager.cpp
@@ -52,7 +52,7 @@ void MxSoundManager::Destroy(MxBool p_fromDestructor)
 		TickleManager()->UnregisterClient(this);
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_dsBuffer) {
 		m_dsBuffer->Release();
@@ -77,7 +77,7 @@ MxResult MxSoundManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 		goto done;
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	locked = TRUE;
 
 	if (DirectSoundCreate(NULL, &m_directSound, NULL) != DS_OK) {
@@ -166,7 +166,7 @@ void MxSoundManager::SetVolume(MxS32 p_volume)
 {
 	MxAudioManager::SetVolume(p_volume);
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	MxPresenter* presenter;
 	MxPresenterListCursor cursor(m_presenters);

--- a/LEGO1/omni/src/audio/mxsoundpresenter.cpp
+++ b/LEGO1/omni/src/audio/mxsoundpresenter.cpp
@@ -13,7 +13,7 @@ void MxSoundPresenter::Destroy(MxBool p_fromDestructor)
 		MSoundManager()->UnregisterPresenter(*this);
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	MxMediaPresenter::Init();
 	m_criticalSection.Leave();
 

--- a/LEGO1/omni/src/audio/mxwavepresenter.cpp
+++ b/LEGO1/omni/src/audio/mxwavepresenter.cpp
@@ -294,7 +294,7 @@ void MxWavePresenter::EndAction()
 // FUNCTION: LEGO1 0x100b2300
 void MxWavePresenter::SetVolume(MxS32 p_volume)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	m_volume = p_volume;
 	if (m_dsBuffer != NULL) {

--- a/LEGO1/omni/src/event/mxeventmanager.cpp
+++ b/LEGO1/omni/src/event/mxeventmanager.cpp
@@ -48,7 +48,7 @@ MxResult MxEventManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 	MxResult result = MxMediaManager::Create();
 	if (result == SUCCESS) {
 		if (p_createThread) {
-			this->m_criticalSection.Enter();
+			ENTER(this->m_criticalSection);
 			locked = TRUE;
 			this->m_thread = new MxTickleThread(this, p_frequencyMS);
 

--- a/LEGO1/omni/src/event/mxeventpresenter.cpp
+++ b/LEGO1/omni/src/event/mxeventpresenter.cpp
@@ -50,7 +50,7 @@ void MxEventPresenter::Destroy()
 		EventManager()->UnregisterPresenter(*this);
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_data) {
 		delete[] m_data;

--- a/LEGO1/omni/src/system/mxautolock.cpp
+++ b/LEGO1/omni/src/system/mxautolock.cpp
@@ -2,8 +2,19 @@
 
 #include "mxcriticalsection.h"
 
-// FUNCTION: LEGO1 0x100b8ed0
+#ifdef BETA10
 // FUNCTION: BETA10 0x101386f0
+MxAutoLock::MxAutoLock(MxCriticalSection* p_criticalSection, const char* filename, int line)
+{
+	m_criticalSection = p_criticalSection;
+	m_currentThreadId = GetCurrentThreadId();
+
+	if (m_criticalSection != NULL) {
+		m_criticalSection->Enter(m_currentThreadId, filename, line);
+	}
+}
+#else
+// FUNCTION: LEGO1 0x100b8ed0
 MxAutoLock::MxAutoLock(MxCriticalSection* p_criticalSection)
 {
 	m_criticalSection = p_criticalSection;
@@ -12,6 +23,7 @@ MxAutoLock::MxAutoLock(MxCriticalSection* p_criticalSection)
 		m_criticalSection->Enter();
 	}
 }
+#endif
 
 // FUNCTION: LEGO1 0x100b8ef0
 // FUNCTION: BETA10 0x10138744

--- a/LEGO1/omni/src/system/mxcriticalsection.cpp
+++ b/LEGO1/omni/src/system/mxcriticalsection.cpp
@@ -35,8 +35,35 @@ MxCriticalSection::~MxCriticalSection()
 	}
 }
 
-// FUNCTION: LEGO1 0x100b6d80
+#ifdef BETA10
 // FUNCTION: BETA10 0x1013c725
+void MxCriticalSection::Enter(unsigned long p_threadId, const char* filename, int line)
+{
+	DWORD result;
+	FILE* file;
+
+	if (m_mutex != NULL) {
+		result = WaitForSingleObject(m_mutex, 5000);
+		if (result == WAIT_FAILED) {
+			file = fopen("C:\\DEADLOCK.TXT", "a");
+			if (file != NULL) {
+				fprintf(file, "mutex timeout occurred!\n");
+				fprintf(file, "file: %s, line: %d\n", filename, line);
+				fclose(file);
+			}
+
+			abort();
+		}
+	}
+	else {
+		EnterCriticalSection(&m_criticalSection);
+	}
+
+	// There is way more structure in here, and the MxCriticalSection class is much larger in BETA10.
+	// The LEGO1 compilation is very unlikely to profit from a further decompilation here.
+}
+#else
+// FUNCTION: LEGO1 0x100b6d80
 void MxCriticalSection::Enter()
 {
 	DWORD result;
@@ -58,8 +85,10 @@ void MxCriticalSection::Enter()
 		EnterCriticalSection(&m_criticalSection);
 	}
 }
+#endif
 
 // FUNCTION: LEGO1 0x100b6de0
+// FUNCTION: BETA10 0x1013c7ef
 void MxCriticalSection::Leave()
 {
 	if (m_mutex != NULL) {

--- a/LEGO1/omni/src/video/mxloopingflcpresenter.cpp
+++ b/LEGO1/omni/src/video/mxloopingflcpresenter.cpp
@@ -29,7 +29,7 @@ void MxLoopingFlcPresenter::Init()
 // FUNCTION: LEGO1 0x100b4430
 void MxLoopingFlcPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	Init();
 	m_criticalSection.Leave();
 
@@ -117,7 +117,7 @@ MxResult MxLoopingFlcPresenter::AddToManager()
 	MxBool locked = FALSE;
 
 	if (MxFlcPresenter::AddToManager() == SUCCESS) {
-		m_criticalSection.Enter();
+		ENTER(m_criticalSection);
 		locked = TRUE;
 		result = SUCCESS;
 	}

--- a/LEGO1/omni/src/video/mxloopingsmkpresenter.cpp
+++ b/LEGO1/omni/src/video/mxloopingsmkpresenter.cpp
@@ -29,7 +29,7 @@ void MxLoopingSmkPresenter::Init()
 // FUNCTION: LEGO1 0x100b49d0
 void MxLoopingSmkPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	Init();
 	m_criticalSection.Leave();
 

--- a/LEGO1/omni/src/video/mxsmkpresenter.cpp
+++ b/LEGO1/omni/src/video/mxsmkpresenter.cpp
@@ -32,7 +32,7 @@ void MxSmkPresenter::Init()
 // FUNCTION: LEGO1 0x100b3900
 void MxSmkPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	MxSmk::Destroy(&m_mxSmk);
 	Init();

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -17,7 +17,7 @@ DECOMP_SIZE_ASSERT(MxStillPresenter, 0x6c);
 // FUNCTION: LEGO1 0x100b9c70
 void MxStillPresenter::Destroy(MxBool p_fromDestructor)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_bitmapInfo) {
 		delete[] ((MxU8*) m_bitmapInfo);

--- a/LEGO1/omni/src/video/mxvideomanager.cpp
+++ b/LEGO1/omni/src/video/mxvideomanager.cpp
@@ -52,7 +52,7 @@ void MxVideoManager::Destroy(MxBool p_fromDestructor)
 		TickleManager()->UnregisterClient(this);
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_displaySurface) {
 		delete m_displaySurface;
@@ -152,7 +152,7 @@ MxResult MxVideoManager::VTable0x28(
 		goto done;
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	locked = TRUE;
 
 	m_videoParam = p_videoParam;
@@ -225,7 +225,7 @@ MxResult MxVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyMS,
 		goto done;
 	}
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 	locked = TRUE;
 
 	m_videoParam = p_videoParam;
@@ -300,7 +300,7 @@ void MxVideoManager::Destroy()
 // FUNCTION: LEGO1 0x100bea60
 void MxVideoManager::InvalidateRect(MxRect32& p_rect)
 {
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (m_region) {
 		m_region->AddRect(p_rect);
@@ -340,7 +340,7 @@ MxResult MxVideoManager::RealizePalette(MxPalette* p_palette)
 {
 	PALETTEENTRY paletteEntries[256];
 
-	m_criticalSection.Enter();
+	ENTER(m_criticalSection);
 
 	if (p_palette && m_videoParam.GetPalette()) {
 		p_palette->GetEntries(paletteEntries);


### PR DESCRIPTION
The call signature for locks / critical sections is quite a bit different in BETA10. In particular, they contain file names and line numbers. There are a bunch of original filenames in BETA10 `AUTOLOCK` calls, too, and I have found some discrepancies already. I plan to submit a second PR with the filenames changed.