### PR TITLE
Beta match `MxThread` and `MxSemaphore`

### DIFF
--- a/LEGO1/omni/include/mxsemaphore.h
+++ b/LEGO1/omni/include/mxsemaphore.h
@@ -6,17 +6,20 @@
 #include <windows.h>
 
 // VTABLE: LEGO1 0x100dccf0
+// VTABLE: BETA10 0x101c28ac
 // SIZE 0x08
 class MxSemaphore {
 public:
 	MxSemaphore();
 
 	// FUNCTION: LEGO1 0x100c87e0
+	// FUNCTION: BETA10 0x101592a9
 	~MxSemaphore() { CloseHandle(m_hSemaphore); }
 
 	virtual MxResult Init(MxU32 p_initialCount, MxU32 p_maxCount);
 
-	void Wait(MxU32 p_timeoutMS);
+	void Acquire(MxU32 p_timeoutMS);
+	void TryAcquire();
 	void Release(MxU32 p_releaseCount);
 
 private:

--- a/LEGO1/omni/include/mxthread.h
+++ b/LEGO1/omni/include/mxthread.h
@@ -8,6 +8,7 @@
 class MxCore;
 
 // VTABLE: LEGO1 0x100dc860
+// VTABLE: BETA10 0x101c23e8
 // SIZE 0x1c
 class MxThread {
 public:
@@ -19,9 +20,16 @@ public:
 	void Terminate();
 	void Sleep(MxS32 p_milliseconds);
 
+	void ResumeThread();
+	void SuspendThread();
+	BOOL TerminateThread(MxU32 p_exitCode);
+	MxS32 GetThreadPriority(MxU16& p_priority);
+	BOOL SetThreadPriority(MxU16 p_priority);
+
 	MxBool IsRunning() { return m_running; }
 
 	// SYNTHETIC: LEGO1 0x100bf580
+	// SYNTHETIC: BETA10 0x10147880
 	// MxThread::`scalar deleting destructor'
 
 protected:

--- a/LEGO1/omni/src/stream/mxdiskstreamprovider.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamprovider.cpp
@@ -161,10 +161,11 @@ void MxDiskStreamProvider::VTable0x20(MxDSAction* p_action)
 }
 
 // FUNCTION: LEGO1 0x100d1750
+// FUNCTION: BETA10 0x101632b8
 MxResult MxDiskStreamProvider::WaitForWorkToComplete()
 {
 	while (m_remainingWork) {
-		m_busySemaphore.Wait(INFINITE);
+		m_busySemaphore.Acquire(INFINITE);
 		if (m_unk0x35) {
 			PerformWork();
 		}

--- a/LEGO1/omni/src/system/mxsemaphore.cpp
+++ b/LEGO1/omni/src/system/mxsemaphore.cpp
@@ -6,30 +6,44 @@
 DECOMP_SIZE_ASSERT(MxSemaphore, 0x08)
 
 // FUNCTION: LEGO1 0x100c87d0
+// FUNCTION: BETA10 0x10159260
 MxSemaphore::MxSemaphore()
 {
 	m_hSemaphore = NULL;
 }
 
 // FUNCTION: LEGO1 0x100c8800
+// FUNCTION: BETA10 0x101592d5
 MxResult MxSemaphore::Init(MxU32 p_initialCount, MxU32 p_maxCount)
 {
 	MxResult result = FAILURE;
 
-	if ((m_hSemaphore = CreateSemaphore(NULL, p_initialCount, p_maxCount, NULL))) {
-		result = SUCCESS;
+	m_hSemaphore = CreateSemaphore(NULL, p_initialCount, p_maxCount, NULL);
+	if (!m_hSemaphore) {
+		goto done;
 	}
 
+	result = SUCCESS;
+
+done:
 	return result;
 }
 
 // FUNCTION: LEGO1 0x100c8830
-void MxSemaphore::Wait(MxU32 p_timeoutMS)
+// FUNCTION: BETA10 0x10159332
+void MxSemaphore::Acquire(MxU32 p_timeoutMS)
 {
 	WaitForSingleObject(m_hSemaphore, p_timeoutMS);
 }
 
+// FUNCTION: BETA10 0x10159385
+void MxSemaphore::TryAcquire()
+{
+	WaitForSingleObject(m_hSemaphore, 0);
+}
+
 // FUNCTION: LEGO1 0x100c8850
+// FUNCTION: BETA10 0x101593aa
 void MxSemaphore::Release(MxU32 p_releaseCount)
 {
 	ReleaseSemaphore(m_hSemaphore, p_releaseCount, NULL);

--- a/LEGO1/omni/src/system/mxthread.cpp
+++ b/LEGO1/omni/src/system/mxthread.cpp
@@ -7,14 +7,16 @@
 DECOMP_SIZE_ASSERT(MxThread, 0x1c)
 
 // FUNCTION: LEGO1 0x100bf510
+// FUNCTION: BETA10 0x10147540
 MxThread::MxThread()
 {
 	m_hThread = NULL;
-	m_running = TRUE;
 	m_threadId = 0;
+	m_running = TRUE;
 }
 
 // FUNCTION: LEGO1 0x100bf5a0
+// FUNCTION: BETA10 0x101475d0
 MxThread::~MxThread()
 {
 	if (m_hThread) {
@@ -25,41 +27,82 @@ MxThread::~MxThread()
 typedef unsigned(__stdcall* ThreadFunc)(void*);
 
 // FUNCTION: LEGO1 0x100bf610
+// FUNCTION: BETA10 0x10147655
 MxResult MxThread::Start(MxS32 p_stackSize, MxS32 p_flag)
 {
 	MxResult result = FAILURE;
 
-	if (m_semaphore.Init(0, 1) == SUCCESS) {
-		if ((m_hThread =
-				 _beginthreadex(NULL, p_stackSize * 4, (ThreadFunc) &MxThread::ThreadProc, this, p_flag, &m_threadId)
-			)) {
-			result = SUCCESS;
-		}
+	if (m_semaphore.Init(0, 1) != SUCCESS) {
+		goto done;
 	}
 
+	m_hThread = _beginthreadex(NULL, p_stackSize * 4, (ThreadFunc) &MxThread::ThreadProc, this, p_flag, &m_threadId);
+	if (!m_hThread) {
+		goto done;
+	}
+
+	result = SUCCESS;
+
+done:
 	return result;
 }
 
 // FUNCTION: LEGO1 0x100bf660
+// FUNCTION: BETA10 0x101476ee
 void MxThread::Sleep(MxS32 p_milliseconds)
 {
 	::Sleep(p_milliseconds);
 }
 
+// FUNCTION: BETA10 0x10147710
+void MxThread::ResumeThread()
+{
+	::ResumeThread((HANDLE) m_hThread);
+}
+
+// FUNCTION: BETA10 0x10147733
+void MxThread::SuspendThread()
+{
+	::SuspendThread((HANDLE) m_hThread);
+}
+
+// FUNCTION: BETA10 0x10147756
+BOOL MxThread::TerminateThread(MxU32 p_exitCode)
+{
+	// TerminateThread returns nonzero for success, zero for failure
+	return ::TerminateThread((HANDLE) m_hThread, p_exitCode) == 0;
+}
+
+// FUNCTION: BETA10 0x10147793
+MxS32 MxThread::GetThreadPriority(MxU16& p_priority)
+{
+	return (p_priority = ::GetThreadPriority((HANDLE) m_hThread));
+}
+
+// FUNCTION: BETA10 0x101477c8
+BOOL MxThread::SetThreadPriority(MxU16 p_priority)
+{
+	// SetThreadPriority returns nonzero for success, zero for failure
+	return ::SetThreadPriority((HANDLE) m_hThread, p_priority) == 0;
+}
+
 // FUNCTION: LEGO1 0x100bf670
+// FUNCTION: BETA10 0x1014780a
 void MxThread::Terminate()
 {
 	m_running = FALSE;
-	m_semaphore.Wait(INFINITE);
+	m_semaphore.Acquire(INFINITE);
 }
 
 // FUNCTION: LEGO1 0x100bf680
+// FUNCTION: BETA10 0x1014783b
 unsigned MxThread::ThreadProc(void* p_thread)
 {
 	return static_cast<MxThread*>(p_thread)->Run();
 }
 
 // FUNCTION: LEGO1 0x100bf690
+// FUNCTION: BETA10 0x10147855
 MxResult MxThread::Run()
 {
 	m_semaphore.Release(1);


### PR DESCRIPTION
Matching `MxThread` and `MxSemaphore` where possible, without adding any new members. Includes the uncalled functions for both.