### PR TITLE
Match `LegoOmni::Create()`, other BETA10 matches

### DIFF
--- a/LEGO1/lego/legoomni/include/legobuildingmanager.h
+++ b/LEGO1/lego/legoomni/include/legobuildingmanager.h
@@ -58,7 +58,8 @@ public:
 	// FUNCTION: LEGO1 0x1002f930
 	const char* ClassName() const override // vtable+0x0c
 	{
-		// not in BETA10
+		// While this class exists in BETA10, it didn't have a ClassName().
+		// The constructor suggests that it did not inherit from MxCore back then and did not have a VTABLE.
 		// STRING: LEGO1 0x100f37d0
 		return "LegoBuildingManager";
 	}

--- a/LEGO1/lego/legoomni/include/legomain.h
+++ b/LEGO1/lego/legoomni/include/legomain.h
@@ -109,6 +109,7 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x10058ab0
+	// FUNCTION: BETA10 0x1008f860
 	MxBool IsA(const char* p_name) const override // vtable+0x10
 	{
 		return !strcmp(p_name, LegoOmni::ClassName()) || MxOmni::IsA(p_name);
@@ -148,9 +149,14 @@ public:
 	// FUNCTION: BETA10 0x1009e7a0
 	LegoInputManager* GetInputManager() { return m_inputManager; }
 
+	// FUNCTION: BETA10 0x100e5400
 	LegoTextureContainer* GetTextureContainer() { return m_textureContainer; }
+
 	ViewLODListManager* GetViewLODListManager() { return m_viewLODListManager; }
+
+	// FUNCTION: BETA10 0x100969b0
 	LegoWorld* GetCurrentWorld() { return m_currentWorld; }
+
 	LegoNavController* GetNavController() { return m_navController; }
 	LegoPathActor* GetUserActor() { return m_userActor; }
 
@@ -186,6 +192,7 @@ public:
 	void CloseMainWindow() { PostMessage(m_windowHandle, WM_CLOSE, 0, 0); }
 
 	// SYNTHETIC: LEGO1 0x10058b30
+	// SYNTHETIC: BETA10 0x1008f8d0
 	// LegoOmni::`scalar deleting destructor'
 
 private:

--- a/LEGO1/lego/legoomni/include/legoplantmanager.h
+++ b/LEGO1/lego/legoomni/include/legoplantmanager.h
@@ -32,7 +32,7 @@ public:
 	const char* ClassName() const override // vtable+0x0c
 	{
 		// While this class exists in BETA10, it didn't have a ClassName().
-		// I suppose it did not inherit from MxCore back then and likely did not have a VTABLE.
+		// The constructor suggests that it did not inherit from MxCore back then and did not have a VTABLE.
 		// STRING: LEGO1 0x100f318c
 		return "LegoPlantManager";
 	}

--- a/LEGO1/lego/legoomni/include/legovideomanager.h
+++ b/LEGO1/lego/legoomni/include/legovideomanager.h
@@ -20,6 +20,7 @@ class Renderer;
 }
 
 // VTABLE: LEGO1 0x100d9c88
+// VTABLE: BETA10 0x101bef08
 // SIZE 0x590
 class LegoVideoManager : public MxVideoManager {
 public:
@@ -41,6 +42,7 @@ public:
 	virtual MxPresenter* GetPresenterAt(MxS32 p_x, MxS32 p_y);                                        // vtable+0x38
 
 	// FUNCTION: LEGO1 0x1007ab10
+	// FUNCTION: BETA10 0x100d8010
 	virtual LegoPhonemeList* GetPhonemeList() { return m_phonemeRefList; } // vtable+0x3c
 
 	void SetSkyColor(float p_red, float p_green, float p_blue);
@@ -66,6 +68,10 @@ public:
 	void SetRender3D(MxBool p_render3d) { m_render3d = p_render3d; }
 
 	void SetUnk0x554(MxBool p_unk0x554) { m_unk0x554 = p_unk0x554; }
+
+	// SYNTHETIC: LEGO1 0x1007ab20
+	// SYNTHETIC: BETA10 0x100d8040
+	// LegoVideoManager::`scalar deleting destructor'
 
 private:
 	MxResult CreateDirect3D();
@@ -121,8 +127,5 @@ private:
 	BOOL m_dither;                        // 0x588
 	DWORD m_bufferCount;                  // 0x58c
 };
-
-// SYNTHETIC: LEGO1 0x1007ab20
-// LegoVideoManager::`scalar deleting destructor'
 
 #endif // LEGOVIDEOMANAGER_H

--- a/LEGO1/lego/legoomni/include/legoworldlist.h
+++ b/LEGO1/lego/legoomni/include/legoworldlist.h
@@ -16,12 +16,15 @@ class LegoWorld;
 // class MxPtrList<LegoWorld>
 
 // VTABLE: LEGO1 0x100d8680
+// VTABLE: BETA10 0x101bc900
 // SIZE 0x18
 class LegoWorldList : public MxPtrList<LegoWorld> {
 public:
+	// FUNCTION: BETA10 0x10092ce0
 	LegoWorldList(MxBool p_ownership = FALSE) : MxPtrList<LegoWorld>(p_ownership) {}
 
 	// FUNCTION: LEGO1 0x100598d0
+	// FUNCTION: BETA10 0x10092d80
 	MxS8 Compare(LegoWorld* p_a, LegoWorld* p_b) override { return p_a == p_b ? 0 : p_a < p_b ? -1 : 1; } // vtable+0x14
 
 	// SYNTHETIC: LEGO1 0x10059a00

--- a/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
@@ -15,6 +15,7 @@
 DECOMP_SIZE_ASSERT(MxBackgroundAudioManager, 0x150)
 
 // FUNCTION: LEGO1 0x1007ea90
+// FUNCTION: BETA10 0x100e8530
 MxBackgroundAudioManager::MxBackgroundAudioManager()
 {
 	NotificationManager()->Register(this);

--- a/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
@@ -251,8 +251,8 @@ LegoBuildingManager::~LegoBuildingManager()
 	delete[] g_customizeAnimFile;
 }
 
-// FUNCTION: LEGO1 0x1002f9d0
 // // FUNCTION: BETA10 0x10063a30 -- see the constructor
+// FUNCTION: LEGO1 0x1002f9d0
 void LegoBuildingManager::Init()
 {
 	for (MxS32 i = 0; i < sizeOfArray(g_buildingInfo); i++) {

--- a/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
@@ -47,6 +47,7 @@ MxU8 g_buildingInfoDownshift[16] = {
 };
 
 // GLOBAL: LEGO1 0x100f3478
+// GLOBAL: BETA10 0x101e4d78
 LegoBuildingInfo g_buildingInfoInit[16] = {
 	{
 		NULL, "infocen",
@@ -236,8 +237,11 @@ void LegoBuildingManager::configureLegoBuildingManager(MxS32 p_buildingManagerCo
 }
 
 // FUNCTION: LEGO1 0x1002f8c0
+// FUNCTION: BETA10 0x10063a30
 LegoBuildingManager::LegoBuildingManager()
 {
+	// Note that Init() is inlined in BETA10 and the class did not inherit from MxCore,
+	// so the BETA10 match is much better on Init().
 	Init();
 }
 
@@ -248,6 +252,7 @@ LegoBuildingManager::~LegoBuildingManager()
 }
 
 // FUNCTION: LEGO1 0x1002f9d0
+// // FUNCTION: BETA10 0x10063a30 -- see the constructor
 void LegoBuildingManager::Init()
 {
 	for (MxS32 i = 0; i < sizeOfArray(g_buildingInfo); i++) {

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -60,8 +60,11 @@ char* LegoPlantManager::g_customizeAnimFile = NULL;
 LegoPlantInfo g_plantInfo[81];
 
 // FUNCTION: LEGO1 0x10026220
+// FUNCTION: BETA10 0x100c4f90
 LegoPlantManager::LegoPlantManager()
 {
+	// Note that Init() is inlined in BETA10 and the class did not inherit from MxCore,
+	// so the BETA10 match is much better on Init().
 	Init();
 }
 
@@ -73,11 +76,9 @@ LegoPlantManager::~LegoPlantManager()
 }
 
 // FUNCTION: LEGO1 0x10026330
-// FUNCTION: BETA10 0x100c4f90
+// // FUNCTION: BETA10 0x100c4f90 -- see the constructor
 void LegoPlantManager::Init()
 {
-	// In BETA10 this appears to be LegoPlantManager::LegoPlantManager()
-
 	for (MxS32 i = 0; i < sizeOfArray(g_plantInfo); i++) {
 		g_plantInfo[i] = g_plantInfoInit[i];
 	}

--- a/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoplantmanager.cpp
@@ -75,8 +75,8 @@ LegoPlantManager::~LegoPlantManager()
 	delete[] g_customizeAnimFile;
 }
 
-// FUNCTION: LEGO1 0x10026330
 // // FUNCTION: BETA10 0x100c4f90 -- see the constructor
+// FUNCTION: LEGO1 0x10026330
 void LegoPlantManager::Init()
 {
 	for (MxS32 i = 0; i < sizeOfArray(g_plantInfo); i++) {

--- a/LEGO1/lego/legoomni/src/common/misc.cpp
+++ b/LEGO1/lego/legoomni/src/common/misc.cpp
@@ -127,8 +127,10 @@ LegoBuildingManager* BuildingManager()
 }
 
 // FUNCTION: LEGO1 0x10015800
+// FUNCTION: BETA10 0x100e4bb7
 LegoTextureContainer* TextureContainer()
 {
+	assert(LegoOmni::GetInstance());
 	return LegoOmni::GetInstance()->GetTextureContainer();
 }
 

--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -18,6 +18,7 @@ DECOMP_SIZE_ASSERT(MxTransitionManager, 0x900)
 RECT g_fullScreenRect = {0, 0, 640, 480};
 
 // FUNCTION: LEGO1 0x1004b8d0
+// FUNCTION: BETA10 0x100ec2c0
 MxTransitionManager::MxTransitionManager()
 {
 	m_animationTimer = 0;

--- a/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
+++ b/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
@@ -14,6 +14,7 @@ DECOMP_SIZE_ASSERT(LegoControlManagerNotificationParam, 0x2c)
 DECOMP_SIZE_ASSERT(LegoEventNotificationParam, 0x20)
 
 // FUNCTION: LEGO1 0x10028520
+// STUB: BETA10 0x1008ae50
 LegoControlManager::LegoControlManager()
 {
 	m_presenterList = NULL;

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -26,6 +26,7 @@ const char* g_clickedAtom = NULL;
 MxBool g_unk0x100f67b8 = TRUE;
 
 // FUNCTION: LEGO1 0x1005b790
+// STUB: BETA10 0x10088a8e
 LegoInputManager::LegoInputManager()
 {
 	m_keyboardNotifyList = NULL;
@@ -59,11 +60,13 @@ LegoInputManager::~LegoInputManager()
 }
 
 // FUNCTION: LEGO1 0x1005b960
+// STUB: BETA10 0x10088c9c
 MxResult LegoInputManager::Create(HWND p_hwnd)
 {
 	MxResult result = SUCCESS;
 
 	m_controlManager = new LegoControlManager;
+	assert(m_controlManager);
 
 	if (!m_keyboardNotifyList) {
 		m_keyboardNotifyList = new LegoNotifyList;

--- a/LEGO1/lego/legoomni/src/main/legomain.cpp
+++ b/LEGO1/lego/legoomni/src/main/legomain.cpp
@@ -241,7 +241,7 @@ MxResult LegoOmni::Create(MxOmniCreateParam& p_param)
 	m_buildingManager = new LegoBuildingManager();
 	// LINE: BETA10 0x1008de7b
 	m_gameState = new LegoGameState();
-	// LINE: BETA10 0x0x1008ded5
+	// LINE: BETA10 0x1008ded5
 	m_worldList = new LegoWorldList(TRUE);
 
 	if (!m_viewLODListManager || !m_textureContainer || !m_worldList || !m_characterManager || !m_plantManager ||

--- a/LEGO1/lego/legoomni/src/main/legomain.cpp
+++ b/LEGO1/lego/legoomni/src/main/legomain.cpp
@@ -38,6 +38,7 @@ DECOMP_SIZE_ASSERT(LegoWorldList, 0x18)
 DECOMP_SIZE_ASSERT(LegoWorldListCursor, 0x10)
 
 // GLOBAL: LEGO1 0x100f6718
+// GLOBAL: BETA10 0x101ee748
 // STRING: LEGO1 0x100f6710
 const char* g_current = "current";
 
@@ -48,12 +49,14 @@ LegoOmni::LegoOmni()
 }
 
 // FUNCTION: LEGO1 0x10058b50
+// FUNCTION: BETA10 0x1008d128
 LegoOmni::~LegoOmni()
 {
 	Destroy();
 }
 
 // FUNCTION: LEGO1 0x10058bd0
+// FUNCTION: BETA10 0x1008d1b4
 void LegoOmni::Init()
 {
 	MxOmni::Init();
@@ -76,6 +79,7 @@ void LegoOmni::Init()
 }
 
 // FUNCTION: LEGO1 0x10058c30
+// STUB: BETA10 0x1008d299
 void LegoOmni::Destroy()
 {
 	AUTOLOCK(m_criticalSection);
@@ -151,6 +155,13 @@ void LegoOmni::Destroy()
 	MxOmni::Destroy();
 }
 
+#ifdef BETA10
+// FUNCTION: BETA10 0x100d4e5e
+void EmptyFunction(int p_unknown)
+{
+}
+#endif
+
 // FUNCTION: LEGO1 0x10058e70
 // FUNCTION: BETA10 0x1008d6bf
 MxResult LegoOmni::Create(MxOmniCreateParam& p_param)
@@ -170,40 +181,67 @@ MxResult LegoOmni::Create(MxOmniCreateParam& p_param)
 	if (MxOmni::Create(p_param) != SUCCESS) {
 		goto done;
 	}
-
+	// LINE: BETA10 0x1008d7fa
 	if (!(m_objectFactory = new LegoObjectFactory())) {
 		goto done;
 	}
-
+	// LINE: BETA10 0x1008d882
 	if (!(m_soundManager = new LegoSoundManager()) || m_soundManager->Create(10, 0) != SUCCESS) {
 		delete m_soundManager;
 		m_soundManager = NULL;
 		goto done;
 	}
-
+	// LINE: BETA10 0x1008d990
 	if (!(m_videoManager = new LegoVideoManager()) ||
 		m_videoManager->Create(p_param.GetVideoParam(), 100, 0) != SUCCESS) {
 		delete m_videoManager;
 		m_videoManager = NULL;
 		goto done;
 	}
-
+	// LINE: BETA10 0x1008daa7
 	if (!(m_inputManager = new LegoInputManager()) || m_inputManager->Create(p_param.GetWindowHandle()) != SUCCESS) {
 		delete m_inputManager;
 		m_inputManager = NULL;
 		goto done;
 	}
-
+	// LINE: BETA10 0x1008dbdb
 	m_viewLODListManager = new ViewLODListManager();
+
+	// LINE: BETA10 0x1008dc32
 	m_textureContainer = new LegoTextureContainer();
+
+#ifndef BETA10
 	m_textureContainer->SetOwnership(FALSE);
+#else
+	// One more class is instantiated here in BETA10 that we don't find in LEGO1.
+
+	// Based on `LegoOmni::getTextureContainer()` we know that `LegoTextureContainer` is at LegoOmni's offset 0x230,
+	// so the first instantiation is `LegoTextureContainer` and the second one is the unknown one.
+
+	// We repeat the initialisation of LegoTextureContainer for the sake of a structural match,
+	// even though it is wrong semantically.
+	// LINE: BETA10 0x1008dc89
+	m_textureContainer = new LegoTextureContainer();
+
+	// Something else happens here starting at BETA10 0x1008dcdd that has not been decompiled.
+	// It involves external calls, bit manipulation, and two globals.
+	// Those appear to involve classes that are either not present in LEGO1 or we have the wrong names for them
+	// (like LegoMaterialCache).
+#endif
+
+	// LINE: BETA10 0x1008dd17
 	LegoPathController::Init();
 
 	m_characterManager = new LegoCharacterManager();
+
 	m_plantManager = new LegoPlantManager();
+	// LINE: BETA10 0x1008ddca
 	m_animationManager = new LegoAnimationManager();
+
 	m_buildingManager = new LegoBuildingManager();
+	// LINE: BETA10 0x1008de7b
 	m_gameState = new LegoGameState();
+	// LINE: BETA10 0x0x1008ded5
 	m_worldList = new LegoWorldList(TRUE);
 
 	if (!m_viewLODListManager || !m_textureContainer || !m_worldList || !m_characterManager || !m_plantManager ||
@@ -211,56 +249,83 @@ MxResult LegoOmni::Create(MxOmniCreateParam& p_param)
 		goto done;
 	}
 
-	MxVariable* variable;
-
-	if (!(variable = new VisibilityVariable())) {
+	MxVariable *visibilityVar, *cameraLocationVar, *cursorVar, *whoAmIVar, *debugVar;
+	// LINE: BETA10 0x1008dfbd
+	visibilityVar = new VisibilityVariable();
+	if (!visibilityVar) {
 		goto done;
 	}
-	m_variableTable->SetVariable(variable);
+	m_variableTable->SetVariable(visibilityVar);
 
-	if (!(variable = new CameraLocationVariable())) {
+	// LINE: BETA10 0x1008e031
+	cameraLocationVar = new CameraLocationVariable();
+	if (!cameraLocationVar) {
 		goto done;
 	}
-	m_variableTable->SetVariable(variable);
+	m_variableTable->SetVariable(cameraLocationVar);
 
-	if (!(variable = new CursorVariable())) {
+	// LINE: BETA10 0x1008e0a5
+	cursorVar = new CursorVariable();
+	if (!cursorVar) {
 		goto done;
 	}
-	m_variableTable->SetVariable(variable);
+	m_variableTable->SetVariable(cursorVar);
 
-	if (!(variable = new WhoAmIVariable())) {
+	// LINE: BETA10 0x1008e119
+	whoAmIVar = new WhoAmIVariable();
+	if (!whoAmIVar) {
 		goto done;
 	}
-	m_variableTable->SetVariable(variable);
+	m_variableTable->SetVariable(whoAmIVar);
 
+#ifdef BETA10
+	debugVar = new DebugVariable();
+	if (!debugVar) {
+		goto done;
+	}
+	m_variableTable->SetVariable(debugVar);
+#endif
+
+	// LINE: BETA10 0x1008e201
 	CreateScripts();
+
+#ifndef BETA10
 	IslePathActor::RegisterSpawnLocations();
 	result = RegisterWorlds();
 
 	if (result != SUCCESS) {
 		goto done;
 	}
+#endif
 
-	if (!(m_bkgAudioManager = new MxBackgroundAudioManager())) {
+	// LINE: BETA10 0x1008e206
+	m_bkgAudioManager = new MxBackgroundAudioManager();
+	if (!m_bkgAudioManager) {
 		goto done;
 	}
 
-	if (!(m_transitionManager = new MxTransitionManager())) {
-		goto done;
+	// LINE: BETA10 0x1008e27d
+	m_transitionManager = new MxTransitionManager();
+
+	if (m_transitionManager) {
+		if (m_transitionManager->GetDDrawSurfaceFromVideoManager() != SUCCESS) {
+			goto done;
+		}
+
+#ifdef BETA10
+		NotificationManager()->Register(this);
+		EmptyFunction(0);
+#else
+		m_notificationManager->Register(this);
+		SetAppCursor(e_cursorBusy);
+		m_gameState->SetCurrentAct(LegoGameState::e_act1);
+#endif
+
+		result = SUCCESS;
 	}
-
-	if (m_transitionManager->GetDDrawSurfaceFromVideoManager() != SUCCESS) {
-		goto done;
-	}
-
-	m_notificationManager->Register(this);
-	SetAppCursor(e_cursorBusy);
-	m_gameState->SetCurrentAct(LegoGameState::e_act1);
-
-	result = SUCCESS;
-
 done:
 	return result;
+	// LINE: BETA10 0x1008e35d
 }
 
 // FUNCTION: LEGO1 0x1005a5f0
@@ -375,6 +440,7 @@ LegoWorld* LegoOmni::FindWorld(const MxAtomId& p_atom, MxS32 p_entityid)
 }
 
 // FUNCTION: LEGO1 0x1005b1d0
+// STUB: BETA10 0x1008e93e
 void LegoOmni::DeleteObject(MxDSAction& p_dsAction)
 {
 	if (p_dsAction.GetAtomId().GetInternal() != NULL) {
@@ -427,15 +493,16 @@ LegoROI* LegoOmni::FindROI(const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x1005b2f0
+// FUNCTION: BETA10 0x1008eb66
 MxEntity* LegoOmni::AddToWorld(const char* p_id, MxS32 p_entityId, MxPresenter* p_presenter)
 {
-	LegoWorld* world = NULL;
+	LegoWorld* world;
 
 	if (strcmpi(p_id, g_current)) {
 		world = FindWorld(MxAtomId(p_id, e_lowerCase2), p_entityId);
 	}
 	else {
-		world = this->m_currentWorld;
+		world = GetCurrentWorld();
 	}
 
 	if (world != NULL) {
@@ -446,14 +513,17 @@ MxEntity* LegoOmni::AddToWorld(const char* p_id, MxS32 p_entityId, MxPresenter* 
 }
 
 // FUNCTION: LEGO1 0x1005b3a0
+// FUNCTION: BETA10 0x1008ec27
 void LegoOmni::NotifyCurrentEntity(const MxNotificationParam& p_param)
 {
-	if (m_currentWorld) {
-		NotificationManager()->Send(m_currentWorld, p_param);
+	LegoWorld* currentWorld = GetCurrentWorld();
+	if (currentWorld) {
+		NotificationManager()->Send(currentWorld, p_param);
 	}
 }
 
 // FUNCTION: LEGO1 0x1005b3c0
+// FUNCTION: BETA10 0x1008ec72
 MxBool LegoOmni::DoesEntityExist(MxDSAction& p_dsAction)
 {
 	if (MxOmni::DoesEntityExist(p_dsAction)) {
@@ -559,12 +629,19 @@ void LegoOmni::CreateBackgroundAudio()
 }
 
 // FUNCTION: LEGO1 0x1005b580
+// FUNCTION: BETA10 0x1008f7e0
 MxResult LegoOmni::Start(MxDSAction* p_dsAction)
 {
 	MxResult result = MxOmni::Start(p_dsAction);
+#ifdef BETA10
+	this->m_action = *p_dsAction;
+#else
+	// TODO: This is likely an inlined `MxDsAction::operator=`, see the BETA10 code.
+	// As of this commit, the operator is not inlined automatically.
 	this->m_action.SetAtomId(p_dsAction->GetAtomId());
 	this->m_action.SetObjectId(p_dsAction->GetObjectId());
 	this->m_action.SetUnknown24(p_dsAction->GetUnknown24());
+#endif
 	return result;
 }
 

--- a/LEGO1/lego/legoomni/src/main/scripts.cpp
+++ b/LEGO1/lego/legoomni/src/main/scripts.cpp
@@ -91,6 +91,7 @@ MxAtomId* g_creditsScript = NULL;
 MxAtomId* g_nocdSourceName = NULL;
 
 // FUNCTION: LEGO1 0x100528e0
+// STUB: BETA10 0x100f6133
 void CreateScripts()
 {
 	g_copterScript = new MxAtomId("\\lego\\scripts\\build\\copter", e_lowerCase2);

--- a/LEGO1/lego/legoomni/src/video/legoflctexturepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoflctexturepresenter.cpp
@@ -4,6 +4,8 @@
 #include "misc/legocontainer.h"
 #include "mxdsaction.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoFlcTexturePresenter, 0x70)
 
 // FUNCTION: LEGO1 0x1005de80
@@ -27,11 +29,14 @@ void LegoFlcTexturePresenter::StartingTickle()
 	char* pp;
 	char extraCopy[128];
 	m_action->GetExtra(extraLength, pp);
+	assert(pp);
 
 	if (pp != NULL) {
 		strcpy(extraCopy, pp);
 		strcat(extraCopy, ".gif");
-		m_texture = TextureContainer()->Get(extraCopy);
+		LegoTextureContainer* textureContainer = TextureContainer();
+		assert(textureContainer);
+		m_texture = textureContainer->Get(extraCopy);
 	}
 
 	MxFlcPresenter::StartingTickle();

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -26,6 +26,7 @@ DECOMP_SIZE_ASSERT(MxStopWatch, 0x18)
 DECOMP_SIZE_ASSERT(MxFrequencyMeter, 0x20)
 
 // FUNCTION: LEGO1 0x1007aa20
+// FUNCTION: BETA10 0x100d5a00
 LegoVideoManager::LegoVideoManager()
 {
 	m_renderer = NULL;
@@ -286,12 +287,15 @@ void LegoVideoManager::ToggleFPS(MxBool p_visible)
 }
 
 // FUNCTION: LEGO1 0x1007b770
+// STUB: BETA10 0x100d69cc
 MxResult LegoVideoManager::Tickle()
 {
+#ifndef BETA10
 	if (m_unk0x554 && !m_videoParam.Flags().GetFlipSurfaces() &&
 		TransitionManager()->GetTransitionType() == MxTransitionManager::e_idle) {
 		Sleep(30);
 	}
+#endif
 
 	m_stopWatch->Stop();
 	m_elapsedSeconds = m_stopWatch->ElapsedSeconds();
@@ -514,6 +518,7 @@ void LegoVideoManager::DrawFPS()
 }
 
 // FUNCTION: LEGO1 0x1007c080
+// FUNCTION: BETA10 0x100d6d28
 MxPresenter* LegoVideoManager::GetPresenterAt(MxS32 p_x, MxS32 p_y)
 {
 	MxPresenterListCursor cursor(m_presenters);
@@ -551,6 +556,7 @@ MxPresenter* LegoVideoManager::GetPresenterByActionObjectName(const char* p_acti
 }
 
 // FUNCTION: LEGO1 0x1007c290
+// FUNCTION: BETA10 0x100d731e
 MxResult LegoVideoManager::RealizePalette(MxPalette* p_pallete)
 {
 	if (p_pallete && m_videoParam.GetPalette()) {
@@ -652,6 +658,7 @@ void LegoVideoManager::OverrideSkyColor(MxBool p_shouldOverride)
 }
 
 // FUNCTION: LEGO1 0x1007c4d0
+// FUNCTION: BETA10 0x100d77d3
 void LegoVideoManager::UpdateView(MxU32 p_x, MxU32 p_y, MxU32 p_width, MxU32 p_height)
 {
 	if (p_width == 0) {

--- a/LEGO1/lego/sources/misc/legocontainer.h
+++ b/LEGO1/lego/sources/misc/legocontainer.h
@@ -122,6 +122,10 @@ public:
 	LegoTextureInfo* GetCached(LegoTextureInfo* p_textureInfo);
 	void EraseCached(LegoTextureInfo* p_textureInfo);
 
+	// Verified by LegoOmni::Create(), even though there have been significant changes.
+	// SYNTHETIC: BETA10 0x10093ea0
+	// LegoTextureContainer::LegoTextureContainer
+
 protected:
 	LegoCachedTextureList m_cached; // 0x18
 };

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -780,6 +780,9 @@
 // LIBRARY: BETA10 0x100fa200
 // strcpy
 
+// LIBRARY: BETA10 0x100fa210
+// strcat
+
 // LIBRARY: BETA10 0x100f8a88
 // ??2@YAPAXI@Z
 

--- a/LEGO1/omni/include/mxomni.h
+++ b/LEGO1/omni/include/mxomni.h
@@ -24,6 +24,7 @@ class MxVariableTable;
 class MxVideoManager;
 
 // VTABLE: LEGO1 0x100dc168
+// VTABLE: BETA10 0x101c1c40
 // SIZE 0x68
 class MxOmni : public MxCore {
 public:
@@ -96,6 +97,7 @@ public:
 	MxLong HandleEndAction(MxParam& p_param);
 
 	// SYNTHETIC: LEGO1 0x100aefd0
+	// SYNTHETIC: BETA10 0x10130c90
 	// MxOmni::`scalar deleting destructor'
 
 protected:

--- a/LEGO1/omni/include/mxomnicreateparam.h
+++ b/LEGO1/omni/include/mxomnicreateparam.h
@@ -23,8 +23,13 @@ public:
 	MxOmniCreateFlags& CreateFlags() { return this->m_createFlags; }
 
 	const MxString& GetMediaPath() const { return m_mediaPath; }
+
+	// FUNCTION: BETA10 0x10092c50
 	const HWND GetWindowHandle() const { return m_windowHandle; }
+
+	// FUNCTION: BETA10 0x10092c80
 	MxVideoParam& GetVideoParam() { return m_videoParam; }
+
 	const MxVideoParam& GetVideoParam() const { return m_videoParam; }
 
 	// SYNTHETIC: LEGO1 0x100b0a70

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -37,23 +37,27 @@ MxOmni::MxOmni()
 }
 
 // FUNCTION: LEGO1 0x100aefb0
+// FUNCTION: BETA10 0x10130c50
 MxEntity* MxOmni::AddToWorld(const char*, MxS32, MxPresenter*)
 {
 	return NULL;
 }
 
 // FUNCTION: LEGO1 0x100aefc0
+// FUNCTION: BETA10 0x10130c70
 void MxOmni::NotifyCurrentEntity(const MxNotificationParam& p_param)
 {
 }
 
 // FUNCTION: LEGO1 0x100aeff0
+// STUB: BETA10 0x1012f2b7
 MxOmni::~MxOmni()
 {
 	Destroy();
 }
 
 // FUNCTION: LEGO1 0x100af080
+// FUNCTION: BETA10 0x1012f359
 void MxOmni::Init()
 {
 	m_windowHandle = NULL;
@@ -81,6 +85,8 @@ void MxOmni::SetInstance(MxOmni* p_instance)
 // FUNCTION: BETA10 0x1012f3ff
 MxResult MxOmni::Create(MxOmniCreateParam& p_param)
 {
+	// TODO: File name is MxMain.cpp according to BETA10
+
 	MxResult result = FAILURE;
 
 	if (!(m_atomSet = new MxAtomSet())) {
@@ -223,6 +229,7 @@ void MxOmni::Destroy()
 }
 
 // FUNCTION: LEGO1 0x100b0090
+// STUB: BETA10 0x101303ce
 MxResult MxOmni::Start(MxDSAction* p_dsAction)
 {
 	MxResult result = FAILURE;
@@ -234,6 +241,7 @@ MxResult MxOmni::Start(MxDSAction* p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100b00c0
+// FUNCTION: BETA10 0x101304aa
 void MxOmni::DeleteObject(MxDSAction& p_dsAction)
 {
 	if (m_streamer != NULL) {
@@ -242,6 +250,7 @@ void MxOmni::DeleteObject(MxDSAction& p_dsAction)
 }
 
 // FUNCTION: LEGO1 0x100b00e0
+// FUNCTION: BETA10 0x101304de
 MxResult MxOmni::CreatePresenter(MxStreamController* p_controller, MxDSAction& p_action)
 {
 	MxResult result = FAILURE;
@@ -322,6 +331,7 @@ MxBool MxOmni::ActionSourceEquals(MxDSAction* p_action, const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x100b07f0
+// STUB: BETA10 0x1013082b
 MxLong MxOmni::Notify(MxParam& p_param)
 {
 	AUTOLOCK(m_criticalSection);
@@ -396,6 +406,7 @@ void MxOmni::SetSound3D(MxBool p_use3dSound)
 }
 
 // FUNCTION: LEGO1 0x100b09a0
+// FUNCTION: BETA10 0x101309f5
 MxBool MxOmni::DoesEntityExist(MxDSAction& p_dsAction)
 {
 	if (m_streamer->FUN_100b9b30(p_dsAction)) {

--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -165,6 +165,7 @@ void MxNotificationManager::FlushPending(MxCore* p_listener)
 }
 
 // FUNCTION: LEGO1 0x100acd20
+// STUB: BETA10 0x1012666a
 void MxNotificationManager::Register(MxCore* p_listener)
 {
 	AUTOLOCK(m_lock);

--- a/LEGO1/omni/src/video/mxvideomanager.cpp
+++ b/LEGO1/omni/src/video/mxvideomanager.cpp
@@ -13,6 +13,7 @@
 DECOMP_SIZE_ASSERT(MxVideoManager, 0x64)
 
 // FUNCTION: LEGO1 0x100be1f0
+// STUB: BETA10 0x1012ca40
 MxVideoManager::MxVideoManager()
 {
 	Init();


### PR DESCRIPTION
Closes #1349 

`LegoOmni::Create()` is at 100 % effective for LEGO1 and has a full structural match against BETA10 (up to one short section that has no corresponding part in LEGO1, so I didn't decompile it).

I'll add a comment where I'll leave TODOs for future PRs since this one is quite large already.