### PR TITLE
Add dead code from `LegoCacheSound`

### DIFF
--- a/LEGO1/lego/legoomni/include/legocachsound.h
+++ b/LEGO1/lego/legoomni/include/legocachsound.h
@@ -12,6 +12,7 @@
 class LegoCacheSound : public MxCore {
 public:
 	LegoCacheSound();
+	LegoCacheSound(LegoCacheSound& p_sound);
 	~LegoCacheSound() override; // vtable+0x00
 
 	// FUNCTION: LEGO1 0x10006580
@@ -48,6 +49,10 @@ public:
 	void SetDistance(MxS32 p_min, MxS32 p_max);
 	void MuteSilence(MxBool p_muted);
 	void MuteStop(MxBool p_mute);
+	MxResult GetFrequency(MxULong* p_freq);
+	MxResult SetFrequency(MxULong p_freq);
+	LegoCacheSound& operator=(LegoCacheSound& p_sound);
+	void CopyFrom(LegoCacheSound& p_sound);
 
 	// SYNTHETIC: LEGO1 0x10006610
 	// SYNTHETIC: BETA10 0x100675b0

--- a/LEGO1/lego/legoomni/src/audio/legocachsound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachsound.cpp
@@ -317,6 +317,42 @@ void LegoCacheSound::MuteStop(MxBool p_muted)
 	}
 }
 
+// FUNCTION: BETA10 0x10066f4d
+MxResult LegoCacheSound::GetFrequency(MxULong* p_freq)
+{
+	return m_dsBuffer->GetFrequency(p_freq);
+}
+
+// FUNCTION: BETA10 0x10066f7b
+MxResult LegoCacheSound::SetFrequency(MxULong p_freq)
+{
+	return m_dsBuffer->SetFrequency(p_freq);
+}
+
+// FUNCTION: BETA10 0x10066fa9
+LegoCacheSound::LegoCacheSound(LegoCacheSound& p_sound)
+{
+	CopyFrom(p_sound);
+}
+
+// FUNCTION: BETA10 0x10067062
+LegoCacheSound& LegoCacheSound::operator=(LegoCacheSound& p_sound)
+{
+	if (this == &p_sound) {
+		return *this;
+	}
+
+	CopyFrom(p_sound);
+	return *this;
+}
+
+// FUNCTION: BETA10 0x1006709d
+void LegoCacheSound::CopyFrom(LegoCacheSound& p_sound)
+{
+	MessageBox(NULL, "don't know how to copy DirectSoundBuffer", NULL, MB_OK);
+	assert(0);
+}
+
 // FUNCTION: LEGO1 0x10006d80
 // FUNCTION: BETA10 0x100670e7
 MxString LegoCacheSound::GetBaseFilename(MxString& p_path)


### PR DESCRIPTION
Here we have:

```
(BETA10 addrs)
0x10066f4d - LegoCacheSound::GetFrequency (new -> 100.00%)
0x10066f7b - LegoCacheSound::SetFrequency (new -> 100.00%)
0x10066fa9 - LegoCacheSound::LegoCacheSound(class LegoCacheSound &) (new -> 82.76%)
0x10067062 - LegoCacheSound::operator= (new -> 100.00%)
0x1006709d - LegoCacheSound::CopyFrom (new -> 100.00%)
```

The constructor diff is from not extending `MxCore` in the beta. I guessed at `MxResult` as the return type for `GetFrequency` and `SetFrequency`, but if there's a better choice for wrapping `HRESULT` then I'll change it.

attn #1643