### PR TITLE
Match Mx3DPointFloat overloads on BETA10

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -231,7 +231,7 @@ private:
 	MxBool FUN_100623a0(AnimInfo& p_info);
 	MxBool ModelExists(AnimInfo& p_info, const char* p_name);
 	void FUN_10062580(AnimInfo& p_info);
-	MxBool FUN_10062650(Vector3& p_position, float p_und, LegoROI* p_roi);
+	MxBool FUN_10062650(Mx3DPointFloat& p_position, float p_und, LegoROI* p_roi);
 	MxBool FUN_10062710(AnimInfo& p_info);
 	MxBool FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_presenter);
 	void FUN_10063950(LegoROI* p_roi);

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1794,7 +1794,7 @@ void LegoAnimationManager::FUN_10062580(AnimInfo& p_info)
 
 // FUNCTION: LEGO1 0x10062650
 // FUNCTION: BETA10 0x100436e2
-MxBool LegoAnimationManager::FUN_10062650(Vector3& p_position, float p_und, LegoROI* p_roi)
+MxBool LegoAnimationManager::FUN_10062650(Mx3DPointFloat& p_position, float p_und, LegoROI* p_roi)
 {
 	if (p_roi != NULL) {
 		Mx3DPointFloat position(p_position);

--- a/LEGO1/mxgeometry/mxgeometry3d.h
+++ b/LEGO1/mxgeometry/mxgeometry3d.h
@@ -22,11 +22,11 @@ public:
 	}
 
 	// FUNCTION: LEGO1 0x100343a0
-	// FUNCTION: BETA10 0x10011600
+	// FUNCTION: BETA10 0x100151e0
 	Mx3DPointFloat(const Mx3DPointFloat& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
 
 	// FUNCTION: LEGO1 0x10048ed0
-	// FUNCTION: BETA10 0x100151e0
+	// FUNCTION: BETA10 0x10011600
 	Mx3DPointFloat(const Vector3& p_other) : Vector3(m_elements) { EqualsImpl(p_other.m_data); }
 
 	// FUNCTION: LEGO1 0x10003c10

--- a/LEGO1/viewmanager/viewmanager.cpp
+++ b/LEGO1/viewmanager/viewmanager.cpp
@@ -270,6 +270,7 @@ inline void ViewManager::ManageVisibilityAndDetailRecursively(ViewROI* p_from, i
 			p_from->SetLodLevel(ViewROI::c_lodLevelUnset);
 
 			for (CompoundObject::const_iterator it = comp->begin(); it != comp->end(); it++) {
+				// LINE: BETA10 0x10172bbd
 				ManageVisibilityAndDetailRecursively((ViewROI*) *it, p_lodLevel);
 			}
 		}


### PR DESCRIPTION
As discussed in #1663. We cannot close that ticket yet since there are other functions still to be matched.

There should be no regressions on BETA10 on this one, but a double check wouldn't hurt.

The constructors on `Vector3::Vector3` appear to be the right way round - switchting them causes major regressions with very few improvements.