### PR TITLE
Improve naming for `Equals` in `MxMatrix`

### DIFF
--- a/LEGO1/mxgeometry/mxmatrix.h
+++ b/LEGO1/mxgeometry/mxmatrix.h
@@ -14,10 +14,10 @@ public:
 
 	// FUNCTION: LEGO1 0x10032770
 	// FUNCTION: BETA10 0x1001ff30
-	MxMatrix(const MxMatrix& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
+	MxMatrix(const MxMatrix& p_matrix) : Matrix4(m_elements) { CopyFrom(p_matrix); }
 
 	// FUNCTION: BETA10 0x1000fc20
-	MxMatrix(const Matrix4& p_matrix) : Matrix4(m_elements) { Equals(p_matrix); }
+	MxMatrix(const Matrix4& p_matrix) : Matrix4(m_elements) { CopyFrom(p_matrix); }
 
 	// FUNCTION: BETA10 0x10010860
 	float* operator[](int idx) { return m_data[idx]; }
@@ -25,10 +25,10 @@ public:
 	const float* operator[](int idx) const { return m_data[idx]; }
 
 	// FUNCTION: LEGO1 0x10002850
-	void operator=(const Matrix4& p_matrix) override { Equals(p_matrix); } // vtable+0x28
+	void operator=(const Matrix4& p_matrix) override { CopyFrom(p_matrix); } // vtable+0x28
 
 	// FUNCTION: LEGO1 0x10002860
-	virtual void operator=(const MxMatrix& p_matrix) { Equals(p_matrix); } // vtable+0x48
+	virtual void operator=(const MxMatrix& p_matrix) { CopyFrom(p_matrix); } // vtable+0x48
 
 private:
 	float m_elements[4][4]; // 0x08

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -22,8 +22,8 @@ public:
 	// FUNCTION: BETA10 0x1000fc70
 	Matrix4(float (*p_data)[4]) { SetData(p_data); }
 
-	inline virtual void Equals(float (*p_data)[4]);                                           // vtable+0x04
-	inline virtual void Equals(const Matrix4& p_matrix);                                      // vtable+0x00
+	inline virtual void CopyFrom(float (*p_data)[4]);                                         // vtable+0x04
+	inline virtual void CopyFrom(const Matrix4& p_matrix);                                    // vtable+0x00
 	inline virtual void SetData(float (*p_data)[4]);                                          // vtable+0x0c
 	inline virtual void SetData(UnknownMatrixType& p_matrix);                                 // vtable+0x08
 	inline virtual float (*GetData())[4];                                                     // vtable+0x14

--- a/LEGO1/realtime/matrix4d.inl.h
+++ b/LEGO1/realtime/matrix4d.inl.h
@@ -8,14 +8,14 @@
 
 // FUNCTION: LEGO1 0x10002320
 // FUNCTION: BETA10 0x1000fcb0
-void Matrix4::Equals(float (*p_data)[4])
+void Matrix4::CopyFrom(float (*p_data)[4])
 {
 	memcpy(m_data, p_data, sizeof(float) * 4 * 4);
 }
 
 // FUNCTION: LEGO1 0x10002340
 // FUNCTION: BETA10 0x1000fcf0
-void Matrix4::Equals(const Matrix4& p_matrix)
+void Matrix4::CopyFrom(const Matrix4& p_matrix)
 {
 	memcpy(m_data, p_matrix.m_data, sizeof(float) * 4 * 4);
 }
@@ -84,7 +84,7 @@ void Matrix4::SetIdentity()
 // FUNCTION: BETA10 0x1000ff20
 void Matrix4::operator=(const Matrix4& p_matrix)
 {
-	Equals(p_matrix);
+	CopyFrom(p_matrix);
 }
 
 // FUNCTION: LEGO1 0x10002430


### PR DESCRIPTION
I usually associate a function like `Equals` with an equality check and not with a clone or copy. So renamed the function respectively.