### PR TITLE
Entropy CI: Use new virtualenv upon retry

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Cache venv
       uses: actions/cache@v4
       with:
-        key: venv-entropy-${{ github.run_id }}
+        key: venv-entropy-${{ github.run_id }}-${{ github.run_attempt }}
         path: .venv
 
     - name: Install python packages
@@ -97,7 +97,7 @@ jobs:
     - name: Restore cached virtualenv
       uses: actions/cache@v4
       with:
-        key: venv-entropy-${{ github.run_id }}
+        key: venv-entropy-${{ github.run_id }}-${{ github.run_attempt }}
         path: .venv
   
     - name: Prepare builds
@@ -166,7 +166,7 @@ jobs:
     - name: Restore cached virtualenv
       uses: actions/cache@v4
       with:
-        key: venv-entropy-${{ github.run_id }}
+        key: venv-entropy-${{ github.run_id }}-${{ github.run_attempt }}
         path: .venv
 
     - name: Aggregate Accuracy


### PR DESCRIPTION
To improve response time for the entropy build, we prepare the python virtualenv once, then restore it from cache on each of the 16 build runners and the final job that stitches the JSON files together. 

We had been using `GITHUB_RUN_ID` as part of the cache key, which [does not change between runs](https://docs.github.com/en/actions/reference/workflows-and-actions/variables). I'm not sure why I did it this way, but a recent breaking change to reccmp latest shows the pitfall. The CI is stuck using the same cached virtualenv with reccmp that lacks the bugfix.

This changes the cache key so it now incorporates `GITHUB_RUN_ATTEMPT`. If you need to retry the entropy build for whatever reason, you get a new python virtualenv.

We could just drop the cache altogether. reccmp install time has improved since isledecomp/reccmp#170.

