### PR TITLE
Delete `#if 0` wrappers around nameref annotations

### DIFF
--- a/CONFIG/StdAfx.h
+++ b/CONFIG/StdAfx.h
@@ -9,8 +9,6 @@
 #include <afxcmn.h> // MFC support for Windows Common Controls
 #endif              // _AFX_NO_AFXCMN_SUPPORT
 
-
-
 // FUNCTION: CONFIG 0x402ca0
 // CObject::Serialize
 
@@ -25,7 +23,5 @@
 
 // FUNCTION: CONFIG 0x00403ca0
 // CWnd::EndModalState
-
-
 
 #endif // !defined(AFX_STDAFX_H)

--- a/CONFIG/StdAfx.h
+++ b/CONFIG/StdAfx.h
@@ -9,7 +9,7 @@
 #include <afxcmn.h> // MFC support for Windows Common Controls
 #endif              // _AFX_NO_AFXCMN_SUPPORT
 
-#if 0
+
 
 // FUNCTION: CONFIG 0x402ca0
 // CObject::Serialize
@@ -26,6 +26,6 @@
 // FUNCTION: CONFIG 0x00403ca0
 // CWnd::EndModalState
 
-#endif
+
 
 #endif // !defined(AFX_STDAFX_H)

--- a/ISLE/library_msvc.h
+++ b/ISLE/library_msvc.h
@@ -344,5 +344,3 @@
 
 // GLOBAL: ISLE 0x4139c0
 // __acmdln
-
-

--- a/ISLE/library_msvc.h
+++ b/ISLE/library_msvc.h
@@ -1,4 +1,4 @@
-#ifdef 0
+
 // For ISLE symbols only
 
 // aka `operator new`
@@ -345,4 +345,4 @@
 // GLOBAL: ISLE 0x4139c0
 // __acmdln
 
-#endif
+

--- a/ISLE/library_smartheap.h
+++ b/ISLE/library_smartheap.h
@@ -1,4 +1,4 @@
-#ifdef 0
+
 
 // LIBRARY: ISLE 0x402f10
 // ?shi_New@@YAPAXKIPAU_SHI_Pool@@@Z
@@ -309,4 +309,4 @@
 // GLOBAL: ISLE 0x412870
 // __shi_mutexGlobal
 
-#endif
+

--- a/ISLE/library_smartheap.h
+++ b/ISLE/library_smartheap.h
@@ -308,5 +308,3 @@
 
 // GLOBAL: ISLE 0x412870
 // __shi_mutexGlobal
-
-

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -839,7 +839,6 @@
 // GLOBAL: BETA10 0x102122d0
 // _bufin
 
-
 // LIBRARY: BETA10 0x100f8a88
 // ??2@YAPAXI@Z
 
@@ -1056,13 +1055,10 @@
 // // GLOBAL: LEGO1 0x10098f80
 // c_dfDIKeyboard
 
-
 /// Globals from libraries without symbols
 
 // STRING: LEGO1 0x100dabb0
 static const char* ___crtLCMapStringA_str = "\0";
 
 // STRING: LEGO1 0x100dabb4
-static const wchar_t *___crtLCMapStringA_wstr = L"\0";
-
-
+static const wchar_t* ___crtLCMapStringA_wstr = L"\0";

--- a/LEGO1/library_msvc.h
+++ b/LEGO1/library_msvc.h
@@ -1,4 +1,4 @@
-#if 0
+
 // For LEGO1 symbols only
 
 // aka `operator new`
@@ -1065,4 +1065,4 @@ static const char* ___crtLCMapStringA_str = "\0";
 // STRING: LEGO1 0x100dabb4
 static const wchar_t *___crtLCMapStringA_wstr = L"\0";
 
-#endif
+

--- a/LEGO1/library_smack.h
+++ b/LEGO1/library_smack.h
@@ -29,5 +29,3 @@
 
 // LIBRARY: LEGO1 0x100d0654
 // _SmackRemapTables
-
-

--- a/LEGO1/library_smack.h
+++ b/LEGO1/library_smack.h
@@ -1,4 +1,4 @@
-#if 0
+
 
 // LIBRARY: LEGO1 0x100cd782
 // LIBRARY: BETA10 0x1015fb82
@@ -30,4 +30,4 @@
 // LIBRARY: LEGO1 0x100d0654
 // _SmackRemapTables
 
-#endif
+

--- a/LEGO1/library_smartheap.h
+++ b/LEGO1/library_smartheap.h
@@ -1,4 +1,4 @@
-#if 0
+
 
 // LIBRARY: LEGO1 0x100861d0
 // ?shi_New@@YAPAXKIPAU_SHI_Pool@@@Z
@@ -309,4 +309,4 @@
 // GLOBAL: LEGO1 0x101095e0
 // __shi_mutexGlobal
 
-#endif
+

--- a/LEGO1/library_smartheap.h
+++ b/LEGO1/library_smartheap.h
@@ -308,5 +308,3 @@
 
 // GLOBAL: LEGO1 0x101095e0
 // __shi_mutexGlobal
-
-


### PR DESCRIPTION
The new `reccmp` code parser I'm working on has limited preprocessor evaluation for `0` and `1` constants. The end result is that these annotations would be completely dropped.

`LEGO1/library_msvc.h` has live code (strings), but it is never part of a build.