### PR TITLE
BETA10-only assertion in Act3Cop::ParseAction

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -275,7 +275,9 @@ void Act3Cop::ParseAction(char* p_extra)
 		}
 	}
 
+#ifdef BETA10
 	assert(m_eatAnim);
+#endif
 }
 
 // FUNCTION: LEGO1 0x100401f0


### PR DESCRIPTION
This assertion fails with retail data on every platform whenever asserts are enabled, aborting the game as soon as the Act 3 world loads. It is the root cause of isledecomp/isle-portable#523 ("ARM devices: Game exit when completing helicopter build for act 3") — the failure is not actually ARM-specific; it reproduces identically on x86_64. The reporters were simply running assert-enabled builds while most x86 users run Release artifacts with `NDEBUG`.

Root cause: in ACT3.SI, the two cops' extra strings separate the animation pairs with a comma instead of a semicolon:

```
Animation:Laura_Walk;1.0,Laura_Eat;-1.0
Animation:Nick_Walk;1.0,Nick_Eat;-1.0
```

(compare the Brickster, which uses semicolons throughout: `Animation:Brickstr_Shoot;-1.0;Brickstr_Walk;1.0;`)

`KeyValueStringParse` (LEGO1 0x100b7050) terminates the extracted value at the first comma — commas legitimately end the ANIMATION value elsewhere in the retail data (e.g. `RcRhod02_Anim;30, ` in CARRACE.SI). So `Laura_Eat;-1.0` and `Nick_Eat;-1.0` are dropped, no anim map with world speed -1.0 exists, and `m_eatAnim` remains NULL. Retail is unaffected by this data bug because `m_eatAnim` is never read anywhere — it is only assigned — so the eat animations silently never loaded in the original game either.

Verified on macOS by loading Act 3 in a Debug build: aborts at this assertion on both arm64 and x86_64 (Rosetta); with the assertion guarded, Act 3 loads and runs normally.
