### PR TITLE
Omni source-shape restoration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ if (MSVC)
   # Visual C++ 4.2 -> cl version 10.2.0
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0")
     set(MSVC_FOR_DECOMP TRUE)
+  else()
+    # The decompiled source preserves 1997 semantics where a for-loop
+    # variable leaks into the enclosing scope.
+    add_compile_options("/Zc:forScope-")
   endif()
 endif()
 

--- a/LEGO1/mxstl/mxstl.h
+++ b/LEGO1/mxstl/mxstl.h
@@ -146,8 +146,10 @@ public:
   typedef Multiset<_K, _Pr> _Myt;
   typedef allocator<_K> _A;
 
-  explicit Multiset(const _Pr& _Pred = _Pr())
-    : multiset<_K, _Pr, _A>(_Pred)
+  explicit Multiset() : multiset<_K, _Pr, _A>()
+  {}
+
+  explicit Multiset(const _Pr& _Pred) : multiset<_K, _Pr, _A>(_Pred)
   {}
 
   void swap(_Myt& _X)
@@ -168,7 +170,10 @@ public:
   typedef Vector<_TYPE> _Myt;
   typedef allocator<_TYPE> _A;
 
-  explicit Vector(const _A& _Al = _A()) : vector<_TYPE, _A>(_Al)
+  explicit Vector() : vector<_TYPE, _A>()
+  {}
+
+  explicit Vector(size_type _N, const _TYPE& _V = _TYPE()) : vector<_TYPE, _A>(_N, _V)
   {}
 
   void swap(_Myt& _X)

--- a/LEGO1/omni/include/mxactionnotificationparam.h
+++ b/LEGO1/omni/include/mxactionnotificationparam.h
@@ -69,7 +69,16 @@ public:
 	{
 	}
 
-	MxNotificationParam* Clone() const override; // vtable+0x04
+	// FUNCTION: LEGO1 0x100b0300
+	MxNotificationParam* Clone() const override
+	{
+		return new MxStartActionNotificationParam(
+			c_notificationStartAction,
+			this->m_sender,
+			this->m_action,
+			this->m_realloc
+		);
+	} // vtable+0x04
 };
 
 // VTABLE: LEGO1 0x100d8358
@@ -98,7 +107,11 @@ public:
 		m_unk0x14 = p_unk0x14;
 	}
 
-	MxNotificationParam* Clone() const override; // vtable+0x04
+	// FUNCTION: LEGO1 0x100b04f0
+	MxNotificationParam* Clone() const override
+	{
+		return new MxType4NotificationParam(this->m_sender, this->m_action, this->m_unk0x14);
+	} // vtable+0x04
 
 private:
 	MxPresenter* m_unk0x14; // 0x14

--- a/LEGO1/omni/include/mxdsbuffer.h
+++ b/LEGO1/omni/include/mxdsbuffer.h
@@ -89,24 +89,24 @@ public:
 	// FUNCTION: BETA10 0x10164260
 	void SetMode(Type p_mode) { m_mode = p_mode; }
 
-	void SetUnk30(MxDSStreamingAction* p_unk0x30) { m_unk0x30 = p_unk0x30; }
+	void SetParentRequest(MxDSStreamingAction* p_parentRequest) { m_parentRequest = p_parentRequest; }
 
 	// SYNTHETIC: LEGO1 0x100c6510
 	// SYNTHETIC: BETA10 0x10158530
 	// MxDSBuffer::`scalar deleting destructor'
 
 private:
-	MxU8* m_pBuffer;                // 0x08
-	MxU8* m_pIntoBuffer;            // 0x0c
-	MxU8* m_pIntoBuffer2;           // 0x10
-	undefined4 m_unk0x14;           // 0x14
-	undefined4 m_unk0x18;           // 0x18
-	undefined4 m_unk0x1c;           // 0x1c
-	MxU16 m_referenceCount;         // 0x20
-	Type m_mode;                    // 0x24
-	MxU32 m_writeOffset;            // 0x28
-	MxU32 m_bytesRemaining;         // 0x2c
-	MxDSStreamingAction* m_unk0x30; // 0x30
+	MxU8* m_pBuffer;                      // 0x08
+	MxU8* m_pIntoBuffer;                  // 0x0c
+	MxU8* m_pIntoBuffer2;                 // 0x10
+	undefined4 m_unk0x14;                 // 0x14
+	undefined4 m_unk0x18;                 // 0x18
+	undefined4 m_unk0x1c;                 // 0x1c
+	MxU16 m_referenceCount;               // 0x20
+	Type m_mode;                          // 0x24
+	MxU32 m_writeOffset;                  // 0x28
+	MxU32 m_bytesRemaining;               // 0x2c
+	MxDSStreamingAction* m_parentRequest; // 0x30
 };
 
 #endif // MXDSBUFFER_H

--- a/LEGO1/omni/include/mxdsfile.h
+++ b/LEGO1/omni/include/mxdsfile.h
@@ -50,7 +50,7 @@ public:
 	// FUNCTION: BETA10 0x1015e110
 	void SetFileName(const char* p_filename) { m_filename = p_filename; }
 
-	MxS32 CalcFileSize() { return GetFileSize(m_io.m_info.hmmio, NULL); }
+	MxS32 CalcFileSize() { return GetFileSize(m_io.hmmio, NULL); }
 
 	// SYNTHETIC: LEGO1 0x100c01e0
 	// SYNTHETIC: BETA10 0x10148e40

--- a/LEGO1/omni/include/mxdsstreamingaction.h
+++ b/LEGO1/omni/include/mxdsstreamingaction.h
@@ -19,7 +19,7 @@ public:
 	MxBool HasId(MxU32 p_objectId) override; // vtable+0x34
 
 	void Init();
-	void SetInternalAction(MxDSAction* p_dsAction);
+	void SetAction(MxDSAction* p_dsAction);
 	void FUN_100cd2d0();
 
 	// FUNCTION: BETA10 0x10156530
@@ -37,7 +37,7 @@ public:
 	// FUNCTION: BETA10 0x10159190
 	MxLong GetUnknowna8() { return m_unk0xa8; }
 
-	MxDSAction* GetInternalAction() { return m_internalAction; }
+	MxDSAction* GetAction() { return m_internalAction; }
 
 	// FUNCTION: BETA10 0x10156580
 	MxU32 GetBufferOffset() { return m_bufferOffset; }

--- a/LEGO1/omni/include/mxgeometry.h
+++ b/LEGO1/omni/include/mxgeometry.h
@@ -145,7 +145,7 @@ public:
 	void operator&=(const MxRect& p_r)
 	{
 		m_left = Max(p_r.m_left, m_left);
-		m_top = Max(p_r.m_top, m_top);
+		m_top = Max(m_top, p_r.m_top);
 		m_right = Min(p_r.m_right, m_right);
 		m_bottom = Min(p_r.m_bottom, m_bottom);
 	}

--- a/LEGO1/omni/include/mxhashtable.h
+++ b/LEGO1/omni/include/mxhashtable.h
@@ -149,9 +149,11 @@ MxHashTable<T>::~MxHashTable()
 template <class T>
 void MxHashTable<T>::DeleteAll()
 {
+	MxHashTableNode<T>* t;
+	MxHashTableNode<T>* next;
+
 	for (MxS32 i = 0; i < m_numSlots; i++) {
-		MxHashTableNode<T>* next;
-		for (MxHashTableNode<T>* t = m_slots[i]; t != NULL; t = next) {
+		for (t = m_slots[i]; t != NULL; t = next) {
 			next = t->m_next;
 			this->m_customDestructor(t->m_obj);
 			delete t;
@@ -169,6 +171,8 @@ inline void MxHashTable<T>::Resize()
 	// so we can walk nodes and re-insert
 	MxU32 oldSize = m_numSlots;
 	MxHashTableNode<T>** oldTable = m_slots;
+	MxHashTableNode<T>* t;
+	MxHashTableNode<T>* next;
 
 	switch (m_resizeOption) {
 	case e_expandAll:
@@ -185,8 +189,7 @@ inline void MxHashTable<T>::Resize()
 	this->m_count = 0;
 
 	for (MxS32 i = 0; i < oldSize; i++) {
-		MxHashTableNode<T>* next;
-		for (MxHashTableNode<T>* t = oldTable[i]; t != NULL; t = next) {
+		for (t = oldTable[i]; t != NULL; t = next) {
 			next = t->m_next;
 			NodeInsert(t);
 		}

--- a/LEGO1/omni/include/mxio.h
+++ b/LEGO1/omni/include/mxio.h
@@ -4,17 +4,15 @@
 #include "mxtypes.h"
 
 // mmsystem.h requires inclusion of windows.h before
-// clang-format off
 #include <windows.h>
 #include <mmsystem.h>
-// clang-format on
 
 #if defined(_M_IX86) || defined(__i386__)
 #define MXIO_MINFO_MFILE
 #endif
 
 // SIZE 0x48
-class MXIOINFO {
+class MXIOINFO : public MMIOINFO {
 public:
 	MXIOINFO();
 	~MXIOINFO();
@@ -33,7 +31,6 @@ public:
 
 	// NOTE: In MXIOINFO, the `hmmio` member of MMIOINFO is used like
 	// an HFILE (int) instead of an HMMIO (WORD).
-	MMIOINFO m_info;
 #ifndef MXIO_MINFO_MFILE
 	HFILE m_file;
 #endif

--- a/LEGO1/omni/include/mxlist.h
+++ b/LEGO1/omni/include/mxlist.h
@@ -130,8 +130,9 @@ public:
 template <class T>
 inline void MxList<T>::DeleteAll()
 {
+	MxListEntry<T>* t;
 	MxListEntry<T>* next;
-	for (MxListEntry<T>* t = m_first; t; t = next) {
+	for (t = m_first; t; t = next) {
 		next = t->GetNext();
 		this->m_customDestructor(t->GetValue());
 		delete t;

--- a/LEGO1/omni/include/mxnextactiondatastart.h
+++ b/LEGO1/omni/include/mxnextactiondatastart.h
@@ -10,10 +10,8 @@ class MxNextActionDataStart : public MxCore {
 public:
 	// inlined constructor at 0x100c1847
 	MxNextActionDataStart(MxU32 p_objectId, MxS16 p_unk0x24, MxU32 p_data)
+		: m_objectId(p_objectId), m_unk0x24(p_unk0x24), m_data(p_data)
 	{
-		m_objectId = p_objectId;
-		m_unk0x24 = p_unk0x24;
-		m_data = p_data;
 	}
 
 	// FUNCTION: LEGO1 0x100c1900

--- a/LEGO1/omni/include/mxnotificationmanager.h
+++ b/LEGO1/omni/include/mxnotificationmanager.h
@@ -28,12 +28,12 @@ class MxNotificationPtrList : public list<MxNotification*> {};
 // VTABLE: LEGO1 0x100dc078
 class MxNotificationManager : public MxCore {
 private:
-	MxNotificationPtrList* m_queue;    // 0x08
-	MxNotificationPtrList* m_sendList; // 0x0c
-	MxCriticalSection m_lock;          // 0x10
-	MxS32 m_unk0x2c;                   // 0x2c
-	MxIdList m_listenerIds;            // 0x30
-	MxBool m_active;                   // 0x3c
+	MxNotificationPtrList* m_postNotificationQueue; // 0x08
+	MxNotificationPtrList* m_flashQueue;            // 0x0c
+	MxCriticalSection m_lock;                       // 0x10
+	MxS32 m_unk0x2c;                                // 0x2c
+	MxIdList m_listenerIds;                         // 0x30
+	MxBool m_active;                                // 0x3c
 
 public:
 	MxNotificationManager();
@@ -46,23 +46,23 @@ public:
 	void Unregister(MxCore* p_listener);
 	MxResult Send(MxCore* p_listener, const MxNotificationParam& p_param);
 
-	MxNotificationPtrList* GetQueue() { return m_queue; }
+	MxNotificationPtrList* GetQueue() { return m_postNotificationQueue; }
 
 	// FUNCTION: BETA10 0x10132270
 	void SetActive(MxBool p_active) { m_active = p_active; }
 
 	// FUNCTION: BETA10 0x10132230
-	MxBool IsEmpty() const { return m_queue ? m_queue->empty() : TRUE; }
+	MxBool IsEmpty() const { return m_postNotificationQueue ? m_postNotificationQueue->empty() : TRUE; }
 
 	// SYNTHETIC: LEGO1 0x100ac390
 	// MxNotificationManager::`scalar deleting destructor'
 
 private:
-	void FlushPending(MxCore* p_listener);
+	void FlushPending(MxCore* p_object);
 };
 
-// TEMPLATE: LEGO1 0x100ac320
-// list<unsigned int,allocator<unsigned int> >::~list<unsigned int,allocator<unsigned int> >
+// TEMPLATE: LEGO1 0x100ac320 SYMBOL
+// ??1?$list@IV?$allocator@I@@@@QAE@XZ
 
 // FUNCTION: LEGO1 0x100ac3b0
 // MxIdList::~MxIdList
@@ -73,20 +73,20 @@ private:
 // TEMPLATE: LEGO1 0x100ac540
 // List<MxNotification *>::~List<MxNotification *>
 
-// TEMPLATE: LEGO1 0x100ac590
-// list<MxNotification *,allocator<MxNotification *> >::~list<MxNotification *,allocator<MxNotification *> >
+// TEMPLATE: LEGO1 0x100ac590 SYMBOL
+// ??1?$list@PAVMxNotification@@V?$allocator@PAVMxNotification@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x100acbf0
-// list<MxNotification *,allocator<MxNotification *> >::begin
+// TEMPLATE: LEGO1 0x100acbf0 SYMBOL
+// ?begin@?$list@PAVMxNotification@@V?$allocator@PAVMxNotification@@@@@@QAE?AViterator@1@XZ
 
-// TEMPLATE: LEGO1 0x100acc00
-// list<MxNotification *,allocator<MxNotification *> >::insert
+// TEMPLATE: LEGO1 0x100acc00 SYMBOL
+// ?insert@?$list@PAVMxNotification@@V?$allocator@PAVMxNotification@@@@@@QAE?AViterator@1@V21@ABQAVMxNotification@@@Z
 
-// TEMPLATE: LEGO1 0x100acc50
-// list<MxNotification *,allocator<MxNotification *> >::erase
+// TEMPLATE: LEGO1 0x100acc50 SYMBOL
+// ?erase@?$list@PAVMxNotification@@V?$allocator@PAVMxNotification@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x100acca0
-// list<MxNotification *,allocator<MxNotification *> >::_Buynode
+// TEMPLATE: LEGO1 0x100acca0 SYMBOL
+// ?_Buynode@?$list@PAVMxNotification@@V?$allocator@PAVMxNotification@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
 // SYNTHETIC: LEGO1 0x100accd0
 // MxNotificationPtrList::~MxNotificationPtrList

--- a/LEGO1/omni/include/mxsemaphore.h
+++ b/LEGO1/omni/include/mxsemaphore.h
@@ -12,9 +12,7 @@ class MxSemaphore {
 public:
 	MxSemaphore();
 
-	// FUNCTION: LEGO1 0x100c87e0
-	// FUNCTION: BETA10 0x101592a9
-	~MxSemaphore() { CloseHandle(m_hSemaphore); }
+	~MxSemaphore();
 
 	virtual MxResult Init(MxU32 p_initialCount, MxU32 p_maxCount);
 

--- a/LEGO1/omni/include/mxsoundmanager.h
+++ b/LEGO1/omni/include/mxsoundmanager.h
@@ -23,7 +23,7 @@ public:
 
 	LPDIRECTSOUND GetDirectSound() { return m_directSound; }
 
-	MxS32 GetAttenuation(MxU32 p_volume);
+	MxS32 GetAttenuation(MxU32 p_percent);
 
 	MxPresenter* FindPresenter(const MxAtomId& p_atomId, MxU32 p_objectId);
 

--- a/LEGO1/omni/include/mxvideopresenter.h
+++ b/LEGO1/omni/include/mxvideopresenter.h
@@ -108,7 +108,6 @@ public:
 		MxU16 m_height;  // 0x08
 	};
 
-	inline MxS32 PrepareRects(RECT& p_rectDest, RECT& p_rectSrc);
 	MxBitmap* GetBitmap() { return m_frameBitmap; }
 	AlphaMask* GetAlphaMask() { return m_alpha; }
 

--- a/LEGO1/omni/src/action/mxdsaction.cpp
+++ b/LEGO1/omni/src/action/mxdsaction.cpp
@@ -10,10 +10,6 @@
 
 DECOMP_SIZE_ASSERT(MxDSAction, 0x94)
 
-// GLOBAL: LEGO1 0x10101410
-// GLOBAL: BETA10 0x10201f5c
-MxU16 g_sep = TWOCC(',', ' ');
-
 // FUNCTION: LEGO1 0x100ad810
 // FUNCTION: BETA10 0x1012afd0
 MxDSAction::MxDSAction()
@@ -230,13 +226,13 @@ void MxDSAction::AppendExtra(MxU16 p_extraLength, const char* p_extraData)
 
 	if (p_extraData) {
 		if (m_extraLength) {
-			char* newExtra = new char[p_extraLength + m_extraLength + sizeof(g_sep)];
+			char* newExtra = new char[p_extraLength + m_extraLength + 2];
 			assert(newExtra);
 			memcpy(newExtra, m_extraData, m_extraLength);
-			memcpy(&newExtra[m_extraLength], &g_sep, sizeof(g_sep));
-			memcpy(&newExtra[m_extraLength + sizeof(g_sep)], p_extraData, p_extraLength);
+			memcpy(&newExtra[m_extraLength], ", ", 2);
+			memcpy(&newExtra[m_extraLength + 2], p_extraData, p_extraLength);
 
-			m_extraLength += p_extraLength + sizeof(g_sep);
+			m_extraLength += p_extraLength + 2;
 			delete[] m_extraData;
 			m_extraData = newExtra;
 		}

--- a/LEGO1/omni/src/action/mxdsanim.cpp
+++ b/LEGO1/omni/src/action/mxdsanim.cpp
@@ -31,7 +31,7 @@ MxDSAnim::MxDSAnim(MxDSAnim& p_dsAnim) : MxDSMediaAction(p_dsAnim)
 // FUNCTION: BETA10 0x1015ceea
 MxDSAnim& MxDSAnim::operator=(MxDSAnim& p_dsAnim)
 {
-	if (this == &p_dsAnim) {
+	if (&p_dsAnim == this) {
 		return *this;
 	}
 

--- a/LEGO1/omni/src/action/mxdsobjectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsobjectaction.cpp
@@ -31,7 +31,7 @@ MxDSObjectAction::MxDSObjectAction(MxDSObjectAction& p_dsObjectAction) : MxDSMed
 // FUNCTION: BETA10 0x1015c529
 MxDSObjectAction& MxDSObjectAction::operator=(MxDSObjectAction& p_dsObjectAction)
 {
-	if (this == &p_dsObjectAction) {
+	if (&p_dsObjectAction == this) {
 		return *this;
 	}
 

--- a/LEGO1/omni/src/action/mxdsselectaction.cpp
+++ b/LEGO1/omni/src/action/mxdsselectaction.cpp
@@ -124,7 +124,7 @@ void MxDSSelectAction::Deserialize(MxU8*& p_source, MxS16 p_flags)
 		MxS32 index = -1;
 		m_unk0xac->DeleteAll();
 
-		MxU32 i;
+		MxS32 i;
 		for (i = 0; i < count; i++) {
 			if (!strcmp(string.GetData(), (char*) p_source)) {
 				index = i;

--- a/LEGO1/omni/src/action/mxdsstreamingaction.cpp
+++ b/LEGO1/omni/src/action/mxdsstreamingaction.cpp
@@ -71,14 +71,14 @@ MxDSStreamingAction* MxDSStreamingAction::CopyFrom(MxDSStreamingAction& p_dsStre
 	m_unk0xa4 = NULL;
 	m_unk0xac = p_dsStreamingAction.m_unk0xac;
 	m_unk0xa8 = p_dsStreamingAction.m_unk0xa8;
-	SetInternalAction(p_dsStreamingAction.m_internalAction ? p_dsStreamingAction.m_internalAction->Clone() : NULL);
+	SetAction(p_dsStreamingAction.m_internalAction ? p_dsStreamingAction.m_internalAction->Clone() : NULL);
 
 	return this;
 }
 
 // FUNCTION: LEGO1 0x100cd2a0
 // FUNCTION: BETA10 0x1015f698
-void MxDSStreamingAction::SetInternalAction(MxDSAction* p_dsAction)
+void MxDSStreamingAction::SetAction(MxDSAction* p_dsAction)
 {
 	if (m_internalAction) {
 		delete m_internalAction;

--- a/LEGO1/omni/src/audio/mxsoundmanager.cpp
+++ b/LEGO1/omni/src/audio/mxsoundmanager.cpp
@@ -9,6 +9,8 @@
 #include "mxticklethread.h"
 #include "mxwavepresenter.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(MxSoundManager, 0x3c);
 
 // GLOBAL: LEGO1 0x10101420
@@ -203,15 +205,17 @@ MxPresenter* MxSoundManager::FindPresenter(const MxAtomId& p_atomId, MxU32 p_obj
 }
 
 // FUNCTION: LEGO1 0x100aecf0
-MxS32 MxSoundManager::GetAttenuation(MxU32 p_volume)
+MxS32 MxSoundManager::GetAttenuation(MxU32 p_percent)
 {
-	// The unit for p_volume is percent, rounded to integer.
+	assert((p_percent >= 0) && (p_percent <= 100));
+
+	// The unit for p_percent is percent, rounded to integer.
 	// Convert to DSOUND attenuation units: -10000 (silent) to 0 (loudest).
-	if (p_volume == 0) {
+	if (p_percent == 0) {
 		return DSBVOLUME_MIN;
 	}
 
-	return g_volumeAttenuation[p_volume - 1];
+	return g_volumeAttenuation[p_percent - 1];
 }
 
 // FUNCTION: LEGO1 0x100aed10

--- a/LEGO1/omni/src/common/mxcompositepresenter.cpp
+++ b/LEGO1/omni/src/common/mxcompositepresenter.cpp
@@ -33,18 +33,18 @@ MxResult MxCompositePresenter::StartAction(MxStreamController* p_controller, MxD
 	MxResult result = FAILURE;
 	MxDSActionList* actions = ((MxDSMultiAction*) p_action)->GetActionList();
 	MxObjectFactory* factory = ObjectFactory();
-	MxDSActionListCursor cursor(actions);
+	MxDSActionListCursor actionCursor(actions);
 	MxDSAction* action;
 
 	if (MxPresenter::StartAction(p_controller, p_action) == SUCCESS) {
-		cursor.Head();
+		actionCursor.Head();
 
-		while (cursor.Current(action)) {
+		while (actionCursor.Current(action)) {
 			MxBool success = FALSE;
 			const char* presenterName;
 			MxPresenter* presenter = NULL;
 
-			cursor.Next();
+			actionCursor.Next();
 
 			if (m_action->GetFlags() & MxDSAction::c_looping) {
 				action->SetFlags(action->GetFlags() | MxDSAction::c_looping);
@@ -148,10 +148,10 @@ void MxCompositePresenter::HandleEndAction(MxEndActionNotificationParam& p_param
 
 	if (m_action) {
 		MxDSActionList* actions = ((MxDSMultiAction*) m_action)->GetActionList();
-		MxDSActionListCursor cursor(actions);
+		MxDSActionListCursor actionCursor(actions);
 
-		if (cursor.Find(action)) {
-			cursor.Detach();
+		if (actionCursor.Find(action)) {
+			actionCursor.Detach();
 		}
 	}
 
@@ -191,10 +191,10 @@ void MxCompositePresenter::HandlePresenter(MxNotificationParam& p_param)
 				}
 
 				MxDSActionList* actions = ((MxDSMultiAction*) m_action)->GetActionList();
-				MxDSActionListCursor cursor(actions);
+				MxDSActionListCursor actionCursor(actions);
 
-				if (cursor.Find(presenter->GetAction())) {
-					cursor.Detach();
+				if (actionCursor.Find(presenter->GetAction())) {
+					actionCursor.Detach();
 				}
 
 				if (m_list.empty()) {

--- a/LEGO1/omni/src/common/mxmediapresenter.cpp
+++ b/LEGO1/omni/src/common/mxmediapresenter.cpp
@@ -166,6 +166,7 @@ void MxMediaPresenter::EndAction()
 }
 
 // FUNCTION: LEGO1 0x100b5d10
+// FUNCTION: BETA10 0x10136415
 MxResult MxMediaPresenter::Tickle()
 {
 	AUTOLOCK(m_criticalSection);
@@ -176,6 +177,7 @@ MxResult MxMediaPresenter::Tickle()
 }
 
 // FUNCTION: LEGO1 0x100b5d90
+// FUNCTION: BETA10 0x1013649f
 void MxMediaPresenter::StreamingTickle()
 {
 	if (!m_currentChunk) {
@@ -200,6 +202,7 @@ void MxMediaPresenter::StreamingTickle()
 }
 
 // FUNCTION: LEGO1 0x100b5e10
+// FUNCTION: BETA10 0x10136597
 void MxMediaPresenter::RepeatingTickle()
 {
 	if (IsEnabled() && !m_currentChunk) {
@@ -210,13 +213,13 @@ void MxMediaPresenter::RepeatingTickle()
 		}
 
 		if (m_currentChunk) {
-			MxLong time = m_currentChunk->GetTime();
-			if (time <= m_action->GetElapsedTime() % m_action->GetLoopCount()) {
+			if (m_currentChunk->GetTime() <= m_action->GetElapsedTime() % m_action->GetLoopCount()) {
 				ProgressTickleState(e_freezing);
 			}
 		}
 		else {
-			if (m_action->GetElapsedTime() >= m_action->GetStartTime() + m_action->GetDuration()) {
+			MxDSAction* action = m_action;
+			if (action->GetElapsedTime() >= action->GetStartTime() + action->GetDuration()) {
 				ProgressTickleState(e_freezing);
 			}
 		}
@@ -224,6 +227,7 @@ void MxMediaPresenter::RepeatingTickle()
 }
 
 // FUNCTION: LEGO1 0x100b5ef0
+// FUNCTION: BETA10 0x101366c0
 void MxMediaPresenter::DoneTickle()
 {
 	ProgressTickleState(e_idle);
@@ -234,15 +238,14 @@ void MxMediaPresenter::DoneTickle()
 // FUNCTION: BETA10 0x101366e9
 void MxMediaPresenter::LoopChunk(MxStreamChunk* p_chunk)
 {
-	MxStreamChunk* chunk = new MxStreamChunk;
+	MxStreamChunk* clone = new MxStreamChunk;
 
-	MxU32 length = p_chunk->GetLength();
-	chunk->SetLength(length);
-	chunk->SetData(new MxU8[length]);
-	chunk->SetTime(p_chunk->GetTime());
+	clone->SetLength(p_chunk->GetLength());
+	clone->SetData(new MxU8[clone->GetLength()]);
+	clone->SetTime(p_chunk->GetTime());
 
-	memcpy(chunk->GetData(), p_chunk->GetData(), chunk->GetLength());
-	m_loopingChunks->Append(chunk);
+	memcpy(clone->GetData(), p_chunk->GetData(), clone->GetLength());
+	m_loopingChunks->Append(clone);
 }
 
 // FUNCTION: LEGO1 0x100b6030

--- a/LEGO1/omni/src/common/mxpresenter.cpp
+++ b/LEGO1/omni/src/common/mxpresenter.cpp
@@ -25,6 +25,7 @@
 #include "mxutilities.h"
 #include "mxwavepresenter.h"
 
+#include <assert.h>
 #include <string.h>
 
 DECOMP_SIZE_ASSERT(MxPresenter, 0x40);
@@ -56,6 +57,7 @@ MxResult MxPresenter::StartAction(MxStreamController*, MxDSAction* p_action)
 }
 
 // FUNCTION: LEGO1 0x100b4e40
+// FUNCTION: BETA10 0x1012e21b
 void MxPresenter::EndAction()
 {
 	if (m_action == NULL) {
@@ -71,12 +73,12 @@ void MxPresenter::EndAction()
 	}
 
 	m_action = NULL;
-	MxS32 previousTickleState = 1 << m_currentTickleState;
-	m_previousTickleStates |= previousTickleState;
+	m_previousTickleStates |= 1 << m_currentTickleState;
 	m_currentTickleState = e_idle;
 }
 
 // FUNCTION: LEGO1 0x100b4fc0
+// FUNCTION: BETA10 0x1012e3c2
 void MxPresenter::ParseExtra()
 {
 	AUTOLOCK(m_criticalSection);
@@ -123,6 +125,7 @@ void MxPresenter::SendToCompositePresenter(MxOmni* p_omni)
 }
 
 // FUNCTION: LEGO1 0x100b5200
+// FUNCTION: BETA10 0x1012e6d5
 MxResult MxPresenter::Tickle()
 {
 	AUTOLOCK(m_criticalSection);
@@ -168,6 +171,7 @@ MxResult MxPresenter::Tickle()
 }
 
 // FUNCTION: LEGO1 0x100b52d0
+// FUNCTION: BETA10 0x1012e848
 void MxPresenter::Enable(MxBool p_enable)
 {
 	if (m_action && IsEnabled() != p_enable) {
@@ -238,13 +242,16 @@ const char* PresenterNameDispatch(const MxDSAction& p_action)
 }
 
 // FUNCTION: LEGO1 0x100b5410
-MxEntity* MxPresenter::CreateEntity(const char* p_defaultName)
+// FUNCTION: BETA10 0x1012eaad
+MxEntity* MxPresenter::CreateEntity(const char* p_defaultObjectName)
 {
 	// create an object from LegoObjectFactory based on OBJECT: value in extra data.
-	// If that is missing, p_defaultName is used
+	// If that is missing, p_defaultObjectName is used
+
+	assert(p_defaultObjectName);
 
 	char objectName[512];
-	strcpy(objectName, p_defaultName);
+	strcpy(objectName, p_defaultObjectName);
 
 	MxU16 extraLength;
 	char* extraData;

--- a/LEGO1/omni/src/common/mxticklemanager.cpp
+++ b/LEGO1/omni/src/common/mxticklemanager.cpp
@@ -13,6 +13,7 @@ DECOMP_SIZE_ASSERT(MxTickleClient, 0x10);
 DECOMP_SIZE_ASSERT(MxTickleManager, 0x14);
 
 // FUNCTION: LEGO1 0x100bdd10
+// FUNCTION: BETA10 0x1013ea10
 MxTickleClient::MxTickleClient(MxCore* p_client, MxTime p_interval)
 {
 	m_flags = 0;
@@ -22,6 +23,7 @@ MxTickleClient::MxTickleClient(MxCore* p_client, MxTime p_interval)
 }
 
 // FUNCTION: LEGO1 0x100bdd30
+// FUNCTION: BETA10 0x1013ea53
 MxTickleManager::~MxTickleManager()
 {
 	while (m_clients.size() != 0) {
@@ -102,6 +104,8 @@ void MxTickleManager::SetClientTickleInterval(MxCore* p_client, MxTime p_interva
 			return;
 		}
 	}
+
+	assert("Tickle Manager client is not registered!" == NULL);
 }
 
 // FUNCTION: LEGO1 0x100be000
@@ -118,5 +122,6 @@ MxTime MxTickleManager::GetClientTickleInterval(MxCore* p_client)
 		it++;
 	}
 
+	assert("Tickle Manager client is not registered!" == NULL);
 	return TICKLE_MANAGER_NOT_FOUND;
 }

--- a/LEGO1/omni/src/common/mxutilities.cpp
+++ b/LEGO1/omni/src/common/mxutilities.cpp
@@ -3,7 +3,6 @@
 #include "mxcompositepresenter.h"
 #include "mxdsaction.h"
 #include "mxdsactionlist.h"
-#include "mxdsfile.h"
 #include "mxdsmultiaction.h"
 #include "mxdsobject.h"
 #include "mxgeometry.h"
@@ -132,6 +131,7 @@ MxBool ContainsPresenter(MxCompositePresenterList& p_presenterList, MxPresenter*
 }
 
 // FUNCTION: LEGO1 0x100b71e0
+// FUNCTION: BETA10 0x10136edd
 void OmniError(const char* p_message, MxS32 p_status)
 {
 	if (g_omniUserMessage) {
@@ -143,6 +143,7 @@ void OmniError(const char* p_message, MxS32 p_status)
 }
 
 // FUNCTION: LEGO1 0x100b7210
+// FUNCTION: BETA10 0x10136f1f
 void SetOmniUserMessage(void (*p_omniUserMessage)(const char*, MxS32))
 {
 	g_omniUserMessage = p_omniUserMessage;

--- a/LEGO1/omni/src/notify/mxactionnotificationparam.cpp
+++ b/LEGO1/omni/src/notify/mxactionnotificationparam.cpp
@@ -2,20 +2,3 @@
 
 DECOMP_SIZE_ASSERT(MxActionNotificationParam, 0x14)
 DECOMP_SIZE_ASSERT(MxEndActionNotificationParam, 0x14)
-
-// FUNCTION: LEGO1 0x100b0300
-MxNotificationParam* MxStartActionNotificationParam::Clone() const
-{
-	return new MxStartActionNotificationParam(
-		c_notificationStartAction,
-		this->m_sender,
-		this->m_action,
-		this->m_realloc
-	);
-}
-
-// FUNCTION: LEGO1 0x100b04f0
-MxNotificationParam* MxType4NotificationParam::Clone() const
-{
-	return new MxType4NotificationParam(this->m_sender, this->m_action, this->m_unk0x14);
-}

--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -9,6 +9,8 @@
 #include "mxticklemanager.h"
 #include "mxtypes.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(MxNotification, 0x08);
 DECOMP_SIZE_ASSERT(MxNotificationManager, 0x40);
 
@@ -30,9 +32,9 @@ MxNotification::~MxNotification()
 MxNotificationManager::MxNotificationManager() : MxCore(), m_lock(), m_listenerIds()
 {
 	m_unk0x2c = 0;
-	m_queue = NULL;
+	m_postNotificationQueue = NULL;
 	m_active = TRUE;
-	m_sendList = NULL;
+	m_flashQueue = NULL;
 }
 
 // FUNCTION: LEGO1 0x100ac450
@@ -40,8 +42,10 @@ MxNotificationManager::~MxNotificationManager()
 {
 	AUTOLOCK(m_lock);
 	Tickle();
-	delete m_queue;
-	m_queue = NULL;
+	assert(m_postNotificationQueue->empty());
+	assert(!m_flashQueue);
+	delete m_postNotificationQueue;
+	m_postNotificationQueue = NULL;
 
 	TickleManager()->UnregisterClient(this);
 }
@@ -50,9 +54,10 @@ MxNotificationManager::~MxNotificationManager()
 MxResult MxNotificationManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 {
 	MxResult result = SUCCESS;
-	m_queue = new MxNotificationPtrList();
+	m_postNotificationQueue = new MxNotificationPtrList();
+	assert(m_postNotificationQueue);
 
-	if (m_queue == NULL) {
+	if (m_postNotificationQueue == NULL) {
 		result = FAILURE;
 	}
 	else {
@@ -74,66 +79,76 @@ MxResult MxNotificationManager::Send(MxCore* p_listener, const MxNotificationPar
 
 	MxIdList::iterator it = find(m_listenerIds.begin(), m_listenerIds.end(), p_listener->GetId());
 	if (it == m_listenerIds.end()) {
+		assert("Post notification recipient not found!" == NULL);
 		return FAILURE;
 	}
 
-	MxNotification* notif = new MxNotification(p_listener, p_param);
-	if (notif != NULL) {
-		m_queue->push_back(notif);
+	MxNotification* notification = new MxNotification(p_listener, p_param);
+	assert(notification);
+
+	if (notification != NULL) {
+		m_postNotificationQueue->push_back(notification);
 		return SUCCESS;
 	}
 
+	assert(0);
 	return FAILURE;
 }
 
 // FUNCTION: LEGO1 0x100ac800
 MxResult MxNotificationManager::Tickle()
 {
-	m_sendList = new MxNotificationPtrList();
-	if (m_sendList == NULL) {
+	m_flashQueue = new MxNotificationPtrList();
+	assert(m_flashQueue);
+
+	if (m_flashQueue == NULL) {
 		return FAILURE;
 	}
 	else {
 		{
 			AUTOLOCK(m_lock);
-			MxNotificationPtrList* temp1 = m_queue;
-			MxNotificationPtrList* temp2 = m_sendList;
-			m_queue = temp2;
-			m_sendList = temp1;
+			assert(m_postNotificationQueue);
+			MxNotificationPtrList* temp1 = m_postNotificationQueue;
+			MxNotificationPtrList* temp2 = m_flashQueue;
+			m_postNotificationQueue = temp2;
+			m_flashQueue = temp1;
 		}
 
-		while (m_sendList->size() != 0) {
-			MxNotification* notif = m_sendList->front();
-			m_sendList->pop_front();
+		while (m_flashQueue->size() != 0) {
+			MxNotification* notif = m_flashQueue->front();
+			m_flashQueue->pop_front();
 			notif->GetTarget()->Notify(*notif->GetParam());
 			delete notif;
 		}
 
-		delete m_sendList;
-		m_sendList = NULL;
+		assert(m_flashQueue->empty());
+		delete m_flashQueue;
+		m_flashQueue = NULL;
 		return SUCCESS;
 	}
 }
 
 // FUNCTION: LEGO1 0x100ac990
-void MxNotificationManager::FlushPending(MxCore* p_listener)
+void MxNotificationManager::FlushPending(MxCore* p_object)
 {
-	MxNotificationPtrList pending;
+	assert(p_object);
+	assert(m_postNotificationQueue);
+
+	MxNotificationPtrList flashQueue;
 	MxNotification* notif;
 
 	{
 		AUTOLOCK(m_lock);
 
-		// Find all notifications from, and addressed to, p_listener.
-		if (m_sendList != NULL) {
-			MxNotificationPtrList::iterator it = m_sendList->begin();
-			while (it != m_sendList->end()) {
+		// Find all notifications from, and addressed to, p_object.
+		if (m_flashQueue != NULL) {
+			MxNotificationPtrList::iterator it = m_flashQueue->begin();
+			while (it != m_flashQueue->end()) {
 				notif = *it;
-				if (notif->GetTarget()->GetId() == p_listener->GetId() ||
-					(notif->GetParam()->GetSender() && notif->GetParam()->GetSender()->GetId() == p_listener->GetId()
-					)) {
-					m_sendList->erase(it++);
-					pending.push_back(notif);
+				if (notif->GetTarget()->GetId() == p_object->GetId() ||
+					(notif->GetParam()->GetSender() && notif->GetParam()->GetSender()->GetId() == p_object->GetId())) {
+					m_flashQueue->erase(it++);
+					flashQueue.push_back(notif);
 				}
 				else {
 					it++;
@@ -141,13 +156,13 @@ void MxNotificationManager::FlushPending(MxCore* p_listener)
 			}
 		}
 
-		MxNotificationPtrList::iterator it = m_queue->begin();
-		while (it != m_queue->end()) {
+		MxNotificationPtrList::iterator it = m_postNotificationQueue->begin();
+		while (it != m_postNotificationQueue->end()) {
 			notif = *it;
-			if (notif->GetTarget()->GetId() == p_listener->GetId() ||
-				(notif->GetParam()->GetSender() && notif->GetParam()->GetSender()->GetId() == p_listener->GetId())) {
-				m_queue->erase(it++);
-				pending.push_back(notif);
+			if (notif->GetTarget()->GetId() == p_object->GetId() ||
+				(notif->GetParam()->GetSender() && notif->GetParam()->GetSender()->GetId() == p_object->GetId())) {
+				m_postNotificationQueue->erase(it++);
+				flashQueue.push_back(notif);
 			}
 			else {
 				it++;
@@ -155,10 +170,12 @@ void MxNotificationManager::FlushPending(MxCore* p_listener)
 		}
 	}
 
+	assert(flashQueue.size() < 500);
+
 	// Deliver those notifications.
-	while (pending.size() != 0) {
-		notif = pending.front();
-		pending.pop_front();
+	while (flashQueue.size() != 0) {
+		notif = flashQueue.front();
+		flashQueue.pop_front();
 		notif->GetTarget()->Notify(*notif->GetParam());
 		delete notif;
 	}

--- a/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxdiskstreamcontroller.cpp
@@ -38,8 +38,6 @@ MxDiskStreamController::~MxDiskStreamController()
 #endif
 	}
 
-	assert(m_subscribers.size() == 0);
-
 	MxDSObject* object;
 	while (m_unk0x3c.PopFront(object)) {
 		delete object;
@@ -100,6 +98,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100c7880
+// FUNCTION: BETA10 0x10154045
 MxResult MxDiskStreamController::VTable0x18(undefined4, undefined4)
 {
 	return SUCCESS;
@@ -120,12 +119,14 @@ MxResult MxDiskStreamController::FUN_100c7890(MxDSStreamingAction* p_action)
 }
 
 // FUNCTION: LEGO1 0x100c7960
+// FUNCTION: BETA10 0x1015447a
 MxResult MxDiskStreamController::VTable0x34(undefined4)
 {
 	return FAILURE;
 }
 
 // FUNCTION: LEGO1 0x100c7970
+// FUNCTION: BETA10 0x101545ff
 void MxDiskStreamController::FUN_100c7970()
 {
 	// Empty
@@ -136,13 +137,15 @@ void MxDiskStreamController::FUN_100c7970()
 void MxDiskStreamController::FUN_100c7980()
 {
 	MxDSBuffer* buffer;
-	MxDSStreamingAction* action = NULL;
+	MxDSStreamingAction* request = NULL;
 
 	{
 		AUTOLOCK(m_criticalSection);
+		assert(m_provider);
 
 		if (m_unk0x3c.size() && m_unk0x8c < m_provider->GetStreamBuffersNum()) {
 			buffer = new MxDSBuffer();
+			assert(buffer);
 
 			if (buffer->AllocateBuffer(m_provider->GetFileSize(), MxDSBuffer::e_chunk) != SUCCESS) {
 				if (buffer) {
@@ -151,21 +154,23 @@ void MxDiskStreamController::FUN_100c7980()
 				return;
 			}
 
-			action = VTable0x28();
-			if (!action) {
+			request = VTable0x28();
+			assert(request);
+
+			if (!request) {
 				if (buffer) {
 					delete buffer;
 				}
 				return;
 			}
 
-			action->SetUnknowna0(buffer);
+			request->SetUnknowna0(buffer);
 			m_unk0x8c++;
 		}
 	}
 
-	if (action) {
-		((MxDiskStreamProvider*) m_provider)->FUN_100d1780(action);
+	if (request) {
+		((MxDiskStreamProvider*) m_provider)->FUN_100d1780(request);
 	}
 }
 
@@ -420,6 +425,7 @@ MxResult MxDiskStreamController::FUN_100c8360(MxDSStreamingAction* p_action)
 }
 
 // FUNCTION: LEGO1 0x100c84a0
+// FUNCTION: BETA10 0x10155a05
 void MxDiskStreamController::InsertToList74(MxDSBuffer* p_buffer)
 {
 	AUTOLOCK(m_criticalSection);
@@ -427,7 +433,7 @@ void MxDiskStreamController::InsertToList74(MxDSBuffer* p_buffer)
 }
 
 // FUNCTION: LEGO1 0x100c8540
-// FUNCTION: BETA10 0x10155a05
+// FUNCTION: BETA10 0x10155a8c
 void MxDiskStreamController::FUN_100c8540()
 {
 	AUTOLOCK(m_criticalSection);

--- a/LEGO1/omni/src/stream/mxdsbuffer.cpp
+++ b/LEGO1/omni/src/stream/mxdsbuffer.cpp
@@ -26,15 +26,13 @@ MxDSBuffer::MxDSBuffer()
 	m_writeOffset = 0;
 	m_bytesRemaining = 0;
 	m_mode = e_preallocated;
-	m_unk0x30 = 0;
+	m_parentRequest = 0;
 }
 
 // FUNCTION: LEGO1 0x100c6530
 // FUNCTION: BETA10 0x10156ff7
 MxDSBuffer::~MxDSBuffer()
 {
-	assert(m_referenceCount == 0);
-
 	if (m_pBuffer != NULL) {
 		switch (m_mode) {
 		case e_allocate:
@@ -64,7 +62,6 @@ MxResult MxDSBuffer::AllocateBuffer(MxU32 p_bufferSize, Type p_mode)
 	switch (p_mode) {
 	case e_allocate:
 		m_pBuffer = new MxU8[p_bufferSize];
-		assert(m_pBuffer); // m_firstRiffChunk?
 		break;
 
 	case e_chunk:
@@ -86,6 +83,7 @@ MxResult MxDSBuffer::AllocateBuffer(MxU32 p_bufferSize, Type p_mode)
 }
 
 // FUNCTION: LEGO1 0x100c6780
+// FUNCTION: BETA10 0x1015723b
 MxResult MxDSBuffer::SetBufferPointer(MxU8* p_buffer, MxU32 p_size)
 {
 	m_pBuffer = p_buffer;
@@ -108,8 +106,8 @@ MxResult MxDSBuffer::FUN_100c67b0(
 	MxResult result = FAILURE;
 	MxU8* data = m_pBuffer;
 
-	m_unk0x30 = (MxDSStreamingAction*) p_controller->GetUnk0x3c().Find(p_action);
-	if (m_unk0x30 == NULL) {
+	m_parentRequest = (MxDSStreamingAction*) p_controller->GetUnk0x3c().Find(p_action);
+	if (m_parentRequest == NULL) {
 		return FAILURE;
 	}
 
@@ -122,7 +120,7 @@ MxResult MxDSBuffer::FUN_100c67b0(
 			}
 
 			if (buffer->GetBytesRemaining() == 0) {
-				buffer->m_unk0x30 = m_unk0x30;
+				buffer->m_parentRequest = m_parentRequest;
 
 				result = buffer->CreateObject(p_controller, (MxU32*) buffer->GetBuffer(), p_action, p_streamingAction);
 				if (result == SUCCESS) {
@@ -183,7 +181,7 @@ MxResult MxDSBuffer::CreateObject(
 	}
 	else if (*p_data == FOURCC('M', 'x', 'C', 'h')) {
 		MxStreamChunk* chunk = (MxStreamChunk*) header;
-		if (!m_unk0x30->HasId((chunk)->GetObjectId())) {
+		if (!m_parentRequest->HasId((chunk)->GetObjectId())) {
 			delete header;
 			return SUCCESS;
 		}
@@ -198,13 +196,14 @@ MxResult MxDSBuffer::CreateObject(
 }
 
 // FUNCTION: LEGO1 0x100c6960
+// FUNCTION: BETA10 0x1015759a
 MxResult MxDSBuffer::StartPresenterFromAction(
 	MxStreamController* p_controller,
 	MxDSAction* p_action1,
 	MxDSAction* p_objectheader
 )
 {
-	if (!m_unk0x30->GetInternalAction()) {
+	if (!m_parentRequest->GetAction()) {
 		p_objectheader->SetAtomId(p_action1->GetAtomId());
 		p_objectheader->SetUnknown28(p_action1->GetUnknown28());
 		p_objectheader->SetNotificationObject(p_action1->GetNotificationObject());
@@ -212,19 +211,22 @@ MxResult MxDSBuffer::StartPresenterFromAction(
 		p_objectheader->SetTimeStarted(p_action1->GetTimeStarted());
 		p_objectheader->MergeFrom(*p_action1);
 
-		m_unk0x30->SetInternalAction(p_objectheader->Clone());
+		m_parentRequest->SetAction(p_objectheader->Clone());
+		assert(m_parentRequest->GetAction());
 
 		p_controller->InsertActionToList54(p_objectheader);
 
 		if (MxOmni::GetInstance()->CreatePresenter(p_controller, *p_objectheader) != SUCCESS) {
+			assert(0);
 			return FAILURE;
 		}
 
-		m_unk0x30->SetLoopCount(p_objectheader->GetLoopCount());
-		m_unk0x30->SetFlags(p_objectheader->GetFlags());
-		m_unk0x30->SetDuration(p_objectheader->GetDuration());
+		m_parentRequest->SetLoopCount(p_objectheader->GetLoopCount());
+		m_parentRequest->SetFlags(p_objectheader->GetFlags());
+		m_parentRequest->SetDuration(p_objectheader->GetDuration());
 
-		if (m_unk0x30->GetInternalAction() == NULL) {
+		if (m_parentRequest->GetAction() == NULL) {
+			assert(0);
 			return FAILURE;
 		}
 	}
@@ -247,12 +249,13 @@ MxResult MxDSBuffer::ParseChunk(
 {
 	MxResult result = SUCCESS;
 
-	if (m_unk0x30->GetFlags() & MxDSAction::c_bit3 && m_unk0x30->GetUnknowna8() && p_header->GetTime() < 0) {
+	if (m_parentRequest->GetFlags() & MxDSAction::c_bit3 && m_parentRequest->GetUnknowna8() &&
+		p_header->GetTime() < 0) {
 		delete p_header;
 		return SUCCESS;
 	}
 
-	p_header->SetTime(p_header->GetTime() + m_unk0x30->GetUnknowna8());
+	p_header->SetTime(p_header->GetTime() + m_parentRequest->GetUnknowna8());
 
 	if (p_header->GetChunkFlags() & DS_CHUNK_SPLIT) {
 		MxU32 length = p_header->GetLength() + MxDSChunk::GetHeaderSize() + 8;
@@ -274,24 +277,24 @@ MxResult MxDSBuffer::ParseChunk(
 	}
 	else {
 		if (p_header->GetChunkFlags() & DS_CHUNK_END_OF_STREAM) {
-			if (m_unk0x30->HasId(p_header->GetObjectId())) {
-				if (m_unk0x30->GetFlags() & MxDSAction::c_bit3 &&
-					(m_unk0x30->GetLoopCount() > 1 || m_unk0x30->GetDuration() == -1)) {
+			if (m_parentRequest->HasId(p_header->GetObjectId())) {
+				if (m_parentRequest->GetFlags() & MxDSAction::c_bit3 &&
+					(m_parentRequest->GetLoopCount() > 1 || m_parentRequest->GetDuration() == -1)) {
 
 					if (p_action->GetObjectId() == p_header->GetObjectId()) {
-						MxU32 val = p_controller->GetProvider()->GetBufferForDWords()[m_unk0x30->GetObjectId()];
+						MxU32 val = p_controller->GetProvider()->GetBufferForDWords()[m_parentRequest->GetObjectId()];
 
-						m_unk0x30->SetUnknown94(val);
-						m_unk0x30->SetBufferOffset(m_writeOffset * (val / m_writeOffset));
+						m_parentRequest->SetUnknown94(val);
+						m_parentRequest->SetBufferOffset(m_writeOffset * (val / m_writeOffset));
 
 						MxNextActionDataStart* data =
-							p_controller->FindNextActionDataStartFromStreamingAction(m_unk0x30);
+							p_controller->FindNextActionDataStartFromStreamingAction(m_parentRequest);
 
 						if (data) {
-							data->SetData(m_unk0x30->GetBufferOffset());
+							data->SetData(m_parentRequest->GetBufferOffset());
 						}
 
-						m_unk0x30->FUN_100cd2d0();
+						m_parentRequest->FUN_100cd2d0();
 					}
 
 					delete p_header;
@@ -396,6 +399,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100c6ec0
+// FUNCTION: BETA10 0x10157fb2
 MxU8 MxDSBuffer::ReleaseRef(MxDSChunk*)
 {
 	if (m_referenceCount != 0) {
@@ -405,6 +409,7 @@ MxU8 MxDSBuffer::ReleaseRef(MxDSChunk*)
 }
 
 // FUNCTION: LEGO1 0x100c6ee0
+// FUNCTION: BETA10 0x10158074
 void MxDSBuffer::AddRef(MxDSChunk* p_chunk)
 {
 	if (p_chunk) {
@@ -459,15 +464,14 @@ void MxDSBuffer::FUN_100c6f80(MxU32 p_writeOffset)
 // FUNCTION: BETA10 0x101582f2
 MxU8* MxDSBuffer::FUN_100c6fa0(MxU8* p_data)
 {
-	MxU8* volatile current = p_data ? p_data : m_pBuffer;
+	MxU8* current = p_data ? p_data : m_pBuffer;
 
 	while (current <= m_writeOffset + m_pBuffer - 8) {
-		switch (*(MxU32*) current) {
+		switch (**(MxU32**) &current) {
 		case FOURCC('M', 'x', 'O', 'b'):
 		case FOURCC('M', 'x', 'C', 'h'):
 			if (current == p_data) {
-				MxU32 size = *(MxU32*) (current + 4);
-				current += (size & 1) + size;
+				current += (*(MxU32*) (current + 4) & 1) + *(MxU32*) (current + 4);
 				current += 8;
 			}
 			else {

--- a/LEGO1/omni/src/stream/mxio.cpp
+++ b/LEGO1/omni/src/stream/mxio.cpp
@@ -10,9 +10,9 @@
 DECOMP_SIZE_ASSERT(MXIOINFO, sizeof(MMIOINFO));
 
 #ifdef MXIO_MINFO_MFILE
-#define ASSIGN_M_FILE(X) m_info.hmmio = (HMMIO) (X)
-#define M_FILE (HFILE)(m_info.hmmio)
-#define RAW_M_FILE m_info.hmmio
+#define ASSIGN_M_FILE(X) hmmio = (HMMIO) (X)
+#define M_FILE (HFILE)(hmmio)
+#define RAW_M_FILE hmmio
 #else
 #define ASSIGN_M_FILE(X) m_file = (X)
 #define M_FILE (m_file)
@@ -23,7 +23,7 @@ DECOMP_SIZE_ASSERT(MXIOINFO, sizeof(MMIOINFO));
 // FUNCTION: BETA10 0x1015e140
 MXIOINFO::MXIOINFO()
 {
-	memset(&m_info, 0, sizeof(m_info));
+	memset(this, 0, sizeof(MXIOINFO));
 }
 
 // FUNCTION: LEGO1 0x100cc820
@@ -40,18 +40,18 @@ MxU16 MXIOINFO::Open(const char* p_filename, MxULong p_flags)
 	OFSTRUCT unused;
 	MxU16 result = MMSYSERR_NOERROR;
 
-	m_info.lDiskOffset = m_info.lBufOffset = 0;
+	lDiskOffset = lBufOffset = 0;
 
 	// DECOMP: Cast of p_flags to u16 forces the `movzx` instruction
-	// original: m_info.hmmio = OpenFile(p_filename, &unused, (MxU16) p_flags);
+	// original: hmmio = OpenFile(p_filename, &unused, (MxU16) p_flags);
 	ASSIGN_M_FILE(OpenFile(p_filename, &unused, (MxU16) p_flags));
 
 	if (M_FILE != HFILE_ERROR) {
-		m_info.dwFlags = p_flags;
-		if (m_info.dwFlags & MMIO_ALLOCBUF) {
+		dwFlags = p_flags;
+		if (dwFlags & MMIO_ALLOCBUF) {
 
 			// Default buffer length of 8k if none specified
-			MxLong len = m_info.cchBuffer;
+			MxLong len = cchBuffer;
 			if (len == 0) {
 				len = 8192;
 			}
@@ -59,18 +59,18 @@ MxU16 MXIOINFO::Open(const char* p_filename, MxULong p_flags)
 			char* buf = new char[len];
 
 			if (!buf) {
-				m_info.dwFlags &= ~MMIO_ALLOCBUF;
-				m_info.cchBuffer = 0;
-				m_info.pchBuffer = 0;
+				dwFlags &= ~MMIO_ALLOCBUF;
+				cchBuffer = 0;
+				pchBuffer = 0;
 				result = MMIOERR_OUTOFMEMORY;
 			}
 			else {
-				m_info.cchBuffer = len;
-				m_info.pchBuffer = (HPSTR) buf;
+				cchBuffer = len;
+				pchBuffer = (HPSTR) buf;
 			}
 
-			m_info.pchNext = m_info.pchEndRead = m_info.pchBuffer;
-			m_info.pchEndWrite = m_info.pchBuffer + m_info.cchBuffer;
+			pchNext = pchEndRead = pchBuffer;
+			pchEndWrite = pchBuffer + cchBuffer;
 		}
 	}
 	else {
@@ -91,12 +91,12 @@ MxU16 MXIOINFO::Close(MxLong p_unused)
 		_lclose(M_FILE);
 		ASSIGN_M_FILE(0);
 
-		if (m_info.dwFlags & MMIO_ALLOCBUF) {
-			delete[] m_info.pchBuffer;
+		if (dwFlags & MMIO_ALLOCBUF) {
+			delete[] pchBuffer;
 		}
 
-		m_info.pchBuffer = m_info.pchEndRead = m_info.pchEndWrite = NULL;
-		m_info.dwFlags = 0;
+		pchBuffer = pchEndRead = pchEndWrite = NULL;
+		dwFlags = 0;
 	}
 
 	return result;
@@ -108,9 +108,9 @@ MxLong MXIOINFO::Read(void* p_buf, MxLong p_len)
 {
 	MxLong bytesRead = 0;
 
-	if (m_info.pchBuffer) {
+	if (pchBuffer) {
 
-		MxLong bytesLeft = m_info.pchEndRead - m_info.pchNext;
+		MxLong bytesLeft = pchEndRead - pchNext;
 		while (p_len > 0) {
 
 			if (bytesLeft > 0) {
@@ -118,9 +118,9 @@ MxLong MXIOINFO::Read(void* p_buf, MxLong p_len)
 					bytesLeft = p_len;
 				}
 
-				memcpy(p_buf, m_info.pchNext, bytesLeft);
+				memcpy(p_buf, pchNext, bytesLeft);
 
-				m_info.pchNext += bytesLeft;
+				pchNext += bytesLeft;
 				bytesRead += bytesLeft;
 				p_len -= bytesLeft;
 			}
@@ -130,7 +130,7 @@ MxLong MXIOINFO::Read(void* p_buf, MxLong p_len)
 					break;
 				}
 				else {
-					bytesLeft = m_info.pchEndRead - m_info.pchNext;
+					bytesLeft = pchEndRead - pchNext;
 					if (bytesLeft <= 0) {
 						break;
 					}
@@ -143,10 +143,10 @@ MxLong MXIOINFO::Read(void* p_buf, MxLong p_len)
 
 		if (bytesRead == -1) {
 			bytesRead = 0;
-			m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+			lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 		}
 		else {
-			m_info.lDiskOffset += bytesRead;
+			lDiskOffset += bytesRead;
 		}
 	}
 
@@ -158,9 +158,9 @@ MxLong MXIOINFO::Write(void* p_buf, MxLong p_len)
 {
 	MxLong bytesWritten = 0;
 
-	if (m_info.pchBuffer) {
+	if (pchBuffer) {
 
-		MxLong bytesLeft = m_info.pchEndWrite - m_info.pchNext;
+		MxLong bytesLeft = pchEndWrite - pchNext;
 		while (p_len > 0) {
 
 			if (bytesLeft > 0) {
@@ -168,10 +168,10 @@ MxLong MXIOINFO::Write(void* p_buf, MxLong p_len)
 					bytesLeft = p_len;
 				}
 
-				memcpy(m_info.pchNext, p_buf, bytesLeft);
-				m_info.dwFlags |= MMIO_DIRTY;
+				memcpy(pchNext, p_buf, bytesLeft);
+				dwFlags |= MMIO_DIRTY;
 
-				m_info.pchNext += bytesLeft;
+				pchNext += bytesLeft;
 				bytesWritten += bytesLeft;
 				p_len -= bytesLeft;
 			}
@@ -182,7 +182,7 @@ MxLong MXIOINFO::Write(void* p_buf, MxLong p_len)
 					break;
 				}
 				else {
-					bytesLeft = m_info.pchEndWrite - m_info.pchNext;
+					bytesLeft = pchEndWrite - pchNext;
 					if (bytesLeft <= 0) {
 						assert(0);
 						break;
@@ -196,17 +196,17 @@ MxLong MXIOINFO::Write(void* p_buf, MxLong p_len)
 
 		if (bytesWritten == -1) {
 			bytesWritten = 0;
-			m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+			lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 		}
 		else {
-			m_info.lDiskOffset += bytesWritten;
+			lDiskOffset += bytesWritten;
 		}
 	}
 
 	// DECOMP: This assert is just "pchNext <= pchEndWrite"
 	// That would suggest that MXIOINFO directly extends MMIOINFO.
 	// TODO: Change that if we still have entropy at the end.
-	assert(m_info.pchNext <= m_info.pchEndWrite);
+	assert(pchNext <= pchEndWrite);
 	return bytesWritten;
 }
 
@@ -218,16 +218,16 @@ MxLong MXIOINFO::Seek(MxLong p_offset, MxLong p_origin)
 	MxLong bytesRead;
 
 	// If buffered I/O
-	if (m_info.pchBuffer) {
+	if (pchBuffer) {
 		if (p_origin == SEEK_CUR) {
 			if (!p_offset) {
 				// don't seek at all and just return where we are.
-				return m_info.lBufOffset + (m_info.pchNext - m_info.pchBuffer);
+				return lBufOffset + (pchNext - pchBuffer);
 			}
 
 			// With SEEK_CUR, p_offset is a relative offset.
 			// Get the absolute position instead and use SEEK_SET.
-			p_offset += m_info.lBufOffset + (m_info.pchNext - m_info.pchBuffer);
+			p_offset += lBufOffset + (pchNext - pchBuffer);
 			p_origin = SEEK_SET;
 		}
 		else if (p_origin == SEEK_END) {
@@ -239,54 +239,54 @@ MxLong MXIOINFO::Seek(MxLong p_offset, MxLong p_origin)
 
 		// is p_offset between the start and end of the buffer?
 		// i.e. can we do the seek without reading more from disk?
-		if (p_offset >= m_info.lBufOffset && p_offset < m_info.lBufOffset + m_info.cchBuffer) {
-			m_info.pchNext = m_info.pchBuffer + (p_offset - m_info.lBufOffset);
+		if (p_offset >= lBufOffset && p_offset < lBufOffset + cchBuffer) {
+			pchNext = pchBuffer + (p_offset - lBufOffset);
 			result = p_offset;
 		}
 		else {
 			// we have to read another chunk from disk.
 			if (RAW_M_FILE && !Flush(0)) {
-				m_info.lDiskOffset = _llseek(M_FILE, p_offset, p_origin);
+				lDiskOffset = _llseek(M_FILE, p_offset, p_origin);
 
-				if (m_info.lDiskOffset == -1) {
-					m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+				if (lDiskOffset == -1) {
+					lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 				}
 				else {
 
 					// align offset to buffer size
-					m_info.lBufOffset = p_offset - (p_offset % m_info.cchBuffer);
+					lBufOffset = p_offset - (p_offset % cchBuffer);
 
 					// do we need to seek again?
 					// (i.e. are we already aligned to buffer size?)
-					if (p_offset != m_info.lBufOffset) {
-						m_info.lDiskOffset = _llseek(M_FILE, m_info.lBufOffset, SEEK_SET);
+					if (p_offset != lBufOffset) {
+						lDiskOffset = _llseek(M_FILE, lBufOffset, SEEK_SET);
 
-						if (m_info.lDiskOffset == -1) {
-							m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+						if (lDiskOffset == -1) {
+							lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 						}
 					}
 
-					if (m_info.lBufOffset == m_info.lDiskOffset) {
+					if (lBufOffset == lDiskOffset) {
 						// is the file open for writing only?
-						if ((m_info.dwFlags & MMIO_RWMODE) == 0 || (m_info.dwFlags & MMIO_RWMODE) == MMIO_READWRITE) {
+						if ((dwFlags & MMIO_RWMODE) == 0 || (dwFlags & MMIO_RWMODE) == MMIO_READWRITE) {
 							// We can read from the file. Fill the buffer.
-							bytesRead = _hread(M_FILE, m_info.pchBuffer, m_info.cchBuffer);
+							bytesRead = _hread(M_FILE, pchBuffer, cchBuffer);
 
 							if (bytesRead == -1) {
-								m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+								lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 							}
 							else {
-								m_info.lDiskOffset += bytesRead;
-								m_info.pchNext = p_offset - m_info.lBufOffset + m_info.pchBuffer;
-								m_info.pchEndRead = m_info.pchBuffer + bytesRead;
+								lDiskOffset += bytesRead;
+								pchNext = p_offset - lBufOffset + pchBuffer;
+								pchEndRead = pchBuffer + bytesRead;
 
-								if (m_info.pchNext < m_info.pchEndRead) {
+								if (pchNext < pchEndRead) {
 									result = p_offset;
 								}
 							}
 						}
 						else {
-							m_info.pchNext = p_offset - m_info.lBufOffset + m_info.pchBuffer;
+							pchNext = p_offset - lBufOffset + pchBuffer;
 							result = p_offset;
 						}
 					}
@@ -298,15 +298,15 @@ MxLong MXIOINFO::Seek(MxLong p_offset, MxLong p_origin)
 		// No buffer so just seek the file directly (if we have a valid handle)
 		// i.e. if we just want to get the current file position
 		if (p_origin == SEEK_CUR && p_offset == 0) {
-			return m_info.lDiskOffset;
+			return lDiskOffset;
 		}
 
-		m_info.lDiskOffset = _llseek(M_FILE, p_offset, p_origin);
+		lDiskOffset = _llseek(M_FILE, p_offset, p_origin);
 
-		result = m_info.lDiskOffset;
+		result = lDiskOffset;
 
 		if (result == -1) {
-			m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+			lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 		}
 	}
 
@@ -320,15 +320,15 @@ MxU16 MXIOINFO::SetBuffer(char* p_buf, MxLong p_len, MxLong p_unused)
 	MxU16 result = MMSYSERR_NOERROR;
 	result = Flush(0);
 
-	if (m_info.dwFlags & MMIO_ALLOCBUF) {
-		m_info.dwFlags &= ~MMIO_ALLOCBUF;
-		delete[] m_info.pchBuffer;
+	if (dwFlags & MMIO_ALLOCBUF) {
+		dwFlags &= ~MMIO_ALLOCBUF;
+		delete[] pchBuffer;
 	}
 
-	m_info.pchBuffer = p_buf;
-	m_info.cchBuffer = p_len;
-	m_info.pchEndWrite = m_info.pchBuffer + m_info.cchBuffer;
-	m_info.pchEndRead = m_info.pchBuffer;
+	pchBuffer = p_buf;
+	cchBuffer = p_len;
+	pchEndWrite = pchBuffer + cchBuffer;
+	pchEndRead = pchBuffer;
 
 	return result;
 }
@@ -341,34 +341,33 @@ MxU16 MXIOINFO::Flush(MxU16 p_unused)
 	MxLong bytesWritten;
 
 	// if buffer is dirty
-	if (m_info.dwFlags & MMIO_DIRTY) {
+	if (dwFlags & MMIO_DIRTY) {
 		// if we have allocated an IO buffer
-		if (m_info.pchBuffer) {
+		if (pchBuffer) {
 			// if we have a file open for writing
-			if (RAW_M_FILE && (m_info.dwFlags & MMIO_RWMODE)) {
-				// DECOMP: pulling this value out into a variable forces it into EBX
-				MxLong cchBuffer = m_info.cchBuffer;
-				if (cchBuffer > 0) {
-					if (m_info.lBufOffset != m_info.lDiskOffset) {
-						m_info.lDiskOffset = _llseek(M_FILE, m_info.lBufOffset, SEEK_SET);
+			if (RAW_M_FILE && (dwFlags & MMIO_RWMODE)) {
+				MxLong cch = cchBuffer;
+				if (cch > 0) {
+					if (lBufOffset != lDiskOffset) {
+						lDiskOffset = _llseek(M_FILE, lBufOffset, SEEK_SET);
 					}
 
 					// Was the previous seek (if required) successful?
-					if (m_info.lBufOffset != m_info.lDiskOffset) {
+					if (lBufOffset != lDiskOffset) {
 						result = MMIOERR_CANNOTSEEK;
-						m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+						lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 					}
 					else {
-						bytesWritten = _hwrite(M_FILE, m_info.pchBuffer, cchBuffer);
+						bytesWritten = _hwrite(M_FILE, pchBuffer, cch);
 
-						if (bytesWritten == -1 || bytesWritten != cchBuffer) {
+						if (bytesWritten == -1 || bytesWritten != cch) {
 							result = MMIOERR_CANNOTWRITE;
-							m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+							lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 						}
 						else {
-							m_info.lDiskOffset += bytesWritten;
-							m_info.pchNext = m_info.pchBuffer;
-							m_info.dwFlags &= ~MMIO_DIRTY;
+							lDiskOffset += bytesWritten;
+							pchNext = pchBuffer;
+							dwFlags &= ~MMIO_DIRTY;
 						}
 					}
 				}
@@ -390,64 +389,66 @@ MxU16 MXIOINFO::Flush(MxU16 p_unused)
 MxU16 MXIOINFO::Advance(MxU16 p_option)
 {
 	MxU16 result = MMSYSERR_NOERROR;
-	MxULong rwmode = m_info.dwFlags & MMIO_RWMODE;
+	MxULong rwmode = dwFlags & MMIO_RWMODE;
 
-	if (m_info.pchBuffer) {
-		MxLong cch = m_info.cchBuffer;
+	if (pchBuffer) {
+		// DECOMP: BETA10 slot order + retail CMP operand order prove bytesCounter
+		// was declared before cch (June 1997 /Od frame: bytesCounter -0xc, cch -0x10).
 		MxLong bytesCounter;
+		MxLong cch = cchBuffer;
 
 		// If we can and should write to the file,
 		// if we are being asked to write to the file,
 		// and if there is a buffer *to* write:
-		if ((rwmode == MMIO_WRITE || rwmode == MMIO_READWRITE) && (m_info.dwFlags & MMIO_DIRTY) &&
+		if ((rwmode == MMIO_WRITE || rwmode == MMIO_READWRITE) && (dwFlags & MMIO_DIRTY) &&
 			((p_option & MMIO_WRITE) || (rwmode == MMIO_READWRITE)) && cch > 0) {
 
-			if (m_info.lBufOffset != m_info.lDiskOffset) {
-				m_info.lDiskOffset = _llseek(M_FILE, m_info.lBufOffset, SEEK_SET);
+			if (lBufOffset != lDiskOffset) {
+				lDiskOffset = _llseek(M_FILE, lBufOffset, SEEK_SET);
 			}
 
-			if (m_info.lBufOffset != m_info.lDiskOffset) {
+			if (lBufOffset != lDiskOffset) {
 				result = MMIOERR_CANNOTSEEK;
-				m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+				lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 			}
 			else {
-				bytesCounter = _hwrite(M_FILE, m_info.pchBuffer, cch);
+				bytesCounter = _hwrite(M_FILE, pchBuffer, cch);
 
 				if (bytesCounter == -1 || bytesCounter != cch) {
 					result = MMIOERR_CANNOTWRITE;
-					m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+					lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 				}
 				else {
-					m_info.lDiskOffset += bytesCounter;
-					m_info.pchNext = m_info.pchBuffer;
-					m_info.pchEndRead = m_info.pchBuffer;
-					m_info.dwFlags &= ~MMIO_DIRTY;
+					lDiskOffset += bytesCounter;
+					pchNext = pchBuffer;
+					pchEndRead = pchBuffer;
+					dwFlags &= ~MMIO_DIRTY;
 				}
 			}
 		}
 
-		m_info.lBufOffset += cch;
+		lBufOffset += cch;
 		if ((!rwmode || rwmode == MMIO_READWRITE) && cch > 0) {
-			if (m_info.lBufOffset != m_info.lDiskOffset) {
-				m_info.lDiskOffset = _llseek(M_FILE, m_info.lBufOffset, SEEK_SET);
+			if (lBufOffset != lDiskOffset) {
+				lDiskOffset = _llseek(M_FILE, lBufOffset, SEEK_SET);
 			}
 
 			// if previous seek failed
-			if (m_info.lBufOffset != m_info.lDiskOffset) {
+			if (lBufOffset != lDiskOffset) {
 				result = MMIOERR_CANNOTSEEK;
-				m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+				lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 			}
 			else {
-				bytesCounter = _hread(M_FILE, m_info.pchBuffer, cch);
+				bytesCounter = _hread(M_FILE, pchBuffer, cch);
 
 				if (bytesCounter == -1) {
 					result = MMIOERR_CANNOTREAD;
-					m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+					lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 				}
 				else {
-					m_info.lDiskOffset += bytesCounter;
-					m_info.pchNext = m_info.pchBuffer;
-					m_info.pchEndRead = m_info.pchBuffer + bytesCounter;
+					lDiskOffset += bytesCounter;
+					pchNext = pchBuffer;
+					pchEndRead = pchBuffer + bytesCounter;
 				}
 			}
 		}
@@ -477,11 +478,11 @@ MxU16 MXIOINFO::Descend(MMCKINFO* p_chunkInfo, const MMCKINFO* p_parentInfo, MxU
 			result = MMIOERR_CANNOTREAD;
 		}
 		else {
-			if (m_info.pchBuffer) {
-				p_chunkInfo->dwDataOffset = m_info.pchNext - m_info.pchBuffer + m_info.lBufOffset;
+			if (pchBuffer) {
+				p_chunkInfo->dwDataOffset = pchNext - pchBuffer + lBufOffset;
 			}
 			else {
-				p_chunkInfo->dwDataOffset = m_info.lDiskOffset;
+				p_chunkInfo->dwDataOffset = lDiskOffset;
 			}
 
 			if ((p_chunkInfo->ckid == FOURCC_RIFF || p_chunkInfo->ckid == FOURCC_LIST) &&
@@ -510,11 +511,11 @@ MxU16 MXIOINFO::Descend(MMCKINFO* p_chunkInfo, const MMCKINFO* p_parentInfo, MxU
 			}
 			else {
 				readOk = TRUE;
-				if (m_info.pchBuffer) {
-					tmp.dwDataOffset = m_info.pchNext - m_info.pchBuffer + m_info.lBufOffset;
+				if (pchBuffer) {
+					tmp.dwDataOffset = pchNext - pchBuffer + lBufOffset;
 				}
 				else {
-					tmp.dwDataOffset = m_info.lDiskOffset;
+					tmp.dwDataOffset = lDiskOffset;
 				}
 
 				if (ofs < tmp.dwDataOffset) {
@@ -560,12 +561,12 @@ MxU16 MXIOINFO::Ascend(MMCKINFO* p_chunkInfo, MxU16 p_ascend)
 		return MMIOERR_BASE;
 	}
 
-	if (m_info.dwFlags & MMIO_RWMODE) {
-		if (m_info.pchBuffer) {
-			size = (MxULong) (m_info.pchNext - m_info.pchBuffer) + m_info.lBufOffset - p_chunkInfo->dwDataOffset;
+	if (dwFlags & MMIO_RWMODE) {
+		if (pchBuffer) {
+			size = (MxULong) (pchNext - pchBuffer) + lBufOffset - p_chunkInfo->dwDataOffset;
 		}
 		else {
-			size = m_info.lDiskOffset - p_chunkInfo->dwDataOffset;
+			size = lDiskOffset - p_chunkInfo->dwDataOffset;
 		}
 
 		// Write a zero byte if the chunk size is odd
@@ -580,24 +581,24 @@ MxU16 MXIOINFO::Ascend(MMCKINFO* p_chunkInfo, MxU16 p_ascend)
 			p_chunkInfo->dwFlags &= ~MMIO_DIRTY;
 
 			// Now write the corrected size
-			if (m_info.pchBuffer && ofs >= m_info.lBufOffset && m_info.cchBuffer + m_info.lBufOffset > ofs) {
-				memcpy(m_info.pchBuffer + (ofs - m_info.lBufOffset), (char*) &size, 4);
-				m_info.dwFlags |= MMIO_DIRTY;
+			if (pchBuffer && ofs >= lBufOffset && cchBuffer + lBufOffset > ofs) {
+				memcpy(pchBuffer + (ofs - lBufOffset), (char*) &size, 4);
+				dwFlags |= MMIO_DIRTY;
 			}
 			else {
-				m_info.lDiskOffset = _llseek(M_FILE, ofs, SEEK_SET);
+				lDiskOffset = _llseek(M_FILE, ofs, SEEK_SET);
 
-				if (m_info.lDiskOffset == ofs) {
+				if (lDiskOffset == ofs) {
 					if (_lwrite(M_FILE, (char*) &size, 4) != 4) {
-						m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+						lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 						result = MMIOERR_CANNOTWRITE;
 					}
 					else {
-						m_info.lDiskOffset += 4; // TODO: compiler weirdness?
+						lDiskOffset += 4; // TODO: compiler weirdness?
 					}
 				}
 				else {
-					m_info.lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
+					lDiskOffset = _llseek(M_FILE, 0, SEEK_CUR);
 					result = MMIOERR_CANNOTSEEK;
 				}
 			}

--- a/LEGO1/omni/src/stream/mxstreamcontroller.cpp
+++ b/LEGO1/omni/src/stream/mxstreamcontroller.cpp
@@ -12,6 +12,8 @@
 #include "mxtimer.h"
 #include "mxutilities.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(MxStreamController, 0x64)
 DECOMP_SIZE_ASSERT(MxNextActionDataStart, 0x14)
 DECOMP_SIZE_ASSERT(MxNextActionDataStartList, 0x0c)
@@ -60,12 +62,15 @@ MxStreamController::~MxStreamController()
 		m_unk0x2c = NULL;
 	}
 
-	while (m_unk0x54.PopFront(action)) {
-		delete action;
+	while (!m_unk0x54.empty()) {
+		MxDSObject* object = m_unk0x54.front();
+		m_unk0x54.pop_front();
+		delete object;
 	}
 }
 
 // FUNCTION: LEGO1 0x100c1520
+// FUNCTION: BETA10 0x1014e652
 MxResult MxStreamController::Open(const char* p_filename)
 {
 	char sourceName[256];
@@ -91,6 +96,7 @@ void MxStreamController::RemoveSubscriber(MxDSSubscriber* p_subscriber)
 }
 
 // FUNCTION: LEGO1 0x100c1690
+// FUNCTION: BETA10 0x1014e838
 MxResult MxStreamController::VTable0x20(MxDSAction* p_action)
 {
 	AUTOLOCK(m_criticalSection);
@@ -153,9 +159,10 @@ MxResult MxStreamController::FUN_100c1a00(MxDSAction* p_action, MxU32 p_offset)
 {
 	if (p_action->GetUnknown24() == -1) {
 		MxS16 newUnknown24 = -1;
+		MxDSObjectList::iterator it;
 
 		// These loops might be a template function in the list classes
-		for (MxDSObjectList::iterator it = m_unk0x54.begin(); it != m_unk0x54.end(); it++) {
+		for (it = m_unk0x54.begin(); it != m_unk0x54.end(); it++) {
 			MxDSObject* action = *it;
 
 			if (action->GetObjectId() == p_action->GetObjectId()) {
@@ -164,8 +171,10 @@ MxResult MxStreamController::FUN_100c1a00(MxDSAction* p_action, MxU32 p_offset)
 		}
 
 		if (newUnknown24 == -1) {
-			for (MxDSObjectList::iterator it = m_unk0x3c.begin(); it != m_unk0x3c.end(); it++) {
-				MxDSObject* action = *it;
+			MxDSObject* action;
+
+			for (it = m_unk0x3c.begin(); it != m_unk0x3c.end(); it++) {
+				action = *it;
 
 				if (action->GetObjectId() == p_action->GetObjectId()) {
 					newUnknown24 = Max(newUnknown24, action->GetUnknown24());
@@ -197,6 +206,7 @@ MxResult MxStreamController::FUN_100c1a00(MxDSAction* p_action, MxU32 p_offset)
 		return FAILURE;
 	}
 
+	assert(m_provider);
 	MxU32 fileSize = m_provider->GetFileSize();
 	streamingAction->SetBufferOffset(fileSize * (p_offset / fileSize));
 	streamingAction->SetObjectId(p_action->GetObjectId());
@@ -218,6 +228,7 @@ MxResult MxStreamController::VTable0x2c(MxDSAction* p_action, MxU32 p_bufferval)
 		return FAILURE;
 	}
 
+	assert(m_provider);
 	return FUN_100c1800(p_action, (p_bufferval / m_provider->GetFileSize()) * m_provider->GetFileSize());
 }
 

--- a/LEGO1/omni/src/system/mxsemaphore.cpp
+++ b/LEGO1/omni/src/system/mxsemaphore.cpp
@@ -12,6 +12,13 @@ MxSemaphore::MxSemaphore()
 	m_hSemaphore = NULL;
 }
 
+// FUNCTION: LEGO1 0x100c87e0
+// FUNCTION: BETA10 0x101592a9
+MxSemaphore::~MxSemaphore()
+{
+	CloseHandle(m_hSemaphore);
+}
+
 // FUNCTION: LEGO1 0x100c8800
 // FUNCTION: BETA10 0x101592d5
 MxResult MxSemaphore::Init(MxU32 p_initialCount, MxU32 p_maxCount)

--- a/LEGO1/omni/src/video/flic.cpp
+++ b/LEGO1/omni/src/video/flic.cpp
@@ -159,14 +159,16 @@ void WritePixelPairs(
 	short is_odd = p_count & 1;
 	p_count >>= 1;
 
-	WORD* dst = (WORD*) (((p_bitmapHeader->biWidth + 3) & -4) * p_row + p_column + p_pixelData);
+	p_pixelData += ((p_bitmapHeader->biWidth + 3) & -4) * p_row + p_column;
+	BYTE* pixel = (BYTE*) &p_pixel;
+	BYTE lo = *pixel;
 	while (--p_count >= 0) {
-		*dst++ = p_pixel;
+		*(WORD*) p_pixelData = p_pixel;
+		p_pixelData += 2;
 	}
 
 	if (is_odd) {
-		BYTE* dst_byte = (BYTE*) dst;
-		*dst_byte = p_pixel;
+		*p_pixelData = lo;
 	}
 }
 
@@ -323,10 +325,11 @@ void DecodeLC(LPBITMAPINFOHEADER p_bitmapHeader, BYTE* p_pixelData, BYTE* p_data
 	short row = p_flcHeader->height - (*word_data + yofs) - 1;
 
 	word_data++;
+	short column;
 	short lines = *word_data;
 
 	while (--lines >= 0) {
-		short column = xofs;
+		column = xofs;
 		BYTE packets = *data++;
 
 		while (packets > 0) {

--- a/LEGO1/omni/src/video/mxbitmap.cpp
+++ b/LEGO1/omni/src/video/mxbitmap.cpp
@@ -334,9 +334,10 @@ void MxBitmap::BitBltTransparent(
 	MxU8* dstStart = GetStart(p_dstLeft, p_dstTop);
 	MxLong srcStride = -p_width + GetAdjustedStride(p_src);
 	MxLong dstStride = -p_width + GetAdjustedStride(this);
+	MxS32 w, h;
 
-	for (MxS32 h = 0; h < p_height; h++) {
-		for (MxS32 w = 0; w < p_width; w++) {
+	for (h = 0; h < p_height; h++) {
+		for (w = 0; w < p_width; w++) {
 			if (*srcStart) {
 				*dstStart = *srcStart;
 			}
@@ -407,6 +408,7 @@ MxResult MxBitmap::SetBitDepth(MxBool p_isHighColor)
 {
 	MxResult ret = FAILURE;
 	MxPalette* pal = NULL;
+	MxU16* buf;
 
 	if (m_isHighColor == p_isHighColor) {
 		// no change: do nothing.
@@ -428,7 +430,7 @@ MxResult MxBitmap::SetBitDepth(MxBool p_isHighColor)
 		m_palette = pal;
 
 		// TODO: what is this? zeroing out top half of palette?
-		MxU16* buf = (MxU16*) m_paletteData;
+		buf = (MxU16*) m_paletteData;
 		for (MxU16 i = 0; i < 256; i++) {
 			buf[i] = i;
 		}

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -113,6 +113,7 @@ MxU8 MxDisplaySurface::CountContiguousBitsSetTo1(MxU32 p_param)
 }
 
 // FUNCTION: LEGO1 0x100ba790
+// FUNCTION: BETA10 0x1013f759
 MxResult MxDisplaySurface::Init(
 	MxVideoParam& p_videoParam,
 	LPDIRECTDRAWSURFACE p_ddSurface1,
@@ -139,10 +140,11 @@ MxResult MxDisplaySurface::Init(
 }
 
 // FUNCTION: LEGO1 0x100ba7f0
+// FUNCTION: BETA10 0x1013f7f1
 MxResult MxDisplaySurface::Create(MxVideoParam& p_videoParam)
 {
-	DDSURFACEDESC ddsd;
 	MxResult result = FAILURE;
+	DDSURFACEDESC ddsd;
 	LPDIRECTDRAW lpDirectDraw = MVideoManager()->GetDirectDraw();
 	HWND hWnd = MxOmni::GetInstance()->GetWindowHandle();
 
@@ -251,6 +253,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100baa90
+// FUNCTION: BETA10 0x1013fd5c
 void MxDisplaySurface::Destroy()
 {
 	if (m_initialized) {
@@ -367,11 +370,13 @@ void MxDisplaySurface::VTable0x28(
 		hr = m_ddSurface2->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
 	}
 
+	MxU8* data;
+
 	if (hr != DD_OK) {
 		return;
 	}
 
-	MxU8* data = p_bitmap->GetStart(p_left, p_top);
+	data = p_bitmap->GetStart(p_left, p_top);
 
 	if (m_videoParam.Flags().GetDoubleScaling()) {
 		p_bottom *= 2;
@@ -474,8 +479,9 @@ void MxDisplaySurface::VTable0x28(
 			MxLong stride = -p_width + GetAdjustedStride(p_bitmap);
 
 			MxLong length = -2 * p_width + ddsd.lPitch;
+			MxS32 j;
 			for (MxS32 i = 0; i < p_height; i++) {
-				for (MxS32 j = 0; j < p_width; j++) {
+				for (j = 0; j < p_width; j++) {
 					*(MxU16*) surface = m_16bitPal[*data++];
 					surface += 2;
 				}
@@ -573,8 +579,9 @@ void MxDisplaySurface::VTable0x30(
 			MxLong stride = -p_width + GetAdjustedStride(p_bitmap);
 
 			MxLong length = -2 * p_width + ddsd.lPitch;
+			MxS32 j;
 			for (MxS32 i = 0; i < p_height; i++) {
-				for (MxS32 j = 0; j < p_width; j++) {
+				for (j = 0; j < p_width; j++) {
 					if (*data != 0) {
 						*(MxU16*) surface = m_16bitPal[*data];
 					}
@@ -624,6 +631,7 @@ void MxDisplaySurface::DrawTransparentRLE(
 	MxU32 skipCount;
 	MxU32 drawCount;
 	MxU32 t;
+	MxU32 rowRemainder;
 
 	if (p_bpp == 16) {
 		// DECOMP: why goto?
@@ -637,7 +645,7 @@ void MxDisplaySurface::DrawTransparentRLE(
 		t = *p_bitmapData++;
 		skipCount += t << 16;
 
-		MxS32 rowRemainder = p_width - count % p_width;
+		rowRemainder = p_width - count % p_width;
 		count += skipCount;
 
 		if (skipCount >= rowRemainder) {
@@ -695,7 +703,7 @@ sixteen_bit:
 		t = *p_bitmapData++;
 		skipCount += t << 16;
 
-		MxS32 rowRemainder = p_width - count % p_width;
+		MxU32 rowRemainder = p_width - count % p_width;
 		count += skipCount;
 
 		if (skipCount >= rowRemainder) {
@@ -729,7 +737,7 @@ sixteen_bit:
 			drawCount -= rowRemainder;
 
 			p_surfaceData += p_pitch - 2 * p_width;
-			MxS32 rows = drawCount / p_width;
+			MxU32 rows = drawCount / p_width;
 
 			for (MxU32 i = 0; i < rows; i++) {
 				// memcpy
@@ -823,6 +831,7 @@ void MxDisplaySurface::VTable0x34(MxU8* p_pixels, MxS32 p_bpp, MxS32 p_width, Mx
 }
 
 // FUNCTION: LEGO1 0x100bba50
+// FUNCTION: BETA10 0x10141498
 void MxDisplaySurface::Display(MxS32 p_left, MxS32 p_top, MxS32 p_left2, MxS32 p_top2, MxS32 p_width, MxS32 p_height)
 {
 	if (m_videoParam.Flags().GetEnabled()) {
@@ -857,10 +866,10 @@ void MxDisplaySurface::Display(MxS32 p_left, MxS32 p_top, MxS32 p_left2, MxS32 p
 			p_left2 += m_videoParam.GetRect().GetLeft() + point.GetX();
 			p_top2 += m_videoParam.GetRect().GetTop() + point.GetY();
 
+			DDBLTFX data;
 			MxRect32 a(MxPoint32(p_left, p_top), MxSize32(p_width + 1, p_height + 1));
 			MxRect32 b(MxPoint32(p_left2, p_top2), MxSize32(p_width + 1, p_height + 1));
 
-			DDBLTFX data;
 			memset(&data, 0, sizeof(data));
 			data.dwSize = sizeof(data);
 			data.dwDDFX = DDBLTFX_NOTEARING;
@@ -874,6 +883,7 @@ void MxDisplaySurface::Display(MxS32 p_left, MxS32 p_top, MxS32 p_left2, MxS32 p
 }
 
 // FUNCTION: LEGO1 0x100bbc10
+// FUNCTION: BETA10 0x101416a6
 void MxDisplaySurface::GetDC(HDC* p_hdc)
 {
 	if (m_ddSurface2 && !m_ddSurface2->GetDC(p_hdc)) {
@@ -884,6 +894,7 @@ void MxDisplaySurface::GetDC(HDC* p_hdc)
 }
 
 // FUNCTION: LEGO1 0x100bbc40
+// FUNCTION: BETA10 0x10141700
 void MxDisplaySurface::ReleaseDC(HDC p_hdc)
 {
 	if (m_ddSurface2 && p_hdc) {
@@ -1100,13 +1111,16 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::CreateCursorSurface()
 		goto done;
 	}
 	else {
+		MxU16* surface2;
 		MxU16* surface = (MxU16*) ddsd.lpSurface;
 		MxLong pitch = ddsd.lPitch;
+		MxS32 x;
+		MxS32 y;
 
 		// draw a simple cursor to the surface
-		for (MxS32 x = 0; x < 16; x++) {
-			MxU16* surface2 = surface;
-			for (MxS32 y = 0; y < 16; y++) {
+		for (x = 0; x < 16; x++) {
+			surface2 = surface;
+			for (y = 0; y < 16; y++) {
 				if ((y > 10 || x) && (x > 10 || y) && x + y != 10) {
 					if (x + y > 10) {
 						*surface2 = RGB555_CREATE(0x1f, 0, 0x1f);
@@ -1181,10 +1195,11 @@ void MxDisplaySurface::VTable0x24(
 			MxLong stride = -p_width + GetAdjustedStride(p_bitmap);
 
 			MxLong length = -2 * p_width + p_desc->lPitch;
+			MxS32 i;
 			while (p_height--) {
 				MxU8* surfaceBefore = surface;
 
-				for (MxS32 i = 0; p_width > i; i++) {
+				for (i = 0; p_width > i; i++) {
 					*surface++ = *data;
 					*surface++ = *data++;
 				}
@@ -1204,16 +1219,16 @@ void MxDisplaySurface::VTable0x24(
 			MxS32 length = -4 * p_width + p_desc->lPitch;
 			MxS32 height = p_height;
 			MxS32 width = p_width;
-			MxS32 copyWidth = width * 4;
 			MxU16* p16bitPal = m_16bitPal;
 
+			MxU16 element;
 			MxS32 i;
 			if (!stride && !length) {
 				while (height--) {
 					MxU8* surfaceBefore = surface;
 
 					for (i = 0; i < width; i++) {
-						MxU16 element = p16bitPal[*data];
+						element = p16bitPal[*data];
 						*(MxU16*) surface = element;
 						surface += 2;
 						*(MxU16*) surface = element;
@@ -1222,7 +1237,7 @@ void MxDisplaySurface::VTable0x24(
 						surface += 2;
 					}
 
-					memcpy(surface, surfaceBefore, copyWidth);
+					memcpy(surface, surfaceBefore, width * 4);
 					surface += p_desc->lPitch;
 				}
 			}
@@ -1231,7 +1246,7 @@ void MxDisplaySurface::VTable0x24(
 					MxU8* surfaceBefore = surface;
 
 					for (i = 0; i < width; i++) {
-						MxU16 element = p16bitPal[*data];
+						element = p16bitPal[*data];
 						*(MxU16*) surface = element;
 						surface += 2;
 						*(MxU16*) surface = element;
@@ -1333,8 +1348,9 @@ void MxDisplaySurface::VTable0x2c(
 			MxLong srcSkip = GetAdjustedStride(p_bitmap) - p_width;
 			MxLong destSkip = destStride - p_width;
 
+			MxS32 j;
 			for (MxS32 i = 0; i < p_height; i++, src += srcSkip, dest += destSkip) {
-				for (MxS32 j = 0; j < p_width; j++, src++, dest++) {
+				for (j = 0; j < p_width; j++, src++, dest++) {
 					if (*src) {
 						*dest = *src;
 					}
@@ -1351,12 +1367,13 @@ void MxDisplaySurface::VTable0x2c(
 			DrawTransparentRLE(src, dest, p_bitmap->GetBmiHeader()->biSizeImage, p_width, p_height, p_desc->lPitch, 16);
 		}
 		else {
+			MxS32 j;
 			MxLong srcStride = GetAdjustedStride(p_bitmap);
 			MxLong srcSkip = srcStride - p_width;
 			MxLong destSkip = destStride - 2 * p_width;
 
 			for (MxS32 i = 0; i < p_height; i++, src += srcSkip, dest += destSkip) {
-				for (MxS32 j = 0; j < p_width; j++, src++, dest += 2) {
+				for (j = 0; j < p_width; j++, src++, dest += 2) {
 					if (*src != 0) {
 						*(MxU16*) dest = m_16bitPal[*src];
 					}

--- a/LEGO1/omni/src/video/mxregion.cpp
+++ b/LEGO1/omni/src/video/mxregion.cpp
@@ -46,22 +46,23 @@ void MxRegion::AddRect(MxRect32& p_rect)
 			rect.SetTop(rect.GetBottom());
 		}
 		else if (rect.GetTop() < span->GetMax()) {
+			MxSpan* newSpan;
 			if (rect.GetTop() < span->GetMin()) {
 				newRect = rect;
 				newRect.SetBottom(span->GetMin());
-				MxSpan* newSpan = new MxSpan(newRect);
+				newSpan = new MxSpan(newRect);
 				cursor.Prepend(newSpan);
 				rect.SetTop(span->GetMin());
 			}
 			else if (span->GetMin() < rect.GetTop()) {
-				MxSpan* newSpan = span->Clone();
+				newSpan = span->Clone();
 				newSpan->SetMax(rect.GetTop());
 				span->SetMin(rect.GetTop());
 				cursor.Prepend(newSpan);
 			}
 
 			if (rect.GetBottom() < span->GetMax()) {
-				MxSpan* newSpan = span->Clone();
+				newSpan = span->Clone();
 				newSpan->SetMax(rect.GetBottom());
 				span->SetMin(rect.GetBottom());
 				newSpan->AddSegment(rect.GetLeft(), rect.GetRight());
@@ -118,6 +119,7 @@ MxRegionCursor::MxRegionCursor(MxRegion* p_region)
 }
 
 // FUNCTION: LEGO1 0x100c40b0
+// FUNCTION: BETA10 0x10149747
 MxRegionCursor::~MxRegionCursor()
 {
 	if (m_rect) {
@@ -134,6 +136,7 @@ MxRegionCursor::~MxRegionCursor()
 }
 
 // FUNCTION: LEGO1 0x100c4140
+// FUNCTION: BETA10 0x10149838
 MxRect32* MxRegionCursor::Head()
 {
 	m_spanListCursor->Head();
@@ -155,6 +158,7 @@ MxRect32* MxRegionCursor::Head()
 }
 
 // FUNCTION: LEGO1 0x100c41d0
+// FUNCTION: BETA10 0x101498d4
 MxRect32* MxRegionCursor::Tail()
 {
 	m_spanListCursor->Tail();
@@ -176,6 +180,7 @@ MxRect32* MxRegionCursor::Tail()
 }
 
 // FUNCTION: LEGO1 0x100c4260
+// FUNCTION: BETA10 0x10149970
 MxRect32* MxRegionCursor::Next()
 {
 	MxSegment* segment;
@@ -201,6 +206,7 @@ MxRect32* MxRegionCursor::Next()
 }
 
 // FUNCTION: LEGO1 0x100c4360
+// FUNCTION: BETA10 0x10149a69
 MxRect32* MxRegionCursor::Prev()
 {
 	MxSegment* segment;
@@ -226,6 +232,7 @@ MxRect32* MxRegionCursor::Prev()
 }
 
 // FUNCTION: LEGO1 0x100c4460
+// FUNCTION: BETA10 0x10149b62
 MxRect32* MxRegionCursor::Head(MxRect32& p_rect)
 {
 	m_spanListCursor->Reset();
@@ -234,6 +241,7 @@ MxRect32* MxRegionCursor::Head(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c4480
+// FUNCTION: BETA10 0x10149b97
 MxRect32* MxRegionCursor::Tail(MxRect32& p_rect)
 {
 	m_spanListCursor->Reset();
@@ -242,6 +250,7 @@ MxRect32* MxRegionCursor::Tail(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c44a0
+// FUNCTION: BETA10 0x10149bcc
 MxRect32* MxRegionCursor::Next(MxRect32& p_rect)
 {
 	MxSegment* segment;
@@ -267,6 +276,7 @@ MxRect32* MxRegionCursor::Next(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c4590
+// FUNCTION: BETA10 0x10149cae
 MxRect32* MxRegionCursor::Prev(MxRect32& p_rect)
 {
 	MxSegment* segment;
@@ -292,6 +302,7 @@ MxRect32* MxRegionCursor::Prev(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c4680
+// FUNCTION: BETA10 0x10149d90
 void MxRegionCursor::Reset()
 {
 	if (m_rect) {
@@ -308,6 +319,7 @@ void MxRegionCursor::Reset()
 }
 
 // FUNCTION: LEGO1 0x100c46c0
+// FUNCTION: BETA10 0x10149e24
 void MxRegionCursor::CreateSegmentListCursor(MxSegmentList* p_segList)
 {
 	if (m_segListCursor) {
@@ -318,6 +330,7 @@ void MxRegionCursor::CreateSegmentListCursor(MxSegmentList* p_segList)
 }
 
 // FUNCTION: LEGO1 0x100c4980
+// FUNCTION: BETA10 0x10149ef1
 void MxRegionCursor::SetRect(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_bottom)
 {
 	if (!m_rect) {
@@ -331,9 +344,11 @@ void MxRegionCursor::SetRect(MxS32 p_left, MxS32 p_top, MxS32 p_right, MxS32 p_b
 }
 
 // FUNCTION: LEGO1 0x100c4a20
+// FUNCTION: BETA10 0x10149fcc
 void MxRegionCursor::NextSpan(MxRect32& p_rect)
 {
 	MxSpan* span;
+	MxSegment* segment;
 	while (m_spanListCursor->Next(span)) {
 		if (p_rect.GetBottom() <= span->GetMin()) {
 			Reset();
@@ -343,7 +358,6 @@ void MxRegionCursor::NextSpan(MxRect32& p_rect)
 		if (p_rect.GetTop() < span->GetMax()) {
 			CreateSegmentListCursor(span->m_segList);
 
-			MxSegment* segment;
 			while (m_segListCursor->Next(segment)) {
 				if (p_rect.GetRight() <= segment->GetMin()) {
 					break;
@@ -362,6 +376,7 @@ void MxRegionCursor::NextSpan(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c4b50
+// FUNCTION: BETA10 0x1014a0fb
 void MxRegionCursor::PrevSpan(MxRect32& p_rect)
 {
 	MxSpan* span;
@@ -393,6 +408,7 @@ void MxRegionCursor::PrevSpan(MxRect32& p_rect)
 }
 
 // FUNCTION: LEGO1 0x100c4c90
+// FUNCTION: BETA10 0x1014a22a
 MxSpan::MxSpan(MxS32 p_min, MxS32 p_max)
 {
 	m_min = p_min;

--- a/LEGO1/omni/src/video/mxstillpresenter.cpp
+++ b/LEGO1/omni/src/video/mxstillpresenter.cpp
@@ -38,8 +38,7 @@ void MxStillPresenter::LoadHeader(MxStreamChunk* p_chunk)
 		delete[] ((MxU8*) m_bitmapInfo);
 	}
 
-	MxU8* data = new MxU8[p_chunk->GetLength()];
-	m_bitmapInfo = (MxBITMAPINFO*) data;
+	m_bitmapInfo = (MxBITMAPINFO*) new MxU8[p_chunk->GetLength()];
 	memcpy(m_bitmapInfo, p_chunk->GetData(), p_chunk->GetLength());
 }
 
@@ -234,11 +233,17 @@ MxStillPresenter* MxStillPresenter::Clone()
 			MxDSAction* action = GetAction()->Clone();
 
 			if (action && presenter->StartAction(NULL, action) == SUCCESS) {
-				presenter->SetLoadedFirstFrame(LoadedFirstFrame());
-				presenter->SetUseSurface(UseSurface());
-				presenter->SetUseVideoMemory(UseVideoMemory());
-				presenter->SetDoNotWriteToSurface(DoNotWriteToSurface());
-				presenter->SetBitmapIsMap(BitmapIsMap());
+				BOOL v;
+				v = LoadedFirstFrame();
+				presenter->m_flags.m_bit0 = v;
+				v = UseSurface();
+				presenter->m_flags.m_bit1 = v;
+				v = UseVideoMemory();
+				presenter->m_flags.m_bit2 = v;
+				v = DoNotWriteToSurface();
+				presenter->m_flags.m_bit3 = v;
+				v = BitmapIsMap();
+				presenter->m_flags.m_bit4 = v;
 
 				if (m_frameBitmap) {
 					presenter->m_frameBitmap = new MxBitmap;

--- a/LEGO1/omni/src/video/mxvideopresenter.cpp
+++ b/LEGO1/omni/src/video/mxvideopresenter.cpp
@@ -8,13 +8,16 @@
 #include "mxregion.h"
 #include "mxvideomanager.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(MxVideoPresenter, 0x64);
 DECOMP_SIZE_ASSERT(MxVideoPresenter::AlphaMask, 0x0c);
 
 // FUNCTION: LEGO1 0x100b24f0
 MxVideoPresenter::AlphaMask::AlphaMask(const MxBitmap& p_bitmap)
 {
-	m_width = p_bitmap.GetBmiWidth();
+	BITMAPINFOHEADER* header = p_bitmap.GetBmiHeader();
+	m_width = header->biWidth;
 	m_height = p_bitmap.GetBmiHeightAbs();
 
 	MxS32 size = ((m_width * m_height) / 8) + 1;
@@ -43,8 +46,8 @@ MxVideoPresenter::AlphaMask::AlphaMask(const MxBitmap& p_bitmap)
 	// are just for counting the pixels.
 	MxS32 offset = 0;
 
+	MxU8* tPtr = bitmapSrcPtr;
 	for (MxS32 j = 0; j < m_height; j++) {
-		MxU8* tPtr = bitmapSrcPtr;
 		for (MxS32 i = 0; i < m_width; i++) {
 			if (*tPtr) {
 				m_bitmask[offset / 8] |= (1 << (offset % 8));
@@ -80,12 +83,12 @@ MxVideoPresenter::AlphaMask::~AlphaMask()
 // FUNCTION: LEGO1 0x100b26f0
 MxS32 MxVideoPresenter::AlphaMask::IsHit(MxU32 p_x, MxU32 p_y)
 {
-	if (p_x >= m_width || p_y >= m_height) {
-		return 0;
+	if (p_x < m_width && p_y < m_height) {
+		MxS32 pos = p_y * m_width + p_x;
+		return m_bitmask[pos / 8] & (1 << (pos % 8)) ? 1 : 0;
 	}
 
-	MxS32 pos = p_y * m_width + p_x;
-	return m_bitmask[pos / 8] & (1 << (pos % 8)) ? 1 : 0;
+	return 0;
 }
 
 // FUNCTION: LEGO1 0x100b2760
@@ -194,7 +197,7 @@ MxBool MxVideoPresenter::IsHit(MxS32 p_x, MxS32 p_y)
 	return TRUE;
 }
 
-inline MxS32 MxVideoPresenter::PrepareRects(RECT& p_rectDest, RECT& p_rectSrc)
+inline MxS32 PrepareRects(RECT& p_rectSrc, RECT& p_rectDest)
 {
 	if (p_rectDest.top > 480 || p_rectDest.left > 640 || p_rectSrc.top > 480 || p_rectSrc.left > 640) {
 		return -1;
@@ -216,19 +219,19 @@ inline MxS32 MxVideoPresenter::PrepareRects(RECT& p_rectDest, RECT& p_rectSrc)
 		p_rectSrc.right = 640;
 	}
 
-	LONG height, width;
+	LONG width, height;
 	if ((height = (p_rectDest.bottom - p_rectDest.top) + 1) <= 1 ||
 		(width = (p_rectDest.right - p_rectDest.left) + 1) <= 1) {
 		return -1;
 	}
-	else if ((p_rectSrc.right - p_rectSrc.left + 1) == width && (p_rectSrc.bottom - p_rectSrc.top + 1) == height) {
+
+	if ((p_rectSrc.right - p_rectSrc.left + 1) == width && (p_rectSrc.bottom - p_rectSrc.top + 1) == height) {
 		return 1;
 	}
-	else {
-		p_rectSrc.right = (p_rectSrc.left + width) - 1;
-		p_rectSrc.bottom = (p_rectSrc.top + height) - 1;
-		return 0;
-	}
+
+	p_rectSrc.right = (p_rectSrc.left + width) - 1;
+	p_rectSrc.bottom = (p_rectSrc.top + height) - 1;
+	return 0;
 }
 
 // FUNCTION: LEGO1 0x100b2a70
@@ -236,13 +239,13 @@ void MxVideoPresenter::PutFrame()
 {
 	MxDisplaySurface* displaySurface = MVideoManager()->GetDisplaySurface();
 	MxRegion* region = MVideoManager()->GetRegion();
-	MxRect32 rect(MxPoint32(0, 0), MxSize32(GetWidth(), GetHeight()));
-	rect += GetLocation();
+	MxRect32 rect(MxPoint32(GetX(), GetY()), MxSize32(GetWidth(), GetHeight()));
 	LPDIRECTDRAWSURFACE ddSurface = displaySurface->GetDirectDrawSurface2();
+	HRESULT r = DD_OK;
 
 	if (m_action->GetFlags() & MxDSAction::c_bit5) {
 		if (m_surface) {
-			RECT src, dest;
+			RECT dest, src;
 			src.top = 0;
 			src.left = 0;
 			src.right = GetWidth();
@@ -255,11 +258,12 @@ void MxVideoPresenter::PutFrame()
 
 			switch (PrepareRects(src, dest)) {
 			case 0:
-				ddSurface->Blt(&dest, m_surface, &src, DDBLT_KEYSRC, NULL);
+				r = ddSurface->Blt(&dest, m_surface, &src, DDBLT_KEYSRC, NULL);
 				break;
 			case 1:
-				ddSurface->BltFast(dest.left, dest.top, m_surface, &src, DDBLTFAST_SRCCOLORKEY | DDBLTFAST_WAIT);
+				r = ddSurface->BltFast(dest.left, dest.top, m_surface, &src, DDBLTFAST_SRCCOLORKEY | DDBLTFAST_WAIT);
 			}
+			assert(r == DD_OK);
 		}
 		else {
 			displaySurface->VTable0x30(
@@ -275,12 +279,12 @@ void MxVideoPresenter::PutFrame()
 		}
 	}
 	else {
-		MxRegionCursor cursor(region);
 		MxRect32* regionRect;
+		MxRegionCursor cursor(region);
 
 		while ((regionRect = cursor.Next(rect))) {
 			if (regionRect->GetWidth() >= 1 && regionRect->GetHeight() >= 1) {
-				RECT src, dest;
+				RECT dest, src;
 
 				if (m_surface) {
 					src.left = regionRect->GetLeft() - GetX();
@@ -297,7 +301,8 @@ void MxVideoPresenter::PutFrame()
 				if (m_action->GetFlags() & MxDSAction::c_bit4) {
 					if (m_surface) {
 						if (PrepareRects(src, dest) >= 0) {
-							ddSurface->Blt(&dest, m_surface, &src, DDBLT_KEYSRC, NULL);
+							r = ddSurface->Blt(&dest, m_surface, &src, DDBLT_KEYSRC, NULL);
+							assert(r == DD_OK);
 						}
 					}
 					else {
@@ -315,16 +320,19 @@ void MxVideoPresenter::PutFrame()
 				}
 				else if (m_surface) {
 					if (PrepareRects(src, dest) >= 0) {
-						ddSurface->Blt(&dest, m_surface, &src, 0, NULL);
+						r = ddSurface->Blt(&dest, m_surface, &src, 0, NULL);
+						assert(r == DD_OK);
 					}
 				}
 				else {
+					MxS32 top = regionRect->GetTop();
+					MxS32 left = regionRect->GetLeft();
 					displaySurface->VTable0x28(
 						m_frameBitmap,
-						regionRect->GetLeft() - GetX(),
-						regionRect->GetTop() - GetY(),
-						regionRect->GetLeft(),
-						regionRect->GetTop(),
+						left - GetX(),
+						top - GetY(),
+						left,
+						top,
 						regionRect->GetWidth(),
 						regionRect->GetHeight()
 					);


### PR DESCRIPTION
Small rewrites in the engine library so the compiler produces exactly the original instructions.

- `MXIOINFO` inherits from the Windows type it was based on.
- Some default constructors are split into two, the way the 1997 code wrote them.
- Loop variables are declared before their loops, as pre-standard C++ required. Modern MSVC gets a flag so it accepts this too.
- Global variables return to their original order, and assertions from the beta build are restored.
- Three functions are reshaped: `PutFrame` names two temporaries before its last call, `MxRegion::AddRect` reuses one pointer instead of declaring three, and `MxDSBuffer::FUN_100c6fa0` reads through the address of its cursor and reads the chunk length twice, as the beta build shows. Each change makes the compiler choose the same registers and instruction order as the original.

---

**About this series:** step 7 of 12 (#1762–#1773). Together the twelve steps make the build produce the original LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte for byte. Each step builds and passes the usual checks on its own; the last step (#1773) adds the check that the output is identical to the original files. See #1761 for the full story.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9hpkbGxzV6BU1BEsWs9E
