### PR TITLE
Legoomni source-shape restoration

### DIFF
--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -17,6 +17,10 @@ const char* g_strATTACH_CAMERA = "ATTACH_CAMERA";
 // STRING: LEGO1 0x10102018
 const char* g_strAUTO_CREATE = "AUTO_CREATE";
 
+// GLOBAL: LEGO1 0x10102058
+// STRING: LEGO1 0x10102010
+const char* g_strBANK = "BANK";
+
 // GLOBAL: LEGO1 0x1010205c
 // STRING: LEGO1 0x10102000
 const char* g_strBOTTOM_TO_TOP = "BOTTOM_TO_TOP";
@@ -36,6 +40,10 @@ const char* g_strGRID = "GRID";
 // GLOBAL: LEGO1 0x1010206c
 // STRING: LEGO1 0x10101fe0
 const char* g_strMAP = "MAP";
+
+// GLOBAL: LEGO1 0x10102070
+// STRING: LEGO1 0x10101fd8
+const char* g_strPUSH = "PUSH";
 
 // GLOBAL: LEGO1 0x10102074
 // STRING: LEGO1 0x10101fd0
@@ -60,6 +68,14 @@ const char* g_strHIDE_ON_STOP = "HIDE_ON_STOP";
 // GLOBAL: LEGO1 0x10102088
 // STRING: LEGO1 0x10101f94
 const char* g_strLEFT_TO_RIGHT = "LEFT_TO_RIGHT";
+
+// GLOBAL: LEGO1 0x1010208c
+// STRING: LEGO1 0x10101f88
+const char* g_mapLocator = "MAP_LOCATOR";
+
+// GLOBAL: LEGO1 0x10102090
+// STRING: LEGO1 0x10101f78
+const char* g_mapGeometry = "MAP_GEOMETRY";
 
 // GLOBAL: LEGO1 0x10102094
 // STRING: LEGO1 0x10101f70
@@ -133,6 +149,10 @@ const char* g_strANIMMAN_ID = "ANIMMAN_ID";
 // STRING: LEGO1 0x10101ec8
 const char* g_strCOMP = "COMP";
 
+// GLOBAL: LEGO1 0x101020dc
+// STRING: LEGO1 0x10101ebc
+const char* g_strBMP_INVIDEO = "BMP_INVIDEO";
+
 // GLOBAL: LEGO1 0x101020e0
 // STRING: LEGO1 0x10101eb0
 const char* g_strBMP_ISMAP = "BMP_ISMAP";
@@ -141,7 +161,3 @@ const char* g_strBMP_ISMAP = "BMP_ISMAP";
 // STRING: LEGO1 0x10101eac
 // GLOBAL: BETA10 0x10202948
 const char* g_parseExtraTokens = ":;";
-
-// GLOBAL: LEGO1 0x100f0c14
-// STRING: LEGO1 0x100f0c04
-const char* g_strHIT_ACTOR_SOUND = "HIT_ACTOR_SOUND";

--- a/LEGO1/define.h
+++ b/LEGO1/define.h
@@ -22,6 +22,8 @@ extern const char* g_strTRIGGERS_SOURCE;
 extern const char* g_strPTATCAM;
 extern const char* g_strTOGGLE;
 extern const char* g_strMAP;
+extern const char* g_mapLocator;
+extern const char* g_mapGeometry;
 extern const char* g_strGRID;
 extern const char* g_strSTYLE;
 extern const char* g_strTYPE;

--- a/LEGO1/lego/legoomni/include/act3.h
+++ b/LEGO1/lego/legoomni/include/act3.h
@@ -1,10 +1,11 @@
 #ifndef ACT3_H
 #define ACT3_H
 
+#include "legoworld.h"
+
 #include "act3ammo.h"
 #include "legogamestate.h"
 #include "legostate.h"
-#include "legoworld.h"
 
 class Act3Brickster;
 class Act3Cop;
@@ -194,17 +195,17 @@ protected:
 	LegoGameState::Area m_destLocation;        // 0x4270
 };
 
-// TEMPLATE: LEGO1 0x10071f10
-// list<Act3ListElement,allocator<Act3ListElement> >::insert
+// TEMPLATE: LEGO1 0x10071f10 SYMBOL
+// ?insert@?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@QAE?AViterator@1@V21@ABUAct3ListElement@@@Z
 
-// TEMPLATE: LEGO1 0x10071f70
-// list<Act3ListElement,allocator<Act3ListElement> >::_Buynode
+// TEMPLATE: LEGO1 0x10071f70 SYMBOL
+// ?_Buynode@?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x10072220
-// list<Act3ListElement,allocator<Act3ListElement> >::erase
+// TEMPLATE: LEGO1 0x10072220 SYMBOL
+// ?erase@?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10072440
-// list<Act3ListElement,allocator<Act3ListElement> >::~list<Act3ListElement,allocator<Act3ListElement> >
+// TEMPLATE: LEGO1 0x10072440 SYMBOL
+// ??1?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x100724b0
 // List<Act3ListElement>::~List<Act3ListElement>

--- a/LEGO1/lego/legoomni/include/act3ammo.h
+++ b/LEGO1/lego/legoomni/include/act3ammo.h
@@ -28,7 +28,7 @@ public:
 	MxU32 IsValid() { return m_ammoFlag & c_valid; }
 
 	// FUNCTION: BETA10 0x100177b0
-	Mx3DPointFloat* GetCoefficients() { return m_coefficients; }
+	Mx3DPointFloat* GetCoefficients() { return m_eq; }
 
 	// FUNCTION: BETA10 0x100177e0
 	MxFloat* GetApexParameter() { return &m_apexParameter; }
@@ -94,11 +94,11 @@ private:
 
 	static Mx3DPointFloat g_hitTranslation;
 
-	MxU16 m_ammoFlag;                 // 0x154
-	MxFloat m_rotateTimeout;          // 0x158
-	Act3* m_world;                    // 0x15c
-	Mx3DPointFloat m_coefficients[3]; // 0x160
-	MxFloat m_apexParameter;          // 0x19c
+	MxU16 m_ammoFlag;        // 0x154
+	MxFloat m_rotateTimeout; // 0x158
+	Act3* m_world;           // 0x15c
+	Mx3DPointFloat m_eq[3];  // 0x160
+	MxFloat m_apexParameter; // 0x19c
 };
 
 #endif // ACT3AMMO_H

--- a/LEGO1/lego/legoomni/include/lego3dsound.h
+++ b/LEGO1/lego/legoomni/include/lego3dsound.h
@@ -18,7 +18,7 @@ public:
 
 	void Init();
 	MxResult Create(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char* p_name, MxS32 p_volume);
-	void Destroy();
+	virtual void Destroy();
 	MxU32 UpdatePosition(LPDIRECTSOUNDBUFFER p_directSoundBuffer);
 	void FUN_10011a60(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char* p_name);
 	void Reset();

--- a/LEGO1/lego/legoomni/include/legoanimactor.h
+++ b/LEGO1/lego/legoomni/include/legoanimactor.h
@@ -11,7 +11,9 @@ struct LegoAnimActorStruct {
 	LegoAnimActorStruct(float p_worldSpeed, LegoAnim* p_AnimTreePtr, LegoROI** p_roiMap, MxU32 p_numROIs);
 	~LegoAnimActorStruct();
 
+	float GetDistance(float p_time);
 	float GetDuration();
+	float GetTotalDistance();
 
 	// FUNCTION: BETA10 0x1000fb10
 	float GetWorldSpeed() { return m_worldSpeed; }
@@ -84,8 +86,8 @@ protected:
 // GLOBAL: LEGO1 0x100d5438
 // LegoAnimActor::`vbtable'
 
-// TEMPLATE: LEGO1 0x1000da20
-// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::~vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >
+// TEMPLATE: LEGO1 0x1000da20 SYMBOL
+// ??1?$vector@PAULegoAnimActorStruct@@V?$allocator@PAULegoAnimActorStruct@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1000da60
 // Vector<LegoAnimActorStruct *>::~Vector<LegoAnimActorStruct *>
@@ -94,21 +96,21 @@ protected:
 // SYNTHETIC: BETA10 0x1000fad0
 // LegoAnimActor::`vbase destructor'
 
-// TEMPLATE: LEGO1 0x1001c010
-// vector<unsigned char *,allocator<unsigned char *> >::~vector<unsigned char *,allocator<unsigned char *> >
+// TEMPLATE: LEGO1 0x1001c010 SYMBOL
+// ??1?$vector@PAEV?$allocator@PAE@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1001c050
 // Vector<unsigned char *>::~Vector<unsigned char *>
 
-// TEMPLATE: LEGO1 0x1001c7c0
-// TEMPLATE: BETA10 0x1000fb40
-// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::size
+// TEMPLATE: LEGO1 0x1001c7c0 SYMBOL
+// TEMPLATE: BETA10 0x1000fb40 SYMBOL
+// ?size@?$vector@PAULegoAnimActorStruct@@V?$allocator@PAULegoAnimActorStruct@@@@@@QBEIXZ
 
 // TEMPLATE: BETA10 0x1000fb90
 // vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::operator[]
 
-// TEMPLATE: LEGO1 0x1001c7e0
-// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::_Destroy
+// TEMPLATE: LEGO1 0x1001c7e0 SYMBOL
+// ?_Destroy@?$vector@PAULegoAnimActorStruct@@V?$allocator@PAULegoAnimActorStruct@@@@@@IAEXPAPAULegoAnimActorStruct@@0@Z
 
 // TEMPLATE: BETA10 0x1000fbc0
 // vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::begin

--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -13,11 +13,11 @@ class MxMatrix;
 class Vector3;
 
 struct LegoAnimStructComparator {
-	MxBool operator()(const char* const& p_a, const char* const& p_b) const { return strcmp(p_a, p_b) < 0; }
+	MxBool operator()(const char* p_a, const char* p_b) const { return strcmp(p_a, p_b) < 0; }
 };
 
 struct LegoAnimSubstComparator {
-	MxBool operator()(const char* const& p_a, const char* const& p_b) const { return strcmp(p_a, p_b) < 0; }
+	MxBool operator()(const char* p_a, const char* p_b) const { return strcmp(p_a, p_b) < 0; }
 };
 
 // SIZE 0x08
@@ -106,6 +106,7 @@ public:
 	// FUNCTION: BETA10 0x1005ab00
 	void SetRoiTransform(Matrix4* p_roiTransform) { m_roiTransform = p_roiTransform; }
 
+	// FUNCTION: BETA10 0x10028490
 	LegoAnim* GetAnimation() { return m_anim; }
 
 protected:
@@ -266,7 +267,7 @@ private:
 class LegoPathBoundary;
 
 struct LegoHideAnimStructComparator {
-	MxBool operator()(const char* const& p_a, const char* const& p_b) const { return strcmp(p_a, p_b) < 0; }
+	MxBool operator()(const char* p_a, const char* p_b) const { return strcmp(p_a, p_b) < 0; }
 };
 
 // SIZE 0x08
@@ -340,89 +341,89 @@ private:
 
 // clang-format off
 
-// TEMPLATE: LEGO1 0x100689c0
-// map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::~map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >
+// TEMPLATE: LEGO1 0x100689c0 SYMBOL
+// ??1?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10068a10
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::~_Tree<char const *,pair<char const * const,char const *>,map
+// TEMPLATE: LEGO1 0x10068a10 SYMBOL
+// ??1?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10068ae0
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10068ae0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10068b20
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::erase
+// TEMPLATE: LEGO1 0x10068b20 SYMBOL
+// ?erase@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10068f70
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::_Erase
+// TEMPLATE: LEGO1 0x10068f70 SYMBOL
+// ?_Erase@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10069d80
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::~_Tree<char const *,pair<char const * const,LegoAni
+// TEMPLATE: LEGO1 0x10069d80 SYMBOL
+// ??1?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10069e50
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10069e50 SYMBOL
+// ?_Inc@iterator@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10069e90
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::erase
+// TEMPLATE: LEGO1 0x10069e90 SYMBOL
+// ?erase@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1006a2e0
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Erase
+// TEMPLATE: LEGO1 0x1006a2e0 SYMBOL
+// ?_Erase@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1006a320
 // Map<char const *,LegoAnimStruct,LegoAnimStructComparator>::~Map<char const *,LegoAnimStruct,LegoAnimStructComparator>
 
-// TEMPLATE: LEGO1 0x1006a370
-// map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::~map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >
+// TEMPLATE: LEGO1 0x1006a370 SYMBOL
+// ??1?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1006a750
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x1006a750 SYMBOL
+// ?_Dec@iterator@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006a7a0
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Insert
+// TEMPLATE: LEGO1 0x1006a7a0 SYMBOL
+// ?_Insert@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@IAE?AViterator@1@PAU_Node@1@0ABU?$pair@QBDULegoAnim
 
-// TEMPLATE: LEGO1 0x1006c1b0
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x1006c1b0 SYMBOL
+// ?_Dec@iterator@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006c200
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::_Insert
+// TEMPLATE: LEGO1 0x1006c200 SYMBOL
+// ?_Insert@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@IAE?AViterator@1@PAU_Node@1@0ABU?$pair@QBDPBD@@@Z
 
-// TEMPLATE: LEGO1 0x1006c4b0
-// list<char *,allocator<char *> >::~list<char *,allocator<char *> >
+// TEMPLATE: LEGO1 0x1006c4b0 SYMBOL
+// ??1?$list@PADV?$allocator@PAD@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1006c520
 // List<char *>::~List<char *>
 
 // GLOBAL: LEGO1 0x100f7680
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::_Nil
+// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *>>::_Kfn,LegoAnimSubstComparator,allocator<char const *>>::_Nil
 
 // GLOBAL: LEGO1 0x100f7688
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Nil
+// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct>>::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct>>::_Nil
 
-// TEMPLATE: LEGO1 0x1006ddb0
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::~_Tree<char const *,pair<ch
+// TEMPLATE: LEGO1 0x1006ddb0 SYMBOL
+// ??1?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1006de80
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x1006de80 SYMBOL
+// ?_Inc@iterator@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006dec0
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::erase
+// TEMPLATE: LEGO1 0x1006dec0 SYMBOL
+// ?erase@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1006e310
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Erase
+// TEMPLATE: LEGO1 0x1006e310 SYMBOL
+// ?_Erase@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1006e350
 // Map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator>::~Map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator>
 
-// TEMPLATE: LEGO1 0x1006e3a0
-// map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::~map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >
+// TEMPLATE: LEGO1 0x1006e3a0 SYMBOL
+// ??1?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1006e6d0
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x1006e6d0 SYMBOL
+// ?_Dec@iterator@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006e720
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Insert
+// TEMPLATE: LEGO1 0x1006e720 SYMBOL
+// ?_Insert@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@IAE?AViterator@1@PAU_Node@1
 
 // GLOBAL: LEGO1 0x100f768c
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Nil
+// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct>>::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct>>::_Nil
 // clang-format on
 
 #endif // LEGOANIMPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legocachsound.h
+++ b/LEGO1/lego/legoomni/include/legocachsound.h
@@ -63,20 +63,20 @@ private:
 	void CopyData(MxU8* p_data, MxU32 p_dataSize);
 	MxString GetBaseFilename(MxString& p_path);
 
-	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x08
-	undefined m_unk0x0c[4];         // 0x0c
-	Lego3DSound m_sound;            // 0x10
-	MxU8* m_data;                   // 0x40
-	MxU32 m_dataSize;               // 0x44
-	MxString m_unk0x48;             // 0x48
-	MxBool m_unk0x58;               // 0x58
-	PCMWAVEFORMAT m_wfx;            // 0x59
-	MxBool m_looping;               // 0x69
-	MxBool m_unk0x6a;               // 0x6a
-	MxS32 m_volume;                 // 0x6c
-	MxBool m_unk0x70;               // 0x70
-	MxString m_unk0x74;             // 0x74
-	MxBool m_muted;                 // 0x84
+	LPDIRECTSOUNDBUFFER m_directSoundBuffer; // 0x08
+	undefined m_unk0x0c[4];                  // 0x0c
+	Lego3DSound m_sound;                     // 0x10
+	MxU8* m_data;                            // 0x40
+	MxU32 m_dataSize;                        // 0x44
+	MxString m_unk0x48;                      // 0x48
+	MxBool m_unk0x58;                        // 0x58
+	PCMWAVEFORMAT m_wfx;                     // 0x59
+	MxBool m_looping;                        // 0x69
+	MxBool m_unk0x6a;                        // 0x6a
+	MxS32 m_volume;                          // 0x6c
+	MxBool m_unk0x70;                        // 0x70
+	MxString m_unk0x74;                      // 0x74
+	MxBool m_muted;                          // 0x84
 };
 
 #endif // LEGOCACHSOUND_H

--- a/LEGO1/lego/legoomni/include/legocarbuild.h
+++ b/LEGO1/lego/legoomni/include/legocarbuild.h
@@ -161,7 +161,7 @@ public:
 	void SetColorControlsEnabled(MxBool p_enabled);
 	void ToggleColorControlsEnabled();
 	void EnableDecalForSelectedPart(MxBool p_enabled);
-	void SetPartColor(MxS32 p_objectId);
+	void SetPartColor(MxU32 p_objectId);
 	void CalculateStartAndTargetTransforms();
 	void StartActorScriptByType(MxS32 p_actionType);
 	void StartActorScript(MxS32 p_streamId);
@@ -256,9 +256,9 @@ private:
 	MxU8 m_presentersEnabled;             // 0x348
 
 	static MxS16 g_lastTickleState;
-	static MxFloat g_selectedPartRotationAngleStepYAxis;
-	static MxFloat g_rotationAngleStepYAxis;
-	static LookupTableActions g_actorScripts[];
+	static const MxFloat g_selectedPartRotationAngleStepYAxis;
+	static const MxFloat g_rotationAngleStepYAxis;
+	static const LookupTableActions g_actorScripts[];
 };
 
 #endif // LEGOCARBUILD_H

--- a/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
@@ -88,6 +88,7 @@ public:
 	void MoveShelfForward();
 	MxBool StringEqualsPlatform(const LegoChar* p_string);
 	MxBool StringEqualsShelf(const LegoChar* p_string);
+	MxBool StringEqualsView(const LegoChar* p_string);
 	MxBool StringEndsOnY(const LegoChar* p_string);
 	MxBool StringDoesNotEndOnZero(const LegoChar* p_string);
 	const LegoChar* GetWiredNameByPartName(const LegoChar* p_name);

--- a/LEGO1/lego/legoomni/include/legoentitypresenter.h
+++ b/LEGO1/lego/legoomni/include/legoentitypresenter.h
@@ -4,6 +4,7 @@
 #include "mxcompositepresenter.h"
 
 class LegoEntity;
+class Mx3DPointFloat;
 class Vector3;
 
 // VTABLE: LEGO1 0x100d8398
@@ -42,6 +43,11 @@ public:
 	virtual undefined4 SetEntity(LegoEntity* p_entity);                                    // vtable+0x6c
 
 	void SetEntityLocation(const Vector3& p_location, const Vector3& p_direction, const Vector3& p_up);
+	Mx3DPointFloat GetWorldPosition();
+	Mx3DPointFloat GetWorldDirection();
+	Mx3DPointFloat GetWorldUp();
+	void SetWorldSpeed(MxFloat p_worldSpeed);
+	MxFloat GetWorldSpeed();
 
 	LegoEntity* GetInternalEntity() { return m_entity; }
 	void SetInternalEntity(LegoEntity* p_entity) { m_entity = p_entity; }

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -46,7 +46,7 @@ public:
 	void ReadyTickle() override; // vtable+0x18
 	void ParseExtra() override;  // vtable+0x30
 
-	MxResult CreateROI(MxDSChunk& p_chunk, LegoEntity* p_entity, MxBool p_roiVisible, LegoWorld* p_world);
+	MxResult CreateROI(MxDSChunk* p_chunk, LegoEntity* p_entity, MxBool p_roiVisible, LegoWorld* p_world);
 
 	void Reset()
 	{

--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -56,6 +56,7 @@ public:
 	);
 	MxU32 AddPresenterIfInRange(LegoAnimPresenter* p_presenter);
 	MxU32 RemovePresenter(LegoAnimPresenter* p_presenter);
+	MxU32 BETA_100b23bb(const Vector3& p_position, LegoOrientedEdge*& p_edge);
 
 	// FUNCTION: BETA10 0x1001ffb0
 	LegoPathActorSet& GetActors() { return m_actors; }
@@ -73,18 +74,18 @@ private:
 };
 
 // clang-format off
-// TEMPLATE: LEGO1 0x1002bee0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::~_Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,a
+// TEMPLATE: LEGO1 0x1002bee0 SYMBOL
+// ??1?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1002bfb0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x1002bfb0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1002bff0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::erase
+// TEMPLATE: LEGO1 0x1002bff0 SYMBOL
+// ?erase@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1002c440
-// TEMPLATE: BETA10 0x10020480
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::find
+// TEMPLATE: LEGO1 0x1002c440 SYMBOL
+// TEMPLATE: BETA10 0x10020480 SYMBOL
+// ?find@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QBE?AVconst_iterator@1@ABQAVLegoPathActor@@@Z
 
 // TEMPLATE: LEGO1 0x1002c4c0
 // ?_Copy@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXABV1@@Z
@@ -92,57 +93,57 @@ private:
 // TEMPLATE: LEGO1 0x1002c5b0
 // ?_Copy@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x1002c630
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Erase
+// TEMPLATE: LEGO1 0x1002c630 SYMBOL
+// ?_Erase@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1002c670
-// set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::~set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >
+// TEMPLATE: LEGO1 0x1002c670 SYMBOL
+// ??1?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1002c6c0
 // TEMPLATE: BETA10 0x10020760
 // Set<LegoPathActor *,LegoPathActorSetCompare>::~Set<LegoPathActor *,LegoPathActorSetCompare>
 
-// TEMPLATE: LEGO1 0x1002eb10
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Init
+// TEMPLATE: LEGO1 0x1002eb10 SYMBOL
+// ?_Init@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXXZ
 
-// TEMPLATE: LEGO1 0x1002ebc0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Min
+// TEMPLATE: LEGO1 0x1002ebc0 SYMBOL
+// ?_Min@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@KAPAU_Node@1@PAU21@@Z
 
-// TEMPLATE: LEGO1 0x100822a0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Min
+// TEMPLATE: LEGO1 0x100822a0 SYMBOL
+// ?_Min@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@KAPAU_Node@1@PAU21@@Z
 
-// TEMPLATE: LEGO1 0x10045d80
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10045d80 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10045dd0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Insert
+// TEMPLATE: LEGO1 0x10045dd0 SYMBOL
+// ?_Insert@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAVLegoPathActor@@@Z
 
-// TEMPLATE: LEGO1 0x10046310
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::insert
+// TEMPLATE: LEGO1 0x10046310 SYMBOL
+// ?insert@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$se
 
-// TEMPLATE: LEGO1 0x10046580
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Lrotate
+// TEMPLATE: LEGO1 0x10046580 SYMBOL
+// ?_Lrotate@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x100465e0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Rrotate
+// TEMPLATE: LEGO1 0x100465e0 SYMBOL
+// ?_Rrotate@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1004a7a0
 // ?_Construct@@YAXPAPAVLegoPathActor@@ABQAV1@@Z
 
-// TEMPLATE: LEGO1 0x10056c20
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::~_Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoA
+// TEMPLATE: LEGO1 0x10056c20 SYMBOL
+// ??1?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10056cf0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10056cf0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAEXXZ
 
 // TEMPLATE: LEGO1 0x10056d30
 // ?erase@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10057180
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Erase
+// TEMPLATE: LEGO1 0x10057180 SYMBOL
+// ?_Erase@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x100571c0
-// set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::~set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >
+// TEMPLATE: LEGO1 0x100571c0 SYMBOL
+// ??1?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x10057210
 // Set<LegoAnimPresenter *,LegoAnimPresenterSetCompare>::~Set<LegoAnimPresenter *,LegoAnimPresenterSetCompare>
@@ -150,35 +151,35 @@ private:
 // TEMPLATE: BETA10 0x10082de0
 // set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::begin
 
-// TEMPLATE: LEGO1 0x100573e0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::begin
+// TEMPLATE: LEGO1 0x100573e0 SYMBOL
+// ?begin@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AViterator@1@XZ
 
-// TEMPLATE: LEGO1 0x100580c0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::insert
+// TEMPLATE: LEGO1 0x100580c0 SYMBOL
+// ?insert@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVLegoAn
 
-// TEMPLATE: LEGO1 0x10058330
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10058330 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10058380
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Buynode
+// TEMPLATE: LEGO1 0x10058380 SYMBOL
+// ?_Buynode@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x100583a0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Insert
+// TEMPLATE: LEGO1 0x100583a0 SYMBOL
+// ?_Insert@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAVLegoA
 
-// TEMPLATE: LEGO1 0x10058620
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Lrotate
+// TEMPLATE: LEGO1 0x10058620 SYMBOL
+// ?_Lrotate@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10058680
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Rrotate
+// TEMPLATE: LEGO1 0x10058680 SYMBOL
+// ?_Rrotate@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x10058820
 // ?erase@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AViterator@1@V21@0@Z
 
-// TEMPLATE: LEGO1 0x100588e0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::equal_range
+// TEMPLATE: LEGO1 0x100588e0 SYMBOL
+// ?equal_range@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVL
 
-// TEMPLATE: LEGO1 0x10058950
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Lbound
+// TEMPLATE: LEGO1 0x10058950 SYMBOL
+// ?_Lbound@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IBEPAU_Node@1@ABQAVLegoAnimPresenter@@@
 
 // TEMPLATE: LEGO1 0x10058980
 // ?_Construct@@YAXPAPAVLegoAnimPresenter@@ABQAV1@@Z
@@ -186,8 +187,8 @@ private:
 // TEMPLATE: LEGO1 0x100589a0
 // _Distance
 
-// TEMPLATE: LEGO1 0x10081cd0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::lower_bound
+// TEMPLATE: LEGO1 0x10081cd0 SYMBOL
+// ?lower_bound@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QBE?AVconst_iterator@1@ABQAVLegoPathActor@@@Z
 
 // TEMPLATE: BETA10 0x10082b90
 // ??Econst_iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AV01@H@Z
@@ -217,10 +218,10 @@ private:
 // set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::end
 
 // GLOBAL: LEGO1 0x100f11a4
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Nil
+// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *>>::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *>>::_Nil
 
 // GLOBAL: LEGO1 0x100f3200
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Nil
+// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *>>::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *>>::_Nil
 // clang-format on
 
 #endif // LEGOPATHBOUNDARY_H

--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -3,8 +3,8 @@
 
 #include "decomp.h"
 #include "geom/legowegedge.h"
-#include "legopathactor.h"
 #include "legopathboundary.h"
+#include "legopathactor.h"
 #include "legopathstruct.h"
 #include "mxstl/stlcompat.h"
 
@@ -209,50 +209,50 @@ private:
 };
 
 // clang-format off
-// TEMPLATE: LEGO1 0x1001fd70
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Lbound
+// TEMPLATE: LEGO1 0x1001fd70 SYMBOL
+// ?_Lbound@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IBEPAU_Node@1@ABQAVLegoPathActor@@@Z
 
-// TEMPLATE: LEGO1 0x1002c4a0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Buynode
+// TEMPLATE: LEGO1 0x1002c4a0 SYMBOL
+// ?_Buynode@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x100451a0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::~_Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathControl
+// TEMPLATE: LEGO1 0x100451a0 SYMBOL
+// ??1?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10045270
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10045270 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAEXXZ
 
 // TEMPLATE: LEGO1 0x100452b0
 // ?erase@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10045700
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Erase
+// TEMPLATE: LEGO1 0x10045700 SYMBOL
+// ?_Erase@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x100457e0
 // Set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare>::~Set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare>
 
-// TEMPLATE: LEGO1 0x10045830
-// set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::~set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >
+// TEMPLATE: LEGO1 0x10045830 SYMBOL
+// ??1?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10046640
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::find
+// TEMPLATE: LEGO1 0x10046640 SYMBOL
+// ?find@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QBE?AVconst_iterator@1@ABQAVLegoAnimPresen
 
-// TEMPLATE: LEGO1 0x100468c0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Ubound
+// TEMPLATE: LEGO1 0x100468c0 SYMBOL
+// ?_Ubound@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IBEPAU_Node@1@ABQAVLegoPathActor@@@Z
 
-// TEMPLATE: LEGO1 0x10047550
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Insert
+// TEMPLATE: LEGO1 0x10047550 SYMBOL
+// ?_Insert@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAULegoPathCtrlEdge@
 
-// TEMPLATE: LEGO1 0x100474e0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x100474e0 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10047530
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Buynode
+// TEMPLATE: LEGO1 0x10047530 SYMBOL
+// ?_Buynode@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x100477d0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Lrotate
+// TEMPLATE: LEGO1 0x100477d0 SYMBOL
+// ?_Lrotate@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10047830
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Rrotate
+// TEMPLATE: LEGO1 0x10047830 SYMBOL
+// ?_Rrotate@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEXPAU_Node@1@@Z
 
 // SYNTHETIC: LEGO1 0x10047940
 // LegoPathCtrlEdge::`vector deleting destructor'
@@ -266,71 +266,71 @@ private:
 // SYNTHETIC: LEGO1 0x10047ae0
 // LegoOrientedEdge::~LegoOrientedEdge
 
-// TEMPLATE: LEGO1 0x10048f00
-// list<LegoBoundaryEdge,allocator<LegoBoundaryEdge> >::begin
+// TEMPLATE: LEGO1 0x10048f00 SYMBOL
+// ?begin@?$list@ULegoBoundaryEdge@@V?$allocator@ULegoBoundaryEdge@@@@@@QAE?AViterator@1@XZ
 
-// TEMPLATE: LEGO1 0x10048f10
-// list<LegoBoundaryEdge,allocator<LegoBoundaryEdge> >::insert
+// TEMPLATE: LEGO1 0x10048f10 SYMBOL
+// ?insert@?$list@ULegoBoundaryEdge@@V?$allocator@ULegoBoundaryEdge@@@@@@QAE?AViterator@1@V21@ABULegoBoundaryEdge@@@Z
 
-// TEMPLATE: LEGO1 0x10048f70
-// list<LegoBoundaryEdge,allocator<LegoBoundaryEdge> >::erase
+// TEMPLATE: LEGO1 0x10048f70 SYMBOL
+// ?erase@?$list@ULegoBoundaryEdge@@V?$allocator@ULegoBoundaryEdge@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10048fc0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,Le
+// TEMPLATE: LEGO1 0x10048fc0 SYMBOL
+// ??0?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE@ABV0@@Z
 
 // TEMPLATE: LEGO1 0x10049160
 // ?erase@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAEIABQAULegoPathCtrlEdge@@@Z
 
-// TEMPLATE: LEGO1 0x10049290
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::find
+// TEMPLATE: LEGO1 0x10049290 SYMBOL
+// ?find@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QBE?AVconst_iterator@1@ABQAULegoPathCtrlEdge@@@Z
 
-// TEMPLATE: LEGO1 0x100492f0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Copy
+// TEMPLATE: LEGO1 0x100492f0 SYMBOL
+// ?_Copy@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x10049370
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Ubound
+// TEMPLATE: LEGO1 0x10049370 SYMBOL
+// ?_Ubound@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IBEPAU_Node@1@ABQAULegoPathCtrlEdge@@@Z
 
-// TEMPLATE: LEGO1 0x100493a0
-// list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >::~list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >
+// TEMPLATE: LEGO1 0x100493a0 SYMBOL
+// ??1?$list@ULegoBEWithMidpoint@@V?$allocator@ULegoBEWithMidpoint@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10049410
-// list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >::insert
+// TEMPLATE: LEGO1 0x10049410 SYMBOL
+// ?insert@?$list@ULegoBEWithMidpoint@@V?$allocator@ULegoBEWithMidpoint@@@@@@QAE?AViterator@1@V21@ABULegoBEWithMidpoint@@@Z
 
-// TEMPLATE: LEGO1 0x10049470
-// list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >::_Buynode
+// TEMPLATE: LEGO1 0x10049470 SYMBOL
+// ?_Buynode@?$list@ULegoBEWithMidpoint@@V?$allocator@ULegoBEWithMidpoint@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x100494a0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x100494a0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x100494e0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::~_Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithFlo
+// TEMPLATE: LEGO1 0x100494e0 SYMBOL
+// ??1?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x100495b0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::insert
+// TEMPLATE: LEGO1 0x100495b0 SYMBOL
+// ?insert@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE?AU?$pair@Viterator@?$_Tre
 
-// TEMPLATE: LEGO1 0x10049840
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10049840 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10049890
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::erase
+// TEMPLATE: LEGO1 0x10049890 SYMBOL
+// ?erase@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10049cf0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Buynode
+// TEMPLATE: LEGO1 0x10049cf0 SYMBOL
+// ?_Buynode@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEPAU_Node@1@PAU21@W4_Redb
 
-// TEMPLATE: LEGO1 0x10049d50
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Init
+// TEMPLATE: LEGO1 0x10049d50 SYMBOL
+// ?_Init@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXXZ
 
-// TEMPLATE: LEGO1 0x10049e00
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Insert
+// TEMPLATE: LEGO1 0x10049e00 SYMBOL
+// ?_Insert@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAE?AViterator@1@PAU_Node@1@
 
-// TEMPLATE: LEGO1 0x10049d10
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Erase
+// TEMPLATE: LEGO1 0x10049d10 SYMBOL
+// ?_Erase@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1004a090
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Lrotate
+// TEMPLATE: LEGO1 0x1004a090 SYMBOL
+// ?_Lrotate@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1004a0f0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Rrotate
+// TEMPLATE: LEGO1 0x1004a0f0 SYMBOL
+// ?_Rrotate@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1004a150
 // List<LegoBEWithMidpoint>::~List<LegoBEWithMidpoint>
@@ -338,8 +338,8 @@ private:
 // TEMPLATE: LEGO1 0x1004a1a0
 // Multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator>::~Multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator>
 
-// TEMPLATE: LEGO1 0x1004a1f0
-// multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::~multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >
+// TEMPLATE: LEGO1 0x1004a1f0 SYMBOL
+// ??1?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1004a760
 // ?_Construct@@YAXPAPAULegoBEWithMidpoint@@ABQAU1@@Z
@@ -348,10 +348,10 @@ private:
 // ?_Construct@@YAXPAPAULegoPathCtrlEdge@@ABQAU1@@Z
 
 // GLOBAL: LEGO1 0x100f4360
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Nil
+// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *>>::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *>>::_Nil
 
 // GLOBAL: LEGO1 0x100f4364
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Nil
+// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *>>::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *>>::_Nil
 // clang-format on
 
 #endif // LEGOPATHCONTROLLER_H

--- a/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
@@ -2,13 +2,13 @@
 #define LEGOPOINTOFVIEWCONTROLLER_H
 
 #include "decomp.h"
+#include "legoentity.h"
 #include "mxcore.h"
 #include "mxgeometry.h"
 
 #include <windows.h>
 
 class Lego3DView;
-class LegoEntity;
 class LegoNavController;
 
 //////////////////////////////////////////////////////////////////////////////

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -1,9 +1,7 @@
 #ifndef LEGORACERS_H
 #define LEGORACERS_H
 
-// clang-format off
 #include "legoracespecial.h"
-// clang-format on
 #include "legoracemap.h"
 
 #define LEGORACECAR_NONE 0
@@ -182,7 +180,7 @@ public:
 	// LegoRaceCar::`scalar deleting destructor'
 
 private:
-	MxU8 m_kickState;         // 0x54
+	MxU8 m_userState;         // 0x54
 	float m_kickStart;        // 0x58
 	Mx3DPointFloat m_unk0x5c; // 0x5c
 

--- a/LEGO1/lego/legoomni/include/legoutils.h
+++ b/LEGO1/lego/legoomni/include/legoutils.h
@@ -5,6 +5,7 @@
 #include "decomp.h"
 #include "extra.h"
 #include "mxtypes.h"
+#include "roi/legoroi.h"
 
 #include <windows.h>
 
@@ -34,7 +35,6 @@ class LegoEntity;
 class LegoAnimPresenter;
 class LegoNamedTexture;
 class LegoPathActor;
-class LegoROI;
 class LegoStorage;
 class LegoTreeNode;
 
@@ -54,6 +54,7 @@ Extra::ActionType MatchActionString(const char*);
 void InvokeAction(Extra::ActionType p_actionId, const MxAtomId& p_pAtom, MxS32 p_streamId, LegoEntity* p_sender);
 void SetCameraControllerFromIsle();
 void ConvertHSVToRGB(float p_h, float p_s, float p_v, float* p_rOut, float* p_gOut, float* p_bOut);
+void ConvertRGBToHSV(float p_r, float p_g, float p_b, float* p_hOut, float* p_sOut, float* p_vOut);
 void PlayCamAnim(LegoPathActor* p_actor, MxBool p_unused, MxU32 p_location, MxBool p_bool);
 void ResetViewVelocity();
 MxBool RemoveFromCurrentWorld(const MxAtomId& p_atomId, MxS32 p_id);

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -1,11 +1,9 @@
 #ifndef LEGOWORLD_H
 #define LEGOWORLD_H
 
-// clang-format off
 #include "mxpresenterlist.h"
 #include "legoentitylist.h"
 #include "legocachesoundlist.h"
-// clang-format on
 
 #include "legoentity.h"
 #include "legomain.h"
@@ -116,7 +114,7 @@ public:
 	LegoEntityList* GetEntityList() { return m_entityList; }
 	LegoOmni::World GetWorldId() { return m_worldId; }
 	MxBool NoDisabledObjects() { return m_disabledObjects.empty(); }
-	list<LegoROI*>& GetROIList() { return m_roiList; }
+	list<LegoROI*>* GetROIList() { return &m_roiList; }
 	LegoHideAnimPresenter* GetHideAnimPresenter() { return m_hideAnim; }
 
 	void SetWorldId(LegoOmni::World p_worldId) { m_worldId = p_worldId; }
@@ -146,68 +144,68 @@ protected:
 };
 
 // clang-format off
-// TEMPLATE: LEGO1 0x1001d780
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::~_Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >
+// TEMPLATE: LEGO1 0x1001d780 SYMBOL
+// ??1?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1001d850
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x1001d850 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1001d890
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::erase
+// TEMPLATE: LEGO1 0x1001d890 SYMBOL
+// ?erase@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1001dcf0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Erase
+// TEMPLATE: LEGO1 0x1001dcf0 SYMBOL
+// ?_Erase@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1001dd30
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Init
+// TEMPLATE: LEGO1 0x1001dd30 SYMBOL
+// ?_Init@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXXZ
 
-// TEMPLATE: LEGO1 0x1001ddf0
-// list<LegoROI *,allocator<LegoROI *> >::~list<LegoROI *,allocator<LegoROI *> >
+// TEMPLATE: LEGO1 0x1001ddf0 SYMBOL
+// ??1?$list@PAVLegoROI@@V?$allocator@PAVLegoROI@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1001df50
 // List<LegoROI *>::~List<LegoROI *>
 
-// TEMPLATE: LEGO1 0x1001de60
-// list<LegoROI *,allocator<LegoROI *> >::_Buynode
+// TEMPLATE: LEGO1 0x1001de60 SYMBOL
+// ?_Buynode@?$list@PAVLegoROI@@V?$allocator@PAVLegoROI@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x1001de90
-// set<MxCore *,CoreSetCompare,allocator<MxCore *> >::~set<MxCore *,CoreSetCompare,allocator<MxCore *> >
+// TEMPLATE: LEGO1 0x1001de90 SYMBOL
+// ??1?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1001df00
 // Set<MxCore *,CoreSetCompare>::~Set<MxCore *,CoreSetCompare>
 
-// TEMPLATE: LEGO1 0x1001f590
-// list<LegoROI *,allocator<LegoROI *> >::erase
+// TEMPLATE: LEGO1 0x1001f590 SYMBOL
+// ?erase@?$list@PAVLegoROI@@V?$allocator@PAVLegoROI@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x100208b0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::insert
+// TEMPLATE: LEGO1 0x100208b0 SYMBOL
+// ?insert@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@
 
-// TEMPLATE: LEGO1 0x10020b20
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10020b20 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10020b70
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::lower_bound
+// TEMPLATE: LEGO1 0x10020b70 SYMBOL
+// ?lower_bound@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QBE?AVconst_iterator@1@ABQAVMxCore@@@Z
 
-// TEMPLATE: LEGO1 0x10020bb0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Buynode
+// TEMPLATE: LEGO1 0x10020bb0 SYMBOL
+// ?_Buynode@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x10020bd0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Insert
+// TEMPLATE: LEGO1 0x10020bd0 SYMBOL
+// ?_Insert@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAVMxCore@@@Z
 
-// TEMPLATE: LEGO1 0x10020e50
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Lrotate
+// TEMPLATE: LEGO1 0x10020e50 SYMBOL
+// ?_Lrotate@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10020eb0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Rrotate
+// TEMPLATE: LEGO1 0x10020eb0 SYMBOL
+// ?_Rrotate@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10021340
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::find
+// TEMPLATE: LEGO1 0x10021340 SYMBOL
+// ?find@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QBE?AVconst_iterator@1@ABQAVMxCore@@@Z
 
 // TEMPLATE: LEGO1 0x10022360
 // ?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z
 
 // GLOBAL: LEGO1 0x100f11a0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Nil
+// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *>>::_Kfn,CoreSetCompare,allocator<MxCore *>>::_Nil
 // clang-format on
 
 #endif // LEGOWORLD_H

--- a/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
+++ b/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
@@ -47,7 +47,7 @@ public:
 	virtual MxResult Create(MxAtomId& p_script, MxU32 p_frequencyMS);
 
 	void Init();
-	void Update(MxS32 p_targetVolume, MxS32 p_speed, MxPresenter::TickleState p_tickleState);
+	void Update(MxS32 p_volume, MxS32 p_speed, MxPresenter::TickleState p_tickleState);
 	void Stop();
 	void LowerVolume();
 	void RaiseVolume();

--- a/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
@@ -15,6 +15,9 @@
 
 DECOMP_SIZE_ASSERT(Act3Ammo, 0x1a0)
 
+// GLOBAL: LEGO1 0x100d841c
+static const float g_hitAnimationDelay = 2000.0f;
+
 // Initialized at LEGO1 0x100537c0
 // GLOBAL: LEGO1 0x10104f08
 Mx3DPointFloat Act3Ammo::g_hitTranslation = Mx3DPointFloat(0.0, 5.0, 0.0);
@@ -125,24 +128,24 @@ MxResult Act3Ammo::CalculateArc(const Vector3& p_srcLoc, const Vector3& p_srcDir
 	negNormalUp[0] = negNormalUp[2] = 0.0f;
 	negNormalUp[1] = -1.0f;
 
-	m_coefficients[1] = p_srcUp;
-	m_coefficients[2] = p_srcLoc;
+	m_eq[1] = p_srcUp;
+	m_eq[2] = p_srcLoc;
 
 	Mx3DPointFloat upRelative(negNormalUp);
-	upRelative -= m_coefficients[1];
+	upRelative -= m_eq[1];
 
 	for (MxS32 i = 0; i < 3; i++) {
 		if (groundPoint[0] == p_srcLoc[0]) {
 			return FAILURE;
 		}
 
-		m_coefficients[0][i] = (upRelative[i] * upRelative[i] + upRelative[i] * m_coefficients[1][i] * 2.0f) /
-							   ((groundPoint[i] - p_srcLoc[i]) * 4.0f);
+		m_eq[0][i] = (upRelative[i] * upRelative[i] + upRelative[i] * m_eq[1][i] * 2.0f) /
+					 ((groundPoint[i] - p_srcLoc[i]) * 4.0f);
 	}
 
-	assert(m_coefficients[0][0] > 0.000001 || m_coefficients[0][0] < -0.000001);
+	assert(m_eq[0][0] > 0.000001 || m_eq[0][0] < -0.000001);
 
-	m_apexParameter = upRelative[0] / (m_coefficients[0][0] * 2.0f);
+	m_apexParameter = upRelative[0] / (m_eq[0][0] * 2.0f);
 	return SUCCESS;
 }
 
@@ -211,16 +214,16 @@ MxResult Act3Ammo::CalculateTransformOnCurve(float p_curveParameter, Matrix4& p_
 	Vector3 pos(p_transform[3]);
 	Mx3DPointFloat sndCoeff;
 
-	sndCoeff = m_coefficients[1];
+	sndCoeff = m_eq[1];
 	sndCoeff *= p_curveParameter;
-	pos = m_coefficients[0];
+	pos = m_eq[0];
 	pos *= curveParameterSquare;
 	pos += sndCoeff;
-	pos += m_coefficients[2];
-	dir = m_coefficients[0];
+	pos += m_eq[2];
+	dir = m_eq[0];
 	dir *= 2.0f;
 	dir *= p_curveParameter;
-	dir += m_coefficients[1];
+	dir += m_eq[1];
 	dir *= -1.0f;
 
 	if (dir.Unitize() != 0) {
@@ -258,7 +261,7 @@ void Act3Ammo::Animate(float p_time)
 	case c_ready:
 		break;
 	case c_hit:
-		m_rotateTimeout = p_time + 2000.0f;
+		m_rotateTimeout = g_hitAnimationDelay + p_time;
 		m_actorState = c_hitAnimation;
 		return;
 	case c_hitAnimation:
@@ -298,6 +301,7 @@ void Act3Ammo::Animate(float p_time)
 		m_traveledDistance = 0.0f;
 	}
 
+	float radius;
 	MxMatrix transform;
 	MxMatrix additionalTransform;
 
@@ -309,8 +313,10 @@ void Act3Ammo::Animate(float p_time)
 	MxU32 reachedTarget = FALSE;
 
 	if (f >= p_time) {
-		m_actorTime = (p_time - m_transformTime) * m_worldSpeed + m_actorTime;
-		m_traveledDistance = (p_time - m_transformTime) * m_worldSpeed + m_traveledDistance;
+		float delta = p_time - m_transformTime;
+
+		m_actorTime = delta * m_worldSpeed + m_actorTime;
+		m_traveledDistance = delta * m_worldSpeed + m_traveledDistance;
 		m_transformTime = p_time;
 	}
 	else {
@@ -423,7 +429,7 @@ void Act3Ammo::Animate(float p_time)
 
 				distance -= otherPosition;
 
-				float radius = r->GetWorldBoundingSphere().Radius();
+				radius = r->GetWorldBoundingSphere().Radius();
 				if (distance.LenSquared() <= radius * radius) {
 					MxS32 index = -1;
 					if (sscanf(r->GetName(), "pammo%d", &index) != 1) {

--- a/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
+++ b/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
@@ -33,9 +33,9 @@ BumpBouy::~BumpBouy()
 MxLong BumpBouy::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	IslePathActor* user = (IslePathActor*) UserActor();
 	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	IslePathActor* user = (IslePathActor*) UserActor();
 	assert(user);
 
 	if (user->IsA("Jetski") && param.GetNotification() == c_notificationClick) {

--- a/LEGO1/lego/legoomni/src/actors/doors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/doors.cpp
@@ -12,15 +12,15 @@ DECOMP_SIZE_ASSERT(Doors, 0x1f8)
 
 // GLOBAL: LEGO1 0x100d8e7c
 // GLOBAL: BETA10 0x101b954c
-MxFloat g_timeMoving = 1000.0f;
+const MxFloat g_timeMoving = 1000.0f;
 
 // GLOBAL: LEGO1 0x100d8e80
 // GLOBAL: BETA10 0x101b9550
-MxFloat g_timeOpened = 4000.0f;
+const MxFloat g_timeOpened = 4000.0f;
 
 // GLOBAL: LEGO1 0x100d8e84
 // GLOBAL: BETA10 0x101b9554
-MxFloat g_totalTime = 6000.0f; // = g_timeMoving + g_totalTime + g_timeMoving
+const MxFloat g_totalTime = 6000.0f; // = g_timeMoving + g_totalTime + g_timeMoving
 
 // FUNCTION: LEGO1 0x10066100
 // FUNCTION: BETA10 0x10026850

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -415,8 +415,8 @@ void Helicopter::Animate(float p_time)
 
 			MxMatrix mat;
 			Vector3 v1(m_unk0x160[3]);
-			Vector3 v2(mat[3]);
 			Vector3 v3(m_unk0x1a8[3]);
+			Vector3 v2(mat[3]);
 
 			mat.SetIdentity();
 			m_unk0x1f4.InterpolateToMatrix(mat, f2);

--- a/LEGO1/lego/legoomni/src/actors/pizzeria.cpp
+++ b/LEGO1/lego/legoomni/src/actors/pizzeria.cpp
@@ -94,7 +94,9 @@ PizzeriaState::PizzeriaState()
 	m_playerPlaylists[2] = Playlist((MxU32*) g_papaActions, sizeOfArray(g_papaActions), Playlist::e_once);
 	m_playerPlaylists[3] = Playlist((MxU32*) g_nickActions, sizeOfArray(g_nickActions), Playlist::e_once);
 	m_playerPlaylists[4] = Playlist((MxU32*) g_lauraActions, sizeOfArray(g_lauraActions), Playlist::e_once);
-	memset(m_states, -1, sizeof(m_states));
+	for (MxS32 i = 0; i < 5; i++) {
+		m_states[i] = -1;
+	}
 }
 
 // FUNCTION: LEGO1 0x10017d50

--- a/LEGO1/lego/legoomni/src/audio/lego3dsound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/lego3dsound.cpp
@@ -7,6 +7,7 @@
 #include "misc.h"
 #include "mxmain.h"
 
+#include <assert.h>
 #include <vec.h>
 
 DECOMP_SIZE_ASSERT(Lego3DSound, 0x30)
@@ -108,6 +109,7 @@ MxResult Lego3DSound::Create(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char
 }
 
 // FUNCTION: LEGO1 0x10011880
+// FUNCTION: BETA10 0x1003997e
 void Lego3DSound::Destroy()
 {
 	if (m_ds3dBuffer) {
@@ -131,6 +133,8 @@ void Lego3DSound::Destroy()
 // FUNCTION: BETA10 0x10039a2a
 MxU32 Lego3DSound::UpdatePosition(LPDIRECTSOUNDBUFFER p_directSoundBuffer)
 {
+	assert(p_directSoundBuffer);
+
 	MxU32 updated = FALSE;
 
 	if (m_positionROI != NULL) {
@@ -221,6 +225,8 @@ void Lego3DSound::FUN_10011a60(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const ch
 		else {
 			m_positionROI = m_roi;
 		}
+
+		assert(m_positionROI);
 
 		if (m_ds3dBuffer != NULL) {
 			DWORD dwMode;

--- a/LEGO1/lego/legoomni/src/audio/legocachesoundmanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachesoundmanager.cpp
@@ -4,7 +4,7 @@
 #include "misc.h"
 
 DECOMP_SIZE_ASSERT(LegoCacheSoundEntry, 0x08)
-DECOMP_SIZE_ASSERT(LegoCacheSoundManager, 0x20)
+DECOMP_SIZE_ASSERT(LegoCacheSoundManager, 0x20);
 
 // FUNCTION: LEGO1 0x1003cf20
 // STUB: BETA10 0x100d0700
@@ -13,8 +13,9 @@ LegoCacheSoundManager::~LegoCacheSoundManager()
 	LegoCacheSound* sound;
 
 	while (!m_set.empty()) {
-		sound = (*m_set.begin()).GetSound();
-		m_set.erase(m_set.begin());
+		Set100d6b4c::iterator it = m_set.begin();
+		sound = (*it).GetSound();
+		m_set.erase(it);
 		sound->Stop();
 		delete sound;
 	}
@@ -44,9 +45,11 @@ MxResult LegoCacheSoundManager::Tickle()
 		}
 	}
 
+	LegoCacheSound* sound;
 	List100d6b4c::iterator listIter = m_list.begin();
+
 	while (listIter != m_list.end()) {
-		LegoCacheSound* sound = (*listIter).GetSound();
+		sound = (*listIter).GetSound();
 
 		if (sound->GetUnknown0x58()) {
 			sound->FUN_10006be0();
@@ -80,6 +83,7 @@ LegoCacheSound* LegoCacheSoundManager::FindSoundByKey(const char* p_key)
 }
 
 // FUNCTION: LEGO1 0x1003d290
+// FUNCTION: BETA10 0x100654db
 LegoCacheSound* LegoCacheSoundManager::ManageSoundEntry(LegoCacheSound* p_sound)
 {
 	Set100d6b4c::iterator it = m_set.find(LegoCacheSoundEntry(p_sound));

--- a/LEGO1/lego/legoomni/src/audio/legocachsound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachsound.cpp
@@ -1,6 +1,7 @@
 #include "legocachsound.h"
 
 #include "legosoundmanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "mxmain.h"
 
@@ -26,7 +27,7 @@ LegoCacheSound::~LegoCacheSound()
 // FUNCTION: BETA10 0x10066498
 void LegoCacheSound::Init()
 {
-	m_dsBuffer = NULL;
+	m_directSoundBuffer = NULL;
 	m_data = NULL;
 	m_unk0x58 = FALSE;
 	memset(&m_wfx, 0, sizeof(m_wfx));
@@ -73,7 +74,7 @@ MxResult LegoCacheSound::Create(
 	desc.dwBufferBytes = p_dataSize;
 	desc.lpwfxFormat = &wfx;
 
-	if (SoundManager()->GetDirectSound()->CreateSoundBuffer(&desc, &m_dsBuffer, NULL) != DS_OK) {
+	if (SoundManager()->GetDirectSound()->CreateSoundBuffer(&desc, &m_directSoundBuffer, NULL) != DS_OK) {
 		return FAILURE;
 	}
 
@@ -81,11 +82,11 @@ MxResult LegoCacheSound::Create(
 
 	MxS32 volume = m_volume * SoundManager()->GetVolume() / 100;
 	MxS32 attenuation = SoundManager()->GetAttenuation(volume);
-	m_dsBuffer->SetVolume(attenuation);
+	m_directSoundBuffer->SetVolume(attenuation);
 
-	if (m_sound.Create(m_dsBuffer, NULL, m_volume) != SUCCESS) {
-		m_dsBuffer->Release();
-		m_dsBuffer = NULL;
+	if (m_sound.Create(m_directSoundBuffer, NULL, m_volume) != SUCCESS) {
+		m_directSoundBuffer->Release();
+		m_directSoundBuffer = NULL;
 		return FAILURE;
 	}
 
@@ -115,10 +116,10 @@ void LegoCacheSound::CopyData(MxU8* p_data, MxU32 p_dataSize)
 // FUNCTION: BETA10 0x1006685b
 void LegoCacheSound::Destroy()
 {
-	if (m_dsBuffer) {
-		m_dsBuffer->Stop();
-		m_dsBuffer->Release();
-		m_dsBuffer = NULL;
+	if (m_directSoundBuffer) {
+		m_directSoundBuffer->Stop();
+		m_directSoundBuffer->Release();
+		m_directSoundBuffer = NULL;
 	}
 
 	delete[] m_data;
@@ -146,42 +147,43 @@ LegoCacheSound* LegoCacheSound::Clone()
 // FUNCTION: BETA10 0x10066a23
 MxResult LegoCacheSound::Play(const char* p_name, MxBool p_looping)
 {
-	assert(m_dsBuffer);
+	assert(m_directSoundBuffer);
 
 	if (m_data == NULL || m_dataSize == 0) {
 		return FAILURE;
 	}
 
 	m_unk0x6a = FALSE;
-	m_sound.FUN_10011a60(m_dsBuffer, p_name);
+	m_sound.FUN_10011a60(m_directSoundBuffer, p_name);
 
 	if (p_name != NULL) {
 		m_unk0x74 = p_name;
 	}
 
 	DWORD dwStatus;
-	m_dsBuffer->GetStatus(&dwStatus);
+	m_directSoundBuffer->GetStatus(&dwStatus);
 
 	if (dwStatus == DSBSTATUS_BUFFERLOST) {
-		m_dsBuffer->Restore();
-		m_dsBuffer->GetStatus(&dwStatus);
+		m_directSoundBuffer->Restore();
+		m_directSoundBuffer->GetStatus(&dwStatus);
 	}
 
 	if (dwStatus != DSBSTATUS_BUFFERLOST) {
 		LPVOID pvAudioPtr1, pvAudioPtr2;
 		DWORD dwAudioBytes1, dwAudioBytes2;
 
-		if (m_dsBuffer->Lock(0, m_dataSize, &pvAudioPtr1, &dwAudioBytes1, &pvAudioPtr2, &dwAudioBytes2, 0) == DS_OK) {
+		if (m_directSoundBuffer->Lock(0, m_dataSize, &pvAudioPtr1, &dwAudioBytes1, &pvAudioPtr2, &dwAudioBytes2, 0) ==
+			DS_OK) {
 			memcpy(pvAudioPtr1, m_data, dwAudioBytes1);
 
 			if (dwAudioBytes2 != 0) {
 				memcpy(pvAudioPtr2, m_data + dwAudioBytes1, dwAudioBytes2);
 			}
 
-			DWORD sts = m_dsBuffer->Unlock(pvAudioPtr1, dwAudioBytes1, pvAudioPtr2, dwAudioBytes2);
+			DWORD sts = m_directSoundBuffer->Unlock(pvAudioPtr1, dwAudioBytes1, pvAudioPtr2, dwAudioBytes2);
 			assert(!sts);
-			m_dsBuffer->SetCurrentPosition(0);
-			if (m_dsBuffer->Play(0, 0, p_looping)) {
+			m_directSoundBuffer->SetCurrentPosition(0);
+			if (m_directSoundBuffer->Play(0, 0, p_looping)) {
 				assert(0);
 			}
 		}
@@ -210,10 +212,10 @@ MxResult LegoCacheSound::Play(const char* p_name, MxBool p_looping)
 void LegoCacheSound::Stop()
 {
 	DWORD dwStatus;
-	m_dsBuffer->GetStatus(&dwStatus);
+	m_directSoundBuffer->GetStatus(&dwStatus);
 
 	if (dwStatus) {
-		m_dsBuffer->Stop();
+		m_directSoundBuffer->Stop();
 	}
 
 	m_unk0x58 = FALSE;
@@ -231,7 +233,7 @@ void LegoCacheSound::FUN_10006be0()
 {
 	if (!m_looping) {
 		DWORD dwStatus;
-		m_dsBuffer->GetStatus(&dwStatus);
+		m_directSoundBuffer->GetStatus(&dwStatus);
 
 		if (m_unk0x70) {
 			if (dwStatus == 0) {
@@ -242,7 +244,7 @@ void LegoCacheSound::FUN_10006be0()
 		}
 
 		if (dwStatus == 0) {
-			m_dsBuffer->Stop();
+			m_directSoundBuffer->Stop();
 			m_sound.Reset();
 			if (m_unk0x74.GetLength() != 0) {
 				m_unk0x74 = "";
@@ -258,14 +260,14 @@ void LegoCacheSound::FUN_10006be0()
 	}
 
 	if (!m_muted) {
-		if (!m_sound.UpdatePosition(m_dsBuffer)) {
+		if (!m_sound.UpdatePosition(m_directSoundBuffer)) {
 			if (!m_unk0x6a) {
-				m_dsBuffer->Stop();
+				m_directSoundBuffer->Stop();
 				m_unk0x6a = TRUE;
 			}
 		}
 		else if (m_unk0x6a) {
-			m_dsBuffer->Play(0, 0, m_looping);
+			m_directSoundBuffer->Play(0, 0, m_looping);
 			m_unk0x6a = FALSE;
 		}
 	}
@@ -291,12 +293,12 @@ void LegoCacheSound::MuteSilence(MxBool p_muted)
 		m_muted = p_muted;
 
 		if (m_muted) {
-			m_dsBuffer->SetVolume(-3000);
+			m_directSoundBuffer->SetVolume(-3000);
 		}
 		else {
 			MxS32 volume = m_volume * SoundManager()->GetVolume() / 100;
 			MxS32 attenuation = SoundManager()->GetAttenuation(volume);
-			m_dsBuffer->SetVolume(attenuation);
+			m_directSoundBuffer->SetVolume(attenuation);
 		}
 	}
 }
@@ -309,10 +311,10 @@ void LegoCacheSound::MuteStop(MxBool p_muted)
 		m_muted = p_muted;
 
 		if (m_muted) {
-			m_dsBuffer->Stop();
+			m_directSoundBuffer->Stop();
 		}
 		else {
-			m_dsBuffer->Play(0, 0, m_looping);
+			m_directSoundBuffer->Play(0, 0, m_looping);
 		}
 	}
 }
@@ -320,13 +322,13 @@ void LegoCacheSound::MuteStop(MxBool p_muted)
 // FUNCTION: BETA10 0x10066f4d
 MxResult LegoCacheSound::GetFrequency(LPDWORD p_freq)
 {
-	return m_dsBuffer->GetFrequency(p_freq);
+	return m_directSoundBuffer->GetFrequency(p_freq);
 }
 
 // FUNCTION: BETA10 0x10066f7b
 MxResult LegoCacheSound::SetFrequency(DWORD p_freq)
 {
-	return m_dsBuffer->SetFrequency(p_freq);
+	return m_directSoundBuffer->SetFrequency(p_freq);
 }
 
 // FUNCTION: BETA10 0x10066fa9

--- a/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
@@ -29,6 +29,7 @@ MxBackgroundAudioManager::MxBackgroundAudioManager()
 }
 
 // FUNCTION: LEGO1 0x1007ec20
+// FUNCTION: BETA10 0x100e865e
 MxBackgroundAudioManager::~MxBackgroundAudioManager()
 {
 	TickleManager()->UnregisterClient(this);
@@ -37,6 +38,7 @@ MxBackgroundAudioManager::~MxBackgroundAudioManager()
 }
 
 // FUNCTION: LEGO1 0x1007ece0
+// FUNCTION: BETA10 0x100e874c
 MxResult MxBackgroundAudioManager::Create(MxAtomId& p_script, MxU32 p_frequencyMS)
 {
 	MxResult result = OpenMusic(p_script);
@@ -50,6 +52,7 @@ MxResult MxBackgroundAudioManager::Create(MxAtomId& p_script, MxU32 p_frequencyM
 }
 
 // FUNCTION: LEGO1 0x1007ed20
+// FUNCTION: BETA10 0x100e87cc
 MxResult MxBackgroundAudioManager::OpenMusic(MxAtomId& p_script)
 {
 	if (m_script.GetInternal()) {
@@ -67,6 +70,7 @@ MxResult MxBackgroundAudioManager::OpenMusic(MxAtomId& p_script)
 }
 
 // FUNCTION: LEGO1 0x1007ed70
+// FUNCTION: BETA10 0x100e8859
 void MxBackgroundAudioManager::DestroyMusic()
 {
 	if (m_script.GetInternal()) {
@@ -80,6 +84,7 @@ void MxBackgroundAudioManager::DestroyMusic()
 }
 
 // FUNCTION: LEGO1 0x1007ee40
+// FUNCTION: BETA10 0x100e8953
 MxResult MxBackgroundAudioManager::Tickle()
 {
 	switch (m_tickleState) {
@@ -97,6 +102,7 @@ MxResult MxBackgroundAudioManager::Tickle()
 }
 
 // FUNCTION: LEGO1 0x1007ee70
+// FUNCTION: BETA10 0x100e89e3
 void MxBackgroundAudioManager::MakePendingPresenterActive()
 {
 	if (m_activePresenter && m_activePresenter->GetAction()) {
@@ -114,6 +120,7 @@ void MxBackgroundAudioManager::MakePendingPresenterActive()
 }
 
 // FUNCTION: LEGO1 0x1007ef40
+// FUNCTION: BETA10 0x100e8afa
 void MxBackgroundAudioManager::FadeInPendingPresenter()
 {
 	MxS32 compare, volume;
@@ -213,6 +220,7 @@ MxLong MxBackgroundAudioManager::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1007f1b0
+// FUNCTION: BETA10 0x100e8f2e
 void MxBackgroundAudioManager::StartAction(MxParam& p_param)
 {
 	// TODO: the sender is most likely a MxAudioPresenter?
@@ -224,6 +232,7 @@ void MxBackgroundAudioManager::StartAction(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1007f200
+// FUNCTION: BETA10 0x100e8f8c
 void MxBackgroundAudioManager::StopAction(MxParam& p_param)
 {
 	if (((MxNotificationParam&) p_param).GetSender() == m_activePresenter) {
@@ -283,14 +292,14 @@ MxResult MxBackgroundAudioManager::PlayMusic(
 }
 
 // FUNCTION: BETA10 0x100e92ec
-void MxBackgroundAudioManager::Update(MxS32 p_targetVolume, MxS32 p_speed, MxPresenter::TickleState p_tickleState)
+void MxBackgroundAudioManager::Update(MxS32 p_volume, MxS32 p_speed, MxPresenter::TickleState p_tickleState)
 {
-	assert(p_targetVolume >= 0 && p_targetVolume <= 100);
+	assert(p_volume >= 0 && p_volume <= 100);
 	assert(p_speed > 0);
 
 	m_tickleState = p_tickleState;
 	m_speed = p_speed;
-	m_targetVolume = p_targetVolume;
+	m_targetVolume = p_volume;
 }
 
 // FUNCTION: LEGO1 0x1007f470
@@ -345,6 +354,7 @@ void MxBackgroundAudioManager::RaiseVolume()
 }
 
 // FUNCTION: LEGO1 0x1007f5f0
+// FUNCTION: BETA10 0x100e95a0
 void MxBackgroundAudioManager::Enable(MxBool p_enable)
 {
 	if (this->m_enabled != p_enable) {

--- a/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
@@ -46,9 +46,19 @@ DECOMP_SIZE_ASSERT(LegoCarBuild::LookupTableActions, 0x1c);
 
 // These four structs can be matched to the vehicle types using BETA10 0x10070520
 
+// GLOBAL: LEGO1 0x100d65a4
+const MxFloat LegoCarBuild::g_selectedPartRotationAngleStepYAxis = -0.1f;
+
+// GLOBAL: LEGO1 0x100d65a8
+const MxFloat LegoCarBuild::g_rotationAngleStepYAxis = 0.07;
+
+// GLOBAL: LEGO1 0x100d65ac
+// GLOBAL: BETA10 0x101bb7bc
+static const MxFloat g_unk0x100d65ac = 0.0f;
+
 // GLOBAL: LEGO1 0x100d65b0
 // GLOBAL: BETA10 0x101bb7c0
-LegoCarBuild::LookupTableActions LegoCarBuild::g_actorScripts[] = {
+const LegoCarBuild::LookupTableActions LegoCarBuild::g_actorScripts[] = {
 	{DunecarScript::c_igs001d3_RunAnim,
 	 DunecarScript::c_igs002d3_RunAnim,
 	 DunecarScript::c_igs003d3_RunAnim,
@@ -79,12 +89,6 @@ LegoCarBuild::LookupTableActions LegoCarBuild::g_actorScripts[] = {
 	 RacecarScript::c_irtxx4d1_RunAnim}
 };
 
-// GLOBAL: LEGO1 0x100d65a4
-MxFloat LegoCarBuild::g_selectedPartRotationAngleStepYAxis = -0.1f;
-
-// GLOBAL: LEGO1 0x100d65a8
-MxFloat LegoCarBuild::g_rotationAngleStepYAxis = 0.07;
-
 // GLOBAL: LEGO1 0x100f11cc
 MxS16 LegoCarBuild::g_lastTickleState = -1;
 
@@ -92,8 +96,8 @@ MxS16 LegoCarBuild::g_lastTickleState = -1;
 // FUNCTION: BETA10 0x1006ac10
 LegoCarBuild::LegoCarBuild()
 {
-	m_clickState = e_idle;
 	m_selectedPart = 0;
+	m_clickState = e_idle;
 	m_resetPlacedSelectedPart = c_disabled;
 	m_displayedPartIsPlaced = FALSE;
 	m_animPresenter = NULL;
@@ -160,62 +164,62 @@ MxResult LegoCarBuild::Create(MxDSAction& p_dsAction)
 {
 	MxResult result = LegoWorld::Create(p_dsAction);
 
-	if (!result) {
-		// TickleManager()->RegisterClient(this, 100);
-		InputManager()->SetWorld(this);
-		ControlManager()->Register(this);
-
-		SetIsWorldActive(FALSE);
-
-		InputManager()->Register(this);
-
-		// variable name verified by BETA10 0x1006b1a6
-		const char* buildStateClassName = NULL;
-
-		if (m_atomId == *g_copterScript) {
-			buildStateClassName = "LegoCopterBuildState";
-			GameState()->m_currentArea = LegoGameState::e_copterbuild;
-			m_carId = Helicopter_Actor;
-		}
-		else if (m_atomId == *g_dunecarScript) {
-			buildStateClassName = "LegoDuneCarBuildState";
-			GameState()->m_currentArea = LegoGameState::e_dunecarbuild;
-			m_carId = DuneBugy_Actor;
-		}
-		else if (m_atomId == *g_jetskiScript) {
-			buildStateClassName = "LegoJetskiBuildState";
-			GameState()->m_currentArea = LegoGameState::e_jetskibuild;
-			m_carId = Jetski_Actor;
-		}
-		else if (m_atomId == *g_racecarScript) {
-			buildStateClassName = "LegoRaceCarBuildState";
-			GameState()->m_currentArea = LegoGameState::e_racecarbuild;
-			m_carId = RaceCar_Actor;
-		}
-
-		LegoGameState* gameState = GameState();
-
-		LegoVehicleBuildState* buildState = (LegoVehicleBuildState*) gameState->GetState(buildStateClassName);
-
-		if (!buildState) {
-			buildState = (LegoVehicleBuildState*) gameState->CreateState(buildStateClassName);
-		}
-
-		m_buildState = buildState;
-		m_alreadyFinished = m_buildState->m_finishedBuild;
-
-		GameState()->StopArea(LegoGameState::e_previousArea);
-
-		m_buildState->m_animationState = LegoVehicleBuildState::e_entering;
-		m_clickState = e_idle;
-
-		BackgroundAudioManager()->Stop();
-		EnableAnimations(FALSE);
-
-		result = SUCCESS;
+	if (result != SUCCESS) {
+		return result;
 	}
 
-	return result;
+	// TickleManager()->RegisterClient(this, 100);
+	InputManager()->SetWorld(this);
+	ControlManager()->Register(this);
+
+	SetIsWorldActive(FALSE);
+
+	InputManager()->Register(this);
+
+	// variable name verified by BETA10 0x1006b1a6
+	const char* buildStateClassName = NULL;
+
+	if (m_atomId == *g_copterScript) {
+		buildStateClassName = "LegoCopterBuildState";
+		GameState()->m_currentArea = LegoGameState::e_copterbuild;
+		m_carId = Helicopter_Actor;
+	}
+	else if (m_atomId == *g_dunecarScript) {
+		buildStateClassName = "LegoDuneCarBuildState";
+		GameState()->m_currentArea = LegoGameState::e_dunecarbuild;
+		m_carId = DuneBugy_Actor;
+	}
+	else if (m_atomId == *g_jetskiScript) {
+		buildStateClassName = "LegoJetskiBuildState";
+		GameState()->m_currentArea = LegoGameState::e_jetskibuild;
+		m_carId = Jetski_Actor;
+	}
+	else if (m_atomId == *g_racecarScript) {
+		buildStateClassName = "LegoRaceCarBuildState";
+		GameState()->m_currentArea = LegoGameState::e_racecarbuild;
+		m_carId = RaceCar_Actor;
+	}
+
+	LegoGameState* gameState = GameState();
+
+	LegoVehicleBuildState* buildState = (LegoVehicleBuildState*) gameState->GetState(buildStateClassName);
+
+	if (!buildState) {
+		buildState = (LegoVehicleBuildState*) gameState->CreateState(buildStateClassName);
+	}
+
+	m_buildState = buildState;
+	m_alreadyFinished = m_buildState->m_finishedBuild;
+
+	GameState()->StopArea(LegoGameState::e_previousArea);
+
+	m_buildState->m_animationState = LegoVehicleBuildState::e_entering;
+	m_clickState = e_idle;
+
+	BackgroundAudioManager()->Stop();
+	EnableAnimations(FALSE);
+
+	return SUCCESS;
 }
 
 // FUNCTION: LEGO1 0x10022cd0
@@ -286,6 +290,7 @@ void LegoCarBuild::InitPresenters()
 }
 
 // FUNCTION: LEGO1 0x10022f00
+// FUNCTION: BETA10 0x1006b7e7
 void LegoCarBuild::DisplaySelectedPart()
 {
 	if (m_selectedPart) {
@@ -352,7 +357,7 @@ void LegoCarBuild::CalculateStartAndTargetScreenPositions()
 	m_selectedPartTargetScreenPosition[1] = screenPos[1] / screenPos[3];
 
 	m_normalizedDistance =
-		sqrt((MxDouble) DISTSQRD2(m_selectedPartStartScreenPosition, m_selectedPartTargetScreenPosition));
+		sqrt((MxDouble) DISTSQRD2(m_selectedPartTargetScreenPosition, m_selectedPartStartScreenPosition));
 
 	m_draggingQuarternionTransformer.SetStartEnd(m_selectedPartStartTransform, m_selectedPartTargetTransform);
 }
@@ -372,45 +377,47 @@ void LegoCarBuild::CalculateSelectedPartMatrix(MxLong p_x, MxLong p_y)
 		screenCoordinatesForRay[0] = p_x;
 		screenCoordinatesForRay[1] = p_y;
 
-		if (CalculateRayOriginDirection(screenCoordinatesForRay, local30, local84)) {
-			MxFloat positionOffset[3];
-			MxFloat screenPosition[2];
-
-			screenPosition[0] = p_x;
-			screenPosition[1] = p_y;
-
-			positionOffset[0] = 0;
-			positionOffset[1] = 0;
-			positionOffset[2] = 0;
-
-			MxMatrix transform;
-
-			if (p_y < m_selectedPartStartScreenPosition[1]) {
-				CalculateDragPositionAbove(screenPosition, positionOffset);
-			}
-			else if (p_y > m_selectedPartTargetScreenPosition[1]) {
-				CalculateDragPositionOnGround(screenPosition, positionOffset);
-			}
-			else if (p_y >= m_selectedPartStartScreenPosition[1]) {
-				CalculateDragPositionBetween(screenPosition, positionOffset);
-			}
-
-			MxS32 currentDistance[2];
-
-			currentDistance[0] = p_x - m_selectedPartStartScreenPosition[0];
-			currentDistance[1] = p_y - m_selectedPartStartScreenPosition[1];
-
-			MxFloat distanceRatio = sqrt((double) (NORMSQRD2(currentDistance))) / m_normalizedDistance;
-
-			m_draggingQuarternionTransformer.InterpolateToMatrix(transform, distanceRatio);
-
-			transform[3][0] = m_selectedPartStartTransform[3][0] + positionOffset[0];
-			transform[3][1] = m_selectedPartStartTransform[3][1] + positionOffset[1];
-			transform[3][2] = m_selectedPartStartTransform[3][2] + positionOffset[2];
-			transform[3][3] = 1.0;
-
-			m_selectedPart->WrappedSetLocal2WorldWithWorldDataUpdate(transform);
+		if (!CalculateRayOriginDirection(screenCoordinatesForRay, local30, local84)) {
+			return;
 		}
+
+		MxFloat positionOffset[3];
+		MxFloat screenPosition[2];
+
+		screenPosition[0] = p_x;
+		screenPosition[1] = p_y;
+
+		positionOffset[0] = 0;
+		positionOffset[1] = 0;
+		positionOffset[2] = 0;
+
+		MxMatrix transform;
+
+		if (p_y < m_selectedPartStartScreenPosition[1]) {
+			CalculateDragPositionAbove(screenPosition, positionOffset);
+		}
+		else if (p_y > m_selectedPartTargetScreenPosition[1]) {
+			CalculateDragPositionOnGround(screenPosition, positionOffset);
+		}
+		else if (p_y >= m_selectedPartStartScreenPosition[1]) {
+			CalculateDragPositionBetween(screenPosition, positionOffset);
+		}
+
+		MxS32 currentDistance[2];
+
+		currentDistance[0] = p_x - m_selectedPartStartScreenPosition[0];
+		currentDistance[1] = p_y - m_selectedPartStartScreenPosition[1];
+
+		MxFloat distanceRatio = sqrt((double) (NORMSQRD2(currentDistance))) / m_normalizedDistance;
+
+		m_draggingQuarternionTransformer.InterpolateToMatrix(transform, distanceRatio);
+
+		transform[3][0] = m_selectedPartStartTransform[3][0] + positionOffset[0];
+		transform[3][1] = m_selectedPartStartTransform[3][1] + positionOffset[1];
+		transform[3][2] = m_selectedPartStartTransform[3][2] + positionOffset[2];
+		transform[3][3] = 1.0;
+
+		m_selectedPart->WrappedSetLocal2WorldWithWorldDataUpdate(transform);
 	}
 }
 
@@ -425,8 +432,8 @@ void LegoCarBuild::CalculateDragPositionAbove(MxFloat p_coordinates[2], MxFloat 
 	CalculateRayOriginDirection(p_coordinates, direction, origin);
 
 	planeFactor = (m_selectedPartStartPosition[2] - origin[2]) / direction[2];
-	p_position[0] = (planeFactor * direction[0] + origin[0]) - m_selectedPartStartPosition[0];
-	p_position[1] = (planeFactor * direction[1] + origin[1]) - m_selectedPartStartPosition[1];
+	p_position[0] = planeFactor * direction[0] - m_selectedPartStartPosition[0] + origin[0];
+	p_position[1] = planeFactor * direction[1] - m_selectedPartStartPosition[1] + origin[1];
 	p_position[2] = 0.0;
 }
 
@@ -468,7 +475,7 @@ void LegoCarBuild::CalculateDragPositionOnGround(MxFloat p_coordinates[2], MxFlo
 // FUNCTION: BETA10 0x100701f0
 void LegoCarBuild::VTable0x80(MxFloat p_param1[2], MxFloat p_param2[2], MxFloat p_param3, MxFloat p_param4[2])
 {
-	if (p_param1[1] == 0.0f) {
+	if (p_param1[1] == 0.0) {
 		return;
 	}
 	p_param4[0] = ((p_param3 - p_param2[1]) / p_param1[1]) * p_param1[0] + p_param2[0];
@@ -1355,7 +1362,7 @@ void LegoCarBuild::EnableDecalForSelectedPart(MxBool p_enabled)
 
 // FUNCTION: LEGO1 0x10025350
 // FUNCTION: BETA10 0x1006e3c0
-void LegoCarBuild::SetPartColor(MxS32 p_objectId)
+void LegoCarBuild::SetPartColor(MxU32 p_objectId)
 {
 	const LegoChar* color;
 	LegoChar buffer[256];

--- a/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
@@ -302,12 +302,13 @@ MxResult LegoCarBuildAnimPresenter::Serialize(LegoStorage* p_storage)
 		}
 	}
 	else if (p_storage->IsWriteMode()) {
-		p_storage->WriteS16(m_placedPartCount);
-		p_storage->WriteFloat(m_shelfFrame);
+		LegoStorage* storage = p_storage;
+		storage->WriteS16(m_placedPartCount);
+		storage->WriteFloat(m_shelfFrame);
 		for (MxS16 i = 0; i < m_numberOfParts; i++) {
-			p_storage->WriteString(m_parts[i].m_name);
-			p_storage->WriteString(m_parts[i].m_wiredName);
-			p_storage->WriteS16(m_parts[i].m_objectId);
+			storage->WriteString(m_parts[i].m_name);
+			storage->WriteString(m_parts[i].m_wiredName);
+			storage->WriteS16(m_parts[i].m_objectId);
 		}
 	}
 
@@ -642,6 +643,12 @@ MxBool LegoCarBuildAnimPresenter::StringEqualsShelf(const LegoChar* p_string)
 	return strnicmp(p_string, "SHELF", strlen("SHELF")) == 0;
 }
 
+// FUNCTION: BETA10 0x1007266c
+MxBool LegoCarBuildAnimPresenter::StringEqualsView(const LegoChar* p_string)
+{
+	return stricmp(p_string, "VIEW") == 0;
+}
+
 // FUNCTION: LEGO1 0x10079c30
 // FUNCTION: BETA10 0x100726a6
 MxBool LegoCarBuildAnimPresenter::IsNextPartToPlace(const LegoChar* p_name)
@@ -699,7 +706,7 @@ const LegoChar* LegoCarBuildAnimPresenter::GetWiredNameByPartName(const LegoChar
 void LegoCarBuildAnimPresenter::SetPartObjectIdByName(const LegoChar* p_name, MxS16 p_objectId)
 {
 	for (MxS16 i = 0; i < m_numberOfParts; i++) {
-		if (strcmpi(p_name, m_parts[i].m_name) == 0) {
+		if (strcmpi(m_parts[i].m_name, p_name) == 0) {
 			m_parts[i].m_objectId = p_objectId;
 			return;
 		}

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -3,6 +3,8 @@
 #include "3dmanager/lego3dmanager.h"
 #include "decomp.h"
 #include "define.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "islepathactor.h"
 #include "legoanimationmanager.h"
 #include "legoanimpresenter.h"
@@ -19,6 +21,8 @@
 #include "mxstreamer.h"
 #include "mxtimer.h"
 #include "mxutilities.h"
+
+#include <assert.h>
 
 DECOMP_SIZE_ASSERT(LegoAnimMMPresenter, 0x74)
 
@@ -110,6 +114,7 @@ MxResult LegoAnimMMPresenter::StartAction(MxStreamController* p_controller, MxDS
 		result = SUCCESS;
 	}
 
+	assert(result == SUCCESS);
 	return result;
 }
 
@@ -225,6 +230,7 @@ MxLong LegoAnimMMPresenter::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1004b360
+// FUNCTION: BETA10 0x1004c560
 void LegoAnimMMPresenter::AdvanceSerialAction(MxPresenter* p_presenter)
 {
 	if (m_presenter == p_presenter && ((MxU8) p_presenter->GetCurrentTickleState() == MxPresenter::e_streaming ||
@@ -249,6 +255,7 @@ void LegoAnimMMPresenter::ParseExtra()
 		char output[1024];
 		if (KeyValueStringParse(output, g_strANIMMAN_ID, extraCopy)) {
 			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
 			m_animmanId = atoi(token);
 			m_tranInfo = AnimationManager()->GetTranInfo(m_animmanId);
 
@@ -318,6 +325,8 @@ MxBool LegoAnimMMPresenter::FUN_1004b530(MxLong p_time)
 	if (m_presenter != NULL) {
 		m_presenter->GetTransforms(m_unk0x68, 0);
 		m_roiMap = m_presenter->GetROIMap(m_roiMapSize);
+		assert(m_roiMap);
+		assert(m_roiMapSize);
 		m_roiMapSize++;
 	}
 

--- a/LEGO1/lego/legoomni/src/common/legotesttimer.cpp
+++ b/LEGO1/lego/legoomni/src/common/legotesttimer.cpp
@@ -2,9 +2,12 @@
 
 #include "legoeventnotificationparam.h"
 #include "legoinputmanager.h"
+#include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "mxnotificationparam.h"
 
+#include <conio.h>
 #include <stdio.h>
 
 // FUNCTION: BETA10 0x100d1030
@@ -153,4 +156,21 @@ MxLong LegoTestTimer::Notify(MxParam& p_param)
 	}
 
 	return 0;
+}
+
+void LegoTestTimerConsoleControl(LegoTestTimer* p_timer)
+{
+	while (!_kbhit()) {
+	}
+
+	switch (_getch()) {
+	case 's':
+	case 'S':
+		p_timer->ResetAtNextTick();
+		break;
+	case 'p':
+	case 'P':
+		p_timer->Print();
+		break;
+	}
 }

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -30,6 +30,7 @@
 #include "realtime/realtime.h"
 #include "scripts.h"
 
+#include <assert.h>
 #include <process.h>
 #include <string.h>
 #include <vec.h>
@@ -42,6 +43,9 @@ LegoROI* PickROI(MxLong p_x, MxLong p_y)
 	Lego3DView* view = videoManager->Get3DManager()->GetLego3DView();
 	return (LegoROI*) view->Pick(p_x, p_y);
 }
+
+// GLOBAL: LEGO1 0x100f407c
+undefined4 g_unk0x100f407c = 2;
 
 // FUNCTION: LEGO1 0x1003dd90
 // FUNCTION: BETA10 0x100d3449
@@ -179,23 +183,23 @@ void CalculateViewFromAnimation(LegoAnimPresenter* p_presenter)
 {
 	MxMatrix viewMatrix;
 	LegoTreeNode* rootNode = p_presenter->GetAnimation()->GetRoot();
-	LegoAnimNodeData* camData = NULL;
+	LegoAnimNodeData* cameraData = NULL;
 	LegoAnimNodeData* targetData = NULL;
 	MxS16 nodesCount = CountTotalTreeNodes(rootNode);
 
 	MxFloat fov;
 	for (MxS16 i = 0; i < nodesCount; i++) {
-		if (camData && targetData) {
+		if (cameraData && targetData) {
 			break;
 		}
 
 		LegoAnimNodeData* data = (LegoAnimNodeData*) GetTreeNode(rootNode, i)->GetData();
 
 		if (!strnicmp(data->GetName(), "CAM", strlen("CAM"))) {
-			camData = data;
+			cameraData = data;
 			fov = atof(&data->GetName()[strlen(data->GetName()) - 2]);
 		}
-		else if (!strcmpi(data->GetName(), "TARGET")) {
+		else if (!_strcmpi(data->GetName(), "TARGET")) {
 			targetData = data;
 		}
 	}
@@ -205,7 +209,10 @@ void CalculateViewFromAnimation(LegoAnimPresenter* p_presenter)
 	matrixCam.SetIdentity();
 	matrixTarget.SetIdentity();
 
-	camData->CreateLocalTransform(0.0f, matrixCam);
+	assert(cameraData);
+	assert(targetData);
+
+	cameraData->CreateLocalTransform(0.0f, matrixCam);
 	targetData->CreateLocalTransform(0.0f, matrixTarget);
 
 	Mx3DPointFloat dir;
@@ -227,38 +234,39 @@ void CalculateViewFromAnimation(LegoAnimPresenter* p_presenter)
 }
 
 // FUNCTION: LEGO1 0x1003e300
+// FUNCTION: BETA10 0x100d3e50
 Extra::ActionType MatchActionString(const char* p_str)
 {
 	Extra::ActionType result = Extra::ActionType::e_unknown;
 
-	if (!strcmpi("openram", p_str)) {
+	if (!_strcmpi("openram", p_str)) {
 		result = Extra::ActionType::e_openram;
 	}
-	else if (!strcmpi("opendisk", p_str)) {
+	else if (!_strcmpi("opendisk", p_str)) {
 		result = Extra::ActionType::e_opendisk;
 	}
-	else if (!strcmpi("close", p_str)) {
+	else if (!_strcmpi("close", p_str)) {
 		result = Extra::ActionType::e_close;
 	}
-	else if (!strcmpi("start", p_str)) {
+	else if (!_strcmpi("start", p_str)) {
 		result = Extra::ActionType::e_start;
 	}
-	else if (!strcmpi("stop", p_str)) {
+	else if (!_strcmpi("stop", p_str)) {
 		result = Extra::ActionType::e_stop;
 	}
-	else if (!strcmpi("run", p_str)) {
+	else if (!_strcmpi("run", p_str)) {
 		result = Extra::ActionType::e_run;
 	}
-	else if (!strcmpi("exit", p_str)) {
+	else if (!_strcmpi("exit", p_str)) {
 		result = Extra::ActionType::e_exit;
 	}
-	else if (!strcmpi("enable", p_str)) {
+	else if (!_strcmpi("enable", p_str)) {
 		result = Extra::ActionType::e_enable;
 	}
-	else if (!strcmpi("disable", p_str)) {
+	else if (!_strcmpi("disable", p_str)) {
 		result = Extra::ActionType::e_disable;
 	}
-	else if (!strcmpi("notify", p_str)) {
+	else if (!_strcmpi("notify", p_str)) {
 		result = Extra::ActionType::e_notify;
 	}
 
@@ -383,7 +391,9 @@ void NotifyEntity(const char* p_filename, MxS32 p_entityId, LegoEntity* p_sender
 // FUNCTION: LEGO1 0x1003eab0
 void SetCameraControllerFromIsle()
 {
-	InputManager()->SetCamera(FindWorld(*g_isleScript, IsleScript::c__Isle)->GetCameraController());
+	Isle* isle = (Isle*) FindWorld(*g_isleScript, IsleScript::c__Isle);
+	assert(isle);
+	InputManager()->SetCamera(isle->GetCameraController());
 }
 
 // FUNCTION: LEGO1 0x1003eae0
@@ -398,7 +408,7 @@ void ConvertHSVToRGB(float p_h, float p_s, float p_v, float* p_rOut, float* p_gO
 
 	double sDbl = p_s;
 
-	if (p_s > 0.5f) {
+	if (p_s > 0.5) {
 		calc = (1.0f - p_v) * p_s + p_v;
 	}
 	else {
@@ -454,6 +464,81 @@ void ConvertHSVToRGB(float p_h, float p_s, float p_v, float* p_rOut, float* p_gO
 	default:
 		return;
 	}
+}
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+// FUNCTION: BETA10 0x100d4801
+void ConvertRGBToHSV(float p_r, float p_g, float p_b, float* p_hOut, float* p_sOut, float* p_vOut)
+{
+	double h, min, delta, s, max, gc, l, rc, bc;
+
+	h = 0.0;
+	l = 0.0;
+	s = 0.0;
+
+	max = MAX(max = MAX(p_g, p_r), p_b);
+
+	if ((l = ((min = MIN(p_b, min = MIN(p_r, p_g))) + max) / 2.0) <= 0.0) {
+		l = 0.0;
+		goto done;
+	}
+
+	delta = max - min;
+	s = delta;
+
+	if (s > 0.0) {
+		if (l > 0.5) {
+			s = s / (2.0 - max - min);
+		}
+		else {
+			s = s / (min + max);
+		}
+	}
+	else {
+		goto done;
+	}
+
+	rc = (max - p_r) / delta;
+	gc = (max - p_g) / delta;
+	bc = (max - p_b) / delta;
+
+	if (max == p_r) {
+		h = (min == p_g) ? bc + 5.0 : 1.0 - gc;
+	}
+	else if (max == p_g) {
+		h = (min == p_b) ? rc + 1.0 : 3.0 - bc;
+	}
+	else {
+		h = (min == p_r) ? gc + 3.0 : 5.0 - rc;
+	}
+
+	h = h * (1.0 / 6.0); // BETA10 (1996) still divides: h = h / 6.0;
+
+done:
+	if (h < 0.0) {
+		h += 1.0;
+	}
+	if (h > 1.0) {
+		h -= 1.0;
+	}
+	if (l < 0.0) {
+		l = 0.0;
+	}
+	if (l > 1.0) {
+		l = 1.0;
+	}
+	if (s < 0.0) {
+		s = 0.0;
+	}
+	if (s > 1.0) {
+		s = 1.0;
+	}
+
+	*p_hOut = h;
+	*p_sOut = l;
+	*p_vOut = s;
 }
 
 // FUNCTION: LEGO1 0x1003ecc0
@@ -716,11 +801,14 @@ void WriteDefaultTexture(LegoStorage* p_storage, const char* p_name)
 					memcpy(image->GetBits(), desc.lpSurface, desc.dwWidth * desc.dwHeight);
 				}
 				else {
-					MxU8* surface = (MxU8*) desc.lpSurface;
 					LegoU8* bits = image->GetBits();
+					MxU8* surface = (MxU8*) desc.lpSurface;
 
 					for (MxS32 i = 0; i < desc.dwHeight; i++) {
-						memcpy(bits, surface, desc.dwWidth);
+						// Note: this appears to be a bug. The copy runs the wrong way round -
+						// the branch above reads the surface into the image, while this one
+						// writes the still-uninitialized image into the locked surface.
+						memcpy(surface, bits, desc.dwWidth);
 						surface += desc.lPitch;
 						bits += desc.dwWidth;
 					}
@@ -744,8 +832,8 @@ void WriteDefaultTexture(LegoStorage* p_storage, const char* p_name)
 					image->SetCount(i);
 
 					if (i > 0) {
-						// Note: this appears to be a bug. size should be i * sizeof(LegoPaletteEntry)
-						memcpy(image->GetPalette(), paletteEntries, i);
+						LegoPaletteEntry* palette = image->GetPalette();
+						memcpy(palette, paletteEntries, i);
 					}
 
 					LegoTexture texture;

--- a/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
@@ -2,6 +2,8 @@
 
 #include "define.h"
 #include "legocontrolmanager.h"
+#include "legoutils.h"
+#include "realtime/matrix4d.inl.h"
 #include "mxdsmultiaction.h"
 #include "mxmisc.h"
 #include "mxstillpresenter.h"
@@ -144,6 +146,7 @@ MxBool MxControlPresenter::CheckButtonDown(MxS32 p_x, MxS32 p_y, MxPresenter* p_
 }
 
 // FUNCTION: LEGO1 0x10044480
+// FUNCTION: BETA10 0x100eb1ae
 MxBool MxControlPresenter::Notify(LegoControlManagerNotificationParam* p_param, MxPresenter* p_presenter)
 {
 	if (IsEnabled()) {
@@ -175,6 +178,7 @@ MxBool MxControlPresenter::Notify(LegoControlManagerNotificationParam* p_param, 
 }
 
 // FUNCTION: LEGO1 0x10044540
+// FUNCTION: BETA10 0x100eb3ba
 void MxControlPresenter::UpdateEnabledChild(MxS16 p_enabledChild)
 {
 	if (p_enabledChild == -1) {
@@ -199,6 +203,7 @@ void MxControlPresenter::UpdateEnabledChild(MxS16 p_enabledChild)
 }
 
 // FUNCTION: LEGO1 0x10044610
+// FUNCTION: BETA10 0x100eb59b
 void MxControlPresenter::ReadyTickle()
 {
 	MxPresenter::ParseExtra();

--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -32,6 +32,7 @@ MxTransitionManager::MxTransitionManager()
 }
 
 // FUNCTION: LEGO1 0x1004ba00
+// FUNCTION: BETA10 0x100ec34c
 MxTransitionManager::~MxTransitionManager()
 {
 	delete[] m_copyBuffer;
@@ -45,6 +46,7 @@ MxTransitionManager::~MxTransitionManager()
 }
 
 // FUNCTION: LEGO1 0x1004baa0
+// FUNCTION: BETA10 0x100ec3d1
 MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 {
 	LegoVideoManager* videoManager = VideoManager();
@@ -53,10 +55,10 @@ MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 }
 
 // FUNCTION: LEGO1 0x1004bac0
+// FUNCTION: BETA10 0x100ec402
 MxResult MxTransitionManager::Tickle()
 {
-	MxULong time = m_animationSpeed + m_systemTime;
-	if (time > timeGetTime()) {
+	if (m_animationSpeed + m_systemTime > timeGetTime()) {
 		return SUCCESS;
 	}
 
@@ -199,6 +201,7 @@ void MxTransitionManager::DissolveTransition()
 	}
 
 	// Run one tick of the animation
+	MxS32 col;
 	DDSURFACEDESC ddsd;
 	memset(&ddsd, 0, sizeof(ddsd));
 	ddsd.dwSize = sizeof(ddsd);
@@ -212,7 +215,7 @@ void MxTransitionManager::DissolveTransition()
 	if (res == DD_OK) {
 		SubmitCopyRect(&ddsd);
 
-		for (MxS32 col = 0; col < 640; col++) {
+		for (col = 0; col < 640; col++) {
 			// Select 16 columns on each tick
 			if (m_animationTimer * 16 > m_columnOrder[col]) {
 				continue;
@@ -319,7 +322,7 @@ void MxTransitionManager::MosaicTransition()
 					MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
 
 					// Seek to the sample position.
-					MxU8* source = (MxU8*) ddsd.lpSurface + 10 * row * ddsd.lPitch + bytesPerPixel * xShift;
+					MxU8* source = (MxU8*) ddsd.lpSurface + 10 * row * ddsd.lPitch + xShift * bytesPerPixel;
 
 					// Sample byte or word depending on display mode.
 					MxU32 sample = bytesPerPixel == 1 ? *source : *(MxU16*) source;
@@ -529,6 +532,8 @@ void MxTransitionManager::SubmitCopyRect(LPDDSURFACEDESC p_ddsc)
 // FUNCTION: LEGO1 0x1004c580
 void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 {
+	MxS32 i;
+	MxS32 y;
 	// Check if the copy rect is setup
 	if (m_copyFlags.m_bit0 == FALSE || m_waitIndicator == NULL) {
 		return;
@@ -540,24 +545,29 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 	// Check if wait indicator has started
 	if (m_waitIndicator->GetCurrentTickleState() >= MxPresenter::e_streaming) {
 		// Setup the copy rect
-		MxU32 copyPitch = (p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8) *
-						  (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
 		MxU32 bytesPerPixel = p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
+		MxS32 copyPitch = (p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8) *
+						  (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
 
-		m_copyRect.left = m_waitIndicator->GetLocation().GetX();
-		m_copyRect.top = m_waitIndicator->GetLocation().GetY();
+		MxPoint32 loc;
+		loc = m_waitIndicator->GetLocation();
+		y = loc.GetY();
 
 		MxS32 height = m_waitIndicator->GetHeight();
 		MxS32 width = m_waitIndicator->GetWidth();
+		MxU32 x = loc.GetX();
 
-		m_copyRect.right = m_copyRect.left + width - 1;
-		m_copyRect.bottom = m_copyRect.top + height - 1;
+		m_copyRect.left = x;
+		m_copyRect.top = y;
+		m_copyRect.right = x + width - 1;
+		m_copyRect.bottom = y + height - 1;
 
 		// Allocate the copy buffer
 		const MxU8* src =
 			(const MxU8*) p_ddsc->lpSurface + m_copyRect.top * p_ddsc->lPitch + bytesPerPixel * m_copyRect.left;
 
-		m_copyBuffer = new MxU8[bytesPerPixel * width * height];
+		m_copyBuffer = new MxU8
+			[(m_copyRect.bottom - m_copyRect.top + 1) * (m_copyRect.right - m_copyRect.left + 1) * bytesPerPixel];
 		if (!m_copyBuffer) {
 			return;
 		}
@@ -565,7 +575,7 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 		// Copy into the copy buffer
 		MxU8* dst = m_copyBuffer;
 
-		for (MxS32 i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++) {
+		for (i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++) {
 			memcpy(dst, src, copyPitch);
 			src += p_ddsc->lPitch;
 			dst += copyPitch;
@@ -574,29 +584,27 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 
 	// Setup display surface
 	if ((m_waitIndicator->GetAction()->GetFlags() & MxDSAction::c_bit5) != 0) {
-		MxDisplaySurface* displaySurface = VideoManager()->GetDisplaySurface();
 		MxBool und = FALSE;
-		displaySurface->VTable0x2c(
+		VideoManager()->GetDisplaySurface()->VTable0x2c(
 			p_ddsc,
 			m_waitIndicator->GetBitmap(),
 			0,
 			0,
-			m_waitIndicator->GetLocation().GetX(),
-			m_waitIndicator->GetLocation().GetY(),
+			m_waitIndicator->GetX(),
+			m_waitIndicator->GetY(),
 			m_waitIndicator->GetWidth(),
 			m_waitIndicator->GetHeight(),
 			und
 		);
 	}
 	else {
-		MxDisplaySurface* displaySurface = VideoManager()->GetDisplaySurface();
-		displaySurface->VTable0x24(
+		VideoManager()->GetDisplaySurface()->VTable0x24(
 			p_ddsc,
 			m_waitIndicator->GetBitmap(),
 			0,
 			0,
-			m_waitIndicator->GetLocation().GetX(),
-			m_waitIndicator->GetLocation().GetY(),
+			m_waitIndicator->GetX(),
+			m_waitIndicator->GetY(),
 			m_waitIndicator->GetWidth(),
 			m_waitIndicator->GetHeight()
 		);

--- a/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
+++ b/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
@@ -2,6 +2,8 @@
 
 #include "legoeventnotificationparam.h"
 #include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "misc.h"
 #include "mxcontrolpresenter.h"
 #include "mxdsaction.h"
@@ -12,6 +14,12 @@
 DECOMP_SIZE_ASSERT(LegoControlManager, 0x60)
 DECOMP_SIZE_ASSERT(LegoControlManagerNotificationParam, 0x2c)
 DECOMP_SIZE_ASSERT(LegoEventNotificationParam, 0x20)
+
+// GLOBAL: LEGO1 0x100f31b0
+MxS32 g_clickedObjectId = -1;
+
+// GLOBAL: LEGO1 0x100f31b4
+const char* g_clickedAtom = NULL;
 
 // FUNCTION: LEGO1 0x10028520
 // STUB: BETA10 0x1008ae50
@@ -57,6 +65,7 @@ void LegoControlManager::Unregister(MxCore* p_listener)
 }
 
 // FUNCTION: LEGO1 0x10029210
+// FUNCTION: BETA10 0x1007c406
 MxBool LegoControlManager::HandleButtonDown(LegoEventNotificationParam& p_param, MxPresenter* p_presenter)
 {
 	if (m_presenterList != NULL && m_presenterList->GetNumElements() != 0) {
@@ -109,6 +118,7 @@ MxBool LegoControlManager::HandleButtonDown(LegoEventNotificationParam& p_param,
 }
 
 // FUNCTION: LEGO1 0x100292e0
+// FUNCTION: BETA10 0x1007c772
 void LegoControlManager::Notify()
 {
 	LegoNotifyListCursor cursor(&m_notifyList);
@@ -122,8 +132,10 @@ void LegoControlManager::Notify()
 }
 
 // FUNCTION: LEGO1 0x100293c0
+// FUNCTION: BETA10 0x1007c81b
 void LegoControlManager::UpdateEnabledChild(MxU32 p_objectId, const char* p_atom, MxS16 p_enabledChild)
 {
+	const char* const& atom = p_atom;
 	if (m_presenterList) {
 		MxPresenterListCursor cursor(m_presenterList);
 		MxPresenter* control;
@@ -131,7 +143,7 @@ void LegoControlManager::UpdateEnabledChild(MxU32 p_objectId, const char* p_atom
 		while (cursor.Next(control)) {
 			MxDSAction* action = control->GetAction();
 
-			if (action->GetObjectId() == p_objectId && action->GetAtomId().GetInternal() == p_atom) {
+			if (action->GetObjectId() == p_objectId && action->GetAtomId().GetInternal() == atom) {
 				((MxControlPresenter*) control)->UpdateEnabledChild(p_enabledChild);
 
 				if (((MxControlPresenter*) control)->GetEnabledChild() == 0) {

--- a/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
@@ -8,6 +8,10 @@
 #include "mxutilities.h"
 #include "mxvariabletable.h"
 
+#include "roi/legoroi.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
+
 #include <assert.h>
 
 DECOMP_SIZE_ASSERT(LegoMeterPresenter, 0x94)
@@ -110,9 +114,13 @@ void LegoMeterPresenter::RepeatingTickle()
 // FUNCTION: BETA10 0x10097a40
 void LegoMeterPresenter::DrawMeter()
 {
-	const char* strval = VariableTable()->GetVariable(m_variable.GetData());
-	MxFloat percent = atof(strval);
-	MxS16 row, leftRightCol, bottomTopCol, leftRightEnd, bottomTopEnd;
+	MxFloat percent;
+	const char* strval;
+	MxU8* line;
+	MxS16 leftRightEnd, leftRightRow, leftRightCol, bottomTopEnd, bottomTopRow, bottomTopCol;
+
+	strval = VariableTable()->GetVariable(m_variable.GetData());
+	percent = atof(strval);
 
 	if (strval != NULL && m_curPercent != percent) {
 		m_curPercent = percent;
@@ -132,8 +140,8 @@ void LegoMeterPresenter::DrawMeter()
 		case e_leftToRight:
 			leftRightEnd = m_meterRect.GetWidth() * m_curPercent;
 
-			for (row = m_meterRect.GetTop(); row < m_meterRect.GetBottom(); row++) {
-				MxU8* line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), row);
+			for (leftRightRow = m_meterRect.GetTop(); leftRightRow < m_meterRect.GetBottom(); leftRightRow++) {
+				line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), leftRightRow);
 
 				for (leftRightCol = 0; leftRightCol < leftRightEnd; leftRightCol++, line++) {
 					if (*line) {
@@ -145,8 +153,8 @@ void LegoMeterPresenter::DrawMeter()
 		case e_bottomToTop:
 			bottomTopEnd = m_meterRect.GetBottom() - (MxS16) (m_meterRect.GetHeight() * m_curPercent);
 
-			for (row = m_meterRect.GetBottom(); row > bottomTopEnd; row--) {
-				MxU8* line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), row);
+			for (bottomTopRow = m_meterRect.GetBottom(); bottomTopRow > bottomTopEnd; bottomTopRow--) {
+				line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), bottomTopRow);
 
 				for (bottomTopCol = 0; bottomTopCol < m_meterRect.GetWidth(); bottomTopCol++, line++) {
 					if (*line) {

--- a/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
@@ -89,6 +89,58 @@ void LegoEntityPresenter::SetEntityLocation(const Vector3& p_location, const Vec
 	}
 }
 
+// FUNCTION: BETA10 0x1008034e
+Mx3DPointFloat LegoEntityPresenter::GetWorldPosition()
+{
+	if (m_entity) {
+		return m_entity->GetWorldPosition();
+	}
+	else {
+		return Mx3DPointFloat(0, 0, 0);
+	}
+}
+
+// FUNCTION: BETA10 0x100803a6
+Mx3DPointFloat LegoEntityPresenter::GetWorldDirection()
+{
+	if (m_entity) {
+		return m_entity->GetWorldDirection();
+	}
+	else {
+		return Mx3DPointFloat(1, 0, 0);
+	}
+}
+
+// FUNCTION: BETA10 0x10080401
+Mx3DPointFloat LegoEntityPresenter::GetWorldUp()
+{
+	if (m_entity) {
+		return m_entity->GetWorldUp();
+	}
+	else {
+		return Mx3DPointFloat(0, 1, 0);
+	}
+}
+
+// FUNCTION: BETA10 0x100804b4
+void LegoEntityPresenter::SetWorldSpeed(MxFloat p_worldSpeed)
+{
+	if (m_entity) {
+		m_entity->SetWorldSpeed(p_worldSpeed);
+	}
+}
+
+// FUNCTION: BETA10 0x100804f7
+MxFloat LegoEntityPresenter::GetWorldSpeed()
+{
+	if (m_entity) {
+		return m_entity->GetWorldSpeed();
+	}
+	else {
+		return 0.0f;
+	}
+}
+
 // FUNCTION: LEGO1 0x10053750
 void LegoEntityPresenter::ParseExtra()
 {

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -136,7 +136,7 @@ void LegoWorld::Destroy(MxBool p_fromDestructor)
 		m_objects.erase(it);
 
 		if (object->IsA("MxPresenter")) {
-			MxPresenter* presenter = (MxPresenter*) object;
+			presenter = (MxPresenter*) object;
 			MxDSAction* action = presenter->GetAction();
 
 			if (action) {
@@ -375,6 +375,7 @@ void LegoWorld::RemovePresenterFromBoundaries(LegoAnimPresenter* p_presenter)
 }
 
 // FUNCTION: LEGO1 0x1001ff80
+// FUNCTION: BETA10 0x100da749
 void LegoWorld::AddPath(LegoPathController* p_controller)
 {
 	p_controller->SetWorld(this);
@@ -400,6 +401,7 @@ LegoPathBoundary* LegoWorld::FindPathBoundary(const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x10020120
+// FUNCTION: BETA10 0x100da842
 MxResult LegoWorld::GetCurrPathInfo(LegoPathBoundary** p_boundaries, MxS32& p_numL)
 {
 	LegoPathControllerListCursor cursor(&m_pathControllerList);
@@ -771,7 +773,7 @@ void LegoWorld::Enable(MxBool p_enable)
 			}
 		}
 
-		for (MxCoreSet::iterator it = m_objects.begin(); it != m_objects.end(); it++) {
+		for (it = m_objects.begin(); it != m_objects.end(); it++) {
 			if ((*it)->IsA("LegoActionControlPresenter") ||
 				((*it)->IsA("MxPresenter") && ((MxPresenter*) *it)->IsEnabled())) {
 				m_disabledObjects.insert(*it);

--- a/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
@@ -27,6 +27,7 @@
 #include "mxstl/stlcompat.h"
 #include "mxutilities.h"
 
+#include <assert.h>
 #include <io.h>
 
 DECOMP_SIZE_ASSERT(LegoWorldPresenter, 0x54)
@@ -130,6 +131,8 @@ MxResult LegoWorldPresenter::StartAction(MxStreamController* p_controller, MxDSA
 void LegoWorldPresenter::ReadyTickle()
 {
 	m_entity = (LegoEntity*) MxPresenter::CreateEntity("LegoWorld");
+	assert(m_entity);
+
 	if (m_entity) {
 		m_entity->Create(*m_action);
 		Lego()->AddWorld((LegoWorld*) m_entity);
@@ -214,6 +217,8 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 		}
 
 		buff = new MxU8[size];
+		assert(buff);
+
 		if (fread(buff, size, 1, wdbFile) != 1) {
 			return FAILURE;
 		}
@@ -234,6 +239,8 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 		}
 
 		buff = new MxU8[size];
+		assert(buff);
+
 		if (fread(buff, size, 1, wdbFile) != 1) {
 			return FAILURE;
 		}
@@ -256,7 +263,7 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 		}
 	}
 
-	ModelDbPartListCursor cursor(worlds[i].m_partList);
+	ModelDbPartListCursor cursor(worlds[i].m_partlist);
 	ModelDbPart* part;
 
 	while (cursor.Next(part)) {
@@ -267,35 +274,35 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 	}
 
 	for (j = 0; j < worlds[i].m_numModels; j++) {
-		if (!strnicmp(worlds[i].m_models[j].m_modelName, "isle", 4)) {
+		if (!strnicmp(worlds[i].m_modarr[j].m_modelName, "isle", 4)) {
 			switch (g_legoWorldPresenterQuality) {
 			case 0:
-				if (strcmpi(worlds[i].m_models[j].m_modelName, "isle_lo")) {
+				if (strcmpi(worlds[i].m_modarr[j].m_modelName, "isle_lo")) {
 					continue;
 				}
 				break;
 			case 1:
-				if (strcmpi(worlds[i].m_models[j].m_modelName, "isle")) {
+				if (strcmpi(worlds[i].m_modarr[j].m_modelName, "isle")) {
 					continue;
 				}
 				break;
 			case 2:
-				if (strcmpi(worlds[i].m_models[j].m_modelName, "isle_hi")) {
+				if (strcmpi(worlds[i].m_modarr[j].m_modelName, "isle_hi")) {
 					continue;
 				}
 			}
 		}
-		else if (g_legoWorldPresenterQuality <= 1 && !strnicmp(worlds[i].m_models[j].m_modelName, "haus", 4)) {
-			if (worlds[i].m_models[j].m_modelName[4] == '3') {
-				if (LoadWorldModel(worlds[i].m_models[j], wdbFile, p_world) != SUCCESS) {
+		else if (g_legoWorldPresenterQuality <= 1 && !strnicmp(worlds[i].m_modarr[j].m_modelName, "haus", 4)) {
+			if (worlds[i].m_modarr[j].m_modelName[4] == '3') {
+				if (LoadWorldModel(worlds[i].m_modarr[j], wdbFile, p_world) != SUCCESS) {
 					return FAILURE;
 				}
 
-				if (LoadWorldModel(worlds[i].m_models[j - 2], wdbFile, p_world) != SUCCESS) {
+				if (LoadWorldModel(worlds[i].m_modarr[j - 2], wdbFile, p_world) != SUCCESS) {
 					return FAILURE;
 				}
 
-				if (LoadWorldModel(worlds[i].m_models[j - 1], wdbFile, p_world) != SUCCESS) {
+				if (LoadWorldModel(worlds[i].m_modarr[j - 1], wdbFile, p_world) != SUCCESS) {
 					return FAILURE;
 				}
 			}
@@ -303,7 +310,7 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 			continue;
 		}
 
-		if (LoadWorldModel(worlds[i].m_models[j], wdbFile, p_world) != SUCCESS) {
+		if (LoadWorldModel(worlds[i].m_modarr[j], wdbFile, p_world) != SUCCESS) {
 			return FAILURE;
 		}
 	}
@@ -318,6 +325,7 @@ MxResult LegoWorldPresenter::LoadWorldPart(ModelDbPart& p_part, FILE* p_wdbFile)
 {
 	MxResult result;
 	MxU8* buff = new MxU8[p_part.m_partDataLength];
+	assert(buff);
 
 	fseek(p_wdbFile, p_part.m_partDataOffset, SEEK_SET);
 	if (fread(buff, p_part.m_partDataLength, 1, p_wdbFile) != 1) {
@@ -343,6 +351,7 @@ MxResult LegoWorldPresenter::LoadWorldPart(ModelDbPart& p_part, FILE* p_wdbFile)
 MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFile, LegoWorld* p_world)
 {
 	MxU8* buff = new MxU8[p_model.m_modelDataLength];
+	assert(buff);
 
 	fseek(p_wdbFile, p_model.m_modelDataOffset, SEEK_SET);
 	if (fread(buff, p_model.m_modelDataLength, 1, p_wdbFile) != 1) {
@@ -371,6 +380,7 @@ MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFi
 		LegoActorPresenter presenter;
 		presenter.SetAction(&action);
 		LegoEntity* entity = (LegoEntity*) presenter.CreateEntity("LegoActor");
+		assert(entity);
 		presenter.SetInternalEntity(entity);
 		presenter.SetEntityLocation(p_model.m_location, p_model.m_direction, p_model.m_up);
 		entity->Create(action);
@@ -379,6 +389,7 @@ MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFi
 		LegoEntityPresenter presenter;
 		presenter.SetAction(&action);
 		createdEntity = (LegoEntity*) presenter.CreateEntity("LegoEntity");
+		assert(createdEntity);
 		presenter.SetInternalEntity(createdEntity);
 		presenter.SetEntityLocation(p_model.m_location, p_model.m_direction, p_model.m_up);
 		createdEntity->Create(action);
@@ -388,12 +399,12 @@ MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFi
 
 	if (createdEntity != NULL) {
 		action.SetLocation(Mx3DPointFloat(0.0, 0.0, 0.0));
-		action.SetUp(Mx3DPointFloat(0.0, 0.0, 1.0));
-		action.SetDirection(Mx3DPointFloat(0.0, 1.0, 0.0));
+		action.SetDirection(Mx3DPointFloat(0.0, 0.0, 1.0));
+		action.SetUp(Mx3DPointFloat(0.0, 1.0, 0.0));
 	}
 
 	modelPresenter.SetAction(&action);
-	modelPresenter.CreateROI(chunk, createdEntity, p_model.m_visible, p_world);
+	modelPresenter.CreateROI(&chunk, createdEntity, p_model.m_visible, p_world);
 	delete[] buff;
 
 	return SUCCESS;
@@ -418,6 +429,7 @@ void LegoWorldPresenter::AdvanceSerialAction(MxPresenter* p_presenter)
 	if (!p_presenter->IsA("LegoAnimPresenter") && !p_presenter->IsA("MxControlPresenter") &&
 		!p_presenter->IsA("MxCompositePresenter")) {
 		p_presenter->SendToCompositePresenter(Lego());
+		assert(m_entity);
 		((LegoWorld*) m_entity)->Add(p_presenter);
 	}
 }
@@ -436,9 +448,11 @@ void LegoWorldPresenter::ParseExtra()
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strWORLD, extraCopy)) {
-			char* worldKey = strtok(output, g_parseExtraTokens);
-			LoadWorld(worldKey, (LegoWorld*) m_entity);
-			((LegoWorld*) m_entity)->SetWorldId(Lego()->GetWorldId(worldKey));
+			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
+
+			LoadWorld(token, (LegoWorld*) m_entity);
+			((LegoWorld*) m_entity)->SetWorldId(Lego()->GetWorldId(token));
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -16,12 +16,6 @@ DECOMP_SIZE_ASSERT(LegoNotifyList, 0x18)
 DECOMP_SIZE_ASSERT(LegoNotifyListCursor, 0x10)
 DECOMP_SIZE_ASSERT(LegoEventQueue, 0x18)
 
-// GLOBAL: LEGO1 0x100f31b0
-MxS32 g_clickedObjectId = -1;
-
-// GLOBAL: LEGO1 0x100f31b4
-const char* g_clickedAtom = NULL;
-
 // GLOBAL: LEGO1 0x100f67b8
 MxBool g_unk0x100f67b8 = TRUE;
 
@@ -54,6 +48,7 @@ LegoInputManager::LegoInputManager()
 }
 
 // FUNCTION: LEGO1 0x1005b8f0
+// FUNCTION: BETA10 0x10088c10
 LegoInputManager::~LegoInputManager()
 {
 	Destroy();
@@ -66,7 +61,6 @@ MxResult LegoInputManager::Create(HWND p_hwnd)
 	MxResult result = SUCCESS;
 
 	m_controlManager = new LegoControlManager;
-	assert(m_controlManager);
 
 	if (!m_keyboardNotifyList) {
 		m_keyboardNotifyList = new LegoNotifyList;
@@ -88,6 +82,7 @@ MxResult LegoInputManager::Create(HWND p_hwnd)
 }
 
 // FUNCTION: LEGO1 0x1005bfe0
+// FUNCTION: BETA10 0x10088e8f
 void LegoInputManager::Destroy()
 {
 	ReleaseDX();
@@ -126,6 +121,7 @@ void LegoInputManager::CreateAndAcquireKeyboard(HWND p_hwnd)
 }
 
 // FUNCTION: LEGO1 0x1005c0a0
+// FUNCTION: BETA10 0x1008904e
 void LegoInputManager::ReleaseDX()
 {
 	if (m_directInputDevice != NULL) {
@@ -141,6 +137,7 @@ void LegoInputManager::ReleaseDX()
 }
 
 // FUNCTION: LEGO1 0x1005c0f0
+// FUNCTION: BETA10 0x100890e6
 void LegoInputManager::GetKeyboardState()
 {
 	m_kbStateSuccess = FALSE;
@@ -161,6 +158,7 @@ void LegoInputManager::GetKeyboardState()
 }
 
 // FUNCTION: LEGO1 0x1005c160
+// FUNCTION: BETA10 0x100891b6
 MxResult LegoInputManager::GetNavigationKeyStates(MxU32& p_keyFlags)
 {
 	GetKeyboardState();
@@ -207,6 +205,7 @@ MxResult LegoInputManager::GetNavigationKeyStates(MxU32& p_keyFlags)
 }
 
 // FUNCTION: LEGO1 0x1005c240
+// FUNCTION: BETA10 0x10089298
 MxResult LegoInputManager::GetJoystickId()
 {
 	JOYINFOEX joyinfoex;
@@ -239,6 +238,7 @@ MxResult LegoInputManager::GetJoystickId()
 }
 
 // FUNCTION: LEGO1 0x1005c320
+// FUNCTION: BETA10 0x100893ae
 MxResult LegoInputManager::GetJoystickState(
 	MxU32* p_joystickX,
 	MxU32* p_joystickY,
@@ -294,6 +294,7 @@ MxResult LegoInputManager::GetJoystickState(
 }
 
 // FUNCTION: LEGO1 0x1005c470
+// FUNCTION: BETA10 0x10089529
 void LegoInputManager::Register(MxCore* p_notify)
 {
 	AUTOLOCK(m_criticalSection);
@@ -305,6 +306,7 @@ void LegoInputManager::Register(MxCore* p_notify)
 }
 
 // FUNCTION: LEGO1 0x1005c5c0
+// FUNCTION: BETA10 0x100895b2
 void LegoInputManager::UnRegister(MxCore* p_notify)
 {
 	AUTOLOCK(m_criticalSection);
@@ -316,12 +318,14 @@ void LegoInputManager::UnRegister(MxCore* p_notify)
 }
 
 // FUNCTION: LEGO1 0x1005c700
+// FUNCTION: BETA10 0x10089671
 void LegoInputManager::SetCamera(LegoCameraController* p_camera)
 {
 	m_camera = p_camera;
 }
 
 // FUNCTION: LEGO1 0x1005c710
+// FUNCTION: BETA10 0x10089695
 void LegoInputManager::ClearCamera()
 {
 	m_camera = NULL;
@@ -342,6 +346,7 @@ void LegoInputManager::ClearWorld()
 }
 
 // FUNCTION: LEGO1 0x1005c740
+// FUNCTION: BETA10 0x100896ff
 void LegoInputManager::QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p_x, MxLong p_y, MxU8 p_key)
 {
 	LegoEventNotificationParam param = LegoEventNotificationParam(p_id, NULL, p_modifier, p_x, p_y, p_key);
@@ -353,6 +358,7 @@ void LegoInputManager::QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p
 }
 
 // FUNCTION: LEGO1 0x1005c820
+// FUNCTION: BETA10 0x100897bf
 void LegoInputManager::ProcessEvents()
 {
 	AUTOLOCK(m_criticalSection);
@@ -366,6 +372,7 @@ void LegoInputManager::ProcessEvents()
 }
 
 // FUNCTION: LEGO1 0x1005c9c0
+// FUNCTION: BETA10 0x10089892
 MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 {
 	MxBool processRoi;
@@ -426,6 +433,7 @@ MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 			}
 
 			if (p_param.GetNotification() == c_notificationButtonDown) {
+				assert(VideoManager());
 				MxPresenter* presenter = VideoManager()->GetPresenterAt(p_param.GetX(), p_param.GetY());
 
 				if (presenter) {

--- a/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
@@ -8,8 +8,19 @@
 #include "misc.h"
 #include "mxutilities.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoAnimActor, 0x174)
 DECOMP_SIZE_ASSERT(LegoAnimActorStruct, 0x20)
+
+// SIZE 0x0c
+class LegoDistanceKey : public LegoAnimKey {
+public:
+	float GetDistance() { return m_distance; }
+
+protected:
+	float m_distance; // 0x08
+};
 
 // FUNCTION: LEGO1 0x1001bf80
 // FUNCTION: BETA10 0x1003dc10
@@ -27,11 +38,45 @@ LegoAnimActorStruct::LegoAnimActorStruct(
 }
 
 // FUNCTION: LEGO1 0x1001c0a0
+// FUNCTION: BETA10 0x1003dca1
 LegoAnimActorStruct::~LegoAnimActorStruct()
 {
 	for (MxU16 i = 0; i < m_unk0x10.size(); i++) {
 		delete m_unk0x10[i];
 	}
+}
+
+// FUNCTION: BETA10 0x1003dd5e
+float LegoAnimActorStruct::GetDistance(float p_time)
+{
+	unsigned int i;
+	float f;
+
+	if (m_unk0x10.size() == 0) {
+		return 0.0f;
+	}
+
+	if (((LegoDistanceKey*) m_unk0x10.back())->GetTime() <= p_time) {
+		return ((LegoDistanceKey*) m_unk0x10.back())->GetDistance();
+	}
+
+	if (((LegoDistanceKey*) m_unk0x10.front())->GetTime() >= p_time) {
+		return 0.0f;
+	}
+
+	for (i = 1; i < m_unk0x10.size(); i++) {
+		if (((LegoDistanceKey*) m_unk0x10[i])->GetTime() >= p_time) {
+			f = (p_time - ((LegoDistanceKey*) m_unk0x10[i - 1])->GetTime()) /
+				(((LegoDistanceKey*) m_unk0x10[i])->GetTime() - ((LegoDistanceKey*) m_unk0x10[i - 1])->GetTime());
+			return ((LegoDistanceKey*) m_unk0x10[i - 1])->GetDistance() +
+				   (((LegoDistanceKey*) m_unk0x10[i])->GetDistance() -
+					((LegoDistanceKey*) m_unk0x10[i - 1])->GetDistance()) *
+					   f;
+		}
+	}
+
+	assert(0);
+	return -1.0f;
 }
 
 // FUNCTION: LEGO1 0x1001c130
@@ -40,6 +85,16 @@ float LegoAnimActorStruct::GetDuration()
 {
 	assert(m_AnimTreePtr);
 	return m_AnimTreePtr->GetDuration();
+}
+
+// FUNCTION: BETA10 0x1003df8c
+float LegoAnimActorStruct::GetTotalDistance()
+{
+	if (m_unk0x10.size() == 0) {
+		return 0.0f;
+	}
+
+	return ((LegoDistanceKey*) m_unk0x10.back())->GetDistance();
 }
 
 // FUNCTION: LEGO1 0x1001c140
@@ -63,6 +118,7 @@ MxResult LegoAnimActor::GetTimeInCycle(float& p_timeInCycle)
 }
 
 // FUNCTION: LEGO1 0x1001c240
+// FUNCTION: BETA10 0x1003e0db
 void LegoAnimActor::ApplyTransform(Matrix4& p_transform)
 {
 	float timeInCycle;
@@ -109,7 +165,31 @@ MxResult LegoAnimActor::AnimateWithTransform(float p_time, Matrix4& p_transform)
 		LegoROI** roiMap = m_animMaps[m_curAnim]->m_roiMap;
 		MxU32 numROIs = m_animMaps[m_curAnim]->m_numROIs;
 
-		if (!m_boundary->GetVisibility()) {
+		if (m_boundary->GetVisibility()) {
+			// name verified by BETA10 0x1003e407
+			LegoTreeNode* n = m_animMaps[m_curAnim]->m_AnimTreePtr->GetRoot();
+
+			assert(roiMap && n && m_roi && m_boundary);
+
+			m_roi->SetVisibility(TRUE);
+
+			for (MxS32 i = 0; i < numROIs; i++) {
+				LegoROI* roi = roiMap[i];
+
+				if (roi != NULL && m_roi != roi) {
+					roi->SetVisibility(TRUE);
+				}
+			}
+
+			for (i = 0; i < n->GetNumChildren(); i++) {
+				LegoROI::ApplyAnimationTransformation(n->GetChild(i), p_transform, p_time, roiMap);
+			}
+
+			if (m_cameraFlag) {
+				TransformPointOfView();
+			}
+		}
+		else {
 			MxU32 i;
 			m_roi->SetVisibility(FALSE);
 
@@ -119,30 +199,6 @@ MxResult LegoAnimActor::AnimateWithTransform(float p_time, Matrix4& p_transform)
 				if (roi != NULL && m_roi != roi) {
 					roi->SetVisibility(FALSE);
 				}
-			}
-		}
-		else {
-			// name verified by BETA10 0x1003e407
-			LegoTreeNode* n = m_animMaps[m_curAnim]->m_AnimTreePtr->GetRoot();
-
-			assert(roiMap && n && m_roi && m_boundary);
-
-			m_roi->SetVisibility(TRUE);
-
-			for (MxU32 i = 0; i < numROIs; i++) {
-				LegoROI* roi = roiMap[i];
-
-				if (roi != NULL && m_roi != roi) {
-					roi->SetVisibility(TRUE);
-				}
-			}
-
-			for (MxS32 j = 0; j < n->GetNumChildren(); j++) {
-				LegoROI::ApplyAnimationTransformation(n->GetChild(j), p_transform, p_time, roiMap);
-			}
-
-			if (m_cameraFlag) {
-				TransformPointOfView();
 			}
 		}
 
@@ -242,6 +298,7 @@ void LegoAnimActor::ParseAction(char* p_extra)
 
 				if (p != NULL) {
 					token = strtok(NULL, g_parseExtraTokens);
+					assert(token);
 
 					if (token) {
 						p->CreateROIAndBuildMap(this, atof(token));

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -9,6 +9,8 @@
 #include "mxmisc.h"
 #include "mxtimer.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoExtraActor, 0x1dc)
 
 // GLOBAL: LEGO1 0x100f31d0
@@ -41,6 +43,7 @@ LegoExtraActor::LegoExtraActor()
 }
 
 // FUNCTION: LEGO1 0x1002a6b0
+// FUNCTION: BETA10 0x10080a7e
 LegoExtraActor::~LegoExtraActor()
 {
 	delete m_assAnim;
@@ -48,14 +51,18 @@ LegoExtraActor::~LegoExtraActor()
 }
 
 // FUNCTION: LEGO1 0x1002a720
+// FUNCTION: BETA10 0x10080b4c
 MxU32 LegoExtraActor::StepState(float p_time, Matrix4& p_transform)
 {
+	// GLOBAL: LEGO1 0x100d6b64
+	static const float g_hitAnimationDelay = 2000.0f;
+
 	switch (m_actorState & c_maxState) {
 	case c_initial:
 	case c_ready:
 		return TRUE;
 	case c_hit:
-		m_scheduledTime = p_time + 2000.0f;
+		m_scheduledTime = g_hitAnimationDelay + p_time;
 		m_actorState = c_hitAnimation;
 		m_actorTime += (p_time - m_transformTime) * m_worldSpeed;
 		m_transformTime = p_time;
@@ -109,6 +116,7 @@ MxU32 LegoExtraActor::StepState(float p_time, Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x1002aa90
+// FUNCTION: BETA10 0x10080ea9
 void LegoExtraActor::GetWalkingBehavior(MxBool& p_countCounterclockWise, MxS32& p_selectedEdgeIndex)
 {
 	switch (m_pathWalkingMode) {
@@ -128,6 +136,7 @@ void LegoExtraActor::GetWalkingBehavior(MxBool& p_countCounterclockWise, MxS32& 
 }
 
 // FUNCTION: LEGO1 0x1002aae0
+// FUNCTION: BETA10 0x10080f35
 MxResult LegoExtraActor::SwitchDirection()
 {
 	LegoPathBoundary* oldEdge = m_boundary;
@@ -138,6 +147,7 @@ MxResult LegoExtraActor::SwitchDirection()
 
 	dirRef *= -1.0f;
 	rightRef.EqualsCross(upRef, dirRef);
+	assert(m_destEdge && m_boundary);
 
 	if (m_boundary == m_destEdge->m_faceA) {
 		m_boundary = (LegoPathBoundary*) m_destEdge->m_faceB;
@@ -145,6 +155,8 @@ MxResult LegoExtraActor::SwitchDirection()
 	else {
 		m_boundary = (LegoPathBoundary*) m_destEdge->m_faceA;
 	}
+
+	assert(m_destEdge && m_boundary);
 
 	if (!m_boundary) {
 		m_boundary = oldEdge;
@@ -213,7 +225,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			MxMatrix local(m_roi->GetLocal2World());
 
 			m_localBeforeHit = local;
-			Vector3 positionRef(local[3]);
+			Vector3 positionRef((const float*) local[3]);
 			Mx3DPointFloat otherActorDir(otherActorLocal[2]);
 
 			otherActorDir *= 2.0f;
@@ -369,11 +381,12 @@ void LegoExtraActor::Animate(float p_time)
 		}
 
 		MxMatrix matrix(m_roi->GetLocal2World());
-		LegoTreeNode* root = laas->m_AnimTreePtr->GetRoot();
-		MxS32 count = root->GetNumChildren();
+		LegoTreeNode* n = laas->m_AnimTreePtr->GetRoot();
+		assert(n);
+		MxS32 count = n->GetNumChildren();
 
 		for (MxS32 i = 0; i < count; i++) {
-			LegoROI::ApplyAnimationTransformation(root->GetChild(i), matrix, duration2, laas->m_roiMap);
+			LegoROI::ApplyAnimationTransformation(n->GetChild(i), matrix, duration2, laas->m_roiMap);
 		}
 	}
 }
@@ -443,7 +456,7 @@ inline MxU32 LegoExtraActor::CheckPresenterAndActorIntersections(
 	LegoPathActorSet lpas(plpas);
 
 	for (LegoPathActorSet::iterator itpa = lpas.begin(); itpa != lpas.end(); itpa++) {
-		if (plpas.find(*itpa) != plpas.end()) {
+		if (plpas.end() != plpas.find(*itpa)) {
 			LegoPathActor* actor = *itpa;
 
 			if (this != actor && !(actor->GetActorState() & LegoPathActor::c_noCollide)) {

--- a/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
@@ -18,7 +18,7 @@ LegoPathBoundary::LegoPathBoundary()
 // FUNCTION: BETA10 0x100b140d
 LegoPathBoundary::~LegoPathBoundary()
 {
-	for (LegoPathActorSet::iterator it = m_actors.begin(); !(it == m_actors.end()); it++) {
+	for (LegoPathActorSet::iterator it = m_actors.begin(); it != m_actors.end(); it++) {
 		(*it)->SetBoundary(NULL);
 	}
 
@@ -197,7 +197,7 @@ MxU32 LegoPathBoundary::Intersect(
 	for (MxS32 i = 0; i < m_numEdges; i++) {
 		LegoOrientedEdge* edge = (LegoOrientedEdge*) m_edges[i];
 
-		if (p_newPos.Dot(m_edgeNormals[i], p_newPos) + m_edgeNormals[i][3] <= -1e-07) {
+		if (p_newPos.Dot(p_newPos, m_edgeNormals[i]) + m_edgeNormals[i][3] <= -1e-07) {
 			if (normalizedCalculated == FALSE) {
 				normalizedCalculated = TRUE;
 				direction = p_newPos;
@@ -217,8 +217,8 @@ MxU32 LegoPathBoundary::Intersect(
 				float hitDistance = (-m_edgeNormals[i][3] - p_oldPos.Dot(p_oldPos, m_edgeNormals[i])) / dot;
 
 				if (hitDistance >= -0.001 && hitDistance <= len && (e == NULL || hitDistance < minHitDistance)) {
-					e = edge;
 					minHitDistance = hitDistance;
+					e = edge;
 				}
 			}
 		}
@@ -381,4 +381,17 @@ MxU32 LegoPathBoundary::RemovePresenter(LegoAnimPresenter* p_presenter)
 	}
 
 	return 0;
+}
+
+// FUNCTION: BETA10 0x100b23bb
+MxU32 LegoPathBoundary::BETA_100b23bb(const Vector3& p_position, LegoOrientedEdge*& p_edge)
+{
+	for (MxS32 i = 0; i < m_numEdges; i++) {
+		LegoOrientedEdge* edge = (LegoOrientedEdge*) m_edges[i];
+		if (edge->FUN_10048c40(p_position)) {
+			p_edge = edge;
+			return TRUE;
+		}
+	}
+	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -1,3 +1,5 @@
+#include "realtime/vectorlength.inl.h"
+
 #include "legopathcontroller.h"
 
 #include "legopathedgecontainer.h"
@@ -12,10 +14,10 @@ DECOMP_SIZE_ASSERT(LegoPathController::CtrlBoundary, 0x08)
 DECOMP_SIZE_ASSERT(LegoPathController::CtrlEdge, 0x08)
 
 // GLOBAL: LEGO1 0x100d7cc8
-MxU32 g_ctrlEdgesNamesA[] = {2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0};
+const MxU32 g_ctrlEdgesNamesA[] = {2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0};
 
 // GLOBAL: LEGO1 0x100d7d08
-MxU32 g_ctrlEdgesNamesB[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const MxU32 g_ctrlEdgesNamesB[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 // GLOBAL: LEGO1 0x100f42e8
 // GLOBAL: BETA10 0x101f25f0
@@ -222,7 +224,7 @@ MxResult LegoPathController::PlaceActor(
 
 	assert(pSrcE && pDestE);
 
-	float time = Timer()->GetTime();
+	float time = (float) Timer()->GetTime();
 	MxResult result = p_actor->SetTransformAndDestinationFromEdge(
 		pBoundary,
 		time,
@@ -252,7 +254,7 @@ MxResult LegoPathController::PlaceActor(
 )
 {
 	LegoPathBoundary* boundary = NULL;
-	float time = Timer()->GetTime();
+	float time = (float) Timer()->GetTime();
 
 	if (p_actor->GetController() != NULL) {
 		p_actor->GetController()->RemoveActor(p_actor);
@@ -264,7 +266,7 @@ MxResult LegoPathController::PlaceActor(
 		LegoAnimPresenterSet& presenters = b.GetPresenters();
 		LegoAnimPresenter* presenter = p_presenter;
 
-		if (presenters.find(presenter) != presenters.end()) {
+		if (presenters.end() != presenters.find(presenter)) {
 			MxS32 j;
 
 			for (j = 0; j < b.GetNumEdges(); j++) {
@@ -285,32 +287,35 @@ MxResult LegoPathController::PlaceActor(
 		}
 	}
 
-	if (boundary == NULL) {
-		return FAILURE;
-	}
+	if (boundary != NULL) {
+		for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
+			LegoOrientedEdge* edge = (LegoOrientedEdge*) boundary->GetEdges()[j];
 
-	for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
-		LegoOrientedEdge* edge = (LegoOrientedEdge*) boundary->GetEdges()[j];
+			if (edge->GetMask0x03()) {
+				Mx3DPointFloat vec;
 
-		if (edge->GetMask0x03()) {
-			Mx3DPointFloat vec;
+				if (((LegoOrientedEdge*) edge->GetClockwiseEdge(*boundary))->GetFaceNormal(*boundary, vec) == SUCCESS &&
+					vec.Dot(vec, p_direction) < 0.0f) {
+					edge =
+						(LegoOrientedEdge*) edge->GetCounterclockwiseEdge(*boundary)->GetCounterclockwiseEdge(*boundary
+						);
+				}
 
-			if (((LegoOrientedEdge*) edge->GetClockwiseEdge(*boundary))->GetFaceNormal(*boundary, vec) == SUCCESS &&
-				vec.Dot(vec, p_direction) < 0.0f) {
-				edge = (LegoOrientedEdge*) edge->GetCounterclockwiseEdge(*boundary)->GetCounterclockwiseEdge(*boundary);
-			}
+				if (!edge->GetMask0x03()) {
+					return FAILURE;
+				}
 
-			if (!edge->GetMask0x03()) {
-				return FAILURE;
-			}
-
-			if (p_actor->SetTransformAndDestinationFromPoints(boundary, time, p_position, p_direction, edge, 0.5f) ==
-				SUCCESS) {
-				p_actor->SetController(this);
-				m_actors.insert(p_actor);
-				return SUCCESS;
+				if (p_actor
+						->SetTransformAndDestinationFromPoints(boundary, time, p_position, p_direction, edge, 0.5f) ==
+					SUCCESS) {
+					p_actor->SetController(this);
+					m_actors.insert(p_actor);
+					return SUCCESS;
+				}
 			}
 		}
+
+		return FAILURE;
 	}
 
 	return FAILURE;
@@ -379,7 +384,7 @@ void LegoPathController::AnimateActors()
 	for (LegoPathActorSet::iterator itpa = lpas.begin(); itpa != lpas.end(); itpa++) {
 		LegoPathActor* actor = *itpa;
 
-		if (m_actors.find(actor) != m_actors.end()) {
+		if (m_actors.end() != m_actors.find(actor)) {
 			if (!((MxU8) actor->GetActorState() & LegoPathActor::c_disabled)) {
 				actor->Animate(time);
 			}
@@ -388,6 +393,7 @@ void LegoPathController::AnimateActors()
 }
 
 // FUNCTION: LEGO1 0x10046b30
+// FUNCTION: BETA10 0x100b74fe
 MxResult LegoPathController::GetBoundaries(LegoPathBoundary*& p_boundaries, MxS32& p_numL)
 {
 	p_boundaries = m_boundaries;
@@ -467,6 +473,8 @@ MxResult LegoPathController::Reset()
 // FUNCTION: BETA10 0x100b781f
 MxResult LegoPathController::Read(LegoStorage* p_storage)
 {
+	assert(m_pfsE.size() == 0);
+
 	if (p_storage->Read(&m_numT, sizeof(MxU16)) != SUCCESS) {
 		return FAILURE;
 	}
@@ -746,6 +754,7 @@ MxResult LegoPathController::ReadBoundaries(LegoStorage* p_storage)
 MxResult LegoPathController::ReadVector(LegoStorage* p_storage, Mx3DPointFloat& p_vec)
 {
 	if (p_storage->Read(p_vec.GetData(), sizeof(float) * 3) != SUCCESS) {
+		assert(0);
 		return FAILURE;
 	}
 
@@ -786,6 +795,7 @@ MxResult LegoPathController::FindPath(
 		return SUCCESS;
 	}
 
+	LegoOrientedEdge* e;
 	list<LegoBEWithMidpoint> boundaryList;
 	list<LegoBEWithMidpoint>::iterator boundaryListIt;
 
@@ -796,6 +806,7 @@ MxResult LegoPathController::FindPath(
 	LegoPathCtrlEdgeSet pathCtrlEdgeSet(m_pfsE);
 
 	MxFloat minDistance = 999999.0f;
+	float dist;
 
 	p_grec->SetPath(FALSE);
 
@@ -807,8 +818,7 @@ MxResult LegoPathController::FindPath(
 
 			if (otherFace != NULL && edge->BETA_1004a830(*otherFace, p_mask)) {
 				if (p_newBoundary == otherFace) {
-					float dist;
-					if ((dist = edge->DistanceToMidpoint(p_oldPosition) + edge->DistanceToMidpoint(p_newPosition)) <
+					if ((dist = edge->DistanceToMidpoint(p_newPosition) + edge->DistanceToMidpoint(p_oldPosition)) <
 						minDistance) {
 						minDistance = dist;
 						p_grec->erase(p_grec->begin(), p_grec->end());
@@ -829,9 +839,11 @@ MxResult LegoPathController::FindPath(
 	}
 
 	if (!p_grec->HasPath()) {
+		MxFloat minDist;
+
 		while (pathCtrlEdgeSet.size() > 0) {
 			LegoBEWithMidpoint edgeWithMidpoint;
-			MxFloat minDist = 999999.0f;
+			minDist = 999999.0f;
 
 			boundarySetItA = boundarySetItB = boundarySet.begin();
 
@@ -839,14 +851,18 @@ MxResult LegoPathController::FindPath(
 				boundarySetItB++;
 			}
 
-			while (boundarySetItA != boundarySet.end()) {
-				MxU32 shouldRemove = TRUE;
+			MxU32 shouldRemove;
+			LegoPathBoundary* b;
+			LegoPathBoundary* bOther;
 
-				LegoOrientedEdge* e = (*boundarySetItA)->m_edge;
-				LegoPathBoundary* b = (*boundarySetItA)->m_boundary;
+			while (boundarySetItA != boundarySet.end()) {
+				shouldRemove = TRUE;
+
+				e = (*boundarySetItA)->m_edge;
+				b = (*boundarySetItA)->m_boundary;
 				assert(e && b);
 
-				LegoPathBoundary* bOther = (LegoPathBoundary*) e->OtherFace(b);
+				bOther = (LegoPathBoundary*) e->OtherFace(b);
 				assert(bOther);
 
 				if (!e->BETA_1004a830(*bOther, p_mask)) {
@@ -862,11 +878,10 @@ MxResult LegoPathController::FindPath(
 						float dist;
 						if ((dist = pfs->m_edge->DistanceToMidpoint(p_newPosition) + pfs->m_distanceToMidpoint) <
 							minDist) {
-							edgeWithMidpoint.m_edge = NULL;
 							minDist = dist;
+							edgeWithMidpoint.m_edge = NULL;
 
-							// TODO: Match
-							if (dist < minDistance) {
+							if (minDistance > dist) {
 								minDistance = dist;
 								p_grec->erase(p_grec->begin(), p_grec->end());
 								p_grec->SetPath(TRUE);
@@ -883,14 +898,16 @@ MxResult LegoPathController::FindPath(
 							LegoPathCtrlEdge* edge = (LegoPathCtrlEdge*) bOther->GetEdges()[i];
 
 							if (edge->GetMask0x03()) {
-								if (pathCtrlEdgeSet.find(edge) != pathCtrlEdgeSet.end()) {
+								LegoPathCtrlEdgeSet::iterator it = pathCtrlEdgeSet.find(edge);
+
+								if (it != pathCtrlEdgeSet.end()) {
 									shouldRemove = FALSE;
 
 									float dist;
 									if ((dist = edge->DistanceBetweenMidpoints(*e) +
 												(*boundarySetItA)->m_distanceToMidpoint) < minDist) {
 										minDist = dist;
-										edgeWithMidpoint = LegoBEWithMidpoint(edge, bOther, *boundarySetItA, dist);
+										edgeWithMidpoint = LegoBEWithMidpoint(edge, bOther, *boundarySetItA, minDist);
 									}
 								}
 							}
@@ -1015,7 +1032,7 @@ MxResult LegoPathController::FindIntersectionBoundary(
 
 		float coeffBDotUp = p_coefficients[1].Dot(p_coefficients[1], *up);
 		float coeffCDotUp = p_coefficients[2].Dot(p_coefficients[2], *up) + up->index_operator(3);
-		float quadraticDiscriminant = coeffBDotUp * coeffBDotUp - coeffCDotUp * coeffADotUp * 4.0f;
+		float quadraticDiscriminant = coeffBDotUp * coeffBDotUp + (coeffCDotUp * coeffADotUp) * -4.0f;
 
 		if (quadraticDiscriminant < -0.001) {
 			continue;

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -11,6 +11,13 @@
 
 DECOMP_SIZE_ASSERT(LegoRaceActor, 0x180)
 
+// GLOBAL: LEGO1 0x100f0c14
+// STRING: LEGO1 0x100f0c04
+const char* g_strHIT_ACTOR_SOUND = "HIT_ACTOR_SOUND";
+
+// GLOBAL: LEGO1 0x100d5b2c
+const float g_hitAnimationTimeout = 2000.0f;
+
 // Initialized at LEGO1 0x100145a0
 // GLOBAL: LEGO1 0x10102b08
 // GLOBAL: BETA10 0x102114a8
@@ -54,7 +61,7 @@ MxU32 LegoRaceActor::StepState(float p_time, Matrix4& p_transform)
 	case c_ready:
 		return TRUE;
 	case c_hit:
-		m_unk0x08 = p_time + 2000.0f;
+		m_unk0x08 = p_time + g_hitAnimationTimeout;
 		m_actorState = c_hitAnimation;
 		m_actorTime += (p_time - m_transformTime) * m_worldSpeed;
 		m_transformTime = p_time;

--- a/LEGO1/lego/legoomni/src/race/legoracemap.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracemap.cpp
@@ -28,14 +28,6 @@ LegoRaceMap::~LegoRaceMap()
 	ControlManager()->Unregister(this);
 }
 
-// GLOBAL: LEGO1 0x1010208c
-// STRING: LEGO1 0x10101f88
-const char* g_mapLocator = "MAP_LOCATOR";
-
-// GLOBAL: LEGO1 0x10102090
-// STRING: LEGO1 0x10101f78
-const char* g_mapGeometry = "MAP_GEOMETRY";
-
 // FUNCTION: LEGO1 0x1005d310
 // FUNCTION: BETA10 0x100ca543
 void LegoRaceMap::ParseAction(char* p_extra)

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -171,7 +171,7 @@ MxLong g_timeLastJetskiSoundPlayed = 0;
 // FUNCTION: BETA10 0x100cad10
 LegoRaceCar::LegoRaceCar()
 {
-	m_kickState = LEGORACECAR_NONE;
+	m_userState = LEGORACECAR_NONE;
 	m_skelKick1Anim = 0;
 	m_skelKick2Anim = 0;
 	m_unk0x5c.Clear();
@@ -301,11 +301,11 @@ void LegoRaceCar::KickCamera(float p_param)
 	LegoAnimActorStruct* a; // called `a` in BETA10
 	float deltaTime;
 
-	if (m_kickState == LEGORACECAR_KICK1) {
+	if (m_userState == LEGORACECAR_KICK1) {
 		a = m_skelKick1Anim;
 	}
 	else {
-		assert(m_kickState == LEGORACECAR_KICK2);
+		assert(m_userState == LEGORACECAR_KICK2);
 		a = m_skelKick2Anim;
 	}
 
@@ -314,8 +314,8 @@ void LegoRaceCar::KickCamera(float p_param)
 	if (a->GetAnimTreePtr()) {
 		deltaTime = p_param - m_kickStart;
 
-		if (a->GetDuration() <= deltaTime || deltaTime < 0.0) {
-			if (m_kickState == LEGORACECAR_KICK1) {
+		if (a->GetDuration() <= deltaTime || deltaTime < 0.0f) {
+			if (m_userState == LEGORACECAR_KICK1) {
 				LegoOrientedEdge** edges = m_kick1B->GetEdges();
 				m_destEdge = edges[2];
 				m_boundary = m_kick1B;
@@ -326,7 +326,7 @@ void LegoRaceCar::KickCamera(float p_param)
 				m_boundary = m_kick2B;
 			}
 
-			m_kickState = LEGORACECAR_NONE;
+			m_userState = LEGORACECAR_NONE;
 		}
 		else if (a->GetAnimTreePtr()->GetCamAnim()) {
 			MxMatrix transformationMatrix;
@@ -370,12 +370,12 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 	for (MxS32 i = 0; i < sizeOfArray(g_skeletonKickPhases); i++) {
 		if (m_boundary == current->m_edgeRef->m_b && current->m_lower <= skeletonCurAnimPhase &&
 			skeletonCurAnimPhase <= current->m_upper) {
-			m_kickState = current->m_kickState;
+			m_userState = current->m_kickState;
 		}
 		current = &current[1];
 	}
 
-	if (m_kickState != LEGORACECAR_KICK1 && m_kickState != LEGORACECAR_KICK2) {
+	if (m_userState != LEGORACECAR_KICK1 && m_userState != LEGORACECAR_KICK2) {
 		MxTrace(
 			// STRING: BETA10 0x101f64c8
 			"Got kicked in boundary %s %d %g:%g %g\n",
@@ -397,14 +397,14 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 // FUNCTION: BETA10 0x100cb88a
 void LegoRaceCar::Animate(float p_time)
 {
-	if (m_userNavFlag && (m_kickState == LEGORACECAR_KICK1 || m_kickState == LEGORACECAR_KICK2)) {
+	if (m_userNavFlag && (m_userState == LEGORACECAR_KICK1 || m_userState == LEGORACECAR_KICK2)) {
 		KickCamera(p_time);
 		return;
 	}
 
 	LegoCarRaceActor::Animate(p_time);
 
-	if (m_userNavFlag && m_kickState == LEGORACECAR_NEAR_SKELETON) {
+	if (m_userNavFlag && m_userState == LEGORACECAR_NEAR_SKELETON) {
 		if (HandleSkeletonKicks(p_time)) {
 			return;
 		}
@@ -549,13 +549,13 @@ MxResult LegoRaceCar::CalculateSpline()
 				}
 			}
 
-			if (m_kickState == LEGORACECAR_NEAR_SKELETON) {
+			if (m_userState == LEGORACECAR_NEAR_SKELETON) {
 				if (!onSkeletonBoundary) {
-					m_kickState = LEGORACECAR_NONE;
+					m_userState = LEGORACECAR_NONE;
 				}
 			}
 			else {
-				m_kickState = LEGORACECAR_NEAR_SKELETON;
+				m_userState = LEGORACECAR_NEAR_SKELETON;
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -33,6 +33,9 @@ DECOMP_SIZE_ASSERT(LegoLocomotionAnimPresenter, 0xd8)
 DECOMP_SIZE_ASSERT(LegoHideAnimPresenter, 0xc4)
 DECOMP_SIZE_ASSERT(LegoHideAnimStruct, 0x08)
 
+// GLOBAL: LEGO1 0x100f767c
+undefined4 g_unk0x100f767c = 1;
+
 // FUNCTION: LEGO1 0x10068420
 // FUNCTION: BETA10 0x1004e5f0
 LegoAnimPresenter::LegoAnimPresenter()
@@ -41,12 +44,14 @@ LegoAnimPresenter::LegoAnimPresenter()
 }
 
 // FUNCTION: LEGO1 0x10068670
+// FUNCTION: BETA10 0x1004e696
 LegoAnimPresenter::~LegoAnimPresenter()
 {
 	Destroy(TRUE);
 }
 
 // FUNCTION: LEGO1 0x100686f0
+// FUNCTION: BETA10 0x1004e724
 void LegoAnimPresenter::Init()
 {
 	m_anim = NULL;
@@ -139,6 +144,7 @@ void LegoAnimPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x10068fb0
+// FUNCTION: BETA10 0x1004ebde
 MxResult LegoAnimPresenter::CreateAnim(MxStreamChunk* p_chunk)
 {
 	MxResult result = FAILURE;
@@ -190,6 +196,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10069150
+// FUNCTION: BETA10 0x1004eeaf
 LegoChar* LegoAnimPresenter::GetActorName(const LegoChar* p_name)
 {
 	LegoChar* str;
@@ -217,6 +224,7 @@ LegoChar* LegoAnimPresenter::GetActorName(const LegoChar* p_name)
 }
 
 // FUNCTION: LEGO1 0x100692b0
+// FUNCTION: BETA10 0x1004efb6
 void LegoAnimPresenter::CreateManagedActors()
 {
 	m_managedActors = new LegoROIList();
@@ -224,7 +232,7 @@ void LegoAnimPresenter::CreateManagedActors()
 	if (m_managedActors) {
 		LegoU32 numActors = m_anim->GetNumActors();
 
-		for (LegoU32 i = 0; i < numActors; i++) {
+		for (LegoS32 i = 0; i < numActors; i++) {
 			LegoChar* str = GetVariableOrIdentity(m_anim->GetActorName(i), NULL);
 			LegoU32 actorType = m_anim->GetActorType(i);
 			LegoROI* roi = NULL;
@@ -247,6 +255,7 @@ void LegoAnimPresenter::CreateManagedActors()
 			else if (actorType == LegoAnimActorEntry::e_managedInvisibleRoi) {
 				LegoChar* baseName = new LegoChar[strlen(str)];
 				strcpy(baseName, str + 1);
+				assert(*baseName);
 				strlwr(baseName);
 
 				LegoChar* roiName = GetActorName(str);
@@ -262,6 +271,7 @@ void LegoAnimPresenter::CreateManagedActors()
 			else if (actorType == LegoAnimActorEntry::e_managedInvisibleRoiTrimmed) {
 				LegoChar* lodName = new LegoChar[strlen(str)];
 				strcpy(lodName, str + 1);
+				assert(*lodName);
 
 				for (LegoChar* c = &lodName[strlen(lodName) - 1]; c > lodName; c--) {
 					if ((*c < '0' || *c > '9') && *c != '_') {
@@ -312,6 +322,7 @@ void LegoAnimPresenter::CreateSceneROIs()
 					const LegoChar* actorName = m_anim->GetActorName(i);
 
 					LegoU32 len = strlen(actorName);
+					assert(len < sizeof(lodName));
 					strcpy(lodName, actorName);
 
 					for (LegoChar* i = &lodName[len - 1]; isdigit(*i) || *i == '_'; i--) {
@@ -329,6 +340,7 @@ void LegoAnimPresenter::CreateSceneROIs()
 }
 
 // FUNCTION: LEGO1 0x100697c0
+// FUNCTION: BETA10 0x1004f62c
 LegoChar* LegoAnimPresenter::GetVariableOrIdentity(const LegoChar* p_varName, const LegoChar* p_prefix)
 {
 	const LegoChar* str = p_varName;
@@ -356,6 +368,7 @@ LegoChar* LegoAnimPresenter::GetVariableOrIdentity(const LegoChar* p_varName, co
 }
 
 // FUNCTION: LEGO1 0x100698b0
+// FUNCTION: BETA10 0x1004f704
 LegoBool LegoAnimPresenter::AppendROIToScene(const CompoundObject& p_rois, const LegoChar* p_varName)
 {
 	LegoBool result = FALSE;
@@ -368,7 +381,9 @@ LegoBool LegoAnimPresenter::AppendROIToScene(const CompoundObject& p_rois, const
 	}
 
 	if (str != NULL && *str != '\0' && p_rois.size() > 0) {
-		for (CompoundObject::const_iterator it = p_rois.begin(); it != p_rois.end(); it++) {
+		CompoundObject::const_iterator it;
+
+		for (it = p_rois.begin(); it != p_rois.end(); it++) {
 			LegoROI* roi = (LegoROI*) *it;
 			const char* name = roi->GetName();
 
@@ -387,6 +402,7 @@ LegoBool LegoAnimPresenter::AppendROIToScene(const CompoundObject& p_rois, const
 }
 
 // FUNCTION: LEGO1 0x100699e0
+// FUNCTION: BETA10 0x1004f857
 LegoROI* LegoAnimPresenter::FindROI(const LegoChar* p_name)
 {
 	LegoROIListCursor cursor(m_sceneROIs);
@@ -407,6 +423,7 @@ LegoROI* LegoAnimPresenter::FindROI(const LegoChar* p_name)
 }
 
 // FUNCTION: LEGO1 0x10069b10
+// FUNCTION: BETA10 0x1004f976
 void LegoAnimPresenter::BuildROIMap()
 {
 	LegoAnimStructMap anims;
@@ -426,7 +443,7 @@ void LegoAnimPresenter::BuildROIMap()
 	m_roiMap = new LegoROI*[anims.size() + 1];
 	memset(m_roiMap, 0, (anims.size() + 1) * sizeof(*m_roiMap));
 
-	for (LegoAnimStructMap::iterator it = anims.begin(); it != anims.end();) {
+	for (LegoAnimStructMap::iterator it = anims.begin(); it != anims.end(); ++it, m_roiMapSize++) {
 		MxU32 index = (*it).second.m_index;
 		m_roiMap[index] = (*it).second.m_roi;
 
@@ -442,12 +459,11 @@ void LegoAnimPresenter::BuildROIMap()
 		}
 
 		delete[] const_cast<char*>((*it).first);
-		it++;
-		m_roiMapSize++;
 	}
 }
 
 // FUNCTION: LEGO1 0x1006a3c0
+// FUNCTION: BETA10 0x1004fc10
 void LegoAnimPresenter::UpdateStructMapAndROIIndex(LegoAnimStructMap& p_map, LegoTreeNode* p_node, LegoROI* p_roi)
 {
 	LegoROI* roi = p_roi;
@@ -500,6 +516,7 @@ void LegoAnimPresenter::UpdateStructMapAndROIIndex(LegoAnimStructMap& p_map, Leg
 }
 
 // FUNCTION: LEGO1 0x1006a4f0
+// FUNCTION: BETA10 0x1004fe1f
 void LegoAnimPresenter::UpdateStructMapAndROIIndexForNode(
 	LegoAnimStructMap& p_map,
 	LegoAnimNodeData* p_data,
@@ -544,6 +561,7 @@ void LegoAnimPresenter::ReleaseManagedActors()
 }
 
 // FUNCTION: LEGO1 0x1006ab70
+// FUNCTION: BETA10 0x10050012
 void LegoAnimPresenter::AppendManagedActors()
 {
 	if (m_localActors) {
@@ -555,18 +573,21 @@ void LegoAnimPresenter::AppendManagedActors()
 }
 
 // FUNCTION: LEGO1 0x1006aba0
+// FUNCTION: BETA10 0x10050042
 LegoBool LegoAnimPresenter::VerifyAnimationTree()
 {
 	return VerifyAnimationNode(m_anim->GetRoot(), NULL);
 }
 
 // FUNCTION: LEGO1 0x1006abb0
+// FUNCTION: BETA10 0x10050071
 MxBool LegoAnimPresenter::VerifyAnimationNode(LegoTreeNode* p_node, LegoROI* p_roi)
 {
 	MxBool result = FALSE;
 	LegoROI* roi = p_roi;
 	LegoChar* varOrName = NULL;
-	const LegoChar* name = ((LegoAnimNodeData*) p_node->GetData())->GetName();
+	LegoAnimNodeData* data = (LegoAnimNodeData*) p_node->GetData();
+	const LegoChar* name = data->GetName();
 	MxS32 i, count;
 
 	if (name != NULL && *name != '-') {
@@ -625,6 +646,7 @@ void LegoAnimPresenter::SubstituteVariables()
 }
 
 // FUNCTION: LEGO1 0x1006ad30
+// FUNCTION: BETA10 0x100502c2
 void LegoAnimPresenter::PutFrame()
 {
 	if (m_currentTickleState == e_streaming) {
@@ -734,19 +756,20 @@ MxResult LegoAnimPresenter::CopyTransform(LegoROI* p_roi)
 		}
 	}
 
-	{
-		mn->Product(inverse, local2world);
-		SetRoiTransform(mn);
-		delete[] roiTransforms;
-		SetRoiTransformApplied();
+	mn->Product(inverse, local2world);
+	SetRoiTransform(mn);
+	delete[] roiTransforms;
+	SetRoiTransformApplied();
 
+	{
 		MxMatrix originalTransform(*m_transform);
 		MxMatrix newTransform;
 
 		newTransform.Product(originalTransform, *m_roiTransform);
 		*m_transform = newTransform;
-		return SUCCESS;
 	}
+
+	return SUCCESS;
 
 done:
 	if (mn != NULL) {
@@ -843,10 +866,12 @@ done:
 }
 
 // FUNCTION: LEGO1 0x1006b840
+// FUNCTION: BETA10 0x10050f1b
 void LegoAnimPresenter::StreamingTickle()
 {
 	if (m_subscriber->PeekData()) {
 		MxStreamChunk* chunk = m_subscriber->PopData();
+		assert(chunk->GetChunkFlags() & DS_CHUNK_END_OF_STREAM);
 		m_subscriber->FreeDataChunk(chunk);
 	}
 
@@ -866,24 +891,28 @@ void LegoAnimPresenter::StreamingTickle()
 }
 
 // FUNCTION: LEGO1 0x1006b8c0
+// FUNCTION: BETA10 0x1005105b
 void LegoAnimPresenter::DoneTickle()
 {
 	MxVideoPresenter::DoneTickle();
 }
 
 // FUNCTION: LEGO1 0x1006b8d0
+// FUNCTION: BETA10 0x10051079
 MxResult LegoAnimPresenter::AddToManager()
 {
 	return MxVideoPresenter::AddToManager();
 }
 
 // FUNCTION: LEGO1 0x1006b8e0
+// FUNCTION: BETA10 0x10051097
 void LegoAnimPresenter::Destroy()
 {
 	Destroy(FALSE);
 }
 
 // FUNCTION: LEGO1 0x1006b8f0
+// FUNCTION: BETA10 0x100510b7
 const char* LegoAnimPresenter::GetActionObjectName()
 {
 	return m_action->GetObjectName();
@@ -981,6 +1010,7 @@ void LegoAnimPresenter::ParseExtra()
 
 		if (KeyValueStringParse(output, g_strSUBST, extraCopy)) {
 			m_substMap = new LegoAnimSubstMap();
+			assert(m_substMap);
 
 			char* substToken = output;
 			char *key, *value;
@@ -1000,9 +1030,11 @@ void LegoAnimPresenter::ParseExtra()
 
 		if (KeyValueStringParse(output, g_strWORLD, extraCopy)) {
 			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
 			m_worldAtom = MxAtomId(token, e_lowerCase2);
 
 			token = strtok(NULL, g_parseExtraTokens);
+			assert(token);
 			m_worldId = atoi(token);
 		}
 
@@ -1159,6 +1191,7 @@ void LegoAnimPresenter::RemoveFromWorld()
 }
 
 // FUNCTION: LEGO1 0x1006c8a0
+// FUNCTION: BETA10 0x10051fc7
 void LegoAnimPresenter::SetDisabled(MxBool p_disabled)
 {
 	if (m_roiMapSize != 0 && m_roiMap != NULL) {
@@ -1236,6 +1269,7 @@ void LegoLoopingAnimPresenter::StreamingTickle()
 {
 	if (m_subscriber->PeekData()) {
 		MxStreamChunk* chunk = m_subscriber->PopData();
+		assert(chunk->GetChunkFlags() & DS_CHUNK_END_OF_STREAM);
 		m_subscriber->FreeDataChunk(chunk);
 	}
 
@@ -1304,18 +1338,21 @@ void LegoLoopingAnimPresenter::PutFrame()
 }
 
 // FUNCTION: LEGO1 0x1006cdd0
+// FUNCTION: BETA10 0x10052672
 LegoLocomotionAnimPresenter::LegoLocomotionAnimPresenter()
 {
 	Init();
 }
 
 // FUNCTION: LEGO1 0x1006d050
+// FUNCTION: BETA10 0x100526e9
 LegoLocomotionAnimPresenter::~LegoLocomotionAnimPresenter()
 {
 	Destroy(TRUE);
 }
 
 // FUNCTION: LEGO1 0x1006d0b0
+// FUNCTION: BETA10 0x1005275b
 void LegoLocomotionAnimPresenter::Init()
 {
 	m_unk0xc0 = 0;
@@ -1327,6 +1364,7 @@ void LegoLocomotionAnimPresenter::Init()
 }
 
 // FUNCTION: LEGO1 0x1006d0e0
+// FUNCTION: BETA10 0x100527be
 void LegoLocomotionAnimPresenter::Destroy(MxBool p_fromDestructor)
 {
 	ENTER(m_criticalSection);
@@ -1350,6 +1388,7 @@ void LegoLocomotionAnimPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x1006d140
+// FUNCTION: BETA10 0x1005288c
 MxResult LegoLocomotionAnimPresenter::CreateAnim(MxStreamChunk* p_chunk)
 {
 	MxResult result = LegoAnimPresenter::CreateAnim(p_chunk);
@@ -1370,18 +1409,21 @@ MxResult LegoLocomotionAnimPresenter::AddToManager()
 }
 
 // FUNCTION: LEGO1 0x1006d5b0
+// FUNCTION: BETA10 0x1005297d
 void LegoLocomotionAnimPresenter::Destroy()
 {
 	Destroy(FALSE);
 }
 
 // FUNCTION: LEGO1 0x1006d5c0
+// FUNCTION: BETA10 0x1005299d
 void LegoLocomotionAnimPresenter::PutFrame()
 {
 	// Empty
 }
 
 // FUNCTION: LEGO1 0x1006d5d0
+// FUNCTION: BETA10 0x100529b3
 void LegoLocomotionAnimPresenter::ReadyTickle()
 {
 	LegoLoopingAnimPresenter::ReadyTickle();
@@ -1402,6 +1444,7 @@ void LegoLocomotionAnimPresenter::StartingTickle()
 {
 	if (m_subscriber->PeekData()) {
 		MxStreamChunk* chunk = m_subscriber->PopData();
+		assert(chunk->GetChunkFlags() & DS_CHUNK_END_OF_STREAM);
 		m_subscriber->FreeDataChunk(chunk);
 	}
 
@@ -1411,6 +1454,7 @@ void LegoLocomotionAnimPresenter::StartingTickle()
 }
 
 // FUNCTION: LEGO1 0x1006d660
+// FUNCTION: BETA10 0x10052adf
 void LegoLocomotionAnimPresenter::StreamingTickle()
 {
 	if (m_worldRefCounter == 0) {
@@ -1419,6 +1463,7 @@ void LegoLocomotionAnimPresenter::StreamingTickle()
 }
 
 // FUNCTION: LEGO1 0x1006d670
+// FUNCTION: BETA10 0x10052b12
 void LegoLocomotionAnimPresenter::EndAction()
 {
 	if (m_action) {
@@ -1594,7 +1639,7 @@ void LegoHideAnimPresenter::AssignIndiciesWithMap()
 	m_boundaryMap = new LegoPathBoundary*[anims.size() + 1];
 	m_boundaryMap[0] = NULL;
 
-	for (LegoHideAnimStructMap::iterator it = anims.begin(); !(it == anims.end()); it++) {
+	for (LegoHideAnimStructMap::iterator it = anims.begin(); !(it == anims.end()); ++it) {
 		m_boundaryMap[(*it).second.m_index] = (*it).second.m_boundary;
 		delete[] const_cast<char*>((*it).first);
 	}

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -19,6 +19,8 @@
 #include "realtime/realtime.h"
 #include "roi/legoroi.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoModelPresenter, 0x6c)
 
 // GLOBAL: LEGO1 0x100f7ae0
@@ -195,7 +197,7 @@ done:
 // FUNCTION: LEGO1 0x1007ff70
 // FUNCTION: BETA10 0x10099061
 MxResult LegoModelPresenter::CreateROI(
-	MxDSChunk& p_chunk,
+	MxDSChunk* p_chunk,
 	LegoEntity* p_entity,
 	MxBool p_roiVisible,
 	LegoWorld* p_world
@@ -203,9 +205,10 @@ MxResult LegoModelPresenter::CreateROI(
 {
 	MxResult result = SUCCESS;
 
+	assert(p_chunk);
 	ParseExtra();
 
-	if (m_roi == NULL && (result = CreateROI(&p_chunk)) == SUCCESS && p_entity != NULL) {
+	if (m_roi == NULL && (result = CreateROI(p_chunk)) == SUCCESS && p_entity != NULL) {
 		VideoManager()->Get3DManager()->Add(*m_roi);
 		VideoManager()->Get3DManager()->Moved(*m_roi);
 	}
@@ -219,7 +222,7 @@ MxResult LegoModelPresenter::CreateROI(
 		p_entity->ClearFlag(LegoEntity::c_managerOwned);
 	}
 	else {
-		p_world->GetROIList().push_back(m_roi);
+		p_world->GetROIList()->push_back(m_roi);
 	}
 
 	return result;
@@ -299,6 +302,7 @@ void LegoModelPresenter::ParseExtra()
 
 		if (KeyValueStringParse(output, g_strAUTO_CREATE, extraCopy) != 0) {
 			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
 
 			if (m_roi == NULL) {
 				m_roi = CharacterManager()->GetActorROI(token, FALSE);
@@ -307,12 +311,13 @@ void LegoModelPresenter::ParseExtra()
 		}
 		else if (KeyValueStringParse(output, g_strDB_CREATE, extraCopy) != 0 && m_roi == NULL) {
 			LegoWorld* currentWorld = CurrentWorld();
-			list<LegoROI*>& roiList = currentWorld->GetROIList();
+			list<LegoROI*>* rl = currentWorld->GetROIList();
+			assert(rl);
 
-			for (list<LegoROI*>::iterator it = roiList.begin(); it != roiList.end(); it++) {
+			for (list<LegoROI*>::iterator it = rl->begin(); it != rl->end(); it++) {
 				if (!strcmpi((*it)->GetName(), output)) {
 					m_roi = *it;
-					roiList.erase(it);
+					rl->erase(it);
 
 					m_addedToView = TRUE;
 					VideoManager()->Get3DManager()->Add(*m_roi);
@@ -320,6 +325,8 @@ void LegoModelPresenter::ParseExtra()
 					break;
 				}
 			}
+
+			assert(m_roi);
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
@@ -1,11 +1,14 @@
 #include "legophonemepresenter.h"
 
 #include "legocharactermanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "legovideomanager.h"
 #include "misc.h"
 #include "misc/legocontainer.h"
 #include "mxcompositepresenter.h"
 #include "mxdsaction.h"
+
+#include <assert.h>
 
 DECOMP_SIZE_ASSERT(LegoPhonemePresenter, 0x88)
 
@@ -114,6 +117,7 @@ void LegoPhonemePresenter::LoadFrame(MxStreamChunk* p_chunk)
 void LegoPhonemePresenter::PutFrame()
 {
 	if (m_textureInfo != NULL && m_rectCount != 0) {
+		assert(m_frameBitmap->GetImage());
 		m_textureInfo->LoadBits(m_frameBitmap->GetImage());
 		m_rectCount = 0;
 	}

--- a/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp
@@ -1,6 +1,8 @@
 #include "legotexturepresenter.h"
 
 #include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "misc.h"
 #include "misc/legocontainer.h"
 #include "misc/legoimage.h"
@@ -57,7 +59,7 @@ MxResult LegoTexturePresenter::Read(MxDSChunk& p_chunk)
 		}
 
 		textureName[textureNameLength] = '\0';
-		strlwr(textureName);
+		_strlwr(textureName);
 
 		texture = new LegoTexture();
 		if (texture->Read(&storage, hardwareMode) != SUCCESS) {

--- a/LEGO1/lego/legoomni/src/worlds/act3.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/act3.cpp
@@ -31,7 +31,7 @@ DECOMP_SIZE_ASSERT(Act3ListElement, 0x0c)
 DECOMP_SIZE_ASSERT(Act3List, 0x10)
 
 // GLOBAL: LEGO1 0x100d94f8
-Act3Script::Script g_pizzaHitSounds[] = {
+const Act3Script::Script g_pizzaHitSounds[] = {
 	Act3Script::c_sns02xni_PlayWav,
 	Act3Script::c_sns03xni_PlayWav,
 	Act3Script::c_sns04xni_PlayWav,
@@ -51,7 +51,7 @@ Act3Script::Script g_pizzaHitSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9538
-Act3Script::Script g_pizzaMissSounds[] = {
+const Act3Script::Script g_pizzaMissSounds[] = {
 	Act3Script::c_sns19xni_PlayWav,
 	Act3Script::c_sns20xni_PlayWav,
 	Act3Script::c_sns22xni_PlayWav,
@@ -61,7 +61,7 @@ Act3Script::Script g_pizzaMissSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9550
-Act3Script::Script g_copDonutSounds[] = {
+const Act3Script::Script g_copDonutSounds[] = {
 	Act3Script::c_sns25xni_PlayWav,
 	Act3Script::c_sns26xni_PlayWav,
 	Act3Script::c_sns27xni_PlayWav,
@@ -73,7 +73,7 @@ Act3Script::Script g_copDonutSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9570
-Act3Script::Script g_donutMissSounds[] = {
+const Act3Script::Script g_donutMissSounds[] = {
 	Act3Script::c_sns30xni_PlayWav,
 	Act3Script::c_sns31xni_PlayWav,
 	Act3Script::c_sns32xni_PlayWav,
@@ -83,7 +83,7 @@ Act3Script::Script g_donutMissSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9588
-Act3Script::Script g_islanderSounds[] = {
+const Act3Script::Script g_islanderSounds[] = {
 	Act3Script::c_sns43xma_PlayWav, Act3Script::c_sns46xin_PlayWav, Act3Script::c_sns60xna_PlayWav,
 	Act3Script::c_sns52xro_PlayWav, Act3Script::c_sns58xna_PlayWav, Act3Script::c_sns68xbu_PlayWav,
 	Act3Script::c_sns59xna_PlayWav, Act3Script::c_sns51xin_PlayWav, Act3Script::c_sns61xva_PlayWav,
@@ -94,7 +94,7 @@ Act3Script::Script g_islanderSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d95d8
-Act3Script::Script g_bricksterDonutSounds[] = {
+const Act3Script::Script g_bricksterDonutSounds[] = {
 	Act3Script::c_tns080br_PlayWav,
 	Act3Script::c_tnsx07br_PlayWav,
 	Act3Script::c_snsxx2br_PlayWav,
@@ -105,7 +105,7 @@ Act3Script::Script g_bricksterDonutSounds[] = {
 MxU8 g_copSelector = 0;
 
 // GLOBAL: LEGO1 0x100d95e8
-Act3Script::Script g_explanationAnimations[] =
+const Act3Script::Script g_explanationAnimations[] =
 	{Act3Script::c_tlp053in_RunAnim, Act3Script::c_tlp064la_RunAnim, Act3Script::c_tlp068in_RunAnim};
 
 // FUNCTION: LEGO1 0x10071d40
@@ -176,15 +176,18 @@ void Act3List::Clear()
 // FUNCTION: LEGO1 0x100720d0
 void Act3List::RemoveByObjectIdOrFirst(MxU32 p_objectId)
 {
+	MxU32 removed;
+
 	if (m_cleared) {
 		return;
 	}
+	removed = FALSE;
 
-	MxU32 removed = FALSE;
 	Act3List::iterator it;
 	// This iterator appears to be unnecessary - maybe left in by accident, or it was used for assertions.
 	// Removing it decreases the match percentage.
 	Act3List::iterator unusedIterator;
+	Act3List::iterator first;
 
 	if (empty()) {
 		return;
@@ -208,9 +211,10 @@ void Act3List::RemoveByObjectIdOrFirst(MxU32 p_objectId)
 	}
 
 	if (removed && size() > 0) {
-		it = begin();
-		unusedIterator = it;
-		Act3ListElement& firstItem = front();
+		first = begin();
+		it = first;
+		unusedIterator = first;
+		Act3ListElement& firstItem = *first;
 		it++;
 
 		while (it != end()) {
@@ -420,7 +424,7 @@ MxResult Act3::ShootDonut(LegoPathController* p_controller, Vector3& p_location,
 void Act3::TriggerHitSound(undefined4 p_param1)
 {
 	float time = Timer()->GetTime();
-	Act3Script::Script objectId;
+	MxS32 objectId;
 
 	switch (p_param1) {
 	case 1: {
@@ -633,6 +637,7 @@ MxLong Act3::Notify(MxParam& p_param)
 		}
 		case c_notificationKeyPress:
 			if (m_state->m_state == Act3State::e_ready && ((LegoEventNotificationParam&) p_param).GetKey() == ' ') {
+				assert(AnimationManager());
 				AnimationManager()->FUN_10061010(FALSE);
 				return 1;
 			}
@@ -897,6 +902,8 @@ void Act3::DisableHelicopterDot()
 // FUNCTION: LEGO1 0x10073a90
 void Act3::Enable(MxBool p_enable)
 {
+	MxS32 i;
+
 	if ((MxBool) m_disabledObjects.empty() == p_enable) {
 		return;
 	}
@@ -904,6 +911,8 @@ void Act3::Enable(MxBool p_enable)
 	LegoWorld::Enable(p_enable);
 
 	if (p_enable) {
+		MxS32 j;
+
 		if (GameState()->m_previousArea == LegoGameState::e_infomain) {
 			GameState()->StopArea(LegoGameState::e_infomain);
 		}
@@ -940,7 +949,6 @@ void Act3::Enable(MxBool p_enable)
 			m_shark->SetActorTime(m_shark->GetActorTime() + delta);
 			m_shark->SetUnknown0x2c(m_shark->GetUnknown0x2c() + delta);
 
-			MxS32 i;
 			for (i = 0; i < (MxS32) sizeOfArray(m_pizzas); i++) {
 				if (m_pizzas[i].IsValid()) {
 					m_pizzas[i].SetTransformTime(m_pizzas[i].GetTransformTime() + delta);
@@ -949,11 +957,11 @@ void Act3::Enable(MxBool p_enable)
 				}
 			}
 
-			for (i = 0; i < (MxS32) sizeOfArray(m_donuts); i++) {
-				if (m_donuts[i].IsValid()) {
-					m_donuts[i].SetTransformTime(m_donuts[i].GetTransformTime() + delta);
-					m_donuts[i].SetActorTime(m_donuts[i].GetActorTime() + delta);
-					m_donuts[i].SetRotateTimeout(m_donuts[i].GetRotateTimeout() + delta);
+			for (j = 0; j < MAX_DONUTS; j++) {
+				if (m_donuts[j].IsValid()) {
+					m_donuts[j].SetTransformTime(m_donuts[j].GetTransformTime() + delta);
+					m_donuts[j].SetActorTime(m_donuts[j].GetActorTime() + delta);
+					m_donuts[j].SetRotateTimeout(m_donuts[j].GetRotateTimeout() + delta);
 				}
 			}
 

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -51,6 +51,7 @@ HistoryBook::~HistoryBook()
 }
 
 // FUNCTION: LEGO1 0x10082610
+// FUNCTION: BETA10 0x1002b80f
 MxResult HistoryBook::Create(MxDSAction& p_dsAction)
 {
 	MxResult result = LegoWorld::Create(p_dsAction);
@@ -133,8 +134,9 @@ void HistoryBook::ReadyWorld()
 		}
 
 		for (MxS32 scoreState = 0, scoreboxX = 1; scoreState < 5; scoreState++, scoreboxX += 5) {
+			MxU8 color;
 			for (MxS32 scoreBoxColumn = 0, scoreboxY = 1; scoreBoxColumn < 5; scoreBoxColumn++, scoreboxY += 5) {
-				MxU8 color = score->m_scores[scoreState][scoreBoxColumn];
+				color = score->m_scores[scoreState][scoreBoxColumn];
 
 				if (color > 0) {
 					for (MxS32 lax = 0; lax < 4; lax++) {

--- a/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
@@ -211,6 +211,7 @@ MxBool JukeBox::HandleControl(LegoControlManagerNotificationParam& p_param)
 			break;
 		case JukeboxwScript::c_Note_Ctl:
 			Act1State* act1State = (Act1State*) GameState()->GetState("Act1State");
+			assert(act1State);
 			act1State->m_state = Act1State::e_jukebox;
 			m_destLocation = LegoGameState::Area::e_jukeboxExterior;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, 0, FALSE);

--- a/LEGO1/modeldb/modeldb.cpp
+++ b/LEGO1/modeldb/modeldb.cpp
@@ -1,5 +1,10 @@
 #include "modeldb.h"
 
+#include <assert.h>
+#include <conio.h>
+#include <io.h>
+#include <stdlib.h>
+
 DECOMP_SIZE_ASSERT(ModelDbWorld, 0x18)
 DECOMP_SIZE_ASSERT(ModelDbPart, 0x18)
 DECOMP_SIZE_ASSERT(ModelDbModel, 0x38)
@@ -12,6 +17,63 @@ void ModelDbModel::Free()
 {
 	delete[] m_modelName;
 	delete[] m_presenterName;
+}
+
+// FUNCTION: BETA10 0x100e566b
+void ModelDbModel::Dump(FILE* p_file)
+{
+	fprintf(p_file, "%s\n", m_modelName);
+	fprintf(p_file, "%d\n", m_modelDataLength);
+	fprintf(p_file, "%d\n", m_modelDataOffset);
+	fprintf(p_file, "%s\n", m_presenterName);
+	fprintf(p_file, "%4.4f, %4.4f, %4.4f\n", m_location[0], m_location[1], m_location[2]);
+	fprintf(p_file, "%4.4f, %4.4f, %4.4f\n", m_direction[0], m_direction[1], m_direction[2]);
+	fprintf(p_file, "%4.4f, %4.4f, %4.4f\n", m_up[0], m_up[1], m_up[2]);
+	fprintf(p_file, "%d\n", m_visible);
+}
+
+// FUNCTION: BETA10 0x100e579b
+MxResult ModelDbModel::Write(FILE* p_file)
+{
+	MxU32 len;
+
+	len = strlen(m_modelName) + 1;
+	if (fwrite(&len, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(m_modelName, len, 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	if (fwrite(&m_modelDataLength, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(&m_modelDataOffset, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	len = strlen(m_presenterName) + 1;
+	if (fwrite(&len, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(m_presenterName, len, 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	if (fwrite(&m_location, sizeof(float), 3, p_file) != 3) {
+		return FAILURE;
+	}
+	if (fwrite(&m_direction, sizeof(float), 3, p_file) != 3) {
+		return FAILURE;
+	}
+	if (fwrite(&m_up, sizeof(float), 3, p_file) != 3) {
+		return FAILURE;
+	}
+	if (fwrite(&m_visible, sizeof(MxU8), 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
 }
 
 // FUNCTION: LEGO1 0x100276b0
@@ -59,6 +121,37 @@ MxResult ModelDbModel::Read(FILE* p_file)
 	return SUCCESS;
 }
 
+// FUNCTION: BETA10 0x100e5bfe
+void ModelDbPart::Dump(FILE* p_file)
+{
+	fprintf(p_file, "%s\n", m_roiName.GetData());
+	fprintf(p_file, "%d\n", m_partDataLength);
+	fprintf(p_file, "%d\n", m_partDataOffset);
+}
+
+// FUNCTION: BETA10 0x100e5c60
+MxResult ModelDbPart::Write(FILE* p_file)
+{
+	MxU32 len;
+
+	len = strlen(m_roiName.GetData()) + 1;
+	if (fwrite(&len, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(m_roiName.GetData(), len, 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	if (fwrite(&m_partDataLength, sizeof(undefined4), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(&m_partDataOffset, sizeof(undefined4), 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
 // FUNCTION: LEGO1 0x10027850
 MxResult ModelDbPart::Read(FILE* p_file)
 {
@@ -87,59 +180,69 @@ MxResult ModelDbPart::Read(FILE* p_file)
 }
 
 // FUNCTION: LEGO1 0x10027910
-MxResult ReadModelDbWorlds(FILE* p_file, ModelDbWorld*& p_worlds, MxS32& p_numWorlds)
+MxResult ReadModelDbWorlds(FILE* dbf, ModelDbWorld*& newworld, MxS32& p_numWorlds)
 {
-	p_worlds = NULL;
+	assert(dbf);
+	assert(newworld);
+
+	newworld = NULL;
 	p_numWorlds = 0;
 
 	MxS32 numWorlds;
-	if (fread(&numWorlds, sizeof(numWorlds), 1, p_file) != 1) {
+	if (fread(&numWorlds, sizeof(numWorlds), 1, dbf) != 1) {
 		return FAILURE;
 	}
 
-	ModelDbWorld* worlds = new ModelDbWorld[numWorlds];
-	MxS32 worldNameLen, numParts, i, j;
+	ModelDbWorld* world = new ModelDbWorld[numWorlds];
+	assert(world);
 
-	for (i = 0; i < numWorlds; i++) {
-		if (fread(&worldNameLen, sizeof(MxS32), 1, p_file) != 1) {
+	MxS32 worldNameLen, numParts, ii, j;
+
+	for (ii = 0; ii < numWorlds; ii++) {
+		if (fread(&worldNameLen, sizeof(MxS32), 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		worlds[i].m_worldName = new char[worldNameLen];
-		if (fread(worlds[i].m_worldName, worldNameLen, 1, p_file) != 1) {
+		world[ii].m_worldName = new char[worldNameLen];
+		assert(world[ii].m_worldName);
+
+		if (fread(world[ii].m_worldName, worldNameLen, 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		if (fread(&numParts, sizeof(MxS32), 1, p_file) != 1) {
+		if (fread(&numParts, sizeof(MxS32), 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		worlds[i].m_partList = new ModelDbPartList();
+		world[ii].m_partlist = new ModelDbPartList();
+		assert(world[ii].m_partlist);
 
 		for (j = 0; j < numParts; j++) {
 			ModelDbPart* part = new ModelDbPart();
+			assert(part);
 
-			if (part->Read(p_file) != SUCCESS) {
+			if (part->Read(dbf) != SUCCESS) {
 				return FAILURE;
 			}
 
-			worlds[i].m_partList->Append(part);
+			world[ii].m_partlist->Append(part);
 		}
 
-		if (fread(&worlds[i].m_numModels, sizeof(MxS32), 1, p_file) != 1) {
+		if (fread(&world[ii].m_numModels, sizeof(MxS32), 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		worlds[i].m_models = new ModelDbModel[worlds[i].m_numModels];
+		world[ii].m_modarr = new ModelDbModel[world[ii].m_numModels];
+		assert(world[ii].m_modarr);
 
-		for (j = 0; j < worlds[i].m_numModels; j++) {
-			if (worlds[i].m_models[j].Read(p_file) != SUCCESS) {
+		for (j = 0; j < world[ii].m_numModels; j++) {
+			if (world[ii].m_modarr[j].Read(dbf) != SUCCESS) {
 				return FAILURE;
 			}
 		}
 	}
 
-	p_worlds = worlds;
+	newworld = world;
 	p_numWorlds = numWorlds;
 	return SUCCESS;
 }
@@ -153,23 +256,71 @@ void FreeModelDbWorlds(ModelDbWorld*& p_worlds, MxS32 p_numWorlds)
 	for (MxS32 i = 0; i < p_numWorlds; i++) {
 		delete[] worlds[i].m_worldName;
 
-		ModelDbPartListCursor cursor(worlds[i].m_partList);
+		ModelDbPartListCursor cursor(worlds[i].m_partlist);
 		ModelDbPart* part;
 
 		while (cursor.Next(part)) {
 			delete part;
 		}
 
-		delete worlds[i].m_partList;
+		delete worlds[i].m_partlist;
 
-		ModelDbModel* models = worlds[i].m_models;
+		ModelDbModel* models = worlds[i].m_modarr;
 		for (MxS32 j = 0; j < worlds[i].m_numModels; j++) {
 			models[j].Free();
 		}
 
-		delete[] worlds[i].m_models;
+		delete[] worlds[i].m_modarr;
 	}
 
 	delete[] p_worlds;
 	p_worlds = NULL;
+}
+
+// FUNCTION: BETA10 0x100e7900
+inline void CheckRead(MxS32 p_result, MxS32 p_expected, const char* p_name)
+{
+	if (p_expected != p_result) {
+		fprintf(stdout, "Error reading from file %s\n", p_name);
+		printf("press any key\n");
+		_getch();
+		exit(-1);
+	}
+}
+
+// FUNCTION: BETA10 0x100e7970
+inline void CheckWrite(MxS32 p_result, MxS32 p_expected)
+{
+	if (p_expected != p_result) {
+		fprintf(stdout, "Error writing to db file\n");
+		printf("press any key\n");
+		_getch();
+		exit(-1);
+	}
+}
+
+// FUNCTION: BETA10 0x100e65f0
+void WriteModelDbParts(FILE* p_file, ModelDbPartList* p_list)
+{
+	MxString path("q:\\lego\\media\\model\\part\\");
+	ModelDbPartListCursor cursor(p_list);
+	ModelDbPart* part;
+
+	while (cursor.Next(part)) {
+		MxString name = path + part->m_roiName + ".prt";
+		FILE* f = fopen(name.GetData(), "rb");
+		if (!f) {
+			fprintf(stdout, "Error opening %s\n", name.GetData());
+			continue;
+		}
+
+		part->m_partDataOffset = ftell(p_file);
+		part->m_partDataLength = filelength(fileno(f));
+		char* buf = new char[part->m_partDataLength];
+		assert(buf);
+		CheckRead(fread(buf, part->m_partDataLength, 1, f), 1, part->m_roiName.GetData());
+		CheckWrite(fwrite(buf, part->m_partDataLength, 1, p_file), 1);
+		delete[] buf;
+		fclose(f);
+	}
 }

--- a/LEGO1/modeldb/modeldb.h
+++ b/LEGO1/modeldb/modeldb.h
@@ -10,6 +10,8 @@
 
 // SIZE 0x18
 struct ModelDbPart {
+	void Dump(FILE* p_file);
+	MxResult Write(FILE* p_file);
 	MxResult Read(FILE* p_file);
 
 	MxString m_roiName;          // 0x00
@@ -92,6 +94,8 @@ public:
 // SIZE 0x38
 struct ModelDbModel {
 	void Free();
+	void Dump(FILE* p_file);
+	MxResult Write(FILE* p_file);
 	MxResult Read(FILE* p_file);
 
 	char* m_modelName;       // 0x00
@@ -107,13 +111,13 @@ struct ModelDbModel {
 // SIZE 0x18
 struct ModelDbWorld {
 	char* m_worldName;           // 0x00
-	ModelDbPartList* m_partList; // 0x04
-	ModelDbModel* m_models;      // 0x08
+	ModelDbPartList* m_partlist; // 0x04
+	ModelDbModel* m_modarr;      // 0x08
 	MxS32 m_numModels;           // 0x0c
 	undefined m_unk0x10[0x08];   // 0x10
 };
 
-MxResult ReadModelDbWorlds(FILE* p_file, ModelDbWorld*& p_worlds, MxS32& p_numWorlds);
+MxResult ReadModelDbWorlds(FILE* dbf, ModelDbWorld*& newworld, MxS32& p_numWorlds);
 void FreeModelDbWorlds(ModelDbWorld*& p_worlds, MxS32 p_numWorlds);
 
 #endif // MODELDB_H


### PR DESCRIPTION
The same kind of small rewrites for the game-logic library.

- Assertions from the beta build are restored, read-only globals get `const` back, and names use their 1997 spelling.
- Three functions that were compiled into the original but never called are recovered (`ModelDbModel::Write`, `LegoTestTimerConsoleControl`, `ConvertRGBToHSV`).
- A few operand orders and member initialization orders are corrected; the byte-identical build proves them right.
- Some blank lines are added so the line numbers inside assertions match the original.
- Four functions are reshaped: `PizzeriaState` resets its five saved states with a plain loop, `RemovePresenter` declares its iterator inside the loop, `TriggerHitSound` writes each table lookup as one expression, and `BumpBouy::Notify` declares the user actor earlier.

---

**About this series:** step 8 of 12 (#1762–#1773). Together the twelve steps make the build produce the original LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte for byte. Each step builds and passes the usual checks on its own; the last step (#1773) adds the check that the output is identical to the original files. See #1761 for the full story.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9hpkbGxzV6BU1BEsWs9E
