### PR TITLE
Rename the LegoActor character constants to their original e_ names

### DIFF
--- a/LEGO1/lego/legoomni/include/ambulance.h
+++ b/LEGO1/lego/legoomni/include/ambulance.h
@@ -71,19 +71,19 @@ public:
 	MxS16 GetHighScore(MxU8 p_actorId)
 	{
 		switch (p_actorId) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			return m_peHighScore;
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			return m_maHighScore;
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			return m_paHighScore;
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			return m_niHighScore;
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			return m_laHighScore;
 			break;
 		}
@@ -95,31 +95,31 @@ public:
 	void UpdateScore(ScoreColor p_score, MxS16 p_actorId)
 	{
 		switch (p_actorId) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			m_peScore = p_score;
 			if (m_peHighScore < p_score) {
 				m_peHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			m_maScore = p_score;
 			if (m_maHighScore < p_score) {
 				m_maHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			m_paScore = p_score;
 			if (m_paHighScore < p_score) {
 				m_paHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			m_niScore = p_score;
 			if (m_niHighScore < p_score) {
 				m_niHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			m_laScore = p_score;
 			if (m_laHighScore < p_score) {
 				m_laHighScore = p_score;

--- a/LEGO1/lego/legoomni/include/legoactor.h
+++ b/LEGO1/lego/legoomni/include/legoactor.h
@@ -15,13 +15,13 @@ class LegoCacheSound;
 class LegoActor : public LegoEntity {
 public:
 	enum {
-		c_none = 0,
-		c_pepper,
-		c_mama,
-		c_papa,
-		c_nick,
-		c_laura,
-		c_brickster
+		e_none = 0,
+		e_pepper,
+		e_mama,
+		e_papa,
+		e_nick,
+		e_laura,
+		e_brickster
 	};
 
 	LegoActor();

--- a/LEGO1/lego/legoomni/include/towtrack.h
+++ b/LEGO1/lego/legoomni/include/towtrack.h
@@ -73,19 +73,19 @@ public:
 	MxS16 GetHighScore(MxU8 p_actorId)
 	{
 		switch (p_actorId) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			return m_peHighScore;
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			return m_maHighScore;
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			return m_paHighScore;
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			return m_niHighScore;
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			return m_laHighScore;
 			break;
 		}
@@ -97,31 +97,31 @@ public:
 	void UpdateScore(ScoreColor p_score, MxS16 p_actorId)
 	{
 		switch (p_actorId) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			m_peScore = p_score;
 			if (m_peHighScore < p_score) {
 				m_peHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			m_maScore = p_score;
 			if (m_maHighScore < p_score) {
 				m_maHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			m_paScore = p_score;
 			if (m_paHighScore < p_score) {
 				m_paHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			m_niScore = p_score;
 			if (m_niHighScore < p_score) {
 				m_niHighScore = p_score;
 			}
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			m_laScore = p_score;
 			if (m_laHighScore < p_score) {
 				m_laHighScore = p_score;

--- a/LEGO1/lego/legoomni/src/actors/ambulance.cpp
+++ b/LEGO1/lego/legoomni/src/actors/ambulance.cpp
@@ -325,22 +325,22 @@ MxLong Ambulance::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 
 		Leave();
 
-		if (m_actorId < LegoActor::c_pepper || m_actorId > LegoActor::c_laura) {
-			m_actorId = LegoActor::c_laura;
+		if (m_actorId < LegoActor::e_pepper || m_actorId > LegoActor::e_laura) {
+			m_actorId = LegoActor::e_laura;
 		}
 
 		switch (m_actorId) {
-		case c_pepper:
+		case e_pepper:
 			PlayAnimation(IsleScript::c_hpz049bd_RunAnim);
 			break;
-		case c_mama:
+		case e_mama:
 			PlayAnimation(IsleScript::c_hpz047pe_RunAnim);
 			break;
-		case c_papa:
+		case e_papa:
 			PlayAnimation(IsleScript::c_hpz050bd_RunAnim);
 			break;
-		case c_nick:
-		case c_laura:
+		case e_nick:
+		case e_laura:
 			PlayAnimation(IsleScript::c_hpz048pe_RunAnim);
 			break;
 		}

--- a/LEGO1/lego/legoomni/src/actors/pizza.cpp
+++ b/LEGO1/lego/legoomni/src/actors/pizza.cpp
@@ -282,7 +282,7 @@ MxLong Pizza::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 		MxLong time = Timer()->GetTime() - m_mission->m_startTime;
 
 		if (p_param.GetTrigger() == LegoPathStruct::c_specialMissionWaypointAndAction && p_param.GetData() == 0x12e &&
-			GameState()->GetActorId() == LegoActor::c_pepper) {
+			GameState()->GetActorId() == LegoActor::e_pepper) {
 			m_state->m_state = PizzaMissionState::e_arrivedAtDestination;
 			m_state->SetPlayedAction(SndanimScript::c_TRS302_OpenJailDoor);
 
@@ -299,11 +299,11 @@ MxLong Pizza::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			MxTrace("Pizza mission: ending\n");
 		}
 		else if ((p_param.GetTrigger() == LegoPathStruct::c_camAnim && (
-			((p_param.GetData() == 0x24 || p_param.GetData() == 0x22) && GameState()->GetActorId() == LegoActor::c_mama) ||
-			(p_param.GetData() == 0x33 && GameState()->GetActorId() == LegoActor::c_papa) ||
-			((p_param.GetData() == 0x08 || p_param.GetData() == 0x09) && GameState()->GetActorId() == LegoActor::c_nick) ||
-			(p_param.GetData() == 0x0b && GameState()->GetActorId() == LegoActor::c_laura)
-		)) || (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint && p_param.GetData() == 0x169 && GameState()->GetActorId() == LegoActor::c_nick)) {
+			((p_param.GetData() == 0x24 || p_param.GetData() == 0x22) && GameState()->GetActorId() == LegoActor::e_mama) ||
+			(p_param.GetData() == 0x33 && GameState()->GetActorId() == LegoActor::e_papa) ||
+			((p_param.GetData() == 0x08 || p_param.GetData() == 0x09) && GameState()->GetActorId() == LegoActor::e_nick) ||
+			(p_param.GetData() == 0x0b && GameState()->GetActorId() == LegoActor::e_laura)
+		)) || (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint && p_param.GetData() == 0x169 && GameState()->GetActorId() == LegoActor::e_nick)) {
 			IsleScript::Script action;
 
 			if (time < m_mission->GetRedFinishTime()) {
@@ -354,13 +354,13 @@ MxLong Pizza::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			MxTrace("Pizza mission: ending\n");
 		}
 		else if (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint) {
-			if (p_param.GetData() == 0x15e && GameState()->GetActorId() == LegoActor::c_pepper) {
+			if (p_param.GetData() == 0x15e && GameState()->GetActorId() == LegoActor::e_pepper) {
 				if (!m_playedLocationAnimation) {
 					m_playedLocationAnimation = TRUE;
 					InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_pns050p1_RunAnim, NULL);
 				}
 			}
-			else if (p_param.GetData() == 0x15f && GameState()->GetActorId() == LegoActor::c_papa && !m_playedLocationAnimation) {
+			else if (p_param.GetData() == 0x15f && GameState()->GetActorId() == LegoActor::e_papa && !m_playedLocationAnimation) {
 				m_playedLocationAnimation = TRUE;
 				InvokeAction(Extra::e_start, *g_isleScript, IsleScript::c_wns050p1_RunAnim, NULL);
 			}
@@ -397,19 +397,19 @@ MxResult Pizza::Tickle()
 			}
 			else if (time >= m_mission->m_startTime + 35000 && m_speechAction == IsleScript::c_noneIsle) {
 				switch (GameState()->GetActorId()) {
-				case LegoActor::c_pepper:
+				case LegoActor::e_pepper:
 					m_speechAction = IsleScript::c_Avo914In_PlayWav;
 					break;
-				case LegoActor::c_mama:
+				case LegoActor::e_mama:
 					m_speechAction = IsleScript::c_Avo910In_PlayWav;
 					break;
-				case LegoActor::c_papa:
+				case LegoActor::e_papa:
 					m_speechAction = IsleScript::c_Avo912In_PlayWav;
 					break;
-				case LegoActor::c_nick:
+				case LegoActor::e_nick:
 					m_speechAction = IsleScript::c_Avo911In_PlayWav;
 					break;
-				case LegoActor::c_laura:
+				case LegoActor::e_laura:
 					m_speechAction = IsleScript::c_Avo913In_PlayWav;
 					break;
 				}
@@ -493,7 +493,7 @@ MxLong Pizza::HandleEndAction(MxEndActionNotificationParam& p_param)
 		if (m_state->GetPlayedAction() == objectId) {
 			StopActions();
 
-			if (GameState()->GetActorId() == LegoActor::c_pepper) {
+			if (GameState()->GetActorId() == LegoActor::e_pepper) {
 				IsleScript::Script action = IsleScript::c_noneIsle;
 
 				if (!((Isle*) CurrentWorld())->HasHelicopter()) {
@@ -595,11 +595,11 @@ void Pizza::PlayAction(MxU32 p_objectId, MxBool p_param7)
 PizzaMissionState::PizzaMissionState()
 {
 	m_state = PizzaMissionState::e_none;
-	m_missions[0] = Mission(LegoActor::c_pepper, 2, g_pepperFinishTimes, g_pepperActions, 4);
-	m_missions[1] = Mission(LegoActor::c_mama, 2, g_mamaFinishTimes, g_mamaActions, 4);
-	m_missions[2] = Mission(LegoActor::c_papa, 2, g_papaFinishTimes, g_papaActions, 4);
-	m_missions[3] = Mission(LegoActor::c_nick, 2, g_nickFinishTimes, g_nickActions, 4);
-	m_missions[4] = Mission(LegoActor::c_laura, 2, g_lauraFinishTimes, g_lauraActions, 4);
+	m_missions[0] = Mission(LegoActor::e_pepper, 2, g_pepperFinishTimes, g_pepperActions, 4);
+	m_missions[1] = Mission(LegoActor::e_mama, 2, g_mamaFinishTimes, g_mamaActions, 4);
+	m_missions[2] = Mission(LegoActor::e_papa, 2, g_papaFinishTimes, g_papaActions, 4);
+	m_missions[3] = Mission(LegoActor::e_nick, 2, g_nickFinishTimes, g_nickActions, 4);
+	m_missions[4] = Mission(LegoActor::e_laura, 2, g_lauraFinishTimes, g_lauraActions, 4);
 	m_pizzeriaState = (PizzeriaState*) GameState()->GetState("PizzeriaState");
 	m_playedAction = IsleScript::c_noneIsle;
 }

--- a/LEGO1/lego/legoomni/src/actors/towtrack.cpp
+++ b/LEGO1/lego/legoomni/src/actors/towtrack.cpp
@@ -169,8 +169,8 @@ MxLong TowTrack::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_lastAction = IsleScript::c_noneIsle;
 		}
 		else if (objectId == IsleScript::c_wrt060bm_RunAnim) {
-			if (m_actorId < LegoActor::c_pepper || m_actorId > LegoActor::c_laura) {
-				m_actorId = LegoActor::c_laura;
+			if (m_actorId < LegoActor::e_pepper || m_actorId > LegoActor::e_laura) {
+				m_actorId = LegoActor::e_laura;
 			}
 
 			switch ((rand() % ((m_actorId != 4 ? 4 : 3))) + 1) {
@@ -194,24 +194,24 @@ MxLong TowTrack::HandleEndAction(MxEndActionNotificationParam& p_param)
 			HandleClick();
 		}
 		else if (objectId == IsleScript::c_wgs083nu_RunAnim) {
-			if (m_actorId < LegoActor::c_pepper || m_actorId > LegoActor::c_laura) {
-				m_actorId = LegoActor::c_laura;
+			if (m_actorId < LegoActor::e_pepper || m_actorId > LegoActor::e_laura) {
+				m_actorId = LegoActor::e_laura;
 			}
 
 			switch (m_actorId) {
-			case c_pepper:
+			case e_pepper:
 				PlayActorAnimation(IsleScript::c_wgs085nu_RunAnim);
 				break;
-			case c_mama:
+			case e_mama:
 				PlayActorAnimation(IsleScript::c_wgs086nu_RunAnim);
 				break;
-			case c_papa:
+			case e_papa:
 				PlayActorAnimation(IsleScript::c_wgs088nu_RunAnim);
 				break;
-			case c_nick:
+			case e_nick:
 				PlayActorAnimation(IsleScript::c_wgs087nu_RunAnim);
 				break;
-			case c_laura:
+			case e_laura:
 				PlayActorAnimation(IsleScript::c_wgs089nu_RunAnim);
 				break;
 			}
@@ -223,24 +223,24 @@ MxLong TowTrack::HandleEndAction(MxEndActionNotificationParam& p_param)
 			AnimationManager()->EnableCamAnims(TRUE);
 		}
 		else if (objectId == IsleScript::c_wgs090nu_RunAnim) {
-			if (m_actorId < LegoActor::c_pepper || m_actorId > LegoActor::c_laura) {
-				m_actorId = LegoActor::c_laura;
+			if (m_actorId < LegoActor::e_pepper || m_actorId > LegoActor::e_laura) {
+				m_actorId = LegoActor::e_laura;
 			}
 
 			switch (m_actorId) {
-			case c_pepper:
+			case e_pepper:
 				PlayActorAnimation(IsleScript::c_wgs091nu_RunAnim);
 				break;
-			case c_mama:
+			case e_mama:
 				PlayActorAnimation(IsleScript::c_wgs092nu_RunAnim);
 				break;
-			case c_papa:
+			case e_papa:
 				PlayActorAnimation(IsleScript::c_wgs094nu_RunAnim);
 				break;
-			case c_nick:
+			case e_nick:
 				PlayActorAnimation(IsleScript::c_wgs093nu_RunAnim);
 				break;
-			case c_laura:
+			case e_laura:
 				PlayActorAnimation(IsleScript::c_wgs095nu_RunAnim);
 				break;
 			}
@@ -248,24 +248,24 @@ MxLong TowTrack::HandleEndAction(MxEndActionNotificationParam& p_param)
 			m_state->UpdateScore(LegoState::e_blue, m_actorId);
 		}
 		else if (objectId == IsleScript::c_wgs097nu_RunAnim) {
-			if (m_actorId < LegoActor::c_pepper || m_actorId > LegoActor::c_laura) {
-				m_actorId = LegoActor::c_laura;
+			if (m_actorId < LegoActor::e_pepper || m_actorId > LegoActor::e_laura) {
+				m_actorId = LegoActor::e_laura;
 			}
 
 			switch (m_actorId) {
-			case c_pepper:
+			case e_pepper:
 				PlayActorAnimation(IsleScript::c_wgs098nu_RunAnim);
 				break;
-			case c_mama:
+			case e_mama:
 				PlayActorAnimation(IsleScript::c_wgs099nu_RunAnim);
 				break;
-			case c_papa:
+			case e_papa:
 				PlayActorAnimation(IsleScript::c_wgs101nu_RunAnim);
 				break;
-			case c_nick:
+			case e_nick:
 				PlayActorAnimation(IsleScript::c_wgs100nu_RunAnim);
 				break;
-			case c_laura:
+			case e_laura:
 				PlayActorAnimation(IsleScript::c_wgs102nu_RunAnim);
 				break;
 			}
@@ -341,17 +341,17 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			}
 
 			if (!m_state->m_takingTooLong && m_lastAction == IsleScript::c_noneIsle) {
-				if (m_actorId < LegoActor::c_pepper || m_actorId > LegoActor::c_laura) {
-					m_actorId = LegoActor::c_laura;
+				if (m_actorId < LegoActor::e_pepper || m_actorId > LegoActor::e_laura) {
+					m_actorId = LegoActor::e_laura;
 				}
 
 				IsleScript::Script objectId;
 
 				switch (m_actorId) {
-				case c_pepper:
+				case e_pepper:
 					objectId = IsleScript::c_wns034na_PlayWav;
 					break;
-				case c_mama:
+				case e_mama:
 					switch ((rand() % 2) + 1) {
 					case 1:
 						objectId = IsleScript::c_wns037na_PlayWav;
@@ -361,7 +361,7 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 						break;
 					}
 					break;
-				case c_papa:
+				case e_papa:
 					switch ((rand() % 2) + 1) {
 					case 1:
 						objectId = IsleScript::c_wns041na_PlayWav;
@@ -371,7 +371,7 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 						break;
 					}
 					break;
-				case c_nick:
+				case e_nick:
 					switch ((rand() % 2) + 1) {
 					case 1:
 						objectId = IsleScript::c_wns039na_PlayWav;
@@ -381,7 +381,7 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 						break;
 					}
 					break;
-				case c_laura:
+				case e_laura:
 					switch ((rand() % 2) + 1) {
 					case 1:
 						objectId = IsleScript::c_wns043na_PlayWav;

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1557,7 +1557,7 @@ MxResult LegoAnimationManager::Tickle()
 		MxU8 unk0x0c = 0;
 		MxU8 actorId = GameState()->GetActorId();
 
-		if (actorId <= LegoActor::c_laura) {
+		if (actorId <= LegoActor::e_laura) {
 			unk0x0c = g_unk0x100d8b28[actorId];
 		}
 
@@ -1821,7 +1821,7 @@ MxBool LegoAnimationManager::FUN_10062710(AnimInfo& p_info)
 	MxU8 und = 0;
 	MxU8 actorId = GameState()->GetActorId();
 
-	if (actorId <= LegoActor::c_laura) {
+	if (actorId <= LegoActor::e_laura) {
 		und = g_unk0x100d8b28[actorId];
 	}
 
@@ -2775,11 +2775,11 @@ MxResult LegoAnimationManager::FUN_10064740(Vector3* p_position)
 	}
 
 	if (success) {
-		if (GameState()->GetActorId() != LegoActor::c_mama) {
+		if (GameState()->GetActorId() != LegoActor::e_mama) {
 			FUN_10064380("mama", "USR00_47", 1, 0.43f, 3, 0.84f, rand() % 3 + 13, -1, rand() % 3, -1, 0.7f);
 		}
 
-		if (GameState()->GetActorId() != LegoActor::c_papa) {
+		if (GameState()->GetActorId() != LegoActor::e_papa) {
 			FUN_10064380("papa", "USR00_193", 3, 0.55f, 1, 0.4f, rand() % 3 + 13, -1, rand() % 3, -1, 0.9f);
 		}
 

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -167,19 +167,19 @@ void WhoAmIVariable::SetValue(const char* p_value)
 	MxVariable::SetValue(p_value);
 
 	if (!strcmpi(p_value, g_papa)) {
-		GameState()->SetActorId(LegoActor::c_papa);
+		GameState()->SetActorId(LegoActor::e_papa);
 	}
 	else if (!strcmpi(p_value, g_mama)) {
-		GameState()->SetActorId(LegoActor::c_mama);
+		GameState()->SetActorId(LegoActor::e_mama);
 	}
 	else if (!strcmpi(p_value, g_pepper)) {
-		GameState()->SetActorId(LegoActor::c_pepper);
+		GameState()->SetActorId(LegoActor::e_pepper);
 	}
 	else if (!strcmpi(p_value, g_nick)) {
-		GameState()->SetActorId(LegoActor::c_nick);
+		GameState()->SetActorId(LegoActor::e_nick);
 	}
 	else if (!strcmpi(p_value, g_laura)) {
-		GameState()->SetActorId(LegoActor::c_laura);
+		GameState()->SetActorId(LegoActor::e_laura);
 	}
 }
 

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -484,25 +484,25 @@ MxLong LegoEntity::Notify(MxParam& p_param)
 	}
 	else {
 		switch (GameState()->GetActorId()) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			if (GameState()->GetCurrentAct() != LegoGameState::e_act2 &&
 				GameState()->GetCurrentAct() != LegoGameState::e_act3) {
 				SwitchVariant();
 			}
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			SwitchSound();
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			SwitchMove();
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			SwitchColor(param.GetROI());
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			SwitchMood();
 			break;
-		case LegoActor::c_brickster:
+		case LegoActor::e_brickster:
 			switch (m_type) {
 			case e_actor:
 			case e_unk1:

--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -1015,15 +1015,15 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 				case VK_MULTIPLY: {
 					MxU8 newActor = GameState()->GetActorId() + 1;
 
-					if (newActor > LegoActor::c_laura) {
-						newActor = LegoActor::c_pepper;
+					if (newActor > LegoActor::e_laura) {
+						newActor = LegoActor::e_pepper;
 					}
 
 					GameState()->SetActorId(newActor);
 					break;
 				}
 				case VK_DIVIDE:
-					GameState()->SetActorId(LegoActor::c_brickster);
+					GameState()->SetActorId(LegoActor::e_brickster);
 					break;
 				case VK_F11:
 					if (GameState()->m_isDirty) {

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -823,24 +823,24 @@ MxResult LegoPathActor::CalculateSpline()
 void LegoPathActor::GetWalkingBehavior(MxBool& p_countCounterclockWise, MxS32& p_selectedEdgeIndex)
 {
 	switch (GetActorId()) {
-	case c_pepper:
+	case e_pepper:
 		p_countCounterclockWise = TRUE;
 		p_selectedEdgeIndex = 2;
 		break;
-	case c_mama:
+	case e_mama:
 		p_countCounterclockWise = FALSE;
 		p_selectedEdgeIndex = 1;
 		break;
-	case c_papa:
+	case e_papa:
 		p_countCounterclockWise = TRUE;
 		p_selectedEdgeIndex = 1;
 		break;
-	case c_nick:
-	case c_brickster:
+	case e_nick:
+	case e_brickster:
 		p_countCounterclockWise = TRUE;
 		p_selectedEdgeIndex = rand() % p_selectedEdgeIndex + 1;
 		break;
-	case c_laura:
+	case e_laura:
 		p_countCounterclockWise = FALSE;
 		p_selectedEdgeIndex = 2;
 		break;

--- a/LEGO1/lego/legoomni/src/race/legorace.cpp
+++ b/LEGO1/lego/legoomni/src/race/legorace.cpp
@@ -116,19 +116,19 @@ void LegoRace::Enable(MxBool p_enable)
 // FUNCTION: LEGO1 0x10015f30
 RaceState::RaceState()
 {
-	m_entries[0].m_id = LegoActor::c_pepper;
+	m_entries[0].m_id = LegoActor::e_pepper;
 	m_entries[0].m_lastScore = 0;
 	m_entries[0].m_score = 0;
-	m_entries[1].m_id = LegoActor::c_mama;
+	m_entries[1].m_id = LegoActor::e_mama;
 	m_entries[1].m_lastScore = 0;
 	m_entries[1].m_score = 0;
-	m_entries[2].m_id = LegoActor::c_papa;
+	m_entries[2].m_id = LegoActor::e_papa;
 	m_entries[2].m_lastScore = 0;
 	m_entries[2].m_score = 0;
-	m_entries[3].m_id = LegoActor::c_nick;
+	m_entries[3].m_id = LegoActor::e_nick;
 	m_entries[3].m_lastScore = 0;
 	m_entries[3].m_score = 0;
-	m_entries[4].m_id = LegoActor::c_laura;
+	m_entries[4].m_id = LegoActor::e_laura;
 	m_entries[4].m_lastScore = 0;
 	m_entries[4].m_score = 0;
 	m_state = RaceState::e_carrace;

--- a/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
@@ -34,7 +34,7 @@ MxBool g_trackLedEnabled = FALSE;
 // FUNCTION: LEGO1 0x100046a0
 GasStation::GasStation()
 {
-	m_currentActorId = LegoActor::c_none;
+	m_currentActorId = LegoActor::e_none;
 	m_state = NULL;
 	m_destLocation = LegoGameState::e_undefined;
 	m_trackLedBitmap = NULL;
@@ -136,7 +136,7 @@ void GasStation::ReadyWorld()
 	m_currentActorId = UserActor()->GetActorId();
 
 	switch (m_currentActorId) {
-	case LegoActor::c_pepper:
+	case LegoActor::e_pepper:
 		switch (m_state->m_pepperAction) {
 		case 0:
 			m_state->m_state = GasStationState::e_introduction;
@@ -165,7 +165,7 @@ void GasStation::ReadyWorld()
 			m_state->m_pepperAction++;
 		}
 		break;
-	case LegoActor::c_mama:
+	case LegoActor::e_mama:
 		switch (m_state->m_mamaAction) {
 		case 0:
 			m_state->m_state = GasStationState::e_introduction;
@@ -189,7 +189,7 @@ void GasStation::ReadyWorld()
 			m_state->m_mamaAction++;
 		}
 		break;
-	case LegoActor::c_nick:
+	case LegoActor::e_nick:
 		switch (m_state->m_nickAction) {
 		case 0:
 			m_state->m_state = GasStationState::e_introduction;
@@ -213,7 +213,7 @@ void GasStation::ReadyWorld()
 			m_state->m_nickAction++;
 		}
 		break;
-	case LegoActor::c_papa:
+	case LegoActor::e_papa:
 		switch (m_state->m_papaAction) {
 		case 0:
 			m_state->m_state = GasStationState::e_introduction;
@@ -237,7 +237,7 @@ void GasStation::ReadyWorld()
 			m_state->m_papaAction++;
 		}
 		break;
-	case LegoActor::c_laura:
+	case LegoActor::e_laura:
 		switch (m_state->m_lauraAction) {
 		case 0:
 			m_state->m_state = GasStationState::e_introduction;

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -35,7 +35,7 @@ MxBool g_pizzaLedEnabled = FALSE;
 // FUNCTION: LEGO1 0x100745e0
 Hospital::Hospital()
 {
-	m_currentActorId = LegoActor::c_none;
+	m_currentActorId = LegoActor::e_none;
 	m_interactionMode = 0;
 	m_hospitalState = NULL;
 	m_setWithCurrentAction = 0;
@@ -141,14 +141,14 @@ void Hospital::ReadyWorld()
 	m_pizzaLedBitmap = (MxStillPresenter*) Find("MxStillPresenter", "PizzaLed_Bitmap");
 
 	if (UserActor() == NULL) {
-		m_currentActorId = LegoActor::c_laura;
+		m_currentActorId = LegoActor::e_laura;
 	}
 	else {
 		m_currentActorId = UserActor()->GetActorId();
 	}
 
 	switch (m_currentActorId) {
-	case LegoActor::c_pepper:
+	case LegoActor::e_pepper:
 		m_hospitalState->m_stateActor = m_hospitalState->m_statePepper;
 
 		if (m_hospitalState->m_statePepper < 5) {
@@ -156,7 +156,7 @@ void Hospital::ReadyWorld()
 		}
 
 		break;
-	case LegoActor::c_mama:
+	case LegoActor::e_mama:
 		m_hospitalState->m_stateActor = m_hospitalState->m_stateMama;
 
 		if (m_hospitalState->m_stateMama < 5) {
@@ -164,7 +164,7 @@ void Hospital::ReadyWorld()
 		}
 
 		break;
-	case LegoActor::c_papa:
+	case LegoActor::e_papa:
 		m_hospitalState->m_stateActor = m_hospitalState->m_statePapa;
 
 		if (m_hospitalState->m_statePapa < 5) {
@@ -172,7 +172,7 @@ void Hospital::ReadyWorld()
 		}
 
 		break;
-	case LegoActor::c_nick:
+	case LegoActor::e_nick:
 		m_hospitalState->m_stateActor = m_hospitalState->m_stateNick;
 
 		if (m_hospitalState->m_stateNick < 5) {
@@ -180,7 +180,7 @@ void Hospital::ReadyWorld()
 		}
 
 		break;
-	case LegoActor::c_laura:
+	case LegoActor::e_laura:
 		m_hospitalState->m_stateActor = m_hospitalState->m_stateLaura;
 
 		if (m_hospitalState->m_stateLaura < 5) {
@@ -265,7 +265,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 		break;
 	case HospitalState::e_unknown11:
 		switch (m_currentActorId) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			switch (m_hospitalState->m_statePepper) {
 			case 0:
 			case 1:
@@ -284,7 +284,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				break;
 			}
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			switch (m_hospitalState->m_stateMama) {
 			case 0:
 			case 1:
@@ -303,7 +303,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				break;
 			}
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			switch (m_hospitalState->m_statePapa) {
 			case 0:
 			case 1:
@@ -322,7 +322,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				break;
 			}
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			switch (m_hospitalState->m_stateNick) {
 			case 0:
 			case 1:
@@ -341,7 +341,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 				break;
 			}
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			switch (m_hospitalState->m_stateLaura) {
 			case 0:
 			case 1:
@@ -443,7 +443,7 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 					}
 					else {
 						switch (m_currentActorId) {
-						case LegoActor::c_pepper:
+						case LegoActor::e_pepper:
 							switch (m_hospitalState->m_statePepper) {
 							case 0:
 							case 1:
@@ -462,7 +462,7 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								break;
 							}
 							break;
-						case LegoActor::c_mama:
+						case LegoActor::e_mama:
 							switch (m_hospitalState->m_stateMama) {
 							case 0:
 							case 1:
@@ -481,7 +481,7 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								break;
 							}
 							break;
-						case LegoActor::c_nick:
+						case LegoActor::e_nick:
 							switch (m_hospitalState->m_stateNick) {
 							case 0:
 							case 1:
@@ -500,7 +500,7 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								break;
 							}
 							break;
-						case LegoActor::c_papa:
+						case LegoActor::e_papa:
 							switch (m_hospitalState->m_statePapa) {
 							case 0:
 							case 1:
@@ -519,7 +519,7 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 								break;
 							}
 							break;
-						case LegoActor::c_laura:
+						case LegoActor::e_laura:
 							switch (m_hospitalState->m_stateLaura) {
 							case 0:
 							case 1:

--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -129,7 +129,7 @@ InfomainScript::Script g_bricksterDialogue[2] = {
 // FUNCTION: LEGO1 0x1006ea20
 Infocenter::Infocenter()
 {
-	m_selectedCharacter = LegoActor::c_none;
+	m_selectedCharacter = LegoActor::e_none;
 	m_dragPresenter = NULL;
 	m_infocenterState = NULL;
 	m_frame = NULL;
@@ -307,19 +307,19 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 			GameState()->SetActor(m_selectedCharacter);
 
 			switch (m_selectedCharacter) {
-			case LegoActor::c_pepper:
+			case LegoActor::e_pepper:
 				PlayAction(InfomainScript::c_avo901in_RunAnim);
 				break;
-			case LegoActor::c_mama:
+			case LegoActor::e_mama:
 				PlayAction(InfomainScript::c_avo902in_RunAnim);
 				break;
-			case LegoActor::c_papa:
+			case LegoActor::e_papa:
 				PlayAction(InfomainScript::c_avo903in_RunAnim);
 				break;
-			case LegoActor::c_nick:
+			case LegoActor::e_nick:
 				PlayAction(InfomainScript::c_avo904in_RunAnim);
 				break;
-			case LegoActor::c_laura:
+			case LegoActor::e_laura:
 				PlayAction(InfomainScript::c_avo905in_RunAnim);
 				break;
 			default:
@@ -406,7 +406,7 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 		break;
 	case InfocenterState::e_selectedCharacterAndDestination:
 		if (action->GetObjectId() == m_currentInfomainScript) {
-			if (GameState()->GetCurrentAct() != LegoGameState::e_act3 && m_selectedCharacter != LegoActor::c_none) {
+			if (GameState()->GetCurrentAct() != LegoGameState::e_act3 && m_selectedCharacter != LegoActor::e_none) {
 				GameState()->SetActor(m_selectedCharacter);
 			}
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
@@ -753,19 +753,19 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 
 		switch (m_dragPresenter->GetAction()->GetObjectId()) {
 		case InfomainScript::c_PepperHot_Bitmap:
-			m_selectedCharacter = LegoActor::c_pepper;
+			m_selectedCharacter = LegoActor::e_pepper;
 			break;
 		case InfomainScript::c_MamaHot_Bitmap:
-			m_selectedCharacter = LegoActor::c_mama;
+			m_selectedCharacter = LegoActor::e_mama;
 			break;
 		case InfomainScript::c_PapaHot_Bitmap:
-			m_selectedCharacter = LegoActor::c_papa;
+			m_selectedCharacter = LegoActor::e_papa;
 			break;
 		case InfomainScript::c_NickHot_Bitmap:
-			m_selectedCharacter = LegoActor::c_nick;
+			m_selectedCharacter = LegoActor::e_nick;
 			break;
 		case InfomainScript::c_LauraHot_Bitmap:
-			m_selectedCharacter = LegoActor::c_laura;
+			m_selectedCharacter = LegoActor::e_laura;
 			break;
 		}
 
@@ -774,7 +774,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 
 			switch (control->GetAction()->GetObjectId()) {
 			case InfomainScript::c_Pepper_Ctl:
-				if (m_selectedCharacter == LegoActor::c_pepper) {
+				if (m_selectedCharacter == LegoActor::e_pepper) {
 					m_radio.Stop();
 					BackgroundAudioManager()->Stop();
 					PlayAction(InfomainScript::c_Pepper_All_Movie);
@@ -782,7 +782,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				}
 				break;
 			case InfomainScript::c_Mama_Ctl:
-				if (m_selectedCharacter == LegoActor::c_mama) {
+				if (m_selectedCharacter == LegoActor::e_mama) {
 					m_radio.Stop();
 					BackgroundAudioManager()->Stop();
 					PlayAction(InfomainScript::c_Mama_All_Movie);
@@ -790,7 +790,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				}
 				break;
 			case InfomainScript::c_Papa_Ctl:
-				if (m_selectedCharacter == LegoActor::c_papa) {
+				if (m_selectedCharacter == LegoActor::e_papa) {
 					m_radio.Stop();
 					BackgroundAudioManager()->Stop();
 					PlayAction(InfomainScript::c_Papa_All_Movie);
@@ -798,7 +798,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				}
 				break;
 			case InfomainScript::c_Nick_Ctl:
-				if (m_selectedCharacter == LegoActor::c_nick) {
+				if (m_selectedCharacter == LegoActor::e_nick) {
 					m_radio.Stop();
 					BackgroundAudioManager()->Stop();
 					PlayAction(InfomainScript::c_Nick_All_Movie);
@@ -806,7 +806,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				}
 				break;
 			case InfomainScript::c_Laura_Ctl:
-				if (m_selectedCharacter == LegoActor::c_laura) {
+				if (m_selectedCharacter == LegoActor::e_laura) {
 					m_radio.Stop();
 					BackgroundAudioManager()->Stop();
 					PlayAction(InfomainScript::c_Laura_All_Movie);
@@ -824,19 +824,19 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 					GameState()->SetActor(m_selectedCharacter);
 
 					switch (m_selectedCharacter) {
-					case LegoActor::c_pepper:
+					case LegoActor::e_pepper:
 						PlayAction(InfomainScript::c_avo901in_RunAnim);
 						break;
-					case LegoActor::c_mama:
+					case LegoActor::e_mama:
 						PlayAction(InfomainScript::c_avo902in_RunAnim);
 						break;
-					case LegoActor::c_papa:
+					case LegoActor::e_papa:
 						PlayAction(InfomainScript::c_avo903in_RunAnim);
 						break;
-					case LegoActor::c_nick:
+					case LegoActor::e_nick:
 						PlayAction(InfomainScript::c_avo904in_RunAnim);
 						break;
-					case LegoActor::c_laura:
+					case LegoActor::e_laura:
 						PlayAction(InfomainScript::c_avo905in_RunAnim);
 						break;
 					}
@@ -895,23 +895,23 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				}
 				else {
 					switch (m_selectedCharacter) {
-					case LegoActor::c_pepper:
+					case LegoActor::e_pepper:
 						dialogueToPlay = InfomainScript::c_avo901in_RunAnim;
 						GameState()->SetActorId(m_selectedCharacter);
 						break;
-					case LegoActor::c_mama:
+					case LegoActor::e_mama:
 						dialogueToPlay = InfomainScript::c_avo902in_RunAnim;
 						GameState()->SetActorId(m_selectedCharacter);
 						break;
-					case LegoActor::c_papa:
+					case LegoActor::e_papa:
 						dialogueToPlay = InfomainScript::c_avo903in_RunAnim;
 						GameState()->SetActorId(m_selectedCharacter);
 						break;
-					case LegoActor::c_nick:
+					case LegoActor::e_nick:
 						dialogueToPlay = InfomainScript::c_avo904in_RunAnim;
 						GameState()->SetActorId(m_selectedCharacter);
 						break;
-					case LegoActor::c_laura:
+					case LegoActor::e_laura:
 						dialogueToPlay = InfomainScript::c_avo905in_RunAnim;
 						GameState()->SetActorId(m_selectedCharacter);
 						break;
@@ -1043,7 +1043,7 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 					case LegoGameState::e_elevdown:
 						break;
 					default:
-						if (state->GetActorId() != LegoActor::c_none) {
+						if (state->GetActorId() != LegoActor::e_none) {
 							if (!m_infocenterState->HasRegistered()) {
 								PlayAction(InfomainScript::c_iic007in_PlayWav);
 								m_infocenterState->m_state = InfocenterState::e_notRegistered;
@@ -1335,23 +1335,23 @@ void Infocenter::UpdateFrameHot(MxBool p_display)
 		MxS32 x, y;
 
 		switch (GameState()->GetActorId()) {
-		case LegoActor::c_pepper:
+		case LegoActor::e_pepper:
 			x = 302;
 			y = 81;
 			break;
-		case LegoActor::c_mama:
+		case LegoActor::e_mama:
 			x = 204;
 			y = 81;
 			break;
-		case LegoActor::c_papa:
+		case LegoActor::e_papa:
 			x = 253;
 			y = 81;
 			break;
-		case LegoActor::c_nick:
+		case LegoActor::e_nick:
 			x = 353;
 			y = 81;
 			break;
-		case LegoActor::c_laura:
+		case LegoActor::e_laura:
 			x = 399;
 			y = 81;
 			break;
@@ -1396,9 +1396,9 @@ void Infocenter::Reset()
 	GameState()->m_savedPreviousArea = LegoGameState::e_undefined;
 
 	InitializeBitmaps();
-	m_selectedCharacter = LegoActor::c_pepper;
+	m_selectedCharacter = LegoActor::e_pepper;
 
-	GameState()->SetActor(LegoActor::c_pepper);
+	GameState()->SetActor(LegoActor::e_pepper);
 
 	HelicopterState* state = (HelicopterState*) GameState()->GetState("HelicopterState");
 

--- a/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
@@ -116,7 +116,7 @@ MxLong InfocenterDoor::HandleControl(LegoControlManagerNotificationParam& p_para
 			result = 1;
 			break;
 		case InfodoorScript::c_Door_Ctl:
-			if (GameState()->GetActorId() != LegoActor::c_none) {
+			if (GameState()->GetActorId() != LegoActor::e_none) {
 				InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
 				if (state->HasRegistered()) {
 					m_destLocation = LegoGameState::e_infocenterExited;

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -542,8 +542,8 @@ void Isle::Enable(MxBool p_enable)
 		VideoManager()->ResetPalette(FALSE);
 		m_act1state->PlaceActors();
 
-		if (UserActor() != NULL && UserActor()->GetActorId() != LegoActor::c_none) {
-			IsleScript::Script noPizzaSign = UserActor()->GetActorId() == LegoActor::c_pepper
+		if (UserActor() != NULL && UserActor()->GetActorId() != LegoActor::e_none) {
+			IsleScript::Script noPizzaSign = UserActor()->GetActorId() == LegoActor::e_pepper
 												 ? IsleScript::c_NoPizaz_Texture
 												 : IsleScript::c_NoPizza_Texture;
 

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -484,7 +484,7 @@ void LegoAct2::ReadyWorld()
 	m_ready = TRUE;
 	m_siFile = VariableTable()->GetVariable("ACT2_ANIMS_FILE");
 
-	GameState()->SetActor(LegoActor::c_pepper);
+	GameState()->SetActor(LegoActor::e_pepper);
 	m_pepper = FindROI("pepper");
 	IslePathActor* pepper = (IslePathActor*) m_pepper->GetEntity();
 	pepper->SpawnPlayer(
@@ -531,7 +531,7 @@ void LegoAct2::Enable(MxBool p_enable)
 	if (p_enable) {
 		m_gameState->m_enabled = TRUE;
 
-		GameState()->SetActor(LegoActor::c_pepper);
+		GameState()->SetActor(LegoActor::e_pepper);
 		m_pepper = FindROI("pepper");
 
 		((IslePathActor*) m_pepper->GetEntity())->UpdateWorld(m_transformOnDisable, m_boundaryOnDisable, TRUE);

--- a/LEGO1/lego/legoomni/src/worlds/police.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/police.cpp
@@ -227,11 +227,11 @@ void PoliceState::StartAnimation()
 	}
 
 	switch (UserActor()->GetActorId()) {
-	case LegoActor::c_nick:
+	case LegoActor::e_nick:
 		policeScript = PoliceScript::c_nps002la_RunAnim;
 		m_policeScript = policeScript;
 		break;
-	case LegoActor::c_laura:
+	case LegoActor::e_laura:
 		policeScript = PoliceScript::c_nps001ni_RunAnim;
 		m_policeScript = policeScript;
 		break;


### PR DESCRIPTION
`c_pepper`, `c_mama`, `c_papa`, `c_nick`, `c_laura`, `c_brickster` and `c_none` become `e_pepper` and so on, as in the 1997 source: BETA10's assert text contains `p_id != LegoActor::e_none`, which fixes the prefix for this enum. The other six names follow that prefix but are not individually attested. Every use is renamed; nothing else changes.

Part of a stacked series that makes the build of LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte-identical to the retail binaries. CI on this PR checks that everything still builds and passes the usual lints; the last PR in the series proves the byte-identical result.
