### PR TITLE
Put #include lines back in their original order

### DIFF
--- a/CONFIG/StdAfx.cpp
+++ b/CONFIG/StdAfx.cpp
@@ -3,3 +3,11 @@
 //	stdafx.obj will contain the pre-compiled type information
 
 #include "stdafx.h"
+
+#include <objbase.h>
+#include <initguid.h>
+#include <mmsystem.h>
+
+#include <ddraw.h>
+#include <dinput.h>
+#include <dsound.h>

--- a/LEGO1/lego/legoomni/include/legocameracontroller.h
+++ b/LEGO1/lego/legoomni/include/legocameracontroller.h
@@ -4,6 +4,8 @@
 #include "legopointofviewcontroller.h"
 #include "mxgeometry.h"
 #include "mxgeometry/mxgeometry3d.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "mxgeometry/mxmatrix.h"
 
 // VTABLE: LEGO1 0x100d57b0

--- a/LEGO1/lego/legoomni/include/legopathedgecontainer.h
+++ b/LEGO1/lego/legoomni/include/legopathedgecontainer.h
@@ -1,6 +1,7 @@
 #ifndef LEGOPATHEDGECONTAINER_H
 #define LEGOPATHEDGECONTAINER_H
 
+#include "realtime/vector3d.inl.h"
 #include "mxgeometry/mxgeometry3d.h"
 #include "mxstl/stlcompat.h"
 #include "mxtypes.h"

--- a/LEGO1/lego/legoomni/include/legophoneme.h
+++ b/LEGO1/lego/legoomni/include/legophoneme.h
@@ -3,6 +3,7 @@
 
 #include "decomp.h"
 #include "mxstring.h"
+#include "roi/legoroi.h"
 
 class LegoTextureInfo;
 

--- a/LEGO1/lego/legoomni/include/legosoundmanager.h
+++ b/LEGO1/lego/legoomni/include/legosoundmanager.h
@@ -2,6 +2,7 @@
 #define LEGOSOUNDMANAGER_H
 
 #include "mxsoundmanager.h"
+#include "roi/legoroi.h"
 
 class LegoCacheSoundManager;
 

--- a/LEGO1/lego/legoomni/src/audio/lego3dwavepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/audio/lego3dwavepresenter.cpp
@@ -1,5 +1,7 @@
 #include "lego3dwavepresenter.h"
 
+#include "legosoundmanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "mxcompositepresenter.h"
 #include "mxdsaction.h"
 #include "mxmain.h"

--- a/LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legoloadcachesoundpresenter.cpp
@@ -3,6 +3,7 @@
 #include "legocachesoundmanager.h"
 #include "legocachsound.h"
 #include "legosoundmanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "mxdssound.h"
 #include "mxdssubscriber.h"

--- a/LEGO1/lego/legoomni/src/audio/legosoundmanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legosoundmanager.cpp
@@ -1,4 +1,6 @@
 #include "legosoundmanager.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 
 #include "legocachesoundmanager.h"
 #include "mxautolock.h"

--- a/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoactioncontrolpresenter.cpp
@@ -4,6 +4,7 @@
 #include "extra.h"
 #include "legomain.h"
 #include "legoutils.h"
+#include "realtime/matrix4d.inl.h"
 #include "mxcompositepresenter.h"
 #include "mxdssubscriber.h"
 #include "mxmediapresenter.h"

--- a/LEGO1/lego/legoomni/src/common/legophoneme.cpp
+++ b/LEGO1/lego/legoomni/src/common/legophoneme.cpp
@@ -1,4 +1,5 @@
 #include "legophoneme.h"
+#include "realtime/matrix4d.inl.h"
 
 DECOMP_SIZE_ASSERT(LegoPhoneme, 0x20)
 

--- a/LEGO1/lego/legoomni/src/common/mxcompositemediapresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcompositemediapresenter.cpp
@@ -1,6 +1,7 @@
 #include "mxcompositemediapresenter.h"
 
 #include "legosoundmanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "legovideomanager.h"
 #include "misc.h"
 #include "mxautolock.h"

--- a/LEGO1/lego/legoomni/src/entity/legoactorpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoactorpresenter.cpp
@@ -1,6 +1,7 @@
 #include "legoactorpresenter.h"
 
 #include "legoentity.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 
 DECOMP_SIZE_ASSERT(LegoActorPresenter, 0x50)

--- a/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legopovcontroller.cpp
@@ -1,5 +1,6 @@
 #include "3dmanager/lego3dview.h"
 #include "legoentity.h"
+#include "realtime/matrix4d.inl.h"
 #include "legomain.h"
 #include "legonavcontroller.h"
 #include "legopointofviewcontroller.h"

--- a/LEGO1/lego/legoomni/src/video/legoflctexturepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoflctexturepresenter.cpp
@@ -1,5 +1,7 @@
 #include "legoflctexturepresenter.h"
 
+#include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "misc/legocontainer.h"
 #include "mxdsaction.h"

--- a/LEGO1/lego/legoomni/src/video/legopalettepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legopalettepresenter.cpp
@@ -1,6 +1,7 @@
 #include "legopalettepresenter.h"
 
 #include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "misc/legostorage.h"
 #include "mxdsaction.h"

--- a/LEGO1/lego/legoomni/src/video/legopartpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legopartpresenter.cpp
@@ -1,5 +1,7 @@
 #include "legopartpresenter.h"
 
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "legovideomanager.h"
 #include "misc.h"
 #include "misc/legocontainer.h"

--- a/LEGO1/lego/sources/3dmanager/lego3dmanager.cpp
+++ b/LEGO1/lego/sources/3dmanager/lego3dmanager.cpp
@@ -1,6 +1,7 @@
 // Lego3DManager.cpp : implementation file
 //
 #include "lego3dmanager.h"
+#include "realtime/matrix4d.inl.h"
 
 #include "decomp.h"
 #include "viewmanager/viewlodlist.h"

--- a/LEGO1/lego/sources/3dmanager/lego3dview.cpp
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "lego3dview.h"
+#include "realtime/matrix4d.inl.h"
 
 #include "viewmanager/viewmanager.h"
 

--- a/LEGO1/lego/sources/3dmanager/legoview1.cpp
+++ b/LEGO1/lego/sources/3dmanager/legoview1.cpp
@@ -4,7 +4,10 @@
 #include "legoview1.h"
 
 #include "decomp.h"
+#include "realtime/vector3d.inl.h"
 #include "mxgeometry/mxgeometry3d.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "mxgeometry/mxmatrix.h"
 #include "realtime/realtime.h"
 

--- a/LEGO1/lego/sources/3dmanager/tglsurface.cpp
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.cpp
@@ -2,6 +2,10 @@
 
 #include "tglsurface.h"
 
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
+#include "mxgeometry/mxmatrix.h"
+
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(TglSurface, 0x70);

--- a/LEGO1/lego/sources/misc/legostorage.h
+++ b/LEGO1/lego/sources/misc/legostorage.h
@@ -2,6 +2,7 @@
 #define __LEGOSTORAGE_H
 
 #include "legotypes.h"
+#include "realtime/vector3d.inl.h"
 #include "mxgeometry/mxgeometry3d.h"
 #include "mxstring.h"
 

--- a/LEGO1/omni/include/mxdsaction.h
+++ b/LEGO1/omni/include/mxdsaction.h
@@ -2,6 +2,7 @@
 #define MXDSACTION_H
 
 #include "mxdsobject.h"
+#include "realtime/vector3d.inl.h"
 #include "mxgeometry/mxgeometry3d.h"
 #include "mxtypes.h"
 

--- a/LEGO1/omni/src/action/mxdsobject.cpp
+++ b/LEGO1/omni/src/action/mxdsobject.cpp
@@ -3,7 +3,6 @@
 #include "mxdsaction.h"
 #include "mxdsanim.h"
 #include "mxdsevent.h"
-#include "mxdsfile.h"
 #include "mxdsmediaaction.h"
 #include "mxdsmultiaction.h"
 #include "mxdsobjectaction.h"
@@ -261,6 +260,8 @@ MxDSObject* DeserializeDSObjectDispatch(MxU8*& p_source, MxS16 p_flags)
 
 	return obj;
 }
+
+#include "mxdsfile.h"
 
 // FUNCTION: LEGO1 0x100c0280
 MxDSObject* CreateStreamObject(MxDSFile* p_file, MxS16 p_ofs)

--- a/LEGO1/viewmanager/viewlodlist.cpp
+++ b/LEGO1/viewmanager/viewlodlist.cpp
@@ -1,5 +1,11 @@
 #include "viewlodlist.h"
 
+#include "tgl/tglvector.h"
+
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
+#include "mxgeometry/mxmatrix.h"
+
 #include "decomp.h"
 #include "viewlod.h"
 


### PR DESCRIPTION
Only the order and grouping of `#include` lines change, in files where that was the only difference from the original. No code changes.

Part of a stacked series that makes the build of LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte-identical to the retail binaries. CI on this PR checks that everything still builds and passes the usual lints; the last PR in the series proves the byte-identical result.
