### PR TITLE
Match the original legoomni source: worlds, actors and races

### DIFF
--- a/LEGO1/define.cpp
+++ b/LEGO1/define.cpp
@@ -17,6 +17,10 @@ const char* g_strATTACH_CAMERA = "ATTACH_CAMERA";
 // STRING: LEGO1 0x10102018
 const char* g_strAUTO_CREATE = "AUTO_CREATE";
 
+// GLOBAL: LEGO1 0x10102058
+// STRING: LEGO1 0x10102010
+const char* g_strBANK = "BANK";
+
 // GLOBAL: LEGO1 0x1010205c
 // STRING: LEGO1 0x10102000
 const char* g_strBOTTOM_TO_TOP = "BOTTOM_TO_TOP";
@@ -36,6 +40,10 @@ const char* g_strGRID = "GRID";
 // GLOBAL: LEGO1 0x1010206c
 // STRING: LEGO1 0x10101fe0
 const char* g_strMAP = "MAP";
+
+// GLOBAL: LEGO1 0x10102070
+// STRING: LEGO1 0x10101fd8
+const char* g_strPUSH = "PUSH";
 
 // GLOBAL: LEGO1 0x10102074
 // STRING: LEGO1 0x10101fd0
@@ -60,6 +68,14 @@ const char* g_strHIDE_ON_STOP = "HIDE_ON_STOP";
 // GLOBAL: LEGO1 0x10102088
 // STRING: LEGO1 0x10101f94
 const char* g_strLEFT_TO_RIGHT = "LEFT_TO_RIGHT";
+
+// GLOBAL: LEGO1 0x1010208c
+// STRING: LEGO1 0x10101f88
+const char* g_mapLocator = "MAP_LOCATOR";
+
+// GLOBAL: LEGO1 0x10102090
+// STRING: LEGO1 0x10101f78
+const char* g_mapGeometry = "MAP_GEOMETRY";
 
 // GLOBAL: LEGO1 0x10102094
 // STRING: LEGO1 0x10101f70
@@ -133,6 +149,10 @@ const char* g_strANIMMAN_ID = "ANIMMAN_ID";
 // STRING: LEGO1 0x10101ec8
 const char* g_strCOMP = "COMP";
 
+// GLOBAL: LEGO1 0x101020dc
+// STRING: LEGO1 0x10101ebc
+const char* g_strBMP_INVIDEO = "BMP_INVIDEO";
+
 // GLOBAL: LEGO1 0x101020e0
 // STRING: LEGO1 0x10101eb0
 const char* g_strBMP_ISMAP = "BMP_ISMAP";
@@ -141,7 +161,3 @@ const char* g_strBMP_ISMAP = "BMP_ISMAP";
 // STRING: LEGO1 0x10101eac
 // GLOBAL: BETA10 0x10202948
 const char* g_parseExtraTokens = ":;";
-
-// GLOBAL: LEGO1 0x100f0c14
-// STRING: LEGO1 0x100f0c04
-const char* g_strHIT_ACTOR_SOUND = "HIT_ACTOR_SOUND";

--- a/LEGO1/define.h
+++ b/LEGO1/define.h
@@ -22,6 +22,8 @@ extern const char* g_strTRIGGERS_SOURCE;
 extern const char* g_strPTATCAM;
 extern const char* g_strTOGGLE;
 extern const char* g_strMAP;
+extern const char* g_mapLocator;
+extern const char* g_mapGeometry;
 extern const char* g_strGRID;
 extern const char* g_strSTYLE;
 extern const char* g_strTYPE;

--- a/LEGO1/lego/legoomni/include/act3.h
+++ b/LEGO1/lego/legoomni/include/act3.h
@@ -1,10 +1,11 @@
 #ifndef ACT3_H
 #define ACT3_H
 
+#include "legoworld.h"
+
 #include "act3ammo.h"
 #include "legogamestate.h"
 #include "legostate.h"
-#include "legoworld.h"
 
 class Act3Brickster;
 class Act3Cop;
@@ -194,17 +195,17 @@ protected:
 	LegoGameState::Area m_destLocation;        // 0x4270
 };
 
-// TEMPLATE: LEGO1 0x10071f10
-// list<Act3ListElement,allocator<Act3ListElement> >::insert
+// TEMPLATE: LEGO1 0x10071f10 SYMBOL
+// ?insert@?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@QAE?AViterator@1@V21@ABUAct3ListElement@@@Z
 
-// TEMPLATE: LEGO1 0x10071f70
-// list<Act3ListElement,allocator<Act3ListElement> >::_Buynode
+// TEMPLATE: LEGO1 0x10071f70 SYMBOL
+// ?_Buynode@?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x10072220
-// list<Act3ListElement,allocator<Act3ListElement> >::erase
+// TEMPLATE: LEGO1 0x10072220 SYMBOL
+// ?erase@?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10072440
-// list<Act3ListElement,allocator<Act3ListElement> >::~list<Act3ListElement,allocator<Act3ListElement> >
+// TEMPLATE: LEGO1 0x10072440 SYMBOL
+// ??1?$list@UAct3ListElement@@V?$allocator@UAct3ListElement@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x100724b0
 // List<Act3ListElement>::~List<Act3ListElement>

--- a/LEGO1/lego/legoomni/include/act3ammo.h
+++ b/LEGO1/lego/legoomni/include/act3ammo.h
@@ -28,7 +28,7 @@ public:
 	MxU32 IsValid() { return m_ammoFlag & c_valid; }
 
 	// FUNCTION: BETA10 0x100177b0
-	Mx3DPointFloat* GetCoefficients() { return m_coefficients; }
+	Mx3DPointFloat* GetCoefficients() { return m_eq; }
 
 	// FUNCTION: BETA10 0x100177e0
 	MxFloat* GetApexParameter() { return &m_apexParameter; }
@@ -94,11 +94,11 @@ private:
 
 	static Mx3DPointFloat g_hitTranslation;
 
-	MxU16 m_ammoFlag;                 // 0x154
-	MxFloat m_rotateTimeout;          // 0x158
-	Act3* m_world;                    // 0x15c
-	Mx3DPointFloat m_coefficients[3]; // 0x160
-	MxFloat m_apexParameter;          // 0x19c
+	MxU16 m_ammoFlag;        // 0x154
+	MxFloat m_rotateTimeout; // 0x158
+	Act3* m_world;           // 0x15c
+	Mx3DPointFloat m_eq[3];  // 0x160
+	MxFloat m_apexParameter; // 0x19c
 };
 
 #endif // ACT3AMMO_H

--- a/LEGO1/lego/legoomni/include/infocenter.h
+++ b/LEGO1/lego/legoomni/include/infocenter.h
@@ -31,7 +31,7 @@ public:
 		// e_9 = 9,
 		// e_10 = 10,
 		e_welcomeAnimation = 11,
-		e_exiting = 12,
+		e_quiting = 12,
 		e_playCredits = 13,
 		e_exitingToIsland = 14,
 		e_backToInfoAct1 = 15,
@@ -91,7 +91,7 @@ public:
 	Playlist m_returnDialogue[3];   // 0x20
 	Playlist m_leaveDialogue[3];    // 0x44
 	Playlist m_bricksterDialogue;   // 0x68
-	MxU32 m_state;                  // 0x74
+	MxU32 m_step;                   // 0x74
 	MxStillPresenter* m_letters[7]; // 0x78
 };
 
@@ -161,7 +161,7 @@ private:
 	void UpdateFrameHot(MxBool p_display);
 	void Reset();
 
-	void PlayCutscene(IntroScript::Script p_entityId, MxBool p_scale);
+	void PlayCutscene(IntroScript::Script p_movieId, MxBool p_scale);
 	void StopCutscene();
 
 	void UpdateEnabledGlowControl(MxS32 p_x, MxS32 p_y);
@@ -177,7 +177,7 @@ private:
 
 	InfomainScript::Script m_currentInfomainScript; // 0xf8
 	MxS16 m_selectedCharacter;                      // 0xfc
-	InfocenterState* m_infocenterState;             // 0x100
+	InfocenterState* m_state;                       // 0x100
 	LegoGameState::Area m_destLocation;             // 0x104
 	IntroScript::Script m_currentCutscene;          // 0x108
 	Radio m_radio;                                  // 0x10c

--- a/LEGO1/lego/legoomni/include/legoracers.h
+++ b/LEGO1/lego/legoomni/include/legoracers.h
@@ -1,9 +1,7 @@
 #ifndef LEGORACERS_H
 #define LEGORACERS_H
 
-// clang-format off
 #include "legoracespecial.h"
-// clang-format on
 #include "legoracemap.h"
 
 #define LEGORACECAR_NONE 0
@@ -182,7 +180,7 @@ public:
 	// LegoRaceCar::`scalar deleting destructor'
 
 private:
-	MxU8 m_kickState;         // 0x54
+	MxU8 m_userState;         // 0x54
 	float m_kickStart;        // 0x58
 	Mx3DPointFloat m_unk0x5c; // 0x5c
 

--- a/LEGO1/lego/legoomni/include/pizza.h
+++ b/LEGO1/lego/legoomni/include/pizza.h
@@ -193,9 +193,12 @@ public:
 		return !strcmp(p_name, Pizza::ClassName()) || IsleActor::IsA(p_name);
 	}
 
-	MxResult Create(MxDSAction& p_dsAction) override;                           // vtable+0x18
-	MxLong HandleClick() override;                                              // vtable+0x68
-	MxLong HandleEndAction(MxEndActionNotificationParam& p_param) override;     // vtable+0x74
+	MxResult Create(MxDSAction& p_dsAction) override;                       // vtable+0x18
+	MxLong HandleClick() override;                                          // vtable+0x68
+	MxLong HandleEndAction(MxEndActionNotificationParam& p_param) override; // vtable+0x74
+#ifdef BETA10
+	MxLong HandleButtonDown(LegoControlManagerNotificationParam& p_param) override; // vtable+0x78
+#endif
 	MxLong HandlePathStruct(LegoPathStructNotificationParam& p_param) override; // vtable+0x80
 
 	void CreateState();

--- a/LEGO1/lego/legoomni/include/registrationbook.h
+++ b/LEGO1/lego/legoomni/include/registrationbook.h
@@ -46,15 +46,13 @@ public:
 	// RegistrationBook::`scalar deleting destructor'
 
 private:
-	MxS32 m_registerDialogueTimer;    // 0xf8
-	undefined m_unk0xfc;              // 0xfc
-	undefined m_unk0xfd[3];           // 0xfd
-	MxStillPresenter* m_alphabet[26]; // 0x100
-	MxStillPresenter* m_name[10][7];  // 0x168
-	struct {
-		MxS16 m_letters[7];                // 0x00
-		MxS16 m_cursorPos;                 // 0x0e
-	} m_newName;                           // 0x280
+	MxS32 m_registerDialogueTimer;         // 0xf8
+	undefined m_unk0xfc;                   // 0xfc
+	undefined m_unk0xfd[3];                // 0xfd
+	MxStillPresenter* m_alphabet[26];      // 0x100
+	MxStillPresenter* m_name[10][7];       // 0x168
+	MxS16 m_letters[7];                    // 0x280
+	MxS16 m_cursorPos;                     // 0x28e
 	MxControlPresenter* m_checkmark[10];   // 0x290
 	undefined2 m_vehiclesToPosition;       // 0x2b8
 	InfocenterState* m_infocenterState;    // 0x2bc

--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -102,13 +102,16 @@ Act3Actor::Act3Actor()
 // FUNCTION: BETA10 0x100180ab
 MxU32 Act3Actor::StepState(float p_time, Matrix4& p_transform)
 {
+	// GLOBAL: LEGO1 0x100d75e4
+	static const float g_hitAnimationDelay = 2000.0f;
+
 	// Note: Code duplication with LegoExtraActor::StepState
 	switch (m_actorState & c_maxState) {
 	case c_initial:
 	case c_ready:
 		return TRUE;
 	case c_hit:
-		m_unk0x1c = p_time + 2000.0f;
+		m_unk0x1c = g_hitAnimationDelay + p_time;
 		m_actorState = c_hitAnimation;
 		m_actorTime += (p_time - m_transformTime) * m_worldSpeed;
 		m_transformTime = p_time;
@@ -156,9 +159,9 @@ MxResult Act3Actor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			return FAILURE;
 		}
 
+		MxMatrix local2world;
 		LegoROI* roi = p_actor->GetROI();
 
-		MxMatrix local2world;
 		local2world = roi->GetLocal2World();
 
 		Vector3(local2world[3]) += g_unk0x10104ef0;
@@ -335,6 +338,7 @@ MxResult Act3Cop::FUN_10040360()
 	Vector3 local20(local74[2]);
 
 	Mx3DPointFloat local7c;
+	float local18;
 	local7c = a3->m_brickster->GetROI()->GetLocal2World()[3];
 	local7c -= local2c;
 
@@ -364,8 +368,6 @@ MxResult Act3Cop::FUN_10040360()
 	}
 
 	if (grec == NULL) {
-		float local18;
-
 		for (MxS32 i = 0; i < MAX_DONUTS; i++) {
 			Act3Ammo* donut = &a3->m_donuts[i];
 			assert(donut);
@@ -373,7 +375,6 @@ MxResult Act3Cop::FUN_10040360()
 			if (donut->IsValid() && donut->GetActorState() == c_initial) {
 				LegoROI* proi = donut->GetROI();
 				assert(proi);
-
 				MxMatrix locald0 = proi->GetLocal2World();
 				Vector3 local88(locald0[3]);
 				Mx3DPointFloat localec(local88);
@@ -412,34 +413,34 @@ MxResult Act3Cop::FUN_10040360()
 				}
 			}
 		}
+	}
 
-		if (grec == NULL) {
-			MxS32 random = rand() % (MxS32) sizeOfArray(g_copDest);
-			Vector3 localf8(g_copDest[random].m_unk0x08);
-			Vector3 local108(g_copDest[random].m_unk0x14);
+	if (grec == NULL) {
+		MxS32 random = rand() % (MxS32) sizeOfArray(g_copDest);
+		Vector3 localf8(g_copDest[random].m_unk0x08);
+		MxFloat local100;
+		Vector3 local108(g_copDest[random].m_unk0x14);
 
-			grec = new LegoPathEdgeContainer();
-			LegoPathBoundary* boundary = g_copDest[random].m_boundary;
+		grec = new LegoPathEdgeContainer();
+		LegoPathBoundary* boundary = g_copDest[random].m_boundary;
 
-			if (boundary != NULL) {
-				MxFloat local100;
-				LegoPathEdgeContainer *local150, *local14c; // unused
+		if (boundary != NULL) {
+			LegoPathEdgeContainer *local150, *local14c; // unused
 
-				if (m_pathController->FindPath(
-						grec,
-						local2c,
-						local20,
-						m_boundary,
-						localf8,
-						local108,
-						boundary,
-						LegoOrientedEdge::c_bit1,
-						&local100
-					) != SUCCESS) {
-					local14c = local150 = grec;
-					delete grec;
-					grec = NULL;
-				}
+			if (m_pathController->FindPath(
+					grec,
+					local2c,
+					local20,
+					m_boundary,
+					localf8,
+					local108,
+					boundary,
+					LegoOrientedEdge::c_bit1,
+					&local100
+				) != SUCCESS) {
+				local14c = local150 = grec;
+				delete grec;
+				grec = NULL;
 			}
 		}
 	}
@@ -533,11 +534,11 @@ Act3Brickster::Act3Brickster()
 	m_shootAnim = NULL;
 	m_unk0x38 = 0;
 	m_unk0x20 = 0.0f;
-	m_unk0x24 = 0.0f;
 	m_unk0x54 = 0.0f;
 
 	SetActorState(c_disabled);
 	m_unk0x58 = 0;
+	m_unk0x24 = 0.0f;
 
 	m_unk0x3c.Clear();
 }
@@ -792,6 +793,7 @@ MxResult Act3Brickster::FUN_100417c0()
 	m_pInfo = NULL;
 	m_bInfo = NULL;
 	m_unk0x38 = 0;
+	MxS32 i;
 	LegoPathEdgeContainer* grec = NULL;
 	Act3* a3 = (Act3*) m_world;
 
@@ -802,7 +804,7 @@ MxResult Act3Brickster::FUN_100417c0()
 	if (m_unk0x58 < 8 && m_unk0x24 + 5000.0f < m_transformTime) {
 		float local18;
 
-		for (MxS32 i = 0; i < MAX_PIZZAS; i++) {
+		for (i = 0; i < MAX_PIZZAS; i++) {
 			Act3Ammo* pizza = &a3->m_pizzas[i];
 			assert(pizza);
 
@@ -939,9 +941,9 @@ MxResult Act3Brickster::FUN_100417c0()
 	if (grec != NULL) {
 		Mx3DPointFloat local150;
 
-		LegoPathEdgeContainer *local1c4, *local1c8; // unused
+		LegoPathEdgeContainer* local1c8; // unused
 		if (m_grec != NULL) {
-			local1c4 = local1c8 = m_grec;
+			local1c8 = m_grec;
 			delete m_grec;
 		}
 

--- a/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
@@ -15,6 +15,9 @@
 
 DECOMP_SIZE_ASSERT(Act3Ammo, 0x1a0)
 
+// GLOBAL: LEGO1 0x100d841c
+static const float g_hitAnimationDelay = 2000.0f;
+
 // Initialized at LEGO1 0x100537c0
 // GLOBAL: LEGO1 0x10104f08
 Mx3DPointFloat Act3Ammo::g_hitTranslation = Mx3DPointFloat(0.0, 5.0, 0.0);
@@ -125,24 +128,24 @@ MxResult Act3Ammo::CalculateArc(const Vector3& p_srcLoc, const Vector3& p_srcDir
 	negNormalUp[0] = negNormalUp[2] = 0.0f;
 	negNormalUp[1] = -1.0f;
 
-	m_coefficients[1] = p_srcUp;
-	m_coefficients[2] = p_srcLoc;
+	m_eq[1] = p_srcUp;
+	m_eq[2] = p_srcLoc;
 
 	Mx3DPointFloat upRelative(negNormalUp);
-	upRelative -= m_coefficients[1];
+	upRelative -= m_eq[1];
 
 	for (MxS32 i = 0; i < 3; i++) {
 		if (groundPoint[0] == p_srcLoc[0]) {
 			return FAILURE;
 		}
 
-		m_coefficients[0][i] = (upRelative[i] * upRelative[i] + upRelative[i] * m_coefficients[1][i] * 2.0f) /
-							   ((groundPoint[i] - p_srcLoc[i]) * 4.0f);
+		m_eq[0][i] = (upRelative[i] * upRelative[i] + upRelative[i] * m_eq[1][i] * 2.0f) /
+					 ((groundPoint[i] - p_srcLoc[i]) * 4.0f);
 	}
 
-	assert(m_coefficients[0][0] > 0.000001 || m_coefficients[0][0] < -0.000001);
+	assert(m_eq[0][0] > 0.000001 || m_eq[0][0] < -0.000001);
 
-	m_apexParameter = upRelative[0] / (m_coefficients[0][0] * 2.0f);
+	m_apexParameter = upRelative[0] / (m_eq[0][0] * 2.0f);
 	return SUCCESS;
 }
 
@@ -211,16 +214,16 @@ MxResult Act3Ammo::CalculateTransformOnCurve(float p_curveParameter, Matrix4& p_
 	Vector3 pos(p_transform[3]);
 	Mx3DPointFloat sndCoeff;
 
-	sndCoeff = m_coefficients[1];
+	sndCoeff = m_eq[1];
 	sndCoeff *= p_curveParameter;
-	pos = m_coefficients[0];
+	pos = m_eq[0];
 	pos *= curveParameterSquare;
 	pos += sndCoeff;
-	pos += m_coefficients[2];
-	dir = m_coefficients[0];
+	pos += m_eq[2];
+	dir = m_eq[0];
 	dir *= 2.0f;
 	dir *= p_curveParameter;
-	dir += m_coefficients[1];
+	dir += m_eq[1];
 	dir *= -1.0f;
 
 	if (dir.Unitize() != 0) {
@@ -258,7 +261,7 @@ void Act3Ammo::Animate(float p_time)
 	case c_ready:
 		break;
 	case c_hit:
-		m_rotateTimeout = p_time + 2000.0f;
+		m_rotateTimeout = g_hitAnimationDelay + p_time;
 		m_actorState = c_hitAnimation;
 		return;
 	case c_hitAnimation:
@@ -298,6 +301,7 @@ void Act3Ammo::Animate(float p_time)
 		m_traveledDistance = 0.0f;
 	}
 
+	float radius;
 	MxMatrix transform;
 	MxMatrix additionalTransform;
 
@@ -309,8 +313,10 @@ void Act3Ammo::Animate(float p_time)
 	MxU32 reachedTarget = FALSE;
 
 	if (f >= p_time) {
-		m_actorTime = (p_time - m_transformTime) * m_worldSpeed + m_actorTime;
-		m_traveledDistance = (p_time - m_transformTime) * m_worldSpeed + m_traveledDistance;
+		float delta = p_time - m_transformTime;
+
+		m_actorTime = delta * m_worldSpeed + m_actorTime;
+		m_traveledDistance = delta * m_worldSpeed + m_traveledDistance;
 		m_transformTime = p_time;
 	}
 	else {
@@ -423,7 +429,7 @@ void Act3Ammo::Animate(float p_time)
 
 				distance -= otherPosition;
 
-				float radius = r->GetWorldBoundingSphere().Radius();
+				radius = r->GetWorldBoundingSphere().Radius();
 				if (distance.LenSquared() <= radius * radius) {
 					MxS32 index = -1;
 					if (sscanf(r->GetName(), "pammo%d", &index) != 1) {

--- a/LEGO1/lego/legoomni/src/actors/ambulance.cpp
+++ b/LEGO1/lego/legoomni/src/actors/ambulance.cpp
@@ -23,11 +23,21 @@
 #include "mxvariabletable.h"
 #include "scripts.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(Ambulance, 0x184)
 DECOMP_SIZE_ASSERT(AmbulanceMissionState, 0x24)
 
 // Flags used in isle.cpp
 extern MxU32 g_isleFlags;
+
+// GLOBAL: LEGO1 0x100f39b8
+// STRING: LEGO1 0x100f39ac
+const char* g_varAMBULSPEED = "ambulSPEED";
+
+// GLOBAL: LEGO1 0x100f39bc
+// STRING: LEGO1 0x100f39a0
+const char* g_varAMBULFUEL = "ambulFUEL";
 
 // FUNCTION: LEGO1 0x10035ee0
 // FUNCTION: BETA10 0x10022820
@@ -367,6 +377,8 @@ MxLong Ambulance::HandleClick()
 	if (((Act1State*) GameState()->GetState("Act1State"))->m_state != Act1State::e_ambulance) {
 		return 1;
 	}
+
+	assert(m_state);
 
 	if (m_state->m_state == AmbulanceMissionState::e_prepareAmbulance) {
 		return 1;

--- a/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
+++ b/LEGO1/lego/legoomni/src/actors/bumpbouy.cpp
@@ -33,9 +33,9 @@ BumpBouy::~BumpBouy()
 MxLong BumpBouy::Notify(MxParam& p_param)
 {
 	MxLong result = 0;
+	IslePathActor* user = (IslePathActor*) UserActor();
 	MxNotificationParam& param = (MxNotificationParam&) p_param;
 
-	IslePathActor* user = (IslePathActor*) UserActor();
 	assert(user);
 
 	if (user->IsA("Jetski") && param.GetNotification() == c_notificationClick) {

--- a/LEGO1/lego/legoomni/src/actors/doors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/doors.cpp
@@ -12,15 +12,15 @@ DECOMP_SIZE_ASSERT(Doors, 0x1f8)
 
 // GLOBAL: LEGO1 0x100d8e7c
 // GLOBAL: BETA10 0x101b954c
-MxFloat g_timeMoving = 1000.0f;
+const MxFloat g_timeMoving = 1000.0f;
 
 // GLOBAL: LEGO1 0x100d8e80
 // GLOBAL: BETA10 0x101b9550
-MxFloat g_timeOpened = 4000.0f;
+const MxFloat g_timeOpened = 4000.0f;
 
 // GLOBAL: LEGO1 0x100d8e84
 // GLOBAL: BETA10 0x101b9554
-MxFloat g_totalTime = 6000.0f; // = g_timeMoving + g_totalTime + g_timeMoving
+const MxFloat g_totalTime = 6000.0f; // = g_timeMoving + g_totalTime + g_timeMoving
 
 // FUNCTION: LEGO1 0x10066100
 // FUNCTION: BETA10 0x10026850

--- a/LEGO1/lego/legoomni/src/actors/dunebuggy.cpp
+++ b/LEGO1/lego/legoomni/src/actors/dunebuggy.cpp
@@ -20,9 +20,20 @@
 
 DECOMP_SIZE_ASSERT(DuneBuggy, 0x16c)
 
+// GLOBAL: LEGO1 0x100f7658
+// STRING: LEGO1 0x100f764c
+const char* g_varDUNESPEED = "duneSPEED";
+
+// GLOBAL: LEGO1 0x100f765c
+// STRING: LEGO1 0x100f7640
+const char* g_varDUNEFUEL = "duneFUEL";
+
 // GLOBAL: LEGO1 0x100f7660
 // STRING: LEGO1 0x100f7634
 const char* g_varDBFRFNY4 = "C_DBFRFNY4";
+
+// GLOBAL: LEGO1 0x100f7664
+undefined4 g_unk0x100f7664 = 0;
 
 // FUNCTION: LEGO1 0x10067bb0
 DuneBuggy::DuneBuggy()

--- a/LEGO1/lego/legoomni/src/actors/helicopter.cpp
+++ b/LEGO1/lego/legoomni/src/actors/helicopter.cpp
@@ -415,8 +415,8 @@ void Helicopter::Animate(float p_time)
 
 			MxMatrix mat;
 			Vector3 v1(m_unk0x160[3]);
-			Vector3 v2(mat[3]);
 			Vector3 v3(m_unk0x1a8[3]);
+			Vector3 v2(mat[3]);
 
 			mat.SetIdentity();
 			m_unk0x1f4.InterpolateToMatrix(mat, f2);

--- a/LEGO1/lego/legoomni/src/actors/jetski.cpp
+++ b/LEGO1/lego/legoomni/src/actors/jetski.cpp
@@ -18,6 +18,14 @@
 
 DECOMP_SIZE_ASSERT(Jetski, 0x164)
 
+// GLOBAL: LEGO1 0x100f7ab0
+// STRING: LEGO1 0x100f09c0
+const char* g_varJETSPEED = "jetSPEED";
+
+// GLOBAL: LEGO1 0x100f7ab4
+// STRING: LEGO1 0x100f7aa8
+const char* g_varJETFUEL = "jetFUEL";
+
 // These two have been changed between BETA10 and LEGO1
 // GLOBAL: LEGO1 0x100f7ab8
 // STRING: LEGO1 0x100f3ce0

--- a/LEGO1/lego/legoomni/src/actors/motorcycle.cpp
+++ b/LEGO1/lego/legoomni/src/actors/motorcycle.cpp
@@ -18,6 +18,14 @@
 
 DECOMP_SIZE_ASSERT(Motocycle, 0x16c)
 
+// GLOBAL: LEGO1 0x100f3994
+// STRING: LEGO1 0x100f3988
+const char* g_varMOTOSPEED = "motoSPEED";
+
+// GLOBAL: LEGO1 0x100f3998
+// STRING: LEGO1 0x100f397c
+const char* g_varMOTOFUEL = "motoFUEL";
+
 // FUNCTION: LEGO1 0x100357b0
 Motocycle::Motocycle()
 {

--- a/LEGO1/lego/legoomni/src/actors/pizza.cpp
+++ b/LEGO1/lego/legoomni/src/actors/pizza.cpp
@@ -22,12 +22,24 @@
 #include "skateboard.h"
 #include "sndanim_actions.h"
 
+#include <assert.h>
+
+#ifdef BETA10
+#include "legocontrolmanager.h"
+#endif
+
 DECOMP_SIZE_ASSERT(Pizza, 0x9c)
 DECOMP_SIZE_ASSERT(PizzaMissionState, 0xb4)
 DECOMP_SIZE_ASSERT(PizzaMissionState::Mission, 0x20)
 
 // Flags used in isle.cpp
 extern MxU32 g_isleFlags;
+
+// GLOBAL: LEGO1 0x100f3a78
+// GLOBAL: BETA10 0x101f92a0
+// STRING: LEGO1 0x100f3840
+// STRING: BETA10 0x101f9410
+const char* g_pizPie = "pizpie";
 
 // GLOBAL: LEGO1 0x100f3a80
 IsleScript::Script PizzaMissionState::g_pepperActions[] = {
@@ -222,12 +234,13 @@ void Pizza::Reset()
 // FUNCTION: LEGO1 0x10038380
 void Pizza::StopActions()
 {
+	MxS32 i;
 	InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_pns050p1_RunAnim, NULL);
 	InvokeAction(Extra::e_stop, *g_isleScript, IsleScript::c_wns050p1_RunAnim, NULL);
 
-	PizzaMissionState::Mission* mission = m_mission;
-	if (mission != NULL) {
-		for (MxS32 i = 0; i < mission->m_numActions; i++) {
+	if (m_mission != NULL) {
+		PizzaMissionState::Mission* mission = m_mission;
+		for (i = 0; i < mission->m_numActions; i++) {
 			InvokeAction(Extra::e_stop, *g_isleScript, mission->GetActions()[i], NULL);
 		}
 	}
@@ -305,6 +318,7 @@ MxLong Pizza::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			(p_param.GetData() == 0x0b && GameState()->GetActorId() == LegoActor::e_laura)
 		)) || (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint && p_param.GetData() == 0x169 && GameState()->GetActorId() == LegoActor::e_nick)) {
 			IsleScript::Script action;
+			assert(m_mission);
 
 			if (time < m_mission->GetRedFinishTime()) {
 				action = m_mission->GetRedFinishAction();
@@ -369,6 +383,30 @@ MxLong Pizza::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 
 	return 0;
 }
+
+#ifdef BETA10
+// FUNCTION: BETA10 0x100ee1f8
+MxLong Pizza::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
+{
+	assert(m_mission);
+
+	if (m_state->m_state == PizzaMissionState::e_introduction ||
+		m_state->m_state == PizzaMissionState::e_transitionToAct2) {
+		AnimationManager()->FUN_10061010(FALSE);
+	}
+
+	LegoROI* roi = PickROI(p_param.GetX(), p_param.GetY());
+
+	if (roi == NULL || strcmpi(roi->GetName(), g_pizPie) != 0) {
+		if (m_state->m_state == PizzaMissionState::e_introduction) {
+			Reset();
+			return 1;
+		}
+	}
+
+	return 0;
+}
+#endif
 
 // FUNCTION: LEGO1 0x100388a0
 // FUNCTION: BETA10 0x100ee2d9
@@ -601,6 +639,7 @@ PizzaMissionState::PizzaMissionState()
 	m_missions[3] = Mission(LegoActor::e_nick, 2, g_nickFinishTimes, g_nickActions, 4);
 	m_missions[4] = Mission(LegoActor::e_laura, 2, g_lauraFinishTimes, g_lauraActions, 4);
 	m_pizzeriaState = (PizzeriaState*) GameState()->GetState("PizzeriaState");
+	assert(m_pizzeriaState);
 	m_playedAction = IsleScript::c_noneIsle;
 }
 

--- a/LEGO1/lego/legoomni/src/actors/pizzeria.cpp
+++ b/LEGO1/lego/legoomni/src/actors/pizzeria.cpp
@@ -94,7 +94,9 @@ PizzeriaState::PizzeriaState()
 	m_playerPlaylists[2] = Playlist((MxU32*) g_papaActions, sizeOfArray(g_papaActions), Playlist::e_once);
 	m_playerPlaylists[3] = Playlist((MxU32*) g_nickActions, sizeOfArray(g_nickActions), Playlist::e_once);
 	m_playerPlaylists[4] = Playlist((MxU32*) g_lauraActions, sizeOfArray(g_lauraActions), Playlist::e_once);
-	memset(m_states, -1, sizeof(m_states));
+	for (MxS32 i = 0; i < 5; i++) {
+		m_states[i] = -1;
+	}
 }
 
 // FUNCTION: LEGO1 0x10017d50

--- a/LEGO1/lego/legoomni/src/actors/towtrack.cpp
+++ b/LEGO1/lego/legoomni/src/actors/towtrack.cpp
@@ -26,6 +26,14 @@ DECOMP_SIZE_ASSERT(TowTrackMissionState, 0x28)
 // Flags used in isle.cpp
 extern MxU32 g_isleFlags;
 
+// GLOBAL: LEGO1 0x100f43b0
+// STRING: LEGO1 0x100f43a4
+const char* g_varTOWSPEED = "towSPEED";
+
+// GLOBAL: LEGO1 0x100f43b4
+// STRING: LEGO1 0x100f439c
+const char* g_varTOWFUEL = "towFUEL";
+
 // FUNCTION: LEGO1 0x1004c720
 TowTrack::TowTrack()
 {
@@ -145,6 +153,7 @@ MxLong TowTrack::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1004cd30
+// FUNCTION: BETA10 0x100f6f02
 MxLong TowTrack::HandleEndAnim(LegoEndAnimNotificationParam& p_param)
 {
 	return 1;
@@ -287,6 +296,7 @@ MxLong TowTrack::HandleEndAction(MxEndActionNotificationParam& p_param)
 // FUNCTION: BETA10 0x100f74c0
 MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 {
+	MxLong time;
 	MxDSAction action;
 
 	// 0x168 corresponds to the path at the gas station
@@ -298,12 +308,14 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 		return 0;
 	}
 
-	if (m_state->m_state == TowTrackMissionState::e_hookedUp &&
+	MxU32 state = m_state->m_state;
+
+	if (state == TowTrackMissionState::e_hookedUp &&
 		((p_param.GetTrigger() == LegoPathStruct::c_camAnim && (p_param.GetData() == 9 || p_param.GetData() == 8)) ||
 		 (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint && p_param.GetData() == 0x169))) {
 		m_state->m_state = TowTrackMissionState::e_none;
 
-		MxLong time = Timer()->GetTime() - m_state->m_startTime;
+		time = Timer()->GetTime() - m_state->m_startTime;
 		Leave();
 
 		if (time < 200000) {
@@ -316,7 +328,7 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 			PlayFinalAnimation(IsleScript::c_wgs097nu_RunAnim);
 		}
 	}
-	else if (m_state->m_state == TowTrackMissionState::e_started && p_param.GetTrigger() == LegoPathStruct::c_camAnim && p_param.GetData() == 0x37) {
+	else if (state == TowTrackMissionState::e_started && p_param.GetTrigger() == LegoPathStruct::c_camAnim && p_param.GetData() == 0x37) {
 		m_state->m_state = TowTrackMissionState::e_hookingUp;
 		StopActions();
 
@@ -327,7 +339,7 @@ MxLong TowTrack::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 		Leave();
 		PlayFinalAnimation(IsleScript::c_wrt060bm_RunAnim);
 	}
-	else if (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint && m_state->m_state == TowTrackMissionState::e_started) {
+	else if (p_param.GetTrigger() == LegoPathStruct::c_missionFinalWaypoint && state == TowTrackMissionState::e_started) {
 		if (p_param.GetData() == 0x15f) {
 			if (m_treeBlockageTriggered == 0) {
 				m_treeBlockageTriggered = 1;

--- a/LEGO1/lego/legoomni/src/common/legovariables.cpp
+++ b/LEGO1/lego/legoomni/src/common/legovariables.cpp
@@ -14,46 +14,6 @@ DECOMP_SIZE_ASSERT(CameraLocationVariable, 0x24)
 DECOMP_SIZE_ASSERT(CursorVariable, 0x24)
 DECOMP_SIZE_ASSERT(WhoAmIVariable, 0x24)
 
-// GLOBAL: LEGO1 0x100f7ab0
-// STRING: LEGO1 0x100f09c0
-const char* g_varJETSPEED = "jetSPEED";
-
-// GLOBAL: LEGO1 0x100f7ab4
-// STRING: LEGO1 0x100f7aa8
-const char* g_varJETFUEL = "jetFUEL";
-
-// GLOBAL: LEGO1 0x100f7658
-// STRING: LEGO1 0x100f764c
-const char* g_varDUNESPEED = "duneSPEED";
-
-// GLOBAL: LEGO1 0x100f765c
-// STRING: LEGO1 0x100f7640
-const char* g_varDUNEFUEL = "duneFUEL";
-
-// GLOBAL: LEGO1 0x100f3994
-// STRING: LEGO1 0x100f3988
-const char* g_varMOTOSPEED = "motoSPEED";
-
-// GLOBAL: LEGO1 0x100f3998
-// STRING: LEGO1 0x100f397c
-const char* g_varMOTOFUEL = "motoFUEL";
-
-// GLOBAL: LEGO1 0x100f39b8
-// STRING: LEGO1 0x100f39ac
-const char* g_varAMBULSPEED = "ambulSPEED";
-
-// GLOBAL: LEGO1 0x100f39bc
-// STRING: LEGO1 0x100f39a0
-const char* g_varAMBULFUEL = "ambulFUEL";
-
-// GLOBAL: LEGO1 0x100f43b0
-// STRING: LEGO1 0x100f43a4
-const char* g_varTOWSPEED = "towSPEED";
-
-// GLOBAL: LEGO1 0x100f43b4
-// STRING: LEGO1 0x100f439c
-const char* g_varTOWFUEL = "towFUEL";
-
 // the STRING is already declared for GLOBAL 0x101020cc
 // GLOBAL: LEGO1 0x100f3a40
 const char* g_varVISIBILITY = "VISIBILITY";
@@ -102,9 +62,11 @@ const char* g_nick = "Nick";
 // STRING: LEGO1 0x100f39e0
 const char* g_laura = "Laura";
 
+#ifdef BETA10
 // GLOBAL: BETA10 0x101f6ce4
 // STRING: BETA10 0x101f6d54
 const char* g_varDEBUG = "DEBUG";
+#endif
 
 // FUNCTION: LEGO1 0x10037d00
 // FUNCTION: BETA10 0x100d5620

--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -1730,10 +1730,10 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 			if (currentWorld != NULL) {
 				InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
 
-				if (state != NULL && state->m_state != InfocenterState::e_exitQueried && currentWorld->Escape()) {
+				if (state != NULL && state->m_step != InfocenterState::e_exitQueried && currentWorld->Escape()) {
 					BackgroundAudioManager()->Stop();
 					TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
-					state->m_state = InfocenterState::e_exitQueried;
+					state->m_step = InfocenterState::e_exitQueried;
 				}
 			}
 			break;

--- a/LEGO1/lego/legoomni/src/paths/legopathstruct.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathstruct.cpp
@@ -12,11 +12,13 @@
 #include "mxnotificationmanager.h"
 #include "scripts.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoPathStructBase, 0x0c)
 DECOMP_SIZE_ASSERT(LegoPathStruct, 0x14)
 
-// Flags used in isle.cpp
-extern MxU32 g_isleFlags;
+// GLOBAL: LEGO1 0x100f1198
+MxU32 g_isleFlags = 0x7f;
 
 // GLOBAL: LEGO1 0x100f119c
 MxBool g_triggerHandlingIgnoreDirection = FALSE;
@@ -48,18 +50,19 @@ MxBool LegoPathStruct::HandleTrigger(LegoPathActor* p_actor, MxBool p_direction,
 				PlayCamAnim(p_actor, actualDirection, p_data, TRUE);
 			}
 			break;
-		case c_waypoint: {
+		case c_waypoint:
 			p_actor->SetLastPathStruct(p_data);
 
-			LegoPathStructNotificationParam param(c_notificationPathStruct, p_actor, m_name[2], p_data);
-			p_actor->Notify(param);
+			{
+				LegoPathStructNotificationParam param(c_notificationPathStruct, p_actor, m_name[2], p_data);
+				p_actor->Notify(param);
 
-			LegoWorld* world = CurrentWorld();
-			if (world != NULL) {
-				NotificationManager()->Send(world, param);
+				LegoWorld* world = CurrentWorld();
+				if (world != NULL) {
+					NotificationManager()->Send(world, param);
+				}
 			}
 			break;
-		}
 		case c_deleteAction:
 			HandleAction(m_name, p_data, !(p_invertDirection == FALSE));
 			break;
@@ -155,6 +158,8 @@ void LegoPathStruct::PlayMusic(MxBool p_direction, MxU32 p_data)
 	MxDSAction action;
 	action.SetAtomId(*g_jukeboxScript);
 	action.SetUnknown24(-1);
+
+	assert(p_data <= sizeOfArray(triggersReff));
 
 	if (p_data <= sizeOfArray(triggersReff)) {
 		action.SetObjectId(music[triggersReff[p_data - 1][p_direction == FALSE] - 1]);

--- a/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoraceactor.cpp
@@ -11,6 +11,13 @@
 
 DECOMP_SIZE_ASSERT(LegoRaceActor, 0x180)
 
+// GLOBAL: LEGO1 0x100f0c14
+// STRING: LEGO1 0x100f0c04
+const char* g_strHIT_ACTOR_SOUND = "HIT_ACTOR_SOUND";
+
+// GLOBAL: LEGO1 0x100d5b2c
+const float g_hitAnimationTimeout = 2000.0f;
+
 // Initialized at LEGO1 0x100145a0
 // GLOBAL: LEGO1 0x10102b08
 // GLOBAL: BETA10 0x102114a8
@@ -54,7 +61,7 @@ MxU32 LegoRaceActor::StepState(float p_time, Matrix4& p_transform)
 	case c_ready:
 		return TRUE;
 	case c_hit:
-		m_unk0x08 = p_time + 2000.0f;
+		m_unk0x08 = p_time + g_hitAnimationTimeout;
 		m_actorState = c_hitAnimation;
 		m_actorTime += (p_time - m_transformTime) * m_worldSpeed;
 		m_transformTime = p_time;

--- a/LEGO1/lego/legoomni/src/race/legoracemap.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracemap.cpp
@@ -28,14 +28,6 @@ LegoRaceMap::~LegoRaceMap()
 	ControlManager()->Unregister(this);
 }
 
-// GLOBAL: LEGO1 0x1010208c
-// STRING: LEGO1 0x10101f88
-const char* g_mapLocator = "MAP_LOCATOR";
-
-// GLOBAL: LEGO1 0x10102090
-// STRING: LEGO1 0x10101f78
-const char* g_mapGeometry = "MAP_GEOMETRY";
-
 // FUNCTION: LEGO1 0x1005d310
 // FUNCTION: BETA10 0x100ca543
 void LegoRaceMap::ParseAction(char* p_extra)

--- a/LEGO1/lego/legoomni/src/race/legoracers.cpp
+++ b/LEGO1/lego/legoomni/src/race/legoracers.cpp
@@ -171,7 +171,7 @@ MxLong g_timeLastJetskiSoundPlayed = 0;
 // FUNCTION: BETA10 0x100cad10
 LegoRaceCar::LegoRaceCar()
 {
-	m_kickState = LEGORACECAR_NONE;
+	m_userState = LEGORACECAR_NONE;
 	m_skelKick1Anim = 0;
 	m_skelKick2Anim = 0;
 	m_unk0x5c.Clear();
@@ -301,11 +301,11 @@ void LegoRaceCar::KickCamera(float p_param)
 	LegoAnimActorStruct* a; // called `a` in BETA10
 	float deltaTime;
 
-	if (m_kickState == LEGORACECAR_KICK1) {
+	if (m_userState == LEGORACECAR_KICK1) {
 		a = m_skelKick1Anim;
 	}
 	else {
-		assert(m_kickState == LEGORACECAR_KICK2);
+		assert(m_userState == LEGORACECAR_KICK2);
 		a = m_skelKick2Anim;
 	}
 
@@ -314,8 +314,8 @@ void LegoRaceCar::KickCamera(float p_param)
 	if (a->GetAnimTreePtr()) {
 		deltaTime = p_param - m_kickStart;
 
-		if (a->GetDuration() <= deltaTime || deltaTime < 0.0) {
-			if (m_kickState == LEGORACECAR_KICK1) {
+		if (a->GetDuration() <= deltaTime || deltaTime < 0.0f) {
+			if (m_userState == LEGORACECAR_KICK1) {
 				LegoOrientedEdge** edges = m_kick1B->GetEdges();
 				m_destEdge = edges[2];
 				m_boundary = m_kick1B;
@@ -326,7 +326,7 @@ void LegoRaceCar::KickCamera(float p_param)
 				m_boundary = m_kick2B;
 			}
 
-			m_kickState = LEGORACECAR_NONE;
+			m_userState = LEGORACECAR_NONE;
 		}
 		else if (a->GetAnimTreePtr()->GetCamAnim()) {
 			MxMatrix transformationMatrix;
@@ -370,12 +370,12 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 	for (MxS32 i = 0; i < sizeOfArray(g_skeletonKickPhases); i++) {
 		if (m_boundary == current->m_edgeRef->m_b && current->m_lower <= skeletonCurAnimPhase &&
 			skeletonCurAnimPhase <= current->m_upper) {
-			m_kickState = current->m_kickState;
+			m_userState = current->m_kickState;
 		}
 		current = &current[1];
 	}
 
-	if (m_kickState != LEGORACECAR_KICK1 && m_kickState != LEGORACECAR_KICK2) {
+	if (m_userState != LEGORACECAR_KICK1 && m_userState != LEGORACECAR_KICK2) {
 		MxTrace(
 			// STRING: BETA10 0x101f64c8
 			"Got kicked in boundary %s %d %g:%g %g\n",
@@ -397,14 +397,14 @@ MxU32 LegoRaceCar::HandleSkeletonKicks(float p_param1)
 // FUNCTION: BETA10 0x100cb88a
 void LegoRaceCar::Animate(float p_time)
 {
-	if (m_userNavFlag && (m_kickState == LEGORACECAR_KICK1 || m_kickState == LEGORACECAR_KICK2)) {
+	if (m_userNavFlag && (m_userState == LEGORACECAR_KICK1 || m_userState == LEGORACECAR_KICK2)) {
 		KickCamera(p_time);
 		return;
 	}
 
 	LegoCarRaceActor::Animate(p_time);
 
-	if (m_userNavFlag && m_kickState == LEGORACECAR_NEAR_SKELETON) {
+	if (m_userNavFlag && m_userState == LEGORACECAR_NEAR_SKELETON) {
 		if (HandleSkeletonKicks(p_time)) {
 			return;
 		}
@@ -549,13 +549,13 @@ MxResult LegoRaceCar::CalculateSpline()
 				}
 			}
 
-			if (m_kickState == LEGORACECAR_NEAR_SKELETON) {
+			if (m_userState == LEGORACECAR_NEAR_SKELETON) {
 				if (!onSkeletonBoundary) {
-					m_kickState = LEGORACECAR_NONE;
+					m_userState = LEGORACECAR_NONE;
 				}
 			}
 			else {
-				m_kickState = LEGORACECAR_NEAR_SKELETON;
+				m_userState = LEGORACECAR_NEAR_SKELETON;
 			}
 		}
 	}

--- a/LEGO1/lego/legoomni/src/worlds/act3.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/act3.cpp
@@ -31,7 +31,7 @@ DECOMP_SIZE_ASSERT(Act3ListElement, 0x0c)
 DECOMP_SIZE_ASSERT(Act3List, 0x10)
 
 // GLOBAL: LEGO1 0x100d94f8
-Act3Script::Script g_pizzaHitSounds[] = {
+const Act3Script::Script g_pizzaHitSounds[] = {
 	Act3Script::c_sns02xni_PlayWav,
 	Act3Script::c_sns03xni_PlayWav,
 	Act3Script::c_sns04xni_PlayWav,
@@ -51,7 +51,7 @@ Act3Script::Script g_pizzaHitSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9538
-Act3Script::Script g_pizzaMissSounds[] = {
+const Act3Script::Script g_pizzaMissSounds[] = {
 	Act3Script::c_sns19xni_PlayWav,
 	Act3Script::c_sns20xni_PlayWav,
 	Act3Script::c_sns22xni_PlayWav,
@@ -61,7 +61,7 @@ Act3Script::Script g_pizzaMissSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9550
-Act3Script::Script g_copDonutSounds[] = {
+const Act3Script::Script g_copDonutSounds[] = {
 	Act3Script::c_sns25xni_PlayWav,
 	Act3Script::c_sns26xni_PlayWav,
 	Act3Script::c_sns27xni_PlayWav,
@@ -73,7 +73,7 @@ Act3Script::Script g_copDonutSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9570
-Act3Script::Script g_donutMissSounds[] = {
+const Act3Script::Script g_donutMissSounds[] = {
 	Act3Script::c_sns30xni_PlayWav,
 	Act3Script::c_sns31xni_PlayWav,
 	Act3Script::c_sns32xni_PlayWav,
@@ -83,7 +83,7 @@ Act3Script::Script g_donutMissSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d9588
-Act3Script::Script g_islanderSounds[] = {
+const Act3Script::Script g_islanderSounds[] = {
 	Act3Script::c_sns43xma_PlayWav, Act3Script::c_sns46xin_PlayWav, Act3Script::c_sns60xna_PlayWav,
 	Act3Script::c_sns52xro_PlayWav, Act3Script::c_sns58xna_PlayWav, Act3Script::c_sns68xbu_PlayWav,
 	Act3Script::c_sns59xna_PlayWav, Act3Script::c_sns51xin_PlayWav, Act3Script::c_sns61xva_PlayWav,
@@ -94,7 +94,7 @@ Act3Script::Script g_islanderSounds[] = {
 };
 
 // GLOBAL: LEGO1 0x100d95d8
-Act3Script::Script g_bricksterDonutSounds[] = {
+const Act3Script::Script g_bricksterDonutSounds[] = {
 	Act3Script::c_tns080br_PlayWav,
 	Act3Script::c_tnsx07br_PlayWav,
 	Act3Script::c_snsxx2br_PlayWav,
@@ -105,7 +105,7 @@ Act3Script::Script g_bricksterDonutSounds[] = {
 MxU8 g_copSelector = 0;
 
 // GLOBAL: LEGO1 0x100d95e8
-Act3Script::Script g_explanationAnimations[] =
+const Act3Script::Script g_explanationAnimations[] =
 	{Act3Script::c_tlp053in_RunAnim, Act3Script::c_tlp064la_RunAnim, Act3Script::c_tlp068in_RunAnim};
 
 // FUNCTION: LEGO1 0x10071d40
@@ -176,15 +176,18 @@ void Act3List::Clear()
 // FUNCTION: LEGO1 0x100720d0
 void Act3List::RemoveByObjectIdOrFirst(MxU32 p_objectId)
 {
+	MxU32 removed;
+
 	if (m_cleared) {
 		return;
 	}
+	removed = FALSE;
 
-	MxU32 removed = FALSE;
 	Act3List::iterator it;
 	// This iterator appears to be unnecessary - maybe left in by accident, or it was used for assertions.
 	// Removing it decreases the match percentage.
 	Act3List::iterator unusedIterator;
+	Act3List::iterator first;
 
 	if (empty()) {
 		return;
@@ -208,9 +211,10 @@ void Act3List::RemoveByObjectIdOrFirst(MxU32 p_objectId)
 	}
 
 	if (removed && size() > 0) {
-		it = begin();
-		unusedIterator = it;
-		Act3ListElement& firstItem = front();
+		first = begin();
+		it = first;
+		unusedIterator = first;
+		Act3ListElement& firstItem = *first;
 		it++;
 
 		while (it != end()) {
@@ -420,7 +424,7 @@ MxResult Act3::ShootDonut(LegoPathController* p_controller, Vector3& p_location,
 void Act3::TriggerHitSound(undefined4 p_param1)
 {
 	float time = Timer()->GetTime();
-	Act3Script::Script objectId;
+	MxS32 objectId;
 
 	switch (p_param1) {
 	case 1: {
@@ -633,6 +637,7 @@ MxLong Act3::Notify(MxParam& p_param)
 		}
 		case c_notificationKeyPress:
 			if (m_state->m_state == Act3State::e_ready && ((LegoEventNotificationParam&) p_param).GetKey() == ' ') {
+				assert(AnimationManager());
 				AnimationManager()->FUN_10061010(FALSE);
 				return 1;
 			}
@@ -897,6 +902,8 @@ void Act3::DisableHelicopterDot()
 // FUNCTION: LEGO1 0x10073a90
 void Act3::Enable(MxBool p_enable)
 {
+	MxS32 i;
+
 	if ((MxBool) m_disabledObjects.empty() == p_enable) {
 		return;
 	}
@@ -904,6 +911,8 @@ void Act3::Enable(MxBool p_enable)
 	LegoWorld::Enable(p_enable);
 
 	if (p_enable) {
+		MxS32 j;
+
 		if (GameState()->m_previousArea == LegoGameState::e_infomain) {
 			GameState()->StopArea(LegoGameState::e_infomain);
 		}
@@ -940,7 +949,6 @@ void Act3::Enable(MxBool p_enable)
 			m_shark->SetActorTime(m_shark->GetActorTime() + delta);
 			m_shark->SetUnknown0x2c(m_shark->GetUnknown0x2c() + delta);
 
-			MxS32 i;
 			for (i = 0; i < (MxS32) sizeOfArray(m_pizzas); i++) {
 				if (m_pizzas[i].IsValid()) {
 					m_pizzas[i].SetTransformTime(m_pizzas[i].GetTransformTime() + delta);
@@ -949,11 +957,11 @@ void Act3::Enable(MxBool p_enable)
 				}
 			}
 
-			for (i = 0; i < (MxS32) sizeOfArray(m_donuts); i++) {
-				if (m_donuts[i].IsValid()) {
-					m_donuts[i].SetTransformTime(m_donuts[i].GetTransformTime() + delta);
-					m_donuts[i].SetActorTime(m_donuts[i].GetActorTime() + delta);
-					m_donuts[i].SetRotateTimeout(m_donuts[i].GetRotateTimeout() + delta);
+			for (j = 0; j < MAX_DONUTS; j++) {
+				if (m_donuts[j].IsValid()) {
+					m_donuts[j].SetTransformTime(m_donuts[j].GetTransformTime() + delta);
+					m_donuts[j].SetActorTime(m_donuts[j].GetActorTime() + delta);
+					m_donuts[j].SetRotateTimeout(m_donuts[j].GetRotateTimeout() + delta);
 				}
 			}
 

--- a/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/gasstation.cpp
@@ -22,6 +22,8 @@
 #include "radio.h"
 #include "scripts.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(GasStation, 0x128)
 DECOMP_SIZE_ASSERT(GasStationState, 0x24)
 
@@ -328,6 +330,7 @@ MxLong GasStation::HandleEndAction(MxEndActionNotificationParam& p_param)
 				break;
 			case GasStationState::e_afterAcceptingQuest:
 				m_state->m_state = GasStationState::e_beforeExitingForQuest;
+				assert(GameState()->GetState("Act1State"));
 				((Act1State*) GameState()->GetState("Act1State"))->m_state = Act1State::e_transitionToTowtrack;
 				m_destLocation = LegoGameState::e_garageExited;
 				m_radio.Stop();

--- a/LEGO1/lego/legoomni/src/worlds/historybook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/historybook.cpp
@@ -51,6 +51,7 @@ HistoryBook::~HistoryBook()
 }
 
 // FUNCTION: LEGO1 0x10082610
+// FUNCTION: BETA10 0x1002b80f
 MxResult HistoryBook::Create(MxDSAction& p_dsAction)
 {
 	MxResult result = LegoWorld::Create(p_dsAction);
@@ -133,8 +134,9 @@ void HistoryBook::ReadyWorld()
 		}
 
 		for (MxS32 scoreState = 0, scoreboxX = 1; scoreState < 5; scoreState++, scoreboxX += 5) {
+			MxU8 color;
 			for (MxS32 scoreBoxColumn = 0, scoreboxY = 1; scoreBoxColumn < 5; scoreBoxColumn++, scoreboxY += 5) {
-				MxU8 color = score->m_scores[scoreState][scoreBoxColumn];
+				color = score->m_scores[scoreState][scoreBoxColumn];
 
 				if (color > 0) {
 					for (MxS32 lax = 0; lax < 4; lax++) {

--- a/LEGO1/lego/legoomni/src/worlds/hospital.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/hospital.cpp
@@ -20,6 +20,8 @@
 #include "mxtransitionmanager.h"
 #include "scripts.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(Hospital, 0x12c)
 DECOMP_SIZE_ASSERT(HospitalState, 0x18)
 
@@ -122,6 +124,8 @@ MxLong Hospital::Notify(MxParam& p_param)
 			result = HandleControl((LegoControlManagerNotificationParam&) p_param);
 			break;
 		case c_notificationTransitioned:
+			assert(m_destLocation != LegoGameState::e_undefined);
+
 			if (m_destLocation != LegoGameState::e_undefined) {
 				GameState()->SwitchArea(m_destLocation);
 			}
@@ -365,6 +369,7 @@ MxLong Hospital::HandleEndAction(MxEndActionNotificationParam& p_param)
 	case HospitalState::e_afterAcceptingQuest:
 		m_hospitalState->m_state = HospitalState::e_beforeEnteringAmbulance;
 		act1State = (Act1State*) GameState()->GetState("Act1State");
+		assert(act1State);
 		act1State->SetState(Act1State::e_transitionToAmbulance);
 	case HospitalState::e_exitToFront:
 		if (m_exited == FALSE) {
@@ -554,7 +559,9 @@ MxLong Hospital::HandleButtonDown(LegoControlManagerNotificationParam& p_param)
 MxBool Hospital::HandleControl(LegoControlManagerNotificationParam& p_param)
 {
 	if (p_param.m_enabledChild == 1) {
-		switch (p_param.m_clickedObjectId) {
+		MxS32 objectId = p_param.m_clickedObjectId;
+
+		switch (objectId) {
 		case HospitalScript::c_Info_Ctl:
 			BackgroundAudioManager()->RaiseVolume();
 			DeleteObjects(&m_atomId, HospitalScript::c_hho002cl_RunAnim, HospitalScript::c_hho006cl_RunAnim);

--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -131,7 +131,7 @@ Infocenter::Infocenter()
 {
 	m_selectedCharacter = LegoActor::e_none;
 	m_dragPresenter = NULL;
-	m_infocenterState = NULL;
+	m_state = NULL;
 	m_frame = NULL;
 	m_destLocation = LegoGameState::e_undefined;
 	m_currentInfomainScript = InfomainScript::c_noneInfomain;
@@ -161,11 +161,11 @@ Infocenter::~Infocenter()
 
 	MxS16 i = 0;
 	do {
-		if (m_infocenterState->GetNameLetter(i) != NULL) {
-			m_infocenterState->GetNameLetter(i)->Enable(FALSE);
+		if (m_state->GetNameLetter(i) != NULL) {
+			m_state->GetNameLetter(i)->Enable(FALSE);
 		}
 		i++;
-	} while (i < m_infocenterState->GetMaxNameLength());
+	} while (i < m_state->GetMaxNameLength());
 
 	ControlManager()->Unregister(this);
 
@@ -188,30 +188,29 @@ MxResult Infocenter::Create(MxDSAction& p_dsAction)
 		ControlManager()->Register(this);
 	}
 
-	m_infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
-	if (!m_infocenterState) {
-		m_infocenterState = (InfocenterState*) GameState()->CreateState("InfocenterState");
-		m_infocenterState->m_state = InfocenterState::e_newState;
+	m_state = (InfocenterState*) GameState()->GetState("InfocenterState");
+	if (!m_state) {
+		m_state = (InfocenterState*) GameState()->CreateState("InfocenterState");
+		m_state->m_step = InfocenterState::e_newState;
 	}
 	else {
-		if (m_infocenterState->m_state != InfocenterState::e_exitQueried &&
-			m_infocenterState->m_state != InfocenterState::e_selectedSave &&
-			m_infocenterState->m_state != InfocenterState::e_backToInfoAct1) {
-			m_infocenterState->m_state = InfocenterState::e_notRegistered;
+		if (m_state->m_step != InfocenterState::e_exitQueried && m_state->m_step != InfocenterState::e_selectedSave &&
+			m_state->m_step != InfocenterState::e_backToInfoAct1) {
+			m_state->m_step = InfocenterState::e_notRegistered;
 		}
 
 		MxS16 count, i;
-		for (count = 0; count < m_infocenterState->GetMaxNameLength(); count++) {
-			if (m_infocenterState->GetNameLetter(count) == NULL) {
+		for (count = 0; count < m_state->GetMaxNameLength(); count++) {
+			if (m_state->GetNameLetter(count) == NULL) {
 				break;
 			}
 		}
 
 		for (i = 0; i < count; i++) {
-			if (m_infocenterState->GetNameLetter(i)) {
-				m_infocenterState->GetNameLetter(i)->Enable(TRUE);
-				m_infocenterState->GetNameLetter(i)->SetTickleState(MxPresenter::e_repeating);
-				m_infocenterState->GetNameLetter(i)->SetPosition(((7 - count) / 2 + i) * 29 + 223, 45);
+			if (m_state->GetNameLetter(i)) {
+				m_state->m_letters[i]->Enable(TRUE);
+				m_state->GetNameLetter(i)->SetTickleState(MxPresenter::e_repeating);
+				m_state->GetNameLetter(i)->SetPosition(((7 - count) / 2 + i) * 29 + 223, 45);
 			}
 		}
 	}
@@ -219,7 +218,7 @@ MxResult Infocenter::Create(MxDSAction& p_dsAction)
 	GameState()->m_currentArea = LegoGameState::e_infomain;
 	GameState()->StopArea(LegoGameState::e_previousArea);
 
-	if (m_infocenterState->m_state == InfocenterState::e_selectedSave) {
+	if (m_state->m_step == InfocenterState::e_selectedSave) {
 		LegoGameState* state = GameState();
 		state->m_previousArea = GameState()->m_savedPreviousArea;
 	}
@@ -268,9 +267,9 @@ MxLong Infocenter::Notify(MxParam& p_param)
 			StopBookAnimation();
 			m_bookAnimationTimer = 0;
 
-			if (m_infocenterState->m_state == InfocenterState::e_exiting) {
+			if (m_state->m_step == InfocenterState::e_quiting) {
 				StartCredits();
-				m_infocenterState->m_state = InfocenterState::e_playCredits;
+				m_state->m_step = InfocenterState::e_playCredits;
 			}
 			else if (m_destLocation != 0) {
 				BackgroundAudioManager()->RaiseVolume();
@@ -337,11 +336,11 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 	}
 
 	if (action->GetObjectId() == InfomainScript::c_iicx26in_RunAnim) {
-		ControlManager()->UpdateEnabledChild(InfomainScript::c_BigInfo_Ctl, action->GetAtomId().GetInternal(), 0);
+		ControlManager()->UpdateEnabledChild(InfomainScript::c_BigInfo_Ctl, m_atomId.GetInternal(), 0);
 		m_bigInfoBlinkTimer = 0;
 	}
 
-	switch (m_infocenterState->m_state) {
+	switch (m_state->m_step) {
 	case InfocenterState::e_playCutscene:
 		switch (m_currentCutscene) {
 		case IntroScript::c_Lego_Movie:
@@ -352,13 +351,13 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 			return 1;
 		case IntroScript::c_BadEnd_Movie:
 			StopCutscene();
-			m_infocenterState->m_state = InfocenterState::e_welcomeAnimation;
+			m_state->m_step = InfocenterState::e_welcomeAnimation;
 			PlayAction(InfomainScript::c_tic092in_RunAnim);
 			m_currentCutscene = IntroScript::c_noneIntro;
 			return 1;
 		case IntroScript::c_GoodEnd_Movie:
 			StopCutscene();
-			m_infocenterState->m_state = InfocenterState::e_welcomeAnimation;
+			m_state->m_step = InfocenterState::e_welcomeAnimation;
 			PlayAction(InfomainScript::c_tic089in_RunAnim);
 			m_currentCutscene = IntroScript::c_noneIntro;
 			return 1;
@@ -366,17 +365,17 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 
 		// default / 2nd case probably?
 		StopCutscene();
-		m_infocenterState->m_state = InfocenterState::e_welcomeAnimation;
+		m_state->m_step = InfocenterState::e_welcomeAnimation;
 		PlayAction(InfomainScript::c_iic001in_RunAnim);
 		m_currentCutscene = IntroScript::c_noneIntro;
 
-		if (!m_infocenterState->HasRegistered()) {
+		if (!m_state->HasRegistered()) {
 			m_bookAnimationTimer = 1;
 			return 1;
 		}
 		break;
 	case InfocenterState::e_introCancelled:
-		m_infocenterState->m_state = InfocenterState::e_welcomeAnimation;
+		m_state->m_step = InfocenterState::e_welcomeAnimation;
 
 		switch (m_currentCutscene) {
 		case IntroScript::c_BadEnd_Movie:
@@ -400,7 +399,7 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 		if (action->GetObjectId() == InfomainScript::c_GoTo_RegBook ||
 			action->GetObjectId() == InfomainScript::c_GoTo_RegBook_Red) {
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
-			m_infocenterState->m_state = InfocenterState::e_exitingToIsland;
+			m_state->m_step = InfocenterState::e_exitingToIsland;
 			return 1;
 		}
 		break;
@@ -410,12 +409,12 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 				GameState()->SetActor(m_selectedCharacter);
 			}
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
-			m_infocenterState->m_state = InfocenterState::e_exitingToIsland;
+			m_state->m_step = InfocenterState::e_exitingToIsland;
 			return 1;
 		}
 		break;
 	case InfocenterState::e_welcomeAnimation:
-		if (!m_infocenterState->HasRegistered() && m_currentInfomainScript != InfomainScript::c_Mama_All_Movie &&
+		if (!m_state->HasRegistered() && m_currentInfomainScript != InfomainScript::c_Mama_All_Movie &&
 			m_currentInfomainScript != InfomainScript::c_Papa_All_Movie &&
 			m_currentInfomainScript != InfomainScript::c_Pepper_All_Movie &&
 			m_currentInfomainScript != InfomainScript::c_Nick_All_Movie &&
@@ -424,10 +423,10 @@ MxLong Infocenter::HandleEndAction(MxEndActionNotificationParam& p_param)
 			PlayMusic(JukeboxScript::c_InformationCenter_Music);
 		}
 
-		m_infocenterState->m_state = InfocenterState::e_notRegistered;
+		m_state->m_step = InfocenterState::e_notRegistered;
 		SetROIVisible("infoman", TRUE);
 		return 1;
-	case InfocenterState::e_exiting:
+	case InfocenterState::e_quiting:
 		if (action->GetObjectId() == m_currentInfomainScript) {
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
 		}
@@ -454,14 +453,14 @@ void Infocenter::ReadyWorld()
 		bg->Enable(TRUE);
 		InitializeBitmaps();
 
-		switch (m_infocenterState->m_state) {
+		switch (m_state->m_step) {
 		case InfocenterState::e_newState:
 			PlayCutscene(IntroScript::c_Lego_Movie, TRUE);
-			m_infocenterState->m_state = InfocenterState::e_playCutscene;
+			m_state->m_step = InfocenterState::e_playCutscene;
 			return;
 		case InfocenterState::e_selectedSave:
-			m_infocenterState->m_state = InfocenterState::e_notRegistered;
-			if (!m_infocenterState->HasRegistered()) {
+			m_state->m_step = InfocenterState::e_notRegistered;
+			if (!m_state->HasRegistered()) {
 				m_bookAnimationTimer = 1;
 			}
 
@@ -473,7 +472,7 @@ void Infocenter::ReadyWorld()
 		default: {
 			PlayMusic(JukeboxScript::c_InformationCenter_Music);
 
-			InfomainScript::Script script = m_infocenterState->GetNextReturnDialogue();
+			InfomainScript::Script script = m_state->GetNextReturnDialogue();
 			PlayAction(script);
 
 			if (script == InfomainScript::c_iicx26in_RunAnim) { // want to get back? Click on I!
@@ -482,7 +481,7 @@ void Infocenter::ReadyWorld()
 
 			Disable(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 
-			if (!m_infocenterState->HasRegistered()) {
+			if (!m_state->HasRegistered()) {
 				m_bookAnimationTimer = 1;
 			}
 
@@ -494,8 +493,8 @@ void Infocenter::ReadyWorld()
 			Disable(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 			return;
 		case InfocenterState::e_backToInfoAct1:
-			m_infocenterState->m_state = InfocenterState::e_notRegistered;
-			if (!m_infocenterState->HasRegistered()) {
+			m_state->m_step = InfocenterState::e_notRegistered;
+			if (!m_state->HasRegistered()) {
 				m_bookAnimationTimer = 1;
 			}
 
@@ -506,7 +505,7 @@ void Infocenter::ReadyWorld()
 		}
 		break;
 	case LegoGameState::e_act2: {
-		if (m_infocenterState->m_state == InfocenterState::e_exitQueried) {
+		if (m_state->m_step == InfocenterState::e_exitQueried) {
 			PlayMusic(JukeboxScript::c_InformationCenter_Music);
 			bgRed->Enable(TRUE);
 			PlayAction(InfomainScript::c_iic043in_RunAnim);
@@ -514,29 +513,30 @@ void Infocenter::ReadyWorld()
 			return;
 		}
 
-		LegoAct2State* state = (LegoAct2State*) GameState()->GetState("LegoAct2State");
+		LegoAct2State* act2State = (LegoAct2State*) GameState()->GetState("LegoAct2State");
+		assert(act2State);
 		GameState()->FindLoadedAct();
 
-		if (state && state->GetState() == LegoAct2State::c_badEnding) {
+		if (act2State && act2State->GetState() == LegoAct2State::c_badEnding) {
 			bg->Enable(TRUE);
 			PlayCutscene(IntroScript::c_BadEnd_Movie, TRUE);
-			m_infocenterState->m_state = InfocenterState::e_playCutscene;
+			m_state->m_step = InfocenterState::e_playCutscene;
 			return;
 		}
 
-		if (m_infocenterState->m_state == InfocenterState::e_selectedSave) {
+		if (m_state->m_step == InfocenterState::e_selectedSave) {
 			bgRed->Enable(TRUE);
 
-			if (GameState()->GetCurrentAct() == GameState()->GetLoadedAct()) {
+			if (GameState()->GetLoadedAct() == GameState()->GetCurrentAct()) {
 				GameState()->m_currentArea = LegoGameState::e_act2main;
 				GameState()->StopArea(LegoGameState::e_act2main);
 				GameState()->m_currentArea = LegoGameState::e_infomain;
 			}
 
-			m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+			m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 			m_destLocation = LegoGameState::e_act2main;
 
-			InfomainScript::Script script = m_infocenterState->GetNextReturnDialogue();
+			InfomainScript::Script script = m_state->GetNextReturnDialogue();
 			PlayAction(script);
 
 			InputManager()->DisableInputProcessing();
@@ -545,13 +545,13 @@ void Infocenter::ReadyWorld()
 		}
 
 		PlayMusic(JukeboxScript::c_InformationCenter_Music);
-		InfomainScript::Script script = m_infocenterState->GetNextReturnDialogue();
+		InfomainScript::Script script = m_state->GetNextReturnDialogue();
 		PlayAction(script);
 		bgRed->Enable(TRUE);
 		break;
 	}
 	case LegoGameState::e_act3: {
-		if (m_infocenterState->m_state == InfocenterState::e_exitQueried) {
+		if (m_state->m_step == InfocenterState::e_exitQueried) {
 			PlayMusic(JukeboxScript::c_InformationCenter_Music);
 			bgRed->Enable(TRUE);
 			PlayAction(InfomainScript::c_iic043in_RunAnim);
@@ -559,36 +559,37 @@ void Infocenter::ReadyWorld()
 			return;
 		}
 
-		Act3State* state = (Act3State*) GameState()->GetState("Act3State");
+		Act3State* act3State = (Act3State*) GameState()->GetState("Act3State");
+		assert(act3State);
 		GameState()->FindLoadedAct();
 
-		if (state && state->GetState() == Act3State::e_badEnding) {
+		if (act3State && act3State->GetState() == Act3State::e_badEnding) {
 			bg->Enable(TRUE);
 			PlayCutscene(IntroScript::c_BadEnd_Movie, TRUE);
-			m_infocenterState->m_state = InfocenterState::e_playCutscene;
+			m_state->m_step = InfocenterState::e_playCutscene;
 			return;
 		}
 
-		if (state && state->GetState() == Act3State::e_goodEnding) {
+		if (act3State && act3State->GetState() == Act3State::e_goodEnding) {
 			bg->Enable(TRUE);
 			PlayCutscene(IntroScript::c_GoodEnd_Movie, TRUE);
-			m_infocenterState->m_state = InfocenterState::e_playCutscene;
+			m_state->m_step = InfocenterState::e_playCutscene;
 			return;
 		}
 
-		if (m_infocenterState->m_state == InfocenterState::e_selectedSave) {
+		if (m_state->m_step == InfocenterState::e_selectedSave) {
 			bgRed->Enable(TRUE);
 
-			if (GameState()->GetCurrentAct() == GameState()->GetLoadedAct()) {
+			if (GameState()->GetLoadedAct() == GameState()->GetCurrentAct()) {
 				GameState()->m_currentArea = LegoGameState::e_act3script;
 				GameState()->StopArea(LegoGameState::e_act3script);
 				GameState()->m_currentArea = LegoGameState::e_infomain;
 			}
 
-			m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+			m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 			m_destLocation = LegoGameState::e_act3script;
 
-			InfomainScript::Script script = m_infocenterState->GetNextReturnDialogue();
+			InfomainScript::Script script = m_state->GetNextReturnDialogue();
 			PlayAction(script);
 
 			InputManager()->DisableInputProcessing();
@@ -597,14 +598,13 @@ void Infocenter::ReadyWorld()
 		}
 
 		PlayMusic(JukeboxScript::c_InformationCenter_Music);
-		InfomainScript::Script script = m_infocenterState->GetNextReturnDialogue();
-		PlayAction(script);
+		PlayAction(m_state->GetNextReturnDialogue());
 		bgRed->Enable(TRUE);
 		break;
 	}
 	}
 
-	m_infocenterState->m_state = InfocenterState::e_welcomeAnimation;
+	m_state->m_step = InfocenterState::e_welcomeAnimation;
 	Disable(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 }
 
@@ -703,14 +703,15 @@ MxLong Infocenter::HandleKeyPress(MxS8 p_key)
 	MxLong result = 0;
 
 	if (p_key == VK_SPACE && m_worldStarted) {
-		switch (m_infocenterState->m_state) {
+		switch (m_state->m_step) {
 		case InfocenterState::e_playCutscene:
 			StopCutscene();
-			m_infocenterState->m_state = InfocenterState::e_introCancelled;
+			m_state->m_step = InfocenterState::e_introCancelled;
 
-			if (!m_infocenterState->HasRegistered()) {
+			if (!m_state->HasRegistered()) {
 				m_bookAnimationTimer = 1;
-				return 1;
+				result = 1;
+				break;
 			}
 			break;
 		case InfocenterState::e_introCancelled:
@@ -720,18 +721,20 @@ MxLong Infocenter::HandleKeyPress(MxS8 p_key)
 			InfomainScript::Script script = m_currentInfomainScript;
 			StopCurrentAction();
 
-			switch (m_infocenterState->m_state) {
+			switch (m_state->m_step) {
 			case InfocenterState::e_selectedCharacterAndDestination:
-			case InfocenterState::e_exiting:
+			case InfocenterState::e_quiting:
 				m_currentInfomainScript = script;
 				return 1;
 			default:
-				m_infocenterState->m_state = InfocenterState::e_notRegistered;
+				m_state->m_step = InfocenterState::e_notRegistered;
 				return 1;
 			case InfocenterState::e_exitQueried:
 			case InfocenterState::e_welcomeAnimation:
 				break;
 			}
+
+			break;
 		}
 		case InfocenterState::e_playCredits:
 			StopCredits();
@@ -844,37 +847,37 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				case InfocenterMapEntry::e_jetrace:
 					if (m_selectedCharacter) {
 						m_destLocation = LegoGameState::e_jetraceExterior;
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 					}
 					break;
 				case InfocenterMapEntry::e_carrace:
 					if (m_selectedCharacter) {
 						m_destLocation = LegoGameState::e_carraceExterior;
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 					}
 					break;
 				case InfocenterMapEntry::e_pizzeria:
 					if (m_selectedCharacter) {
 						m_destLocation = LegoGameState::e_pizzeriaExterior;
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 					}
 					break;
 				case InfocenterMapEntry::e_garage:
 					if (m_selectedCharacter) {
 						m_destLocation = LegoGameState::e_garageExterior;
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 					}
 					break;
 				case InfocenterMapEntry::e_hospital:
 					if (m_selectedCharacter) {
 						m_destLocation = LegoGameState::e_hospitalExterior;
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 					}
 					break;
 				case InfocenterMapEntry::e_police:
 					if (m_selectedCharacter) {
 						m_destLocation = LegoGameState::e_policeExterior;
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 					}
 					break;
 				}
@@ -884,13 +887,13 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 		m_dragPresenter->Enable(FALSE);
 		m_dragPresenter = NULL;
 
-		if (m_infocenterState->m_state == InfocenterState::e_selectedCharacterAndDestination) {
+		if (m_state->m_step == InfocenterState::e_selectedCharacterAndDestination) {
 			InfomainScript::Script dialogueToPlay;
 
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
-				if (!m_infocenterState->HasRegistered()) {
+				if (!m_state->HasRegistered()) {
 					dialogueToPlay = InfomainScript::c_iic007in_PlayWav;
-					m_infocenterState->m_state = InfocenterState::e_notRegistered;
+					m_state->m_step = InfocenterState::e_notRegistered;
 					m_destLocation = LegoGameState::e_undefined;
 				}
 				else {
@@ -917,7 +920,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 						break;
 					default:
 						assert(0);
-						dialogueToPlay = m_infocenterState->GetNextLeaveDialogue();
+						dialogueToPlay = m_state->GetNextLeaveDialogue();
 						break;
 					}
 
@@ -926,7 +929,7 @@ MxU8 Infocenter::HandleButtonUp(MxS32 p_x, MxS32 p_y)
 				}
 			}
 			else {
-				dialogueToPlay = m_infocenterState->GetNextLeaveDialogue();
+				dialogueToPlay = m_state->GetNextLeaveDialogue();
 			}
 
 			PlayAction(dialogueToPlay);
@@ -954,7 +957,7 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 
 		switch (p_param.m_clickedObjectId) {
 		case InfomainScript::c_LeftArrow_Ctl:
-			m_infocenterState->m_state = InfocenterState::e_exitingToIsland;
+			m_state->m_step = InfocenterState::e_exitingToIsland;
 			StopCurrentAction();
 
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
@@ -963,13 +966,13 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				m_destLocation = LegoGameState::e_elevbott;
 			}
 			else {
-				MxU32 objectId = m_infocenterState->GetBricksterDialogue().Next();
+				MxU32 objectId = m_state->GetBricksterDialogue().Next();
 				PlayAction((InfomainScript::Script) objectId);
 			}
 
 			break;
 		case InfomainScript::c_RightArrow_Ctl:
-			m_infocenterState->m_state = InfocenterState::e_exitingToIsland;
+			m_state->m_step = InfocenterState::e_exitingToIsland;
 			StopCurrentAction();
 
 			if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
@@ -978,7 +981,7 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				m_destLocation = LegoGameState::e_infoscor;
 			}
 			else {
-				MxU32 objectId = m_infocenterState->GetBricksterDialogue().Next();
+				MxU32 objectId = m_state->GetBricksterDialogue().Next();
 				PlayAction((InfomainScript::Script) objectId);
 			}
 
@@ -988,10 +991,10 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 			m_radio.Stop();
 			break;
 		case InfomainScript::c_Door_Ctl:
-			if (m_infocenterState->m_state != InfocenterState::e_exitQueried) {
-				actionToPlay = InfomainScript::c_iic043in_RunAnim;
+			if (m_state->m_step != InfocenterState::e_exitQueried) {
 				m_radio.Stop();
-				m_infocenterState->m_state = InfocenterState::e_exitQueried;
+				actionToPlay = InfomainScript::c_iic043in_RunAnim;
+				m_state->m_step = InfocenterState::e_exitQueried;
 			}
 
 			break;
@@ -1027,9 +1030,9 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 					case LegoGameState::e_infodoor:
 					case LegoGameState::e_regbook:
 					case LegoGameState::e_infoscor:
-						m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+						m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 						m_destLocation = state->m_previousArea;
-						actionToPlay = (InfomainScript::Script) m_infocenterState->GetNextLeaveDialogue();
+						actionToPlay = (InfomainScript::Script) m_state->GetNextLeaveDialogue();
 						m_radio.Stop();
 						InputManager()->DisableInputProcessing();
 						InputManager()->SetUnknown336(TRUE);
@@ -1044,14 +1047,14 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 						break;
 					default:
 						if (state->GetActorId() != LegoActor::e_none) {
-							if (!m_infocenterState->HasRegistered()) {
+							if (!m_state->HasRegistered()) {
 								PlayAction(InfomainScript::c_iic007in_PlayWav);
-								m_infocenterState->m_state = InfocenterState::e_notRegistered;
+								m_state->m_step = InfocenterState::e_notRegistered;
 							}
 							else {
-								m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+								m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 								m_destLocation = state->m_previousArea;
-								actionToPlay = (InfomainScript::Script) m_infocenterState->GetNextLeaveDialogue();
+								actionToPlay = (InfomainScript::Script) m_state->GetNextLeaveDialogue();
 								m_radio.Stop();
 								InputManager()->DisableInputProcessing();
 								InputManager()->SetUnknown336(TRUE);
@@ -1062,16 +1065,16 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 				}
 				break;
 			case LegoGameState::e_act2:
-				m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+				m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 				m_destLocation = LegoGameState::e_act2main;
-				actionToPlay = (InfomainScript::Script) m_infocenterState->GetNextLeaveDialogue();
+				actionToPlay = (InfomainScript::Script) m_state->GetNextLeaveDialogue();
 				InputManager()->DisableInputProcessing();
 				InputManager()->SetUnknown336(TRUE);
 				break;
 			case LegoGameState::e_act3:
-				m_infocenterState->m_state = InfocenterState::e_selectedCharacterAndDestination;
+				m_state->m_step = InfocenterState::e_selectedCharacterAndDestination;
 				m_destLocation = LegoGameState::e_act3script;
-				actionToPlay = (InfomainScript::Script) m_infocenterState->GetNextLeaveDialogue();
+				actionToPlay = (InfomainScript::Script) m_state->GetNextLeaveDialogue();
 				InputManager()->DisableInputProcessing();
 				InputManager()->SetUnknown336(TRUE);
 				break;
@@ -1079,7 +1082,7 @@ MxU8 Infocenter::HandleControl(LegoControlManagerNotificationParam& p_param)
 			break;
 		case InfomainScript::c_Book_Ctl:
 			m_destLocation = LegoGameState::e_regbook;
-			m_infocenterState->m_state = InfocenterState::e_selectedSave;
+			m_state->m_step = InfocenterState::e_selectedSave;
 			actionToPlay = GameState()->GetCurrentAct() != LegoGameState::e_act1 ? InfomainScript::c_GoTo_RegBook_Red
 																				 : InfomainScript::c_GoTo_RegBook;
 			m_radio.Stop();
@@ -1127,58 +1130,53 @@ MxLong Infocenter::HandleNotification0(MxNotificationParam& p_param)
 {
 	// This function has changed significantly since BETA10
 
-	MxCore* sender = p_param.GetSender();
+	if (p_param.GetSender() != NULL) {
+		if (p_param.GetSender()->IsA("MxEntity") &&
+			m_state->m_step != InfocenterState::e_selectedCharacterAndDestination &&
+			m_state->m_step != InfocenterState::e_quiting) {
+			switch (((MxEntity*) p_param.GetSender())->GetEntityId()) {
+			case 5: {
+				m_infoManDialogueTimer = 0;
 
-	if (sender == NULL) {
-		if (m_infocenterState->m_state == InfocenterState::e_exitQueried) {
-			m_infoManDialogueTimer = 0;
-			StopCutscene();
-			PlayAction(InfomainScript::c_iic043in_RunAnim);
-		}
-	}
-	else if (sender->IsA("MxEntity") && m_infocenterState->m_state != InfocenterState::e_selectedCharacterAndDestination && m_infocenterState->m_state != InfocenterState::e_exiting) {
-		switch (((MxEntity*) sender)->GetEntityId()) {
-		case 5: {
-			m_infoManDialogueTimer = 0;
+				InfocenterState* infocenterState = m_state;
+				assert(infocenterState);
+				InfomainScript::Script objectId;
 
-			InfomainScript::Script objectId;
-			if (GameState()->GetCurrentAct() != LegoGameState::e_act1) {
-				objectId = (InfomainScript::Script) m_infocenterState->GetExitDialogueAct23().Next();
-			}
-			else {
-				objectId = (InfomainScript::Script) m_infocenterState->GetExitDialogueAct1().Next();
-			}
-
-			PlayAction(objectId);
-			SetROIVisible(g_object2x4red, FALSE);
-			SetROIVisible(g_object2x4grn, FALSE);
-			return 1;
-		}
-		case 6:
-			if (m_infocenterState->m_state == InfocenterState::e_exitQueried) {
-				StopCurrentAction();
-				SetROIVisible(g_object2x4red, FALSE);
-				SetROIVisible(g_object2x4grn, FALSE);
-				m_infocenterState->m_state = InfocenterState::e_notRegistered;
-				PlayAction(InfomainScript::c_iicb28in_RunAnim);
-				return 1;
-			}
-		case 7:
-			if (m_infocenterState->m_state == InfocenterState::e_exitQueried) {
-				if (m_infocenterState->HasRegistered()) {
-					GameState()->Save(0);
+				if (GameState()->GetCurrentAct() != LegoGameState::e_act1) {
+					objectId = (InfomainScript::Script) infocenterState->GetExitDialogueAct23().Next();
+				}
+				else {
+					objectId = (InfomainScript::Script) infocenterState->GetExitDialogueAct1().Next();
 				}
 
-				m_infocenterState->m_state = InfocenterState::e_exiting;
-				PlayAction(InfomainScript::c_iic046in_RunAnim);
-				InputManager()->DisableInputProcessing();
-				InputManager()->SetUnknown336(TRUE);
+				PlayAction(objectId);
+				SetROIVisible(g_object2x4red, FALSE);
+				SetROIVisible(g_object2x4grn, FALSE);
 				return 1;
 			}
+			case 6:
+				if (m_state->m_step == InfocenterState::e_exitQueried) {
+					StopCurrentAction();
+					SetROIVisible(g_object2x4red, FALSE);
+					SetROIVisible(g_object2x4grn, FALSE);
+					m_state->m_step = InfocenterState::e_notRegistered;
+					PlayAction(InfomainScript::c_iicb28in_RunAnim);
+					return 1;
+				}
+			case 7:
+				if (m_state->m_step == InfocenterState::e_exitQueried) {
+					if (m_state->HasRegistered()) {
+						GameState()->Save(0);
+					}
+
+					m_state->m_step = InfocenterState::e_quiting;
+					PlayAction(InfomainScript::c_iic046in_RunAnim);
+					InputManager()->DisableInputProcessing();
+					InputManager()->SetUnknown336(TRUE);
+				}
+			}
 		}
-	}
-	else {
-		if (sender->IsA("Radio") && m_radio.GetState()->IsActive()) {
+		else if (p_param.GetSender()->IsA("Radio") && m_radio.GetState()->IsActive()) {
 			if (m_currentInfomainScript == InfomainScript::c_Mama_All_Movie ||
 				m_currentInfomainScript == InfomainScript::c_Papa_All_Movie ||
 				m_currentInfomainScript == InfomainScript::c_Pepper_All_Movie ||
@@ -1194,6 +1192,11 @@ MxLong Infocenter::HandleNotification0(MxNotificationParam& p_param)
 				StopCurrentAction();
 			}
 		}
+	}
+	else if (m_state->m_step == InfocenterState::e_exitQueried) {
+		m_infoManDialogueTimer = 0;
+		StopCutscene();
+		PlayAction(InfomainScript::c_iic043in_RunAnim);
 	}
 
 	return 1;
@@ -1256,9 +1259,11 @@ MxResult Infocenter::Tickle()
 }
 
 // FUNCTION: LEGO1 0x10070c20
-void Infocenter::PlayCutscene(IntroScript::Script p_entityId, MxBool p_scale)
+void Infocenter::PlayCutscene(IntroScript::Script p_movieId, MxBool p_scale)
 {
-	m_currentCutscene = p_entityId;
+	assert(p_movieId != DS_NOT_A_STREAM);
+
+	m_currentCutscene = p_movieId;
 
 	VideoManager()->EnableFullScreenMovie(TRUE, p_scale);
 	InputManager()->SetUnknown336(TRUE);
@@ -1299,12 +1304,13 @@ MxBool Infocenter::WaitForTransition()
 // FUNCTION: BETA10 0x100307d4
 void Infocenter::UpdateEnabledGlowControl(MxS32 p_x, MxS32 p_y)
 {
+	MxS32 left, top, right, bottom;
 	MxS16 i;
 	for (i = 0; i < (MxS32) (sizeof(m_glowInfo) / sizeof(m_glowInfo[0])); i++) {
-		MxS32 right = m_glowInfo[i].m_area.GetRight();
-		MxS32 bottom = m_glowInfo[i].m_area.GetBottom();
-		MxS32 left = m_glowInfo[i].m_area.GetLeft();
-		MxS32 top = m_glowInfo[i].m_area.GetTop();
+		left = m_glowInfo[i].m_area.GetLeft();
+		top = m_glowInfo[i].m_area.GetTop();
+		right = m_glowInfo[i].m_area.GetRight();
+		bottom = m_glowInfo[i].m_area.GetBottom();
 
 		if (left <= p_x && p_x <= right && top <= p_y && p_y <= bottom) {
 			break;
@@ -1410,18 +1416,18 @@ void Infocenter::Reset()
 // FUNCTION: LEGO1 0x10070f60
 MxBool Infocenter::Escape()
 {
-	if (m_infocenterState != NULL) {
-		MxU32 val = m_infocenterState->m_state;
+	if (m_state != NULL) {
+		MxU32 val = m_state->m_step;
 
 		if (val == InfocenterState::e_playCutscene) {
 			StopCutscene();
-			m_infocenterState->m_state = InfocenterState::e_introCancelled;
+			m_state->m_step = InfocenterState::e_introCancelled;
 		}
 		else if (val == InfocenterState::e_playCredits) {
 			StopCredits();
 		}
 		else if (val != InfocenterState::e_exitQueried) {
-			m_infocenterState->m_state = InfocenterState::e_exitQueried;
+			m_state->m_step = InfocenterState::e_exitQueried;
 
 #ifdef COMPAT_MODE
 			{
@@ -1477,11 +1483,11 @@ void Infocenter::StartCredits()
 
 	MxS16 i = 0;
 	do {
-		if (m_infocenterState->GetNameLetter(i) != NULL) {
-			m_infocenterState->GetNameLetter(i)->Enable(FALSE);
+		if (m_state->GetNameLetter(i) != NULL) {
+			m_state->GetNameLetter(i)->Enable(FALSE);
 		}
 		i++;
-	} while (i < m_infocenterState->GetMaxNameLength());
+	} while (i < m_state->GetMaxNameLength());
 
 	VideoManager()->FUN_1007c520();
 	GetViewManager()->RemoveAll(NULL);
@@ -1510,6 +1516,7 @@ void Infocenter::PlayAction(InfomainScript::Script p_script)
 	StopCurrentAction();
 
 	m_currentInfomainScript = p_script;
+
 	BackgroundAudioManager()->LowerVolume();
 	Start(&action);
 }
@@ -1581,10 +1588,10 @@ InfocenterState::~InfocenterState()
 {
 	MxS16 i = 0;
 	do {
-		if (GetNameLetter(i) != NULL) {
-			delete GetNameLetter(i)->GetAction();
-			delete GetNameLetter(i);
+		if (m_letters[i] != NULL) {
+			delete m_letters[i]->GetAction();
+			delete m_letters[i];
 		}
 		i++;
-	} while (i < GetMaxNameLength());
+	} while (i < (MxS16) sizeOfArray(m_letters));
 }

--- a/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenterdoor.cpp
@@ -16,6 +16,8 @@
 #include "mxtransitionmanager.h"
 #include "scripts.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(InfocenterDoor, 0xfc)
 
 // FUNCTION: LEGO1 0x10037730
@@ -117,8 +119,9 @@ MxLong InfocenterDoor::HandleControl(LegoControlManagerNotificationParam& p_para
 			break;
 		case InfodoorScript::c_Door_Ctl:
 			if (GameState()->GetActorId() != LegoActor::e_none) {
-				InfocenterState* state = (InfocenterState*) GameState()->GetState("InfocenterState");
-				if (state->HasRegistered()) {
+				InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
+				assert(infocenterState);
+				if (infocenterState->HasRegistered()) {
 					m_destLocation = LegoGameState::e_infocenterExited;
 				}
 				else {

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -39,11 +39,10 @@
 #include "viewmanager/viewmanager.h"
 
 DECOMP_SIZE_ASSERT(Act1State, 0x26c)
-DECOMP_SIZE_ASSERT(LegoNamedPlane, 0x4c)
 DECOMP_SIZE_ASSERT(Isle, 0x140)
 
-// GLOBAL: LEGO1 0x100f1198
-MxU32 g_isleFlags = 0x7f;
+// Defined in legopathstruct.cpp
+extern MxU32 g_isleFlags;
 
 // GLOBAL: LEGO1 0x100f37f0
 IsleScript::Script g_cptClickDialogue[] =
@@ -144,9 +143,11 @@ MxLong Isle::Notify(MxParam& p_param)
 		case c_notificationButtonDown:
 			switch (m_act1state->m_state) {
 			case Act1State::e_pizza:
+				assert(m_pizza);
 				result = m_pizza->Notify(p_param);
 				break;
 			case Act1State::e_ambulance:
+				assert(m_ambulance);
 				result = m_ambulance->Notify(p_param);
 				break;
 			}
@@ -156,13 +157,18 @@ MxLong Isle::Notify(MxParam& p_param)
 			break;
 		case c_notificationEndAnim:
 			switch (m_act1state->m_state) {
-			case Act1State::e_helicopter:
-				result = UserActor()->Notify(p_param);
+			case Act1State::e_helicopter: {
+				Helicopter* helicopter = (Helicopter*) UserActor();
+				assert(helicopter);
+				result = helicopter->Notify(p_param);
 				break;
+			}
 			case Act1State::e_towtrack:
+				assert(m_towtrack);
 				result = m_towtrack->Notify(p_param);
 				break;
 			case Act1State::e_ambulance:
+				assert(m_ambulance);
 				result = m_ambulance->Notify(p_param);
 				break;
 			}
@@ -183,6 +189,7 @@ MxLong Isle::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x10030d90
+// FUNCTION: BETA10 0x10032ea7
 MxLong Isle::HandleEndAction(MxEndActionNotificationParam& p_param)
 {
 	MxLong result;
@@ -193,12 +200,15 @@ MxLong Isle::HandleEndAction(MxEndActionNotificationParam& p_param)
 		result = 1;
 		break;
 	case Act1State::e_pizza:
+		assert(m_pizza);
 		result = m_pizza->Notify(p_param);
 		break;
 	case Act1State::e_towtrack:
+		assert(m_towtrack);
 		result = m_towtrack->Notify(p_param);
 		break;
 	case Act1State::e_ambulance:
+		assert(m_ambulance);
 		result = m_ambulance->Notify(p_param);
 		break;
 	default:
@@ -209,6 +219,7 @@ MxLong Isle::HandleEndAction(MxEndActionNotificationParam& p_param)
 				MxS32 script = p_param.GetAction()->GetObjectId();
 
 				if (script >= JukeboxScript::c_JBMusic1 && script <= JukeboxScript::c_JBMusic6) {
+					assert(m_jukebox);
 					m_jukebox->StopAction((JukeboxScript::Script) script);
 					result = 1;
 				}
@@ -455,10 +466,11 @@ void Isle::UpdateGlobe()
 	MxS32 lightPosition = atoi(VariableTable()->GetVariable("lightposition"));
 
 	for (MxS32 i = 0; i < 6; i++) {
-		MxStillPresenter* presenter = (MxStillPresenter*) Find(*g_isleScript, IsleScript::c_Observe_Globe1_Bitmap + i);
+		MxStillPresenter* bmap = (MxStillPresenter*) Find(*g_isleScript, IsleScript::c_Observe_Globe1_Bitmap + i);
+		assert(bmap);
 
-		if (presenter != NULL) {
-			presenter->Enable(i == lightPosition);
+		if (bmap != NULL) {
+			bmap->Enable(i == lightPosition);
 		}
 	}
 }
@@ -480,12 +492,15 @@ MxLong Isle::HandlePathStruct(LegoPathStructNotificationParam& p_param)
 
 	switch (m_act1state->m_state) {
 	case Act1State::e_pizza:
+		assert(m_pizza);
 		result = m_pizza->Notify(p_param);
 		break;
 	case Act1State::e_towtrack:
+		assert(m_towtrack);
 		result = m_towtrack->Notify(p_param);
 		break;
 	case Act1State::e_ambulance:
+		assert(m_ambulance);
 		result = m_ambulance->Notify(p_param);
 		break;
 	}
@@ -735,12 +750,13 @@ void Isle::Enable(MxBool p_enable)
 					FALSE,
 					IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
 				);
-			JetskiRaceState* raceState = (JetskiRaceState*) GameState()->GetState("JetskiRaceState");
+			JetskiRaceState* jetRaceState = (JetskiRaceState*) GameState()->GetState("JetskiRaceState");
+			assert(jetRaceState);
 
-			if (raceState->m_state == RaceState::e_finished) {
+			if (jetRaceState->m_state == RaceState::e_finished) {
 				IsleScript::Script script = IsleScript::c_noneIsle;
 
-				switch (raceState->GetState(GameState()->GetActorId())->GetLastScore()) {
+				switch (jetRaceState->GetState(GameState()->GetActorId())->GetLastScore()) {
 				case 1:
 					script = IsleScript::c_sjs014in_RunAnim;
 					break;
@@ -769,12 +785,13 @@ void Isle::Enable(MxBool p_enable)
 					FALSE,
 					IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
 				);
-			CarRaceState* raceState = (CarRaceState*) GameState()->GetState("CarRaceState");
+			CarRaceState* carRaceState = (CarRaceState*) GameState()->GetState("CarRaceState");
+			assert(carRaceState);
 
-			if (raceState->m_state == RaceState::e_finished) {
+			if (carRaceState->m_state == RaceState::e_finished) {
 				IsleScript::Script script = IsleScript::c_noneIsle;
 
-				switch (raceState->GetState(GameState()->GetActorId())->GetLastScore()) {
+				switch (carRaceState->GetState(GameState()->GetActorId())->GetLastScore()) {
 				case 1:
 					script = IsleScript::c_srt003in_RunAnim;
 					break;
@@ -797,33 +814,40 @@ void Isle::Enable(MxBool p_enable)
 		case Act1State::e_transitionToTowtrack:
 			m_act1state->m_state = Act1State::e_towtrack;
 
+			assert(AnimationManager());
 			AnimationManager()->FUN_1005f6d0(FALSE);
 			AnimationManager()->EnableCamAnims(FALSE);
 
 			g_isleFlags &= ~c_playMusic;
+			assert(m_towtrack);
 			m_towtrack->Init();
 			break;
 		case Act1State::e_transitionToAmbulance:
 			m_act1state->m_state = Act1State::e_ambulance;
 
+			assert(AnimationManager());
 			AnimationManager()->FUN_1005f6d0(FALSE);
 			AnimationManager()->EnableCamAnims(FALSE);
 
 			g_isleFlags &= ~c_playMusic;
+			assert(m_ambulance);
 			m_ambulance->Init();
 			break;
-		case 11:
+		case 11: {
 			m_act1state->m_state = Act1State::e_none;
-			((IslePathActor*) UserActor())
-				->SpawnPlayer(
-					LegoGameState::e_jukeboxExterior,
-					TRUE,
-					IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
-				);
+			IslePathActor* user = (IslePathActor*) UserActor();
+			assert(user);
+			user->SpawnPlayer(
+				LegoGameState::e_jukeboxExterior,
+				TRUE,
+				IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
+			);
 			GameState()->m_currentArea = LegoGameState::e_vehicleExited;
 			EnableAnimations(TRUE);
+			assert(m_jukebox);
 			m_jukebox->StartAction();
 			break;
+		}
 		}
 
 		SetAppCursor(e_cursorArrow);
@@ -879,15 +903,17 @@ void Isle::CheckAreaExiting()
 	case LegoGameState::e_garageExterior:
 	case LegoGameState::e_hospitalExterior:
 	case LegoGameState::e_hospitalExited:
-	case LegoGameState::e_policeExterior:
-		((IslePathActor*) UserActor())
-			->SpawnPlayer(
-				GameState()->m_currentArea,
-				TRUE,
-				IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
-			);
+	case LegoGameState::e_policeExterior: {
+		IslePathActor* user = (IslePathActor*) UserActor();
+		assert(user);
+		user->SpawnPlayer(
+			GameState()->m_currentArea,
+			TRUE,
+			IslePathActor::c_spawnBit1 | IslePathActor::c_playMusic | IslePathActor::c_spawnBit3
+		);
 		GameState()->m_currentArea = LegoGameState::e_vehicleExited;
 		break;
+	}
 	}
 }
 
@@ -901,12 +927,17 @@ MxLong Isle::HandleTransitionEnd()
 		m_act1state->m_state = Act1State::e_none;
 	}
 
+	assert(m_destLocation != LegoGameState::e_undefined);
+
 	switch (m_destLocation) {
-	case LegoGameState::e_infomain:
-		((LegoEntity*) Find(*g_isleScript, IsleScript::c_InfoCenter_Entity))->GetROI()->SetVisibility(TRUE);
+	case LegoGameState::e_infomain: {
+		LegoEntity* entity = (LegoEntity*) Find(*g_isleScript, IsleScript::c_InfoCenter_Entity);
+		assert(entity);
+		entity->GetROI()->SetVisibility(TRUE);
 		GameState()->SwitchArea(m_destLocation);
 		m_destLocation = LegoGameState::e_undefined;
 		break;
+	}
 	case LegoGameState::e_elevride:
 		m_act1state->m_switchedToArea = TRUE;
 		VariableTable()->SetVariable("VISIBILITY", "Hide infocen");
@@ -916,6 +947,21 @@ MxLong Isle::HandleTransitionEnd()
 			"LCAMZI1,90",
 			FALSE
 		);
+		break;
+	case LegoGameState::e_polidoor:
+		m_act1state->m_switchedToArea = TRUE;
+		VariableTable()->SetVariable("VISIBILITY", "Hide Policsta");
+		TransitionToOverlay(
+			IsleScript::c_PoliDoor_Background_Bitmap,
+			JukeboxScript::c_PoliceStation_Music,
+			"LCAMZP1,90",
+			FALSE
+		);
+		break;
+	case LegoGameState::e_garadoor:
+		m_act1state->m_switchedToArea = TRUE;
+		VariableTable()->SetVariable("VISIBILITY", "Hide Gas");
+		TransitionToOverlay(IsleScript::c_GaraDoor_Background_Bitmap, JukeboxScript::c_JBMusic2, "LCAMZG1,90", FALSE);
 		break;
 	case LegoGameState::e_elevride2:
 		TransitionToOverlay(
@@ -961,11 +1007,6 @@ MxLong Isle::HandleTransitionEnd()
 			FALSE
 		);
 		break;
-	case LegoGameState::e_garadoor:
-		m_act1state->m_switchedToArea = TRUE;
-		VariableTable()->SetVariable("VISIBILITY", "Hide Gas");
-		TransitionToOverlay(IsleScript::c_GaraDoor_Background_Bitmap, JukeboxScript::c_JBMusic2, "LCAMZG1,90", FALSE);
-		break;
 	case LegoGameState::e_garageExited:
 		GameState()->SwitchArea(m_destLocation);
 		GameState()->StopArea(LegoGameState::e_previousArea);
@@ -985,16 +1026,6 @@ MxLong Isle::HandleTransitionEnd()
 		Disable(FALSE, LegoOmni::c_disableInput | LegoOmni::c_disable3d | LegoOmni::c_clearScreen);
 		SetAppCursor(e_cursorArrow);
 		SetIsWorldActive(TRUE);
-		break;
-	case LegoGameState::e_polidoor:
-		m_act1state->m_switchedToArea = TRUE;
-		VariableTable()->SetVariable("VISIBILITY", "Hide Policsta");
-		TransitionToOverlay(
-			IsleScript::c_PoliDoor_Background_Bitmap,
-			JukeboxScript::c_PoliceStation_Music,
-			"LCAMZP1,90",
-			FALSE
-		);
 		break;
 	case LegoGameState::e_bike:
 		m_act1state->m_switchedToArea = TRUE;
@@ -1311,17 +1342,17 @@ Act1State::Act1State()
 	m_elevFloor = Act1State::c_floor1;
 	m_state = Act1State::e_initial;
 	m_playingFloor2Animation = FALSE;
+	m_planeActive = FALSE;
 	m_cptClickDialogue = Playlist((MxU32*) g_cptClickDialogue, sizeOfArray(g_cptClickDialogue), Playlist::e_loop);
 	m_switchedToArea = FALSE;
-	m_planeActive = FALSE;
 	m_currentCptClickDialogue = IsleScript::c_noneIsle;
 	m_playedExitExplanation = FALSE;
+	m_spawnInInfocenter = 1;
 	m_helicopterWindshield = NULL;
 	m_helicopterJetLeft = NULL;
 	m_helicopterJetRight = NULL;
 	m_helicopter = NULL;
 	m_jetskiFront = NULL;
-	m_spawnInInfocenter = 1;
 	m_jetskiWindshield = NULL;
 	m_jetski = NULL;
 	m_dunebuggyFront = NULL;

--- a/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/jukebox.cpp
@@ -211,6 +211,7 @@ MxBool JukeBox::HandleControl(LegoControlManagerNotificationParam& p_param)
 			break;
 		case JukeboxwScript::c_Note_Ctl:
 			Act1State* act1State = (Act1State*) GameState()->GetState("Act1State");
+			assert(act1State);
 			act1State->m_state = Act1State::e_jukebox;
 			m_destLocation = LegoGameState::Area::e_jukeboxExterior;
 			TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, 0, FALSE);

--- a/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/legoact2.cpp
@@ -32,9 +32,6 @@
 DECOMP_SIZE_ASSERT(LegoAct2, 0x1154)
 DECOMP_SIZE_ASSERT(LegoAct2State, 0x10)
 
-// GLOBAL: LEGO1 0x100f4474
-Act2mainScript::Script g_bricksterSpeech = (Act2mainScript::Script) 0;
-
 // GLOBAL: LEGO1 0x100f43f0
 // GLOBAL: BETA10 0x101e14a8
 MxS32 g_animationsBricksterIsLoose[] = {
@@ -69,6 +66,9 @@ MxS32 g_animationsAfterChase[] = {
 
 // GLOBAL: LEGO1 0x100f4458
 const LegoChar* g_charactersAfterChase[] = {"papa", "nick", "laura", "cl", "pg", "rd", "sy"};
+
+// GLOBAL: LEGO1 0x100f4474
+Act2mainScript::Script g_bricksterSpeech = (Act2mainScript::Script) 0;
 
 // FUNCTION: LEGO1 0x1004fce0
 // FUNCTION: BETA10 0x1003a5a0
@@ -217,10 +217,12 @@ MxResult LegoAct2::Tickle()
 		m_timeSinceLastStage += 50;
 
 		if (m_timeSinceLastStage == 20000) {
-			const MxFloat* pepperPosition = FindROI("pepper")->GetWorldPosition();
 			MxFloat otherPoint[] = {-52.0f, 5.25f, -16.5f};
+			const MxFloat* pepperPosition = FindROI("pepper")->GetWorldPosition();
 
-			distance = DISTSQRD3(pepperPosition, otherPoint);
+			distance = (pepperPosition[2] - otherPoint[2]) * (pepperPosition[2] - otherPoint[2]);
+			distance += (pepperPosition[1] - otherPoint[1]) * (pepperPosition[1] - otherPoint[1]);
+			distance += (pepperPosition[0] - otherPoint[0]) * (pepperPosition[0] - otherPoint[0]);
 
 			if (m_infomanDirecting == (Act2mainScript::Script) 0 && distance > 50.0f && pepperPosition[0] > -57.0f) {
 				StartAction(Act2mainScript::c_Avo906In_PlayWav, FALSE, FALSE, NULL, NULL, NULL);
@@ -277,23 +279,6 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 		case c_notificationEndAction:
 			result = HandleEndAction((MxEndActionNotificationParam&) p_param);
 			break;
-		case c_notificationPathStruct: {
-			MxTrace("trigger %d\n", ((LegoPathStructNotificationParam&) p_param).GetData());
-
-			LegoPathStructNotificationParam& param = (LegoPathStructNotificationParam&) p_param;
-			LegoEntity* entity = (LegoEntity*) param.GetSender();
-
-			if (m_ambulance == NULL) {
-				m_ambulance = FindROI("ambul");
-			}
-
-			if (entity->GetROI() == m_pepper) {
-				HandlePathStruct(param);
-			}
-
-			result = 1;
-			break;
-		}
 		case c_notificationAct2Brick:
 			SoundManager()->GetCacheSoundManager()->Play("28bng", NULL, FALSE);
 
@@ -303,7 +288,7 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 
 				LegoEntity* entity = (LegoEntity*) param.GetSender();
 
-				Mx3DPointFloat pepperToBrick(entity->GetROI()->GetWorldPosition());
+				Mx3DPointFloat pepperToBrick((float*) entity->GetROI()->GetWorldPosition());
 				Mx3DPointFloat pepperPosition(m_pepper->GetWorldPosition());
 				Mx3DPointFloat position(pepperPosition);
 
@@ -333,6 +318,23 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 				((LegoPathActor*) m_pepper->GetEntity())->SetActorState(LegoPathActor::c_disabled);
 			}
 			break;
+		case c_notificationPathStruct: {
+			MxTrace("trigger %d\n", ((LegoPathStructNotificationParam&) p_param).GetData());
+
+			LegoPathStructNotificationParam& param = (LegoPathStructNotificationParam&) p_param;
+			LegoEntity* entity = (LegoEntity*) param.GetSender();
+
+			if (m_ambulance == NULL) {
+				m_ambulance = FindROI("ambul");
+			}
+
+			if (entity->GetROI() == m_pepper) {
+				HandlePathStruct(param);
+			}
+
+			result = 1;
+			break;
+		}
 		case c_notificationTransitioned:
 			result = HandleTransitionEnd();
 			break;
@@ -346,7 +348,8 @@ MxLong LegoAct2::Notify(MxParam& p_param)
 MxLong LegoAct2::HandleEndAction(MxEndActionNotificationParam& p_param)
 {
 	if (m_gameState->m_enabled && p_param.GetAction() != NULL) {
-		MxU32 objectId = p_param.GetAction()->GetObjectId();
+		MxDSAction* action = p_param.GetAction();
+		MxU32 objectId = action->GetObjectId();
 
 		if (m_state == LegoAct2::e_goingToResidentialArea && m_infomanDirecting == objectId) {
 			m_infomanDirecting = (Act2mainScript::Script) 0;
@@ -497,8 +500,7 @@ void LegoAct2::ReadyWorld()
 	BoundingSphere sphere = roi->GetBoundingSphere();
 	sphere.Radius() *= 1.5;
 	roi->SetBoundingSphere(sphere);
-	LegoPathActor* actor = (LegoPathActor*) roi->GetEntity();
-	PlaceActor(actor, "EDG01_04", 1, 0.5f, 3, 0.5f);
+	PlaceActor((LegoPathActor*) roi->GetEntity(), "EDG01_04", 1, 0.5f, 3, 0.5f);
 
 	MxMatrix local2world = roi->GetLocal2World();
 	local2world[3][0] -= 1.5;
@@ -509,8 +511,7 @@ void LegoAct2::ReadyWorld()
 	sphere = roi->GetBoundingSphere();
 	sphere.Radius() *= 1.5;
 	roi->SetBoundingSphere(sphere);
-	actor = (LegoPathActor*) roi->GetEntity();
-	PlaceActor(actor, "EDG00_149", 0, 0.5f, 2, 0.5f);
+	PlaceActor((LegoPathActor*) roi->GetEntity(), "EDG00_149", 0, 0.5f, 2, 0.5f);
 
 	PlayMusic(JukeboxScript::c_Jail_Music);
 	DisableAnimations();
@@ -534,7 +535,8 @@ void LegoAct2::Enable(MxBool p_enable)
 		GameState()->SetActor(LegoActor::e_pepper);
 		m_pepper = FindROI("pepper");
 
-		((IslePathActor*) m_pepper->GetEntity())->UpdateWorld(m_transformOnDisable, m_boundaryOnDisable, TRUE);
+		IslePathActor* actor = (IslePathActor*) m_pepper->GetEntity();
+		actor->UpdateWorld(m_transformOnDisable, m_boundaryOnDisable, TRUE);
 
 		if (GameState()->m_previousArea == LegoGameState::e_infomain) {
 			GameState()->StopArea(LegoGameState::e_infomain);
@@ -1171,7 +1173,7 @@ MxResult LegoAct2::StartAction(
 					TRUE,
 					TRUE,
 					TRUE,
-					TRUE
+					FALSE
 				);
 			}
 			else {
@@ -1184,7 +1186,7 @@ MxResult LegoAct2::StartAction(
 					TRUE,
 					TRUE,
 					TRUE,
-					FALSE
+					TRUE
 				);
 			}
 

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -33,7 +33,10 @@ DECOMP_SIZE_ASSERT(RegistrationBook, 0x2d0)
 
 // GLOBAL: LEGO1 0x100d9924
 // GLOBAL: BETA10 0x101bfb3c
-const char* g_infoman = "infoman";
+const char* const g_infoman = "infoman";
+
+// GLOBAL: LEGO1 0x100f7960
+MxU8 g_unk0x100f7960[] = {1, 2, 3, 4};
 
 // GLOBAL: LEGO1 0x100f7964
 MxLong g_checkboxBlinkTimer = 0;
@@ -46,10 +49,10 @@ RegistrationBook::RegistrationBook() : m_registerDialogueTimer(0x80000000), m_un
 {
 	memset(m_alphabet, 0, sizeof(m_alphabet));
 	memset(m_name, 0, sizeof(m_name));
-	m_newName.m_cursorPos = 0;
+	m_cursorPos = 0;
 
 	memset(m_checkmark, 0, sizeof(m_checkmark));
-	memset(&m_newName, -1, sizeof(m_newName) - 2);
+	memset(m_letters, -1, sizeof(m_letters));
 
 	m_vehiclesToPosition = 0;
 	m_infocenterState = NULL;
@@ -186,37 +189,38 @@ MxLong RegistrationBook::HandleKeyPress(MxU8 p_key)
 			BackgroundAudioManager()->RaiseVolume();
 		}
 	}
-	else if (key != VK_BACK && m_newName.m_cursorPos < 7) {
-		m_name[0][m_newName.m_cursorPos] = m_alphabet[key - 'A']->Clone();
+	else if (key != VK_BACK && m_cursorPos < 7) {
+		m_name[0][m_cursorPos] = m_alphabet[key - 'A']->Clone();
+		assert(m_name[0][m_cursorPos]);
 
-		if (m_name[0][m_newName.m_cursorPos] != NULL) {
+		if (m_name[0][m_cursorPos] != NULL) {
 			m_alphabet[key - 'A']->GetAction()->SetUnknown24(m_alphabet[key - 'A']->GetAction()->GetUnknown24() + 1);
-			m_name[0][m_newName.m_cursorPos]->Enable(TRUE);
-			m_name[0][m_newName.m_cursorPos]->SetTickleState(MxPresenter::e_repeating);
-			m_name[0][m_newName.m_cursorPos]->SetPosition(m_newName.m_cursorPos * 23 + 343, 121);
+			m_name[0][m_cursorPos]->Enable(TRUE);
+			m_name[0][m_cursorPos]->SetTickleState(MxPresenter::e_repeating);
+			m_name[0][m_cursorPos]->SetPosition(m_cursorPos * 23 + 343, 121);
 
-			if (m_newName.m_cursorPos == 0) {
+			if (m_cursorPos == 0) {
 				m_checkmark[0]->Enable(TRUE);
 			}
 
-			m_newName.m_letters[m_newName.m_cursorPos] = key - 'A';
-			m_newName.m_cursorPos++;
+			m_letters[m_cursorPos] = key - 'A';
+			m_cursorPos++;
 		}
 	}
 	else {
-		if (key == VK_BACK && m_newName.m_cursorPos > 0) {
-			m_newName.m_cursorPos--;
+		if (key == VK_BACK && m_cursorPos > 0) {
+			m_cursorPos--;
 
-			m_name[0][m_newName.m_cursorPos]->Enable(FALSE);
+			m_name[0][m_cursorPos]->Enable(FALSE);
 
-			delete m_name[0][m_newName.m_cursorPos];
-			m_name[0][m_newName.m_cursorPos] = NULL;
+			delete m_name[0][m_cursorPos];
+			m_name[0][m_cursorPos] = NULL;
 
-			if (m_newName.m_cursorPos == 0) {
+			if (m_cursorPos == 0) {
 				m_checkmark[0]->Enable(FALSE);
 			}
 
-			m_newName.m_letters[m_newName.m_cursorPos] = -1;
+			m_letters[m_cursorPos] = -1;
 		}
 	}
 
@@ -238,10 +242,10 @@ MxLong RegistrationBook::HandleControl(LegoControlManagerNotificationParam& p_pa
 				DeleteObjects(&m_atomId, RegbookScript::c_iic006in_RunAnim, RegbookScript::c_iic008in_PlayWav);
 
 				if (GameState()->GetCurrentAct() == LegoGameState::e_act1) {
-					m_infocenterState->m_state = InfocenterState::e_backToInfoAct1;
+					m_infocenterState->m_step = InfocenterState::e_backToInfoAct1;
 				}
 				else {
-					m_infocenterState->m_state = InfocenterState::e_notRegistered;
+					m_infocenterState->m_step = InfocenterState::e_notRegistered;
 				}
 
 				TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
@@ -283,8 +287,8 @@ void RegistrationBook::LoadSave(MxS16 p_checkMarkIndex)
 
 	// The first checkmark searches for the name and is -1 if not found, while all other checkmarks start at 1
 	// TODO: structure incorrect
-	MxS16 player = p_checkMarkIndex == 0 ? GameState()->FindPlayer(*(LegoGameState::Username*) &m_newName.m_letters)
-										 : p_checkMarkIndex - 1;
+	MxS16 player =
+		p_checkMarkIndex == 0 ? GameState()->FindPlayer(*(LegoGameState::Username*) &m_letters) : p_checkMarkIndex - 1;
 
 	switch (player) {
 	case 0: // Current save
@@ -302,7 +306,7 @@ void RegistrationBook::LoadSave(MxS16 p_checkMarkIndex)
 		m_awaitLoad = TRUE;
 
 		// TOOD: structure incorrect
-		GameState()->AddPlayer(*(LegoGameState::Username*) &m_newName.m_letters);
+		GameState()->AddPlayer(*(LegoGameState::Username*) &m_letters);
 		GameState()->Save(0);
 
 		WriteInfocenterLetters(0);
@@ -324,7 +328,7 @@ void RegistrationBook::LoadSave(MxS16 p_checkMarkIndex)
 		break;
 	}
 
-	m_infocenterState->m_state = InfocenterState::e_selectedSave;
+	m_infocenterState->m_step = InfocenterState::e_selectedSave;
 	if (m_vehiclesToPosition == 0 && !m_awaitLoad) {
 		DeleteObjects(&m_atomId, RegbookScript::c_iic006in_RunAnim, RegbookScript::c_iic008in_PlayWav);
 		TransitionManager()->StartTransition(MxTransitionManager::e_mosaic, 50, FALSE, FALSE);
@@ -335,7 +339,8 @@ void RegistrationBook::LoadSave(MxS16 p_checkMarkIndex)
 void RegistrationBook::WriteInfocenterLetters(MxS16 p_user)
 {
 	for (MxS16 i = 0; i < 7; i++) {
-		delete m_infocenterState->GetNameLetter(i);
+		MxStillPresenter* letter = m_infocenterState->GetNameLetter(i);
+		delete letter;
 		m_infocenterState->SetNameLetter(i, m_name[p_user][i]);
 		m_name[p_user][i] = NULL;
 	}
@@ -463,12 +468,11 @@ void RegistrationBook::ReadyWorld()
 #ifdef BETA10
 	InfocenterState* infocenterState = (InfocenterState*) GameState()->GetState("InfocenterState");
 	assert(infocenterState);
-
-	if (infocenterState->HasRegistered())
 #else
-	if (m_infocenterState->HasRegistered())
+	InfocenterState* infocenterState = m_infocenterState;
 #endif
-	{
+
+	if (infocenterState->HasRegistered()) {
 		PlayAction(RegbookScript::c_iic008in_PlayWav);
 
 		LegoROI* infoman = FindROI(g_infoman);
@@ -609,14 +613,13 @@ MxLong RegistrationBook::HandlePathStruct(LegoPathStructNotificationParam& p_par
 MxBool RegistrationBook::CreateSurface()
 {
 	MxCompositePresenterList* presenters = m_checkmark[0]->GetList();
-	MxStillPresenter *presenter, *uninitialized;
+	MxStillPresenter* presenter; // intentionally uninitialized
 
 	if (presenters) {
-		if (presenters->begin() != presenters->end()) {
-			presenter = (MxStillPresenter*) presenters->front();
-		}
-		else {
-			presenter = uninitialized; // intentionally uninitialized variable
+		MxCompositePresenterList::iterator it = presenters->begin();
+
+		if (it != presenters->end()) {
+			presenter = (MxStillPresenter*) *it;
 		}
 
 		if (presenter) {


### PR DESCRIPTION
Asserts and names restored from BETA10, `const` restored on read-only tables, globals moved to the files that originally defined them, and small logic and member-initialization fixes confirmed by the byte-identical build. Covers the worlds, actors and race directories.

Part of a stacked series that makes the build of LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte-identical to the retail binaries. CI on this PR checks that everything still builds and passes the usual lints; the last PR in the series proves the byte-identical result.
