### PR TITLE
Match the original legoomni source: paths, entities and the model database

### DIFF
--- a/LEGO1/lego/legoomni/include/legoanimactor.h
+++ b/LEGO1/lego/legoomni/include/legoanimactor.h
@@ -11,7 +11,9 @@ struct LegoAnimActorStruct {
 	LegoAnimActorStruct(float p_worldSpeed, LegoAnim* p_AnimTreePtr, LegoROI** p_roiMap, MxU32 p_numROIs);
 	~LegoAnimActorStruct();
 
+	float GetDistance(float p_time);
 	float GetDuration();
+	float GetTotalDistance();
 
 	// FUNCTION: BETA10 0x1000fb10
 	float GetWorldSpeed() { return m_worldSpeed; }
@@ -84,8 +86,8 @@ protected:
 // GLOBAL: LEGO1 0x100d5438
 // LegoAnimActor::`vbtable'
 
-// TEMPLATE: LEGO1 0x1000da20
-// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::~vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >
+// TEMPLATE: LEGO1 0x1000da20 SYMBOL
+// ??1?$vector@PAULegoAnimActorStruct@@V?$allocator@PAULegoAnimActorStruct@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1000da60
 // Vector<LegoAnimActorStruct *>::~Vector<LegoAnimActorStruct *>
@@ -94,21 +96,21 @@ protected:
 // SYNTHETIC: BETA10 0x1000fad0
 // LegoAnimActor::`vbase destructor'
 
-// TEMPLATE: LEGO1 0x1001c010
-// vector<unsigned char *,allocator<unsigned char *> >::~vector<unsigned char *,allocator<unsigned char *> >
+// TEMPLATE: LEGO1 0x1001c010 SYMBOL
+// ??1?$vector@PAEV?$allocator@PAE@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1001c050
 // Vector<unsigned char *>::~Vector<unsigned char *>
 
-// TEMPLATE: LEGO1 0x1001c7c0
-// TEMPLATE: BETA10 0x1000fb40
-// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::size
+// TEMPLATE: LEGO1 0x1001c7c0 SYMBOL
+// TEMPLATE: BETA10 0x1000fb40 SYMBOL
+// ?size@?$vector@PAULegoAnimActorStruct@@V?$allocator@PAULegoAnimActorStruct@@@@@@QBEIXZ
 
 // TEMPLATE: BETA10 0x1000fb90
 // vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::operator[]
 
-// TEMPLATE: LEGO1 0x1001c7e0
-// vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::_Destroy
+// TEMPLATE: LEGO1 0x1001c7e0 SYMBOL
+// ?_Destroy@?$vector@PAULegoAnimActorStruct@@V?$allocator@PAULegoAnimActorStruct@@@@@@IAEXPAPAULegoAnimActorStruct@@0@Z
 
 // TEMPLATE: BETA10 0x1000fbc0
 // vector<LegoAnimActorStruct *,allocator<LegoAnimActorStruct *> >::begin

--- a/LEGO1/lego/legoomni/include/legoentity.h
+++ b/LEGO1/lego/legoomni/include/legoentity.h
@@ -4,8 +4,8 @@
 #include "decomp.h"
 #include "extra.h"
 #include "mxentity.h"
+#include "roi/legoroi.h"
 
-class LegoROI;
 class MxDSAction;
 class Vector3;
 

--- a/LEGO1/lego/legoomni/include/legoentitypresenter.h
+++ b/LEGO1/lego/legoomni/include/legoentitypresenter.h
@@ -4,6 +4,7 @@
 #include "mxcompositepresenter.h"
 
 class LegoEntity;
+class Mx3DPointFloat;
 class Vector3;
 
 // VTABLE: LEGO1 0x100d8398
@@ -42,6 +43,11 @@ public:
 	virtual undefined4 SetEntity(LegoEntity* p_entity);                                    // vtable+0x6c
 
 	void SetEntityLocation(const Vector3& p_location, const Vector3& p_direction, const Vector3& p_up);
+	Mx3DPointFloat GetWorldPosition();
+	Mx3DPointFloat GetWorldDirection();
+	Mx3DPointFloat GetWorldUp();
+	void SetWorldSpeed(MxFloat p_worldSpeed);
+	MxFloat GetWorldSpeed();
 
 	LegoEntity* GetInternalEntity() { return m_entity; }
 	void SetInternalEntity(LegoEntity* p_entity) { m_entity = p_entity; }

--- a/LEGO1/lego/legoomni/include/legomodelpresenter.h
+++ b/LEGO1/lego/legoomni/include/legomodelpresenter.h
@@ -46,7 +46,7 @@ public:
 	void ReadyTickle() override; // vtable+0x18
 	void ParseExtra() override;  // vtable+0x30
 
-	MxResult CreateROI(MxDSChunk& p_chunk, LegoEntity* p_entity, MxBool p_roiVisible, LegoWorld* p_world);
+	MxResult CreateROI(MxDSChunk* p_chunk, LegoEntity* p_entity, MxBool p_roiVisible, LegoWorld* p_world);
 
 	void Reset()
 	{

--- a/LEGO1/lego/legoomni/include/legopathboundary.h
+++ b/LEGO1/lego/legoomni/include/legopathboundary.h
@@ -56,6 +56,7 @@ public:
 	);
 	MxU32 AddPresenterIfInRange(LegoAnimPresenter* p_presenter);
 	MxU32 RemovePresenter(LegoAnimPresenter* p_presenter);
+	MxU32 BETA_100b23bb(const Vector3& p_position, LegoOrientedEdge*& p_edge);
 
 	// FUNCTION: BETA10 0x1001ffb0
 	LegoPathActorSet& GetActors() { return m_actors; }
@@ -73,18 +74,18 @@ private:
 };
 
 // clang-format off
-// TEMPLATE: LEGO1 0x1002bee0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::~_Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,a
+// TEMPLATE: LEGO1 0x1002bee0 SYMBOL
+// ??1?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1002bfb0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x1002bfb0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1002bff0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::erase
+// TEMPLATE: LEGO1 0x1002bff0 SYMBOL
+// ?erase@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1002c440
-// TEMPLATE: BETA10 0x10020480
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::find
+// TEMPLATE: LEGO1 0x1002c440 SYMBOL
+// TEMPLATE: BETA10 0x10020480 SYMBOL
+// ?find@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QBE?AVconst_iterator@1@ABQAVLegoPathActor@@@Z
 
 // TEMPLATE: LEGO1 0x1002c4c0
 // ?_Copy@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXABV1@@Z
@@ -92,57 +93,57 @@ private:
 // TEMPLATE: LEGO1 0x1002c5b0
 // ?_Copy@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x1002c630
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Erase
+// TEMPLATE: LEGO1 0x1002c630 SYMBOL
+// ?_Erase@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1002c670
-// set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::~set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >
+// TEMPLATE: LEGO1 0x1002c670 SYMBOL
+// ??1?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1002c6c0
 // TEMPLATE: BETA10 0x10020760
 // Set<LegoPathActor *,LegoPathActorSetCompare>::~Set<LegoPathActor *,LegoPathActorSetCompare>
 
-// TEMPLATE: LEGO1 0x1002eb10
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Init
+// TEMPLATE: LEGO1 0x1002eb10 SYMBOL
+// ?_Init@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXXZ
 
-// TEMPLATE: LEGO1 0x1002ebc0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Min
+// TEMPLATE: LEGO1 0x1002ebc0 SYMBOL
+// ?_Min@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@KAPAU_Node@1@PAU21@@Z
 
-// TEMPLATE: LEGO1 0x100822a0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Min
+// TEMPLATE: LEGO1 0x100822a0 SYMBOL
+// ?_Min@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@KAPAU_Node@1@PAU21@@Z
 
-// TEMPLATE: LEGO1 0x10045d80
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10045d80 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10045dd0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Insert
+// TEMPLATE: LEGO1 0x10045dd0 SYMBOL
+// ?_Insert@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAVLegoPathActor@@@Z
 
-// TEMPLATE: LEGO1 0x10046310
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::insert
+// TEMPLATE: LEGO1 0x10046310 SYMBOL
+// ?insert@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$se
 
-// TEMPLATE: LEGO1 0x10046580
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Lrotate
+// TEMPLATE: LEGO1 0x10046580 SYMBOL
+// ?_Lrotate@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x100465e0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Rrotate
+// TEMPLATE: LEGO1 0x100465e0 SYMBOL
+// ?_Rrotate@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1004a7a0
 // ?_Construct@@YAXPAPAVLegoPathActor@@ABQAV1@@Z
 
-// TEMPLATE: LEGO1 0x10056c20
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::~_Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoA
+// TEMPLATE: LEGO1 0x10056c20 SYMBOL
+// ??1?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10056cf0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10056cf0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAEXXZ
 
 // TEMPLATE: LEGO1 0x10056d30
 // ?erase@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10057180
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Erase
+// TEMPLATE: LEGO1 0x10057180 SYMBOL
+// ?_Erase@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x100571c0
-// set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::~set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >
+// TEMPLATE: LEGO1 0x100571c0 SYMBOL
+// ??1?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x10057210
 // Set<LegoAnimPresenter *,LegoAnimPresenterSetCompare>::~Set<LegoAnimPresenter *,LegoAnimPresenterSetCompare>
@@ -150,35 +151,35 @@ private:
 // TEMPLATE: BETA10 0x10082de0
 // set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::begin
 
-// TEMPLATE: LEGO1 0x100573e0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::begin
+// TEMPLATE: LEGO1 0x100573e0 SYMBOL
+// ?begin@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QAE?AViterator@1@XZ
 
-// TEMPLATE: LEGO1 0x100580c0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::insert
+// TEMPLATE: LEGO1 0x100580c0 SYMBOL
+// ?insert@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVLegoAn
 
-// TEMPLATE: LEGO1 0x10058330
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10058330 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10058380
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Buynode
+// TEMPLATE: LEGO1 0x10058380 SYMBOL
+// ?_Buynode@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x100583a0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Insert
+// TEMPLATE: LEGO1 0x100583a0 SYMBOL
+// ?_Insert@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAVLegoA
 
-// TEMPLATE: LEGO1 0x10058620
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Lrotate
+// TEMPLATE: LEGO1 0x10058620 SYMBOL
+// ?_Lrotate@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10058680
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Rrotate
+// TEMPLATE: LEGO1 0x10058680 SYMBOL
+// ?_Rrotate@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x10058820
 // ?erase@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AViterator@1@V21@0@Z
 
-// TEMPLATE: LEGO1 0x100588e0
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::equal_range
+// TEMPLATE: LEGO1 0x100588e0 SYMBOL
+// ?equal_range@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVL
 
-// TEMPLATE: LEGO1 0x10058950
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Lbound
+// TEMPLATE: LEGO1 0x10058950 SYMBOL
+// ?_Lbound@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@IBEPAU_Node@1@ABQAVLegoAnimPresenter@@@
 
 // TEMPLATE: LEGO1 0x10058980
 // ?_Construct@@YAXPAPAVLegoAnimPresenter@@ABQAV1@@Z
@@ -186,8 +187,8 @@ private:
 // TEMPLATE: LEGO1 0x100589a0
 // _Distance
 
-// TEMPLATE: LEGO1 0x10081cd0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::lower_bound
+// TEMPLATE: LEGO1 0x10081cd0 SYMBOL
+// ?lower_bound@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@QBE?AVconst_iterator@1@ABQAVLegoPathActor@@@Z
 
 // TEMPLATE: BETA10 0x10082b90
 // ??Econst_iterator@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QAE?AV01@H@Z
@@ -217,10 +218,10 @@ private:
 // set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::end
 
 // GLOBAL: LEGO1 0x100f11a4
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Nil
+// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *>>::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *>>::_Nil
 
 // GLOBAL: LEGO1 0x100f3200
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Nil
+// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *>>::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *>>::_Nil
 // clang-format on
 
 #endif // LEGOPATHBOUNDARY_H

--- a/LEGO1/lego/legoomni/include/legopathcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopathcontroller.h
@@ -3,8 +3,8 @@
 
 #include "decomp.h"
 #include "geom/legowegedge.h"
-#include "legopathactor.h"
 #include "legopathboundary.h"
+#include "legopathactor.h"
 #include "legopathstruct.h"
 #include "mxstl/stlcompat.h"
 
@@ -209,50 +209,50 @@ private:
 };
 
 // clang-format off
-// TEMPLATE: LEGO1 0x1001fd70
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Lbound
+// TEMPLATE: LEGO1 0x1001fd70 SYMBOL
+// ?_Lbound@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IBEPAU_Node@1@ABQAVLegoPathActor@@@Z
 
-// TEMPLATE: LEGO1 0x1002c4a0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Buynode
+// TEMPLATE: LEGO1 0x1002c4a0 SYMBOL
+// ?_Buynode@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x100451a0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::~_Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathControl
+// TEMPLATE: LEGO1 0x100451a0 SYMBOL
+// ??1?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10045270
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10045270 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAEXXZ
 
 // TEMPLATE: LEGO1 0x100452b0
 // ?erase@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10045700
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Erase
+// TEMPLATE: LEGO1 0x10045700 SYMBOL
+// ?_Erase@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x100457e0
 // Set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare>::~Set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare>
 
-// TEMPLATE: LEGO1 0x10045830
-// set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::~set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >
+// TEMPLATE: LEGO1 0x10045830 SYMBOL
+// ??1?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10046640
-// _Tree<LegoAnimPresenter *,LegoAnimPresenter *,set<LegoAnimPresenter *,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::_Kfn,LegoAnimPresenterSetCompare,allocator<LegoAnimPresenter *> >::find
+// TEMPLATE: LEGO1 0x10046640 SYMBOL
+// ?find@?$_Tree@PAVLegoAnimPresenter@@PAV1@U_Kfn@?$set@PAVLegoAnimPresenter@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@ULegoAnimPresenterSetCompare@@V?$allocator@PAVLegoAnimPresenter@@@@@@QBE?AVconst_iterator@1@ABQAVLegoAnimPresen
 
-// TEMPLATE: LEGO1 0x100468c0
-// _Tree<LegoPathActor *,LegoPathActor *,set<LegoPathActor *,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Kfn,LegoPathActorSetCompare,allocator<LegoPathActor *> >::_Ubound
+// TEMPLATE: LEGO1 0x100468c0 SYMBOL
+// ?_Ubound@?$_Tree@PAVLegoPathActor@@PAV1@U_Kfn@?$set@PAVLegoPathActor@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@ULegoPathActorSetCompare@@V?$allocator@PAVLegoPathActor@@@@@@IBEPAU_Node@1@ABQAVLegoPathActor@@@Z
 
-// TEMPLATE: LEGO1 0x10047550
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Insert
+// TEMPLATE: LEGO1 0x10047550 SYMBOL
+// ?_Insert@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAULegoPathCtrlEdge@
 
-// TEMPLATE: LEGO1 0x100474e0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x100474e0 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10047530
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Buynode
+// TEMPLATE: LEGO1 0x10047530 SYMBOL
+// ?_Buynode@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x100477d0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Lrotate
+// TEMPLATE: LEGO1 0x100477d0 SYMBOL
+// ?_Lrotate@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10047830
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Rrotate
+// TEMPLATE: LEGO1 0x10047830 SYMBOL
+// ?_Rrotate@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEXPAU_Node@1@@Z
 
 // SYNTHETIC: LEGO1 0x10047940
 // LegoPathCtrlEdge::`vector deleting destructor'
@@ -266,71 +266,71 @@ private:
 // SYNTHETIC: LEGO1 0x10047ae0
 // LegoOrientedEdge::~LegoOrientedEdge
 
-// TEMPLATE: LEGO1 0x10048f00
-// list<LegoBoundaryEdge,allocator<LegoBoundaryEdge> >::begin
+// TEMPLATE: LEGO1 0x10048f00 SYMBOL
+// ?begin@?$list@ULegoBoundaryEdge@@V?$allocator@ULegoBoundaryEdge@@@@@@QAE?AViterator@1@XZ
 
-// TEMPLATE: LEGO1 0x10048f10
-// list<LegoBoundaryEdge,allocator<LegoBoundaryEdge> >::insert
+// TEMPLATE: LEGO1 0x10048f10 SYMBOL
+// ?insert@?$list@ULegoBoundaryEdge@@V?$allocator@ULegoBoundaryEdge@@@@@@QAE?AViterator@1@V21@ABULegoBoundaryEdge@@@Z
 
-// TEMPLATE: LEGO1 0x10048f70
-// list<LegoBoundaryEdge,allocator<LegoBoundaryEdge> >::erase
+// TEMPLATE: LEGO1 0x10048f70 SYMBOL
+// ?erase@?$list@ULegoBoundaryEdge@@V?$allocator@ULegoBoundaryEdge@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10048fc0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,Le
+// TEMPLATE: LEGO1 0x10048fc0 SYMBOL
+// ??0?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAE@ABV0@@Z
 
 // TEMPLATE: LEGO1 0x10049160
 // ?erase@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QAEIABQAULegoPathCtrlEdge@@@Z
 
-// TEMPLATE: LEGO1 0x10049290
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::find
+// TEMPLATE: LEGO1 0x10049290 SYMBOL
+// ?find@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@QBE?AVconst_iterator@1@ABQAULegoPathCtrlEdge@@@Z
 
-// TEMPLATE: LEGO1 0x100492f0
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Copy
+// TEMPLATE: LEGO1 0x100492f0 SYMBOL
+// ?_Copy@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x10049370
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Ubound
+// TEMPLATE: LEGO1 0x10049370 SYMBOL
+// ?_Ubound@?$_Tree@PAULegoPathCtrlEdge@@PAU1@U_Kfn@?$set@PAULegoPathCtrlEdge@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@ULegoPathCtrlEdgeCompare@@V?$allocator@PAULegoPathCtrlEdge@@@@@@IBEPAU_Node@1@ABQAULegoPathCtrlEdge@@@Z
 
-// TEMPLATE: LEGO1 0x100493a0
-// list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >::~list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >
+// TEMPLATE: LEGO1 0x100493a0 SYMBOL
+// ??1?$list@ULegoBEWithMidpoint@@V?$allocator@ULegoBEWithMidpoint@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10049410
-// list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >::insert
+// TEMPLATE: LEGO1 0x10049410 SYMBOL
+// ?insert@?$list@ULegoBEWithMidpoint@@V?$allocator@ULegoBEWithMidpoint@@@@@@QAE?AViterator@1@V21@ABULegoBEWithMidpoint@@@Z
 
-// TEMPLATE: LEGO1 0x10049470
-// list<LegoBEWithMidpoint,allocator<LegoBEWithMidpoint> >::_Buynode
+// TEMPLATE: LEGO1 0x10049470 SYMBOL
+// ?_Buynode@?$list@ULegoBEWithMidpoint@@V?$allocator@ULegoBEWithMidpoint@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x100494a0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x100494a0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x100494e0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::~_Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithFlo
+// TEMPLATE: LEGO1 0x100494e0 SYMBOL
+// ??1?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x100495b0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::insert
+// TEMPLATE: LEGO1 0x100495b0 SYMBOL
+// ?insert@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE?AU?$pair@Viterator@?$_Tre
 
-// TEMPLATE: LEGO1 0x10049840
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10049840 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10049890
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::erase
+// TEMPLATE: LEGO1 0x10049890 SYMBOL
+// ?erase@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10049cf0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Buynode
+// TEMPLATE: LEGO1 0x10049cf0 SYMBOL
+// ?_Buynode@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEPAU_Node@1@PAU21@W4_Redb
 
-// TEMPLATE: LEGO1 0x10049d50
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Init
+// TEMPLATE: LEGO1 0x10049d50 SYMBOL
+// ?_Init@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXXZ
 
-// TEMPLATE: LEGO1 0x10049e00
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Insert
+// TEMPLATE: LEGO1 0x10049e00 SYMBOL
+// ?_Insert@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAE?AViterator@1@PAU_Node@1@
 
-// TEMPLATE: LEGO1 0x10049d10
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Erase
+// TEMPLATE: LEGO1 0x10049d10 SYMBOL
+// ?_Erase@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1004a090
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Lrotate
+// TEMPLATE: LEGO1 0x1004a090 SYMBOL
+// ?_Lrotate@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1004a0f0
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Rrotate
+// TEMPLATE: LEGO1 0x1004a0f0 SYMBOL
+// ?_Rrotate@?$_Tree@PAULegoBEWithMidpoint@@PAU1@U_Kfn@?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1004a150
 // List<LegoBEWithMidpoint>::~List<LegoBEWithMidpoint>
@@ -338,8 +338,8 @@ private:
 // TEMPLATE: LEGO1 0x1004a1a0
 // Multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator>::~Multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator>
 
-// TEMPLATE: LEGO1 0x1004a1f0
-// multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::~multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >
+// TEMPLATE: LEGO1 0x1004a1f0 SYMBOL
+// ??1?$multiset@PAULegoBEWithMidpoint@@ULegoBEWithMidpointComparator@@V?$allocator@PAULegoBEWithMidpoint@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1004a760
 // ?_Construct@@YAXPAPAULegoBEWithMidpoint@@ABQAU1@@Z
@@ -348,10 +348,10 @@ private:
 // ?_Construct@@YAXPAPAULegoPathCtrlEdge@@ABQAU1@@Z
 
 // GLOBAL: LEGO1 0x100f4360
-// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *> >::_Nil
+// _Tree<LegoPathCtrlEdge *,LegoPathCtrlEdge *,set<LegoPathCtrlEdge *,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *>>::_Kfn,LegoPathCtrlEdgeCompare,allocator<LegoPathCtrlEdge *>>::_Nil
 
 // GLOBAL: LEGO1 0x100f4364
-// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *> >::_Nil
+// _Tree<LegoBEWithMidpoint *,LegoBEWithMidpoint *,multiset<LegoBEWithMidpoint *,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *>>::_Kfn,LegoBEWithMidpointComparator,allocator<LegoBEWithMidpoint *>>::_Nil
 // clang-format on
 
 #endif // LEGOPATHCONTROLLER_H

--- a/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
+++ b/LEGO1/lego/legoomni/include/legopointofviewcontroller.h
@@ -2,13 +2,13 @@
 #define LEGOPOINTOFVIEWCONTROLLER_H
 
 #include "decomp.h"
+#include "legoentity.h"
 #include "mxcore.h"
 #include "mxgeometry.h"
 
 #include <windows.h>
 
 class Lego3DView;
-class LegoEntity;
 class LegoNavController;
 
 //////////////////////////////////////////////////////////////////////////////

--- a/LEGO1/lego/legoomni/include/legoworld.h
+++ b/LEGO1/lego/legoomni/include/legoworld.h
@@ -1,11 +1,9 @@
 #ifndef LEGOWORLD_H
 #define LEGOWORLD_H
 
-// clang-format off
 #include "mxpresenterlist.h"
 #include "legoentitylist.h"
 #include "legocachesoundlist.h"
-// clang-format on
 
 #include "legoentity.h"
 #include "legomain.h"
@@ -116,7 +114,7 @@ public:
 	LegoEntityList* GetEntityList() { return m_entityList; }
 	LegoOmni::World GetWorldId() { return m_worldId; }
 	MxBool NoDisabledObjects() { return m_disabledObjects.empty(); }
-	list<LegoROI*>& GetROIList() { return m_roiList; }
+	list<LegoROI*>* GetROIList() { return &m_roiList; }
 	LegoHideAnimPresenter* GetHideAnimPresenter() { return m_hideAnim; }
 
 	void SetWorldId(LegoOmni::World p_worldId) { m_worldId = p_worldId; }
@@ -146,68 +144,68 @@ protected:
 };
 
 // clang-format off
-// TEMPLATE: LEGO1 0x1001d780
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::~_Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >
+// TEMPLATE: LEGO1 0x1001d780 SYMBOL
+// ??1?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1001d850
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x1001d850 SYMBOL
+// ?_Inc@iterator@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1001d890
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::erase
+// TEMPLATE: LEGO1 0x1001d890 SYMBOL
+// ?erase@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1001dcf0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Erase
+// TEMPLATE: LEGO1 0x1001dcf0 SYMBOL
+// ?_Erase@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x1001dd30
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Init
+// TEMPLATE: LEGO1 0x1001dd30 SYMBOL
+// ?_Init@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXXZ
 
-// TEMPLATE: LEGO1 0x1001ddf0
-// list<LegoROI *,allocator<LegoROI *> >::~list<LegoROI *,allocator<LegoROI *> >
+// TEMPLATE: LEGO1 0x1001ddf0 SYMBOL
+// ??1?$list@PAVLegoROI@@V?$allocator@PAVLegoROI@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1001df50
 // List<LegoROI *>::~List<LegoROI *>
 
-// TEMPLATE: LEGO1 0x1001de60
-// list<LegoROI *,allocator<LegoROI *> >::_Buynode
+// TEMPLATE: LEGO1 0x1001de60 SYMBOL
+// ?_Buynode@?$list@PAVLegoROI@@V?$allocator@PAVLegoROI@@@@@@IAEPAU_Node@1@PAU21@0@Z
 
-// TEMPLATE: LEGO1 0x1001de90
-// set<MxCore *,CoreSetCompare,allocator<MxCore *> >::~set<MxCore *,CoreSetCompare,allocator<MxCore *> >
+// TEMPLATE: LEGO1 0x1001de90 SYMBOL
+// ??1?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1001df00
 // Set<MxCore *,CoreSetCompare>::~Set<MxCore *,CoreSetCompare>
 
-// TEMPLATE: LEGO1 0x1001f590
-// list<LegoROI *,allocator<LegoROI *> >::erase
+// TEMPLATE: LEGO1 0x1001f590 SYMBOL
+// ?erase@?$list@PAVLegoROI@@V?$allocator@PAVLegoROI@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x100208b0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::insert
+// TEMPLATE: LEGO1 0x100208b0 SYMBOL
+// ?insert@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAE?AU?$pair@Viterator@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@
 
-// TEMPLATE: LEGO1 0x10020b20
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x10020b20 SYMBOL
+// ?_Dec@iterator@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10020b70
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::lower_bound
+// TEMPLATE: LEGO1 0x10020b70 SYMBOL
+// ?lower_bound@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QBE?AVconst_iterator@1@ABQAVMxCore@@@Z
 
-// TEMPLATE: LEGO1 0x10020bb0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Buynode
+// TEMPLATE: LEGO1 0x10020bb0 SYMBOL
+// ?_Buynode@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEPAU_Node@1@PAU21@W4_Redbl@1@@Z
 
-// TEMPLATE: LEGO1 0x10020bd0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Insert
+// TEMPLATE: LEGO1 0x10020bd0 SYMBOL
+// ?_Insert@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAE?AViterator@1@PAU_Node@1@0ABQAVMxCore@@@Z
 
-// TEMPLATE: LEGO1 0x10020e50
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Lrotate
+// TEMPLATE: LEGO1 0x10020e50 SYMBOL
+// ?_Lrotate@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10020eb0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Rrotate
+// TEMPLATE: LEGO1 0x10020eb0 SYMBOL
+// ?_Rrotate@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10021340
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::find
+// TEMPLATE: LEGO1 0x10021340 SYMBOL
+// ?find@?$_Tree@PAVMxCore@@PAV1@U_Kfn@?$set@PAVMxCore@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@UCoreSetCompare@@V?$allocator@PAVMxCore@@@@@@QBE?AVconst_iterator@1@ABQAVMxCore@@@Z
 
 // TEMPLATE: LEGO1 0x10022360
 // ?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z
 
 // GLOBAL: LEGO1 0x100f11a0
-// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *> >::_Kfn,CoreSetCompare,allocator<MxCore *> >::_Nil
+// _Tree<MxCore *,MxCore *,set<MxCore *,CoreSetCompare,allocator<MxCore *>>::_Kfn,CoreSetCompare,allocator<MxCore *>>::_Nil
 // clang-format on
 
 #endif // LEGOWORLD_H

--- a/LEGO1/lego/legoomni/src/entity/legoentity.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentity.cpp
@@ -483,7 +483,9 @@ MxLong LegoEntity::Notify(MxParam& p_param)
 		InvokeAction(m_actionType, MxAtomId(m_siFile, e_lowerCase2), m_targetEntityId, this);
 	}
 	else {
-		switch (GameState()->GetActorId()) {
+		MxU8 actorId = GameState()->GetActorId();
+
+		switch (actorId) {
 		case LegoActor::e_pepper:
 			if (GameState()->GetCurrentAct() != LegoGameState::e_act2 &&
 				GameState()->GetCurrentAct() != LegoGameState::e_act3) {

--- a/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoentitypresenter.cpp
@@ -89,6 +89,58 @@ void LegoEntityPresenter::SetEntityLocation(const Vector3& p_location, const Vec
 	}
 }
 
+// FUNCTION: BETA10 0x1008034e
+Mx3DPointFloat LegoEntityPresenter::GetWorldPosition()
+{
+	if (m_entity) {
+		return m_entity->GetWorldPosition();
+	}
+	else {
+		return Mx3DPointFloat(0, 0, 0);
+	}
+}
+
+// FUNCTION: BETA10 0x100803a6
+Mx3DPointFloat LegoEntityPresenter::GetWorldDirection()
+{
+	if (m_entity) {
+		return m_entity->GetWorldDirection();
+	}
+	else {
+		return Mx3DPointFloat(1, 0, 0);
+	}
+}
+
+// FUNCTION: BETA10 0x10080401
+Mx3DPointFloat LegoEntityPresenter::GetWorldUp()
+{
+	if (m_entity) {
+		return m_entity->GetWorldUp();
+	}
+	else {
+		return Mx3DPointFloat(0, 1, 0);
+	}
+}
+
+// FUNCTION: BETA10 0x100804b4
+void LegoEntityPresenter::SetWorldSpeed(MxFloat p_worldSpeed)
+{
+	if (m_entity) {
+		m_entity->SetWorldSpeed(p_worldSpeed);
+	}
+}
+
+// FUNCTION: BETA10 0x100804f7
+MxFloat LegoEntityPresenter::GetWorldSpeed()
+{
+	if (m_entity) {
+		return m_entity->GetWorldSpeed();
+	}
+	else {
+		return 0.0f;
+	}
+}
+
 // FUNCTION: LEGO1 0x10053750
 void LegoEntityPresenter::ParseExtra()
 {

--- a/LEGO1/lego/legoomni/src/entity/legoworld.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworld.cpp
@@ -136,7 +136,7 @@ void LegoWorld::Destroy(MxBool p_fromDestructor)
 		m_objects.erase(it);
 
 		if (object->IsA("MxPresenter")) {
-			MxPresenter* presenter = (MxPresenter*) object;
+			presenter = (MxPresenter*) object;
 			MxDSAction* action = presenter->GetAction();
 
 			if (action) {
@@ -375,6 +375,7 @@ void LegoWorld::RemovePresenterFromBoundaries(LegoAnimPresenter* p_presenter)
 }
 
 // FUNCTION: LEGO1 0x1001ff80
+// FUNCTION: BETA10 0x100da749
 void LegoWorld::AddPath(LegoPathController* p_controller)
 {
 	p_controller->SetWorld(this);
@@ -400,6 +401,7 @@ LegoPathBoundary* LegoWorld::FindPathBoundary(const char* p_name)
 }
 
 // FUNCTION: LEGO1 0x10020120
+// FUNCTION: BETA10 0x100da842
 MxResult LegoWorld::GetCurrPathInfo(LegoPathBoundary** p_boundaries, MxS32& p_numL)
 {
 	LegoPathControllerListCursor cursor(&m_pathControllerList);
@@ -771,7 +773,7 @@ void LegoWorld::Enable(MxBool p_enable)
 			}
 		}
 
-		for (MxCoreSet::iterator it = m_objects.begin(); it != m_objects.end(); it++) {
+		for (it = m_objects.begin(); it != m_objects.end(); it++) {
 			if ((*it)->IsA("LegoActionControlPresenter") ||
 				((*it)->IsA("MxPresenter") && ((MxPresenter*) *it)->IsEnabled())) {
 				m_disabledObjects.insert(*it);

--- a/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp
@@ -27,6 +27,7 @@
 #include "mxstl/stlcompat.h"
 #include "mxutilities.h"
 
+#include <assert.h>
 #include <io.h>
 
 DECOMP_SIZE_ASSERT(LegoWorldPresenter, 0x54)
@@ -130,6 +131,8 @@ MxResult LegoWorldPresenter::StartAction(MxStreamController* p_controller, MxDSA
 void LegoWorldPresenter::ReadyTickle()
 {
 	m_entity = (LegoEntity*) MxPresenter::CreateEntity("LegoWorld");
+	assert(m_entity);
+
 	if (m_entity) {
 		m_entity->Create(*m_action);
 		Lego()->AddWorld((LegoWorld*) m_entity);
@@ -214,6 +217,8 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 		}
 
 		buff = new MxU8[size];
+		assert(buff);
+
 		if (fread(buff, size, 1, wdbFile) != 1) {
 			return FAILURE;
 		}
@@ -234,6 +239,8 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 		}
 
 		buff = new MxU8[size];
+		assert(buff);
+
 		if (fread(buff, size, 1, wdbFile) != 1) {
 			return FAILURE;
 		}
@@ -256,7 +263,7 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 		}
 	}
 
-	ModelDbPartListCursor cursor(worlds[i].m_partList);
+	ModelDbPartListCursor cursor(worlds[i].m_partlist);
 	ModelDbPart* part;
 
 	while (cursor.Next(part)) {
@@ -267,35 +274,35 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 	}
 
 	for (j = 0; j < worlds[i].m_numModels; j++) {
-		if (!strnicmp(worlds[i].m_models[j].m_modelName, "isle", 4)) {
+		if (!strnicmp(worlds[i].m_modarr[j].m_modelName, "isle", 4)) {
 			switch (g_legoWorldPresenterQuality) {
 			case 0:
-				if (strcmpi(worlds[i].m_models[j].m_modelName, "isle_lo")) {
+				if (strcmpi(worlds[i].m_modarr[j].m_modelName, "isle_lo")) {
 					continue;
 				}
 				break;
 			case 1:
-				if (strcmpi(worlds[i].m_models[j].m_modelName, "isle")) {
+				if (strcmpi(worlds[i].m_modarr[j].m_modelName, "isle")) {
 					continue;
 				}
 				break;
 			case 2:
-				if (strcmpi(worlds[i].m_models[j].m_modelName, "isle_hi")) {
+				if (strcmpi(worlds[i].m_modarr[j].m_modelName, "isle_hi")) {
 					continue;
 				}
 			}
 		}
-		else if (g_legoWorldPresenterQuality <= 1 && !strnicmp(worlds[i].m_models[j].m_modelName, "haus", 4)) {
-			if (worlds[i].m_models[j].m_modelName[4] == '3') {
-				if (LoadWorldModel(worlds[i].m_models[j], wdbFile, p_world) != SUCCESS) {
+		else if (g_legoWorldPresenterQuality <= 1 && !strnicmp(worlds[i].m_modarr[j].m_modelName, "haus", 4)) {
+			if (worlds[i].m_modarr[j].m_modelName[4] == '3') {
+				if (LoadWorldModel(worlds[i].m_modarr[j], wdbFile, p_world) != SUCCESS) {
 					return FAILURE;
 				}
 
-				if (LoadWorldModel(worlds[i].m_models[j - 2], wdbFile, p_world) != SUCCESS) {
+				if (LoadWorldModel(worlds[i].m_modarr[j - 2], wdbFile, p_world) != SUCCESS) {
 					return FAILURE;
 				}
 
-				if (LoadWorldModel(worlds[i].m_models[j - 1], wdbFile, p_world) != SUCCESS) {
+				if (LoadWorldModel(worlds[i].m_modarr[j - 1], wdbFile, p_world) != SUCCESS) {
 					return FAILURE;
 				}
 			}
@@ -303,7 +310,7 @@ MxResult LegoWorldPresenter::LoadWorld(char* p_worldName, LegoWorld* p_world)
 			continue;
 		}
 
-		if (LoadWorldModel(worlds[i].m_models[j], wdbFile, p_world) != SUCCESS) {
+		if (LoadWorldModel(worlds[i].m_modarr[j], wdbFile, p_world) != SUCCESS) {
 			return FAILURE;
 		}
 	}
@@ -318,6 +325,7 @@ MxResult LegoWorldPresenter::LoadWorldPart(ModelDbPart& p_part, FILE* p_wdbFile)
 {
 	MxResult result;
 	MxU8* buff = new MxU8[p_part.m_partDataLength];
+	assert(buff);
 
 	fseek(p_wdbFile, p_part.m_partDataOffset, SEEK_SET);
 	if (fread(buff, p_part.m_partDataLength, 1, p_wdbFile) != 1) {
@@ -343,6 +351,7 @@ MxResult LegoWorldPresenter::LoadWorldPart(ModelDbPart& p_part, FILE* p_wdbFile)
 MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFile, LegoWorld* p_world)
 {
 	MxU8* buff = new MxU8[p_model.m_modelDataLength];
+	assert(buff);
 
 	fseek(p_wdbFile, p_model.m_modelDataOffset, SEEK_SET);
 	if (fread(buff, p_model.m_modelDataLength, 1, p_wdbFile) != 1) {
@@ -371,6 +380,7 @@ MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFi
 		LegoActorPresenter presenter;
 		presenter.SetAction(&action);
 		LegoEntity* entity = (LegoEntity*) presenter.CreateEntity("LegoActor");
+		assert(entity);
 		presenter.SetInternalEntity(entity);
 		presenter.SetEntityLocation(p_model.m_location, p_model.m_direction, p_model.m_up);
 		entity->Create(action);
@@ -379,6 +389,7 @@ MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFi
 		LegoEntityPresenter presenter;
 		presenter.SetAction(&action);
 		createdEntity = (LegoEntity*) presenter.CreateEntity("LegoEntity");
+		assert(createdEntity);
 		presenter.SetInternalEntity(createdEntity);
 		presenter.SetEntityLocation(p_model.m_location, p_model.m_direction, p_model.m_up);
 		createdEntity->Create(action);
@@ -388,12 +399,12 @@ MxResult LegoWorldPresenter::LoadWorldModel(ModelDbModel& p_model, FILE* p_wdbFi
 
 	if (createdEntity != NULL) {
 		action.SetLocation(Mx3DPointFloat(0.0, 0.0, 0.0));
-		action.SetUp(Mx3DPointFloat(0.0, 0.0, 1.0));
-		action.SetDirection(Mx3DPointFloat(0.0, 1.0, 0.0));
+		action.SetDirection(Mx3DPointFloat(0.0, 0.0, 1.0));
+		action.SetUp(Mx3DPointFloat(0.0, 1.0, 0.0));
 	}
 
 	modelPresenter.SetAction(&action);
-	modelPresenter.CreateROI(chunk, createdEntity, p_model.m_visible, p_world);
+	modelPresenter.CreateROI(&chunk, createdEntity, p_model.m_visible, p_world);
 	delete[] buff;
 
 	return SUCCESS;
@@ -418,6 +429,7 @@ void LegoWorldPresenter::AdvanceSerialAction(MxPresenter* p_presenter)
 	if (!p_presenter->IsA("LegoAnimPresenter") && !p_presenter->IsA("MxControlPresenter") &&
 		!p_presenter->IsA("MxCompositePresenter")) {
 		p_presenter->SendToCompositePresenter(Lego());
+		assert(m_entity);
 		((LegoWorld*) m_entity)->Add(p_presenter);
 	}
 }
@@ -436,9 +448,11 @@ void LegoWorldPresenter::ParseExtra()
 
 		char output[1024];
 		if (KeyValueStringParse(output, g_strWORLD, extraCopy)) {
-			char* worldKey = strtok(output, g_parseExtraTokens);
-			LoadWorld(worldKey, (LegoWorld*) m_entity);
-			((LegoWorld*) m_entity)->SetWorldId(Lego()->GetWorldId(worldKey));
+			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
+
+			LoadWorld(token, (LegoWorld*) m_entity);
+			((LegoWorld*) m_entity)->SetWorldId(Lego()->GetWorldId(token));
 		}
 	}
 }

--- a/LEGO1/lego/legoomni/src/main/legomain.cpp
+++ b/LEGO1/lego/legoomni/src/main/legomain.cpp
@@ -32,6 +32,8 @@
 #include "scripts.h"
 #include "viewmanager/viewmanager.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoOmni, 0x140)
 DECOMP_SIZE_ASSERT(LegoOmni::WorldContainer, 0x1c)
 DECOMP_SIZE_ASSERT(LegoWorldList, 0x18)
@@ -375,6 +377,7 @@ LegoOmni* LegoOmni::GetInstance()
 // FUNCTION: LEGO1 0x1005ad20
 void LegoOmni::AddWorld(LegoWorld* p_world)
 {
+	assert(p_world);
 	m_worldList->Append(p_world);
 }
 
@@ -477,7 +480,9 @@ LegoROI* LegoOmni::FindROI(const char* p_name)
 		((LegoVideoManager*) m_videoManager)->Get3DManager()->GetLego3DView()->GetViewManager()->GetROIs();
 
 	if (p_name != NULL && *p_name != '\0' && rois.size() > 0) {
-		for (CompoundObject::const_iterator it = rois.begin(); it != rois.end(); it++) {
+		CompoundObject::const_iterator it;
+
+		for (it = rois.begin(); it != rois.end(); it++) {
 			LegoROI* roi = (LegoROI*) *it;
 			const char* name = roi->GetName();
 
@@ -621,6 +626,7 @@ void LegoOmni::Disable(MxBool p_disable, MxU16 p_flags)
 }
 
 // FUNCTION: LEGO1 0x1005b560
+// FUNCTION: BETA10 0x1008efb9
 void LegoOmni::CreateBackgroundAudio()
 {
 	if (m_bkgAudioManager) {

--- a/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoanimactor.cpp
@@ -8,8 +8,19 @@
 #include "misc.h"
 #include "mxutilities.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoAnimActor, 0x174)
 DECOMP_SIZE_ASSERT(LegoAnimActorStruct, 0x20)
+
+// SIZE 0x0c
+class LegoDistanceKey : public LegoAnimKey {
+public:
+	float GetDistance() { return m_distance; }
+
+protected:
+	float m_distance; // 0x08
+};
 
 // FUNCTION: LEGO1 0x1001bf80
 // FUNCTION: BETA10 0x1003dc10
@@ -27,11 +38,45 @@ LegoAnimActorStruct::LegoAnimActorStruct(
 }
 
 // FUNCTION: LEGO1 0x1001c0a0
+// FUNCTION: BETA10 0x1003dca1
 LegoAnimActorStruct::~LegoAnimActorStruct()
 {
 	for (MxU16 i = 0; i < m_unk0x10.size(); i++) {
 		delete m_unk0x10[i];
 	}
+}
+
+// FUNCTION: BETA10 0x1003dd5e
+float LegoAnimActorStruct::GetDistance(float p_time)
+{
+	unsigned int i;
+	float f;
+
+	if (m_unk0x10.size() == 0) {
+		return 0.0f;
+	}
+
+	if (((LegoDistanceKey*) m_unk0x10.back())->GetTime() <= p_time) {
+		return ((LegoDistanceKey*) m_unk0x10.back())->GetDistance();
+	}
+
+	if (((LegoDistanceKey*) m_unk0x10.front())->GetTime() >= p_time) {
+		return 0.0f;
+	}
+
+	for (i = 1; i < m_unk0x10.size(); i++) {
+		if (((LegoDistanceKey*) m_unk0x10[i])->GetTime() >= p_time) {
+			f = (p_time - ((LegoDistanceKey*) m_unk0x10[i - 1])->GetTime()) /
+				(((LegoDistanceKey*) m_unk0x10[i])->GetTime() - ((LegoDistanceKey*) m_unk0x10[i - 1])->GetTime());
+			return ((LegoDistanceKey*) m_unk0x10[i - 1])->GetDistance() +
+				   (((LegoDistanceKey*) m_unk0x10[i])->GetDistance() -
+					((LegoDistanceKey*) m_unk0x10[i - 1])->GetDistance()) *
+					   f;
+		}
+	}
+
+	assert(0);
+	return -1.0f;
 }
 
 // FUNCTION: LEGO1 0x1001c130
@@ -40,6 +85,16 @@ float LegoAnimActorStruct::GetDuration()
 {
 	assert(m_AnimTreePtr);
 	return m_AnimTreePtr->GetDuration();
+}
+
+// FUNCTION: BETA10 0x1003df8c
+float LegoAnimActorStruct::GetTotalDistance()
+{
+	if (m_unk0x10.size() == 0) {
+		return 0.0f;
+	}
+
+	return ((LegoDistanceKey*) m_unk0x10.back())->GetDistance();
 }
 
 // FUNCTION: LEGO1 0x1001c140
@@ -63,6 +118,7 @@ MxResult LegoAnimActor::GetTimeInCycle(float& p_timeInCycle)
 }
 
 // FUNCTION: LEGO1 0x1001c240
+// FUNCTION: BETA10 0x1003e0db
 void LegoAnimActor::ApplyTransform(Matrix4& p_transform)
 {
 	float timeInCycle;
@@ -109,7 +165,31 @@ MxResult LegoAnimActor::AnimateWithTransform(float p_time, Matrix4& p_transform)
 		LegoROI** roiMap = m_animMaps[m_curAnim]->m_roiMap;
 		MxU32 numROIs = m_animMaps[m_curAnim]->m_numROIs;
 
-		if (!m_boundary->GetVisibility()) {
+		if (m_boundary->GetVisibility()) {
+			// name verified by BETA10 0x1003e407
+			LegoTreeNode* n = m_animMaps[m_curAnim]->m_AnimTreePtr->GetRoot();
+
+			assert(roiMap && n && m_roi && m_boundary);
+
+			m_roi->SetVisibility(TRUE);
+
+			for (MxS32 i = 0; i < numROIs; i++) {
+				LegoROI* roi = roiMap[i];
+
+				if (roi != NULL && m_roi != roi) {
+					roi->SetVisibility(TRUE);
+				}
+			}
+
+			for (i = 0; i < n->GetNumChildren(); i++) {
+				LegoROI::ApplyAnimationTransformation(n->GetChild(i), p_transform, p_time, roiMap);
+			}
+
+			if (m_cameraFlag) {
+				TransformPointOfView();
+			}
+		}
+		else {
 			MxU32 i;
 			m_roi->SetVisibility(FALSE);
 
@@ -119,30 +199,6 @@ MxResult LegoAnimActor::AnimateWithTransform(float p_time, Matrix4& p_transform)
 				if (roi != NULL && m_roi != roi) {
 					roi->SetVisibility(FALSE);
 				}
-			}
-		}
-		else {
-			// name verified by BETA10 0x1003e407
-			LegoTreeNode* n = m_animMaps[m_curAnim]->m_AnimTreePtr->GetRoot();
-
-			assert(roiMap && n && m_roi && m_boundary);
-
-			m_roi->SetVisibility(TRUE);
-
-			for (MxU32 i = 0; i < numROIs; i++) {
-				LegoROI* roi = roiMap[i];
-
-				if (roi != NULL && m_roi != roi) {
-					roi->SetVisibility(TRUE);
-				}
-			}
-
-			for (MxS32 j = 0; j < n->GetNumChildren(); j++) {
-				LegoROI::ApplyAnimationTransformation(n->GetChild(j), p_transform, p_time, roiMap);
-			}
-
-			if (m_cameraFlag) {
-				TransformPointOfView();
 			}
 		}
 
@@ -242,6 +298,7 @@ void LegoAnimActor::ParseAction(char* p_extra)
 
 				if (p != NULL) {
 					token = strtok(NULL, g_parseExtraTokens);
+					assert(token);
 
 					if (token) {
 						p->CreateROIAndBuildMap(this, atof(token));

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -9,6 +9,8 @@
 #include "mxmisc.h"
 #include "mxtimer.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoExtraActor, 0x1dc)
 
 // GLOBAL: LEGO1 0x100f31d0
@@ -41,6 +43,7 @@ LegoExtraActor::LegoExtraActor()
 }
 
 // FUNCTION: LEGO1 0x1002a6b0
+// FUNCTION: BETA10 0x10080a7e
 LegoExtraActor::~LegoExtraActor()
 {
 	delete m_assAnim;
@@ -48,14 +51,18 @@ LegoExtraActor::~LegoExtraActor()
 }
 
 // FUNCTION: LEGO1 0x1002a720
+// FUNCTION: BETA10 0x10080b4c
 MxU32 LegoExtraActor::StepState(float p_time, Matrix4& p_transform)
 {
+	// GLOBAL: LEGO1 0x100d6b64
+	static const float g_hitAnimationDelay = 2000.0f;
+
 	switch (m_actorState & c_maxState) {
 	case c_initial:
 	case c_ready:
 		return TRUE;
 	case c_hit:
-		m_scheduledTime = p_time + 2000.0f;
+		m_scheduledTime = g_hitAnimationDelay + p_time;
 		m_actorState = c_hitAnimation;
 		m_actorTime += (p_time - m_transformTime) * m_worldSpeed;
 		m_transformTime = p_time;
@@ -109,6 +116,7 @@ MxU32 LegoExtraActor::StepState(float p_time, Matrix4& p_transform)
 }
 
 // FUNCTION: LEGO1 0x1002aa90
+// FUNCTION: BETA10 0x10080ea9
 void LegoExtraActor::GetWalkingBehavior(MxBool& p_countCounterclockWise, MxS32& p_selectedEdgeIndex)
 {
 	switch (m_pathWalkingMode) {
@@ -128,6 +136,7 @@ void LegoExtraActor::GetWalkingBehavior(MxBool& p_countCounterclockWise, MxS32& 
 }
 
 // FUNCTION: LEGO1 0x1002aae0
+// FUNCTION: BETA10 0x10080f35
 MxResult LegoExtraActor::SwitchDirection()
 {
 	LegoPathBoundary* oldEdge = m_boundary;
@@ -138,6 +147,7 @@ MxResult LegoExtraActor::SwitchDirection()
 
 	dirRef *= -1.0f;
 	rightRef.EqualsCross(upRef, dirRef);
+	assert(m_destEdge && m_boundary);
 
 	if (m_boundary == m_destEdge->m_faceA) {
 		m_boundary = (LegoPathBoundary*) m_destEdge->m_faceB;
@@ -145,6 +155,8 @@ MxResult LegoExtraActor::SwitchDirection()
 	else {
 		m_boundary = (LegoPathBoundary*) m_destEdge->m_faceA;
 	}
+
+	assert(m_destEdge && m_boundary);
 
 	if (!m_boundary) {
 		m_boundary = oldEdge;
@@ -213,7 +225,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			MxMatrix local(m_roi->GetLocal2World());
 
 			m_localBeforeHit = local;
-			Vector3 positionRef(local[3]);
+			Vector3 positionRef((const float*) local[3]);
 			Mx3DPointFloat otherActorDir(otherActorLocal[2]);
 
 			otherActorDir *= 2.0f;
@@ -369,11 +381,12 @@ void LegoExtraActor::Animate(float p_time)
 		}
 
 		MxMatrix matrix(m_roi->GetLocal2World());
-		LegoTreeNode* root = laas->m_AnimTreePtr->GetRoot();
-		MxS32 count = root->GetNumChildren();
+		LegoTreeNode* n = laas->m_AnimTreePtr->GetRoot();
+		assert(n);
+		MxS32 count = n->GetNumChildren();
 
 		for (MxS32 i = 0; i < count; i++) {
-			LegoROI::ApplyAnimationTransformation(root->GetChild(i), matrix, duration2, laas->m_roiMap);
+			LegoROI::ApplyAnimationTransformation(n->GetChild(i), matrix, duration2, laas->m_roiMap);
 		}
 	}
 }
@@ -443,7 +456,7 @@ inline MxU32 LegoExtraActor::CheckPresenterAndActorIntersections(
 	LegoPathActorSet lpas(plpas);
 
 	for (LegoPathActorSet::iterator itpa = lpas.begin(); itpa != lpas.end(); itpa++) {
-		if (plpas.find(*itpa) != plpas.end()) {
+		if (plpas.end() != plpas.find(*itpa)) {
 			LegoPathActor* actor = *itpa;
 
 			if (this != actor && !(actor->GetActorState() & LegoPathActor::c_noCollide)) {

--- a/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathactor.cpp
@@ -137,7 +137,7 @@ MxResult LegoPathActor::SetTransformAndDestinationFromEdge(
 	startDirection.Unitize();
 
 	MxMatrix matrix;
-	Vector3 pos(matrix[3]);
+	Vector3 pos((const float*) matrix[3]);
 	Vector3 dir(matrix[2]);
 	Vector3 up(matrix[1]);
 	Vector3 right(matrix[0]);
@@ -185,7 +185,8 @@ MxResult LegoPathActor::SetTransformAndDestinationFromPoints(
 	float p_destScale
 )
 {
-	assert(p_destEdge);
+	// BETA10 asserts p_destEdge here; the retail compile has no statement at this seat
+	assertIfBeta10(p_destEdge);
 
 	Vector3* v3 = p_destEdge->CWVertex(*p_boundary);
 	// LINE: LEGO1 0x1002de35
@@ -195,7 +196,6 @@ MxResult LegoPathActor::SetTransformAndDestinationFromPoints(
 
 	Mx3DPointFloat end, destNormal, endDirection;
 
-	// LINE: LEGO1 0x1002de8f
 	end = *v4;
 	end -= *v3;
 	end *= p_destScale;
@@ -211,7 +211,6 @@ MxResult LegoPathActor::SetTransformAndDestinationFromPoints(
 	m_traveledDistance = 0;
 	m_transformTime = p_time;
 	m_actorTime = p_time;
-	// TODO: this one fails to inline
 	// LINE: LEGO1 0x1002deed
 	p_destEdge->GetFaceNormal(*p_boundary, destNormal);
 
@@ -226,14 +225,14 @@ MxResult LegoPathActor::SetTransformAndDestinationFromPoints(
 	dir = p_direction;
 	up = *m_boundary->GetUp();
 
-	if (!m_cameraFlag || !m_userNavFlag) {
+	if (m_cameraFlag == FALSE || m_userNavFlag == FALSE) {
 		dir *= -1.0f;
 	}
 
 	right.EqualsCross(up, dir);
 	m_roi->UpdateTransformationRelativeToParent(matrix);
 
-	if (m_cameraFlag && m_userNavFlag) {
+	if (m_cameraFlag != FALSE && m_userNavFlag != FALSE) {
 		m_boundary->AddActor(this);
 		TransformPointOfView();
 	}
@@ -241,12 +240,13 @@ MxResult LegoPathActor::SetTransformAndDestinationFromPoints(
 		endDirection.EqualsCross(*p_boundary->GetUp(), destNormal);
 		endDirection.Unitize();
 
-		if (SetSpline(p_start, p_direction, end, endDirection) != SUCCESS) {
+		if (SetSpline(p_start, p_direction, end, endDirection) == SUCCESS) {
+			m_boundary->AddActor(this);
+		}
+		else {
 			MxTrace("Warning: m_BADuration = %g, roi = %s\n", m_BADuration, m_roi->GetName());
 			return FAILURE;
 		}
-
-		m_boundary->AddActor(this);
 	}
 
 	m_local2World = m_roi->GetLocal2World();
@@ -354,8 +354,8 @@ MxS32 LegoPathActor::CalculateTransform(float p_time, Matrix4& p_transform)
 		float endTime = (m_BADuration - m_traveledDistance) / m_worldSpeed + m_transformTime;
 
 		if (endTime < p_time) {
-			m_traveledDistance = m_BADuration;
 			m_finishedTravel = TRUE;
+			m_traveledDistance = m_BADuration;
 		}
 		else {
 			endTime = p_time;
@@ -496,7 +496,7 @@ MxU32 LegoPathActor::CheckPresenterAndActorIntersections(
 	LegoPathActorSet lpas(plpas);
 
 	for (LegoPathActorSet::iterator itpa = lpas.begin(); itpa != lpas.end(); itpa++) {
-		if (plpas.find(*itpa) != plpas.end()) {
+		if (plpas.end() != plpas.find(*itpa)) {
 			LegoPathActor* actor = *itpa;
 
 			if (this != actor && !(actor->GetActorState() & LegoPathActor::c_noCollide)) {
@@ -650,18 +650,7 @@ inline MxU32 LegoPathActor::CheckIntersectionBothFaces(
 
 		// LINE: LEGO1 0x1002ee9f
 		if (boundary != NULL) {
-			list<LegoPathBoundary*>::const_iterator it;
-
-			// LINE: LEGO1 0x1002eead
-			for (it = p_checkedBoundaries.begin(); !(it == p_checkedBoundaries.end()); it++) {
-				// LINE: LEGO1 0x1002eeb3
-				if ((*it) == boundary) {
-					break;
-				}
-			}
-
-			// LINE: LEGO1 0x1002eec4
-			if (it == p_checkedBoundaries.end()) {
+			if (find(p_checkedBoundaries.begin(), p_checkedBoundaries.end(), boundary) == p_checkedBoundaries.end()) {
 				result = CheckIntersectionBothFaces(
 					p_checkedBoundaries,
 					boundary,
@@ -703,18 +692,23 @@ void LegoPathActor::ParseAction(char* p_extra)
 		char name[12];
 
 		token = strtok(value, g_parseExtraTokens);
+		assert(token);
 		strcpy(name, token);
 
 		token = strtok(NULL, g_parseExtraTokens);
+		assert(token);
 		MxS32 src = atoi(token);
 
 		token = strtok(NULL, g_parseExtraTokens);
+		assert(token);
 		float srcScale = atof(token);
 
 		token = strtok(NULL, g_parseExtraTokens);
+		assert(token);
 		MxS32 dest = atoi(token);
 
 		token = strtok(NULL, g_parseExtraTokens);
+		assert(token);
 		float destScale = atof(token);
 
 		LegoWorld* world = CurrentWorld();
@@ -725,6 +719,7 @@ void LegoPathActor::ParseAction(char* p_extra)
 
 	if (KeyValueStringParse(value, g_strCOLLIDEBOX, p_extra)) {
 		token = strtok(value, g_parseExtraTokens);
+		assert(token);
 		m_collideBox = atoi(token);
 	}
 }
@@ -738,7 +733,7 @@ MxResult LegoPathActor::CalculateSpline()
 	MxU32 noPath1 = TRUE;
 	MxU32 noPath2 = TRUE;
 
-	if (m_grec != NULL) {
+	if (m_grec) {
 		if (m_grec->HasPath()) {
 			noPath1 = FALSE;
 			noPath2 = FALSE;
@@ -769,12 +764,12 @@ MxResult LegoPathActor::CalculateSpline()
 
 		assert(m_boundary && m_destEdge);
 
-		Vector3* cw = m_destEdge->CWVertex(*m_boundary);
-		Vector3* ccw = m_destEdge->CCWVertex(*m_boundary);
+		Vector3* v1 = m_destEdge->CWVertex(*m_boundary);
+		Vector3* v2 = m_destEdge->CCWVertex(*m_boundary);
 
-		assert(cw && ccw);
+		assert(v1 && v2);
 
-		LERP3(targetPosition, *cw, *ccw, m_destScale);
+		LERP3(targetPosition, *v1, *v2, m_destScale);
 
 		m_destEdge->GetFaceNormal(*m_boundary, normal);
 		endDirection.EqualsCross(*m_boundary->GetUp(), normal);
@@ -809,13 +804,13 @@ MxResult LegoPathActor::CalculateSpline()
 		direction *= -1.0f;
 	}
 
-	if (SetSpline(start, direction, targetPosition, endDirection) != SUCCESS) {
-		MxTrace("Warning: m_BADuration = %g, roi = %s\n", m_BADuration, m_roi->GetName());
-		return FAILURE;
+	if (SetSpline(start, direction, targetPosition, endDirection) == SUCCESS) {
+		m_traveledDistance = 0.0f;
+		return SUCCESS;
 	}
 
-	m_traveledDistance = 0.0f;
-	return SUCCESS;
+	MxTrace("Warning: m_BADuration = %g, roi = %s\n", m_BADuration, m_roi->GetName());
+	return FAILURE;
 }
 
 // FUNCTION: LEGO1 0x1002f650
@@ -855,6 +850,8 @@ void LegoPathActor::GetWalkingBehavior(MxBool& p_countCounterclockWise, MxS32& p
 // FUNCTION: BETA10 0x100afe4c
 void LegoPathActor::ApplyLocal2World()
 {
+	assert(m_roi);
+
 	m_transformTime = Timer()->GetTime();
 	m_roi->SetLocal2World(m_local2World);
 	m_roi->WrappedUpdateWorldData();
@@ -868,7 +865,7 @@ void LegoPathActor::ApplyLocal2World()
 // FUNCTION: LEGO1 0x1002f770
 void LegoPathActor::UpdatePlane(LegoNamedPlane& p_namedPlane)
 {
-	p_namedPlane.SetName(m_boundary->GetName());
+	p_namedPlane.m_name = m_boundary->GetName();
 	p_namedPlane.SetPosition(GetWorldPosition());
 	p_namedPlane.SetDirection(GetWorldDirection());
 	p_namedPlane.SetUp(GetWorldUp());

--- a/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
@@ -18,7 +18,7 @@ LegoPathBoundary::LegoPathBoundary()
 // FUNCTION: BETA10 0x100b140d
 LegoPathBoundary::~LegoPathBoundary()
 {
-	for (LegoPathActorSet::iterator it = m_actors.begin(); !(it == m_actors.end()); it++) {
+	for (LegoPathActorSet::iterator it = m_actors.begin(); it != m_actors.end(); it++) {
 		(*it)->SetBoundary(NULL);
 	}
 
@@ -197,7 +197,7 @@ MxU32 LegoPathBoundary::Intersect(
 	for (MxS32 i = 0; i < m_numEdges; i++) {
 		LegoOrientedEdge* edge = (LegoOrientedEdge*) m_edges[i];
 
-		if (p_newPos.Dot(m_edgeNormals[i], p_newPos) + m_edgeNormals[i][3] <= -1e-07) {
+		if (p_newPos.Dot(p_newPos, m_edgeNormals[i]) + m_edgeNormals[i][3] <= -1e-07) {
 			if (normalizedCalculated == FALSE) {
 				normalizedCalculated = TRUE;
 				direction = p_newPos;
@@ -217,8 +217,8 @@ MxU32 LegoPathBoundary::Intersect(
 				float hitDistance = (-m_edgeNormals[i][3] - p_oldPos.Dot(p_oldPos, m_edgeNormals[i])) / dot;
 
 				if (hitDistance >= -0.001 && hitDistance <= len && (e == NULL || hitDistance < minHitDistance)) {
-					e = edge;
 					minHitDistance = hitDistance;
+					e = edge;
 				}
 			}
 		}
@@ -381,4 +381,17 @@ MxU32 LegoPathBoundary::RemovePresenter(LegoAnimPresenter* p_presenter)
 	}
 
 	return 0;
+}
+
+// FUNCTION: BETA10 0x100b23bb
+MxU32 LegoPathBoundary::BETA_100b23bb(const Vector3& p_position, LegoOrientedEdge*& p_edge)
+{
+	for (MxS32 i = 0; i < m_numEdges; i++) {
+		LegoOrientedEdge* edge = (LegoOrientedEdge*) m_edges[i];
+		if (edge->FUN_10048c40(p_position)) {
+			p_edge = edge;
+			return TRUE;
+		}
+	}
+	return FALSE;
 }

--- a/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathcontroller.cpp
@@ -1,3 +1,5 @@
+#include "realtime/vectorlength.inl.h"
+
 #include "legopathcontroller.h"
 
 #include "legopathedgecontainer.h"
@@ -12,10 +14,10 @@ DECOMP_SIZE_ASSERT(LegoPathController::CtrlBoundary, 0x08)
 DECOMP_SIZE_ASSERT(LegoPathController::CtrlEdge, 0x08)
 
 // GLOBAL: LEGO1 0x100d7cc8
-MxU32 g_ctrlEdgesNamesA[] = {2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0};
+const MxU32 g_ctrlEdgesNamesA[] = {2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0};
 
 // GLOBAL: LEGO1 0x100d7d08
-MxU32 g_ctrlEdgesNamesB[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const MxU32 g_ctrlEdgesNamesB[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 // GLOBAL: LEGO1 0x100f42e8
 // GLOBAL: BETA10 0x101f25f0
@@ -222,7 +224,7 @@ MxResult LegoPathController::PlaceActor(
 
 	assert(pSrcE && pDestE);
 
-	float time = Timer()->GetTime();
+	float time = (float) Timer()->GetTime();
 	MxResult result = p_actor->SetTransformAndDestinationFromEdge(
 		pBoundary,
 		time,
@@ -252,7 +254,7 @@ MxResult LegoPathController::PlaceActor(
 )
 {
 	LegoPathBoundary* boundary = NULL;
-	float time = Timer()->GetTime();
+	float time = (float) Timer()->GetTime();
 
 	if (p_actor->GetController() != NULL) {
 		p_actor->GetController()->RemoveActor(p_actor);
@@ -264,7 +266,7 @@ MxResult LegoPathController::PlaceActor(
 		LegoAnimPresenterSet& presenters = b.GetPresenters();
 		LegoAnimPresenter* presenter = p_presenter;
 
-		if (presenters.find(presenter) != presenters.end()) {
+		if (presenters.end() != presenters.find(presenter)) {
 			MxS32 j;
 
 			for (j = 0; j < b.GetNumEdges(); j++) {
@@ -285,32 +287,35 @@ MxResult LegoPathController::PlaceActor(
 		}
 	}
 
-	if (boundary == NULL) {
-		return FAILURE;
-	}
+	if (boundary != NULL) {
+		for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
+			LegoOrientedEdge* edge = (LegoOrientedEdge*) boundary->GetEdges()[j];
 
-	for (MxS32 j = 0; j < boundary->GetNumEdges(); j++) {
-		LegoOrientedEdge* edge = (LegoOrientedEdge*) boundary->GetEdges()[j];
+			if (edge->GetMask0x03()) {
+				Mx3DPointFloat vec;
 
-		if (edge->GetMask0x03()) {
-			Mx3DPointFloat vec;
+				if (((LegoOrientedEdge*) edge->GetClockwiseEdge(*boundary))->GetFaceNormal(*boundary, vec) == SUCCESS &&
+					vec.Dot(vec, p_direction) < 0.0f) {
+					edge =
+						(LegoOrientedEdge*) edge->GetCounterclockwiseEdge(*boundary)->GetCounterclockwiseEdge(*boundary
+						);
+				}
 
-			if (((LegoOrientedEdge*) edge->GetClockwiseEdge(*boundary))->GetFaceNormal(*boundary, vec) == SUCCESS &&
-				vec.Dot(vec, p_direction) < 0.0f) {
-				edge = (LegoOrientedEdge*) edge->GetCounterclockwiseEdge(*boundary)->GetCounterclockwiseEdge(*boundary);
-			}
+				if (!edge->GetMask0x03()) {
+					return FAILURE;
+				}
 
-			if (!edge->GetMask0x03()) {
-				return FAILURE;
-			}
-
-			if (p_actor->SetTransformAndDestinationFromPoints(boundary, time, p_position, p_direction, edge, 0.5f) ==
-				SUCCESS) {
-				p_actor->SetController(this);
-				m_actors.insert(p_actor);
-				return SUCCESS;
+				if (p_actor
+						->SetTransformAndDestinationFromPoints(boundary, time, p_position, p_direction, edge, 0.5f) ==
+					SUCCESS) {
+					p_actor->SetController(this);
+					m_actors.insert(p_actor);
+					return SUCCESS;
+				}
 			}
 		}
+
+		return FAILURE;
 	}
 
 	return FAILURE;
@@ -379,7 +384,7 @@ void LegoPathController::AnimateActors()
 	for (LegoPathActorSet::iterator itpa = lpas.begin(); itpa != lpas.end(); itpa++) {
 		LegoPathActor* actor = *itpa;
 
-		if (m_actors.find(actor) != m_actors.end()) {
+		if (m_actors.end() != m_actors.find(actor)) {
 			if (!((MxU8) actor->GetActorState() & LegoPathActor::c_disabled)) {
 				actor->Animate(time);
 			}
@@ -388,6 +393,7 @@ void LegoPathController::AnimateActors()
 }
 
 // FUNCTION: LEGO1 0x10046b30
+// FUNCTION: BETA10 0x100b74fe
 MxResult LegoPathController::GetBoundaries(LegoPathBoundary*& p_boundaries, MxS32& p_numL)
 {
 	p_boundaries = m_boundaries;
@@ -467,6 +473,8 @@ MxResult LegoPathController::Reset()
 // FUNCTION: BETA10 0x100b781f
 MxResult LegoPathController::Read(LegoStorage* p_storage)
 {
+	assert(m_pfsE.size() == 0);
+
 	if (p_storage->Read(&m_numT, sizeof(MxU16)) != SUCCESS) {
 		return FAILURE;
 	}
@@ -746,6 +754,7 @@ MxResult LegoPathController::ReadBoundaries(LegoStorage* p_storage)
 MxResult LegoPathController::ReadVector(LegoStorage* p_storage, Mx3DPointFloat& p_vec)
 {
 	if (p_storage->Read(p_vec.GetData(), sizeof(float) * 3) != SUCCESS) {
+		assert(0);
 		return FAILURE;
 	}
 
@@ -786,6 +795,7 @@ MxResult LegoPathController::FindPath(
 		return SUCCESS;
 	}
 
+	LegoOrientedEdge* e;
 	list<LegoBEWithMidpoint> boundaryList;
 	list<LegoBEWithMidpoint>::iterator boundaryListIt;
 
@@ -796,6 +806,7 @@ MxResult LegoPathController::FindPath(
 	LegoPathCtrlEdgeSet pathCtrlEdgeSet(m_pfsE);
 
 	MxFloat minDistance = 999999.0f;
+	float dist;
 
 	p_grec->SetPath(FALSE);
 
@@ -807,8 +818,7 @@ MxResult LegoPathController::FindPath(
 
 			if (otherFace != NULL && edge->BETA_1004a830(*otherFace, p_mask)) {
 				if (p_newBoundary == otherFace) {
-					float dist;
-					if ((dist = edge->DistanceToMidpoint(p_oldPosition) + edge->DistanceToMidpoint(p_newPosition)) <
+					if ((dist = edge->DistanceToMidpoint(p_newPosition) + edge->DistanceToMidpoint(p_oldPosition)) <
 						minDistance) {
 						minDistance = dist;
 						p_grec->erase(p_grec->begin(), p_grec->end());
@@ -829,9 +839,11 @@ MxResult LegoPathController::FindPath(
 	}
 
 	if (!p_grec->HasPath()) {
+		MxFloat minDist;
+
 		while (pathCtrlEdgeSet.size() > 0) {
 			LegoBEWithMidpoint edgeWithMidpoint;
-			MxFloat minDist = 999999.0f;
+			minDist = 999999.0f;
 
 			boundarySetItA = boundarySetItB = boundarySet.begin();
 
@@ -839,14 +851,18 @@ MxResult LegoPathController::FindPath(
 				boundarySetItB++;
 			}
 
-			while (boundarySetItA != boundarySet.end()) {
-				MxU32 shouldRemove = TRUE;
+			MxU32 shouldRemove;
+			LegoPathBoundary* b;
+			LegoPathBoundary* bOther;
 
-				LegoOrientedEdge* e = (*boundarySetItA)->m_edge;
-				LegoPathBoundary* b = (*boundarySetItA)->m_boundary;
+			while (boundarySetItA != boundarySet.end()) {
+				shouldRemove = TRUE;
+
+				e = (*boundarySetItA)->m_edge;
+				b = (*boundarySetItA)->m_boundary;
 				assert(e && b);
 
-				LegoPathBoundary* bOther = (LegoPathBoundary*) e->OtherFace(b);
+				bOther = (LegoPathBoundary*) e->OtherFace(b);
 				assert(bOther);
 
 				if (!e->BETA_1004a830(*bOther, p_mask)) {
@@ -862,11 +878,10 @@ MxResult LegoPathController::FindPath(
 						float dist;
 						if ((dist = pfs->m_edge->DistanceToMidpoint(p_newPosition) + pfs->m_distanceToMidpoint) <
 							minDist) {
-							edgeWithMidpoint.m_edge = NULL;
 							minDist = dist;
+							edgeWithMidpoint.m_edge = NULL;
 
-							// TODO: Match
-							if (dist < minDistance) {
+							if (minDistance > dist) {
 								minDistance = dist;
 								p_grec->erase(p_grec->begin(), p_grec->end());
 								p_grec->SetPath(TRUE);
@@ -883,14 +898,16 @@ MxResult LegoPathController::FindPath(
 							LegoPathCtrlEdge* edge = (LegoPathCtrlEdge*) bOther->GetEdges()[i];
 
 							if (edge->GetMask0x03()) {
-								if (pathCtrlEdgeSet.find(edge) != pathCtrlEdgeSet.end()) {
+								LegoPathCtrlEdgeSet::iterator it = pathCtrlEdgeSet.find(edge);
+
+								if (it != pathCtrlEdgeSet.end()) {
 									shouldRemove = FALSE;
 
 									float dist;
 									if ((dist = edge->DistanceBetweenMidpoints(*e) +
 												(*boundarySetItA)->m_distanceToMidpoint) < minDist) {
 										minDist = dist;
-										edgeWithMidpoint = LegoBEWithMidpoint(edge, bOther, *boundarySetItA, dist);
+										edgeWithMidpoint = LegoBEWithMidpoint(edge, bOther, *boundarySetItA, minDist);
 									}
 								}
 							}
@@ -1015,7 +1032,7 @@ MxResult LegoPathController::FindIntersectionBoundary(
 
 		float coeffBDotUp = p_coefficients[1].Dot(p_coefficients[1], *up);
 		float coeffCDotUp = p_coefficients[2].Dot(p_coefficients[2], *up) + up->index_operator(3);
-		float quadraticDiscriminant = coeffBDotUp * coeffBDotUp - coeffCDotUp * coeffADotUp * 4.0f;
+		float quadraticDiscriminant = coeffBDotUp * coeffBDotUp + (coeffCDotUp * coeffADotUp) * -4.0f;
 
 		if (quadraticDiscriminant < -0.001) {
 			continue;

--- a/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp
@@ -19,6 +19,8 @@
 #include "realtime/realtime.h"
 #include "roi/legoroi.h"
 
+#include <assert.h>
+
 DECOMP_SIZE_ASSERT(LegoModelPresenter, 0x6c)
 
 // GLOBAL: LEGO1 0x100f7ae0
@@ -195,7 +197,7 @@ done:
 // FUNCTION: LEGO1 0x1007ff70
 // FUNCTION: BETA10 0x10099061
 MxResult LegoModelPresenter::CreateROI(
-	MxDSChunk& p_chunk,
+	MxDSChunk* p_chunk,
 	LegoEntity* p_entity,
 	MxBool p_roiVisible,
 	LegoWorld* p_world
@@ -203,9 +205,10 @@ MxResult LegoModelPresenter::CreateROI(
 {
 	MxResult result = SUCCESS;
 
+	assert(p_chunk);
 	ParseExtra();
 
-	if (m_roi == NULL && (result = CreateROI(&p_chunk)) == SUCCESS && p_entity != NULL) {
+	if (m_roi == NULL && (result = CreateROI(p_chunk)) == SUCCESS && p_entity != NULL) {
 		VideoManager()->Get3DManager()->Add(*m_roi);
 		VideoManager()->Get3DManager()->Moved(*m_roi);
 	}
@@ -219,7 +222,7 @@ MxResult LegoModelPresenter::CreateROI(
 		p_entity->ClearFlag(LegoEntity::c_managerOwned);
 	}
 	else {
-		p_world->GetROIList().push_back(m_roi);
+		p_world->GetROIList()->push_back(m_roi);
 	}
 
 	return result;
@@ -299,6 +302,7 @@ void LegoModelPresenter::ParseExtra()
 
 		if (KeyValueStringParse(output, g_strAUTO_CREATE, extraCopy) != 0) {
 			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
 
 			if (m_roi == NULL) {
 				m_roi = CharacterManager()->GetActorROI(token, FALSE);
@@ -307,12 +311,13 @@ void LegoModelPresenter::ParseExtra()
 		}
 		else if (KeyValueStringParse(output, g_strDB_CREATE, extraCopy) != 0 && m_roi == NULL) {
 			LegoWorld* currentWorld = CurrentWorld();
-			list<LegoROI*>& roiList = currentWorld->GetROIList();
+			list<LegoROI*>* rl = currentWorld->GetROIList();
+			assert(rl);
 
-			for (list<LegoROI*>::iterator it = roiList.begin(); it != roiList.end(); it++) {
+			for (list<LegoROI*>::iterator it = rl->begin(); it != rl->end(); it++) {
 				if (!strcmpi((*it)->GetName(), output)) {
 					m_roi = *it;
-					roiList.erase(it);
+					rl->erase(it);
 
 					m_addedToView = TRUE;
 					VideoManager()->Get3DManager()->Add(*m_roi);
@@ -320,6 +325,8 @@ void LegoModelPresenter::ParseExtra()
 					break;
 				}
 			}
+
+			assert(m_roi);
 		}
 	}
 }

--- a/LEGO1/modeldb/modeldb.cpp
+++ b/LEGO1/modeldb/modeldb.cpp
@@ -1,5 +1,10 @@
 #include "modeldb.h"
 
+#include <assert.h>
+#include <conio.h>
+#include <io.h>
+#include <stdlib.h>
+
 DECOMP_SIZE_ASSERT(ModelDbWorld, 0x18)
 DECOMP_SIZE_ASSERT(ModelDbPart, 0x18)
 DECOMP_SIZE_ASSERT(ModelDbModel, 0x38)
@@ -12,6 +17,63 @@ void ModelDbModel::Free()
 {
 	delete[] m_modelName;
 	delete[] m_presenterName;
+}
+
+// FUNCTION: BETA10 0x100e566b
+void ModelDbModel::Dump(FILE* p_file)
+{
+	fprintf(p_file, "%s\n", m_modelName);
+	fprintf(p_file, "%d\n", m_modelDataLength);
+	fprintf(p_file, "%d\n", m_modelDataOffset);
+	fprintf(p_file, "%s\n", m_presenterName);
+	fprintf(p_file, "%4.4f, %4.4f, %4.4f\n", m_location[0], m_location[1], m_location[2]);
+	fprintf(p_file, "%4.4f, %4.4f, %4.4f\n", m_direction[0], m_direction[1], m_direction[2]);
+	fprintf(p_file, "%4.4f, %4.4f, %4.4f\n", m_up[0], m_up[1], m_up[2]);
+	fprintf(p_file, "%d\n", m_visible);
+}
+
+// FUNCTION: BETA10 0x100e579b
+MxResult ModelDbModel::Write(FILE* p_file)
+{
+	MxU32 len;
+
+	len = strlen(m_modelName) + 1;
+	if (fwrite(&len, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(m_modelName, len, 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	if (fwrite(&m_modelDataLength, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(&m_modelDataOffset, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	len = strlen(m_presenterName) + 1;
+	if (fwrite(&len, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(m_presenterName, len, 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	if (fwrite(&m_location, sizeof(float), 3, p_file) != 3) {
+		return FAILURE;
+	}
+	if (fwrite(&m_direction, sizeof(float), 3, p_file) != 3) {
+		return FAILURE;
+	}
+	if (fwrite(&m_up, sizeof(float), 3, p_file) != 3) {
+		return FAILURE;
+	}
+	if (fwrite(&m_visible, sizeof(MxU8), 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
 }
 
 // FUNCTION: LEGO1 0x100276b0
@@ -59,6 +121,37 @@ MxResult ModelDbModel::Read(FILE* p_file)
 	return SUCCESS;
 }
 
+// FUNCTION: BETA10 0x100e5bfe
+void ModelDbPart::Dump(FILE* p_file)
+{
+	fprintf(p_file, "%s\n", m_roiName.GetData());
+	fprintf(p_file, "%d\n", m_partDataLength);
+	fprintf(p_file, "%d\n", m_partDataOffset);
+}
+
+// FUNCTION: BETA10 0x100e5c60
+MxResult ModelDbPart::Write(FILE* p_file)
+{
+	MxU32 len;
+
+	len = strlen(m_roiName.GetData()) + 1;
+	if (fwrite(&len, sizeof(MxU32), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(m_roiName.GetData(), len, 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	if (fwrite(&m_partDataLength, sizeof(undefined4), 1, p_file) != 1) {
+		return FAILURE;
+	}
+	if (fwrite(&m_partDataOffset, sizeof(undefined4), 1, p_file) != 1) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
 // FUNCTION: LEGO1 0x10027850
 MxResult ModelDbPart::Read(FILE* p_file)
 {
@@ -87,59 +180,69 @@ MxResult ModelDbPart::Read(FILE* p_file)
 }
 
 // FUNCTION: LEGO1 0x10027910
-MxResult ReadModelDbWorlds(FILE* p_file, ModelDbWorld*& p_worlds, MxS32& p_numWorlds)
+MxResult ReadModelDbWorlds(FILE* dbf, ModelDbWorld*& newworld, MxS32& p_numWorlds)
 {
-	p_worlds = NULL;
+	assert(dbf);
+	assert(newworld);
+
+	newworld = NULL;
 	p_numWorlds = 0;
 
 	MxS32 numWorlds;
-	if (fread(&numWorlds, sizeof(numWorlds), 1, p_file) != 1) {
+	if (fread(&numWorlds, sizeof(numWorlds), 1, dbf) != 1) {
 		return FAILURE;
 	}
 
-	ModelDbWorld* worlds = new ModelDbWorld[numWorlds];
-	MxS32 worldNameLen, numParts, i, j;
+	ModelDbWorld* world = new ModelDbWorld[numWorlds];
+	assert(world);
 
-	for (i = 0; i < numWorlds; i++) {
-		if (fread(&worldNameLen, sizeof(MxS32), 1, p_file) != 1) {
+	MxS32 worldNameLen, numParts, ii, j;
+
+	for (ii = 0; ii < numWorlds; ii++) {
+		if (fread(&worldNameLen, sizeof(MxS32), 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		worlds[i].m_worldName = new char[worldNameLen];
-		if (fread(worlds[i].m_worldName, worldNameLen, 1, p_file) != 1) {
+		world[ii].m_worldName = new char[worldNameLen];
+		assert(world[ii].m_worldName);
+
+		if (fread(world[ii].m_worldName, worldNameLen, 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		if (fread(&numParts, sizeof(MxS32), 1, p_file) != 1) {
+		if (fread(&numParts, sizeof(MxS32), 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		worlds[i].m_partList = new ModelDbPartList();
+		world[ii].m_partlist = new ModelDbPartList();
+		assert(world[ii].m_partlist);
 
 		for (j = 0; j < numParts; j++) {
 			ModelDbPart* part = new ModelDbPart();
+			assert(part);
 
-			if (part->Read(p_file) != SUCCESS) {
+			if (part->Read(dbf) != SUCCESS) {
 				return FAILURE;
 			}
 
-			worlds[i].m_partList->Append(part);
+			world[ii].m_partlist->Append(part);
 		}
 
-		if (fread(&worlds[i].m_numModels, sizeof(MxS32), 1, p_file) != 1) {
+		if (fread(&world[ii].m_numModels, sizeof(MxS32), 1, dbf) != 1) {
 			return FAILURE;
 		}
 
-		worlds[i].m_models = new ModelDbModel[worlds[i].m_numModels];
+		world[ii].m_modarr = new ModelDbModel[world[ii].m_numModels];
+		assert(world[ii].m_modarr);
 
-		for (j = 0; j < worlds[i].m_numModels; j++) {
-			if (worlds[i].m_models[j].Read(p_file) != SUCCESS) {
+		for (j = 0; j < world[ii].m_numModels; j++) {
+			if (world[ii].m_modarr[j].Read(dbf) != SUCCESS) {
 				return FAILURE;
 			}
 		}
 	}
 
-	p_worlds = worlds;
+	newworld = world;
 	p_numWorlds = numWorlds;
 	return SUCCESS;
 }
@@ -153,23 +256,71 @@ void FreeModelDbWorlds(ModelDbWorld*& p_worlds, MxS32 p_numWorlds)
 	for (MxS32 i = 0; i < p_numWorlds; i++) {
 		delete[] worlds[i].m_worldName;
 
-		ModelDbPartListCursor cursor(worlds[i].m_partList);
+		ModelDbPartListCursor cursor(worlds[i].m_partlist);
 		ModelDbPart* part;
 
 		while (cursor.Next(part)) {
 			delete part;
 		}
 
-		delete worlds[i].m_partList;
+		delete worlds[i].m_partlist;
 
-		ModelDbModel* models = worlds[i].m_models;
+		ModelDbModel* models = worlds[i].m_modarr;
 		for (MxS32 j = 0; j < worlds[i].m_numModels; j++) {
 			models[j].Free();
 		}
 
-		delete[] worlds[i].m_models;
+		delete[] worlds[i].m_modarr;
 	}
 
 	delete[] p_worlds;
 	p_worlds = NULL;
+}
+
+// FUNCTION: BETA10 0x100e7900
+inline void CheckRead(MxS32 p_result, MxS32 p_expected, const char* p_name)
+{
+	if (p_expected != p_result) {
+		fprintf(stdout, "Error reading from file %s\n", p_name);
+		printf("press any key\n");
+		_getch();
+		exit(-1);
+	}
+}
+
+// FUNCTION: BETA10 0x100e7970
+inline void CheckWrite(MxS32 p_result, MxS32 p_expected)
+{
+	if (p_expected != p_result) {
+		fprintf(stdout, "Error writing to db file\n");
+		printf("press any key\n");
+		_getch();
+		exit(-1);
+	}
+}
+
+// FUNCTION: BETA10 0x100e65f0
+void WriteModelDbParts(FILE* p_file, ModelDbPartList* p_list)
+{
+	MxString path("q:\\lego\\media\\model\\part\\");
+	ModelDbPartListCursor cursor(p_list);
+	ModelDbPart* part;
+
+	while (cursor.Next(part)) {
+		MxString name = path + part->m_roiName + ".prt";
+		FILE* f = fopen(name.GetData(), "rb");
+		if (!f) {
+			fprintf(stdout, "Error opening %s\n", name.GetData());
+			continue;
+		}
+
+		part->m_partDataOffset = ftell(p_file);
+		part->m_partDataLength = filelength(fileno(f));
+		char* buf = new char[part->m_partDataLength];
+		assert(buf);
+		CheckRead(fread(buf, part->m_partDataLength, 1, f), 1, part->m_roiName.GetData());
+		CheckWrite(fwrite(buf, part->m_partDataLength, 1, p_file), 1);
+		delete[] buf;
+		fclose(f);
+	}
 }

--- a/LEGO1/modeldb/modeldb.h
+++ b/LEGO1/modeldb/modeldb.h
@@ -10,6 +10,8 @@
 
 // SIZE 0x18
 struct ModelDbPart {
+	void Dump(FILE* p_file);
+	MxResult Write(FILE* p_file);
 	MxResult Read(FILE* p_file);
 
 	MxString m_roiName;          // 0x00
@@ -92,6 +94,8 @@ public:
 // SIZE 0x38
 struct ModelDbModel {
 	void Free();
+	void Dump(FILE* p_file);
+	MxResult Write(FILE* p_file);
 	MxResult Read(FILE* p_file);
 
 	char* m_modelName;       // 0x00
@@ -107,13 +111,13 @@ struct ModelDbModel {
 // SIZE 0x18
 struct ModelDbWorld {
 	char* m_worldName;           // 0x00
-	ModelDbPartList* m_partList; // 0x04
-	ModelDbModel* m_models;      // 0x08
+	ModelDbPartList* m_partlist; // 0x04
+	ModelDbModel* m_modarr;      // 0x08
 	MxS32 m_numModels;           // 0x0c
 	undefined m_unk0x10[0x08];   // 0x10
 };
 
-MxResult ReadModelDbWorlds(FILE* p_file, ModelDbWorld*& p_worlds, MxS32& p_numWorlds);
+MxResult ReadModelDbWorlds(FILE* dbf, ModelDbWorld*& newworld, MxS32& p_numWorlds);
 void FreeModelDbWorlds(ModelDbWorld*& p_worlds, MxS32 p_numWorlds);
 
 #endif // MODELDB_H


### PR DESCRIPTION
Asserts and names restored from BETA10, unused code recovered from BETA10 (`ModelDbModel::Write`), and small logic and member-initialization fixes confirmed by the byte-identical build. Covers the paths and entity directories and modeldb.

Part of a stacked series that makes the build of LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte-identical to the retail binaries. CI on this PR checks that everything still builds and passes the usual lints; the last PR in the series proves the byte-identical result.
