### PR TITLE
Match the original legoomni source: managers and presenters

### DIFF
--- a/LEGO1/lego/legoomni/include/lego3dsound.h
+++ b/LEGO1/lego/legoomni/include/lego3dsound.h
@@ -18,7 +18,7 @@ public:
 
 	void Init();
 	MxResult Create(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char* p_name, MxS32 p_volume);
-	void Destroy();
+	virtual void Destroy();
 	MxU32 UpdatePosition(LPDIRECTSOUNDBUFFER p_directSoundBuffer);
 	void FUN_10011a60(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char* p_name);
 	void Reset();

--- a/LEGO1/lego/legoomni/include/legoanimationmanager.h
+++ b/LEGO1/lego/legoomni/include/legoanimationmanager.h
@@ -22,7 +22,7 @@ class MxDSAction;
 
 // SIZE 0x30
 struct ModelInfo {
-	char* m_name;         // 0x00
+	char* modelName;      // 0x00
 	MxU8 m_unk0x04;       // 0x04
 	float m_location[3];  // 0x08
 	float m_direction[3]; // 0x14
@@ -32,7 +32,7 @@ struct ModelInfo {
 
 // SIZE 0x30
 struct AnimInfo {
-	char* m_name;          // 0x00
+	char* animName;        // 0x00
 	MxU32 m_objectId;      // 0x04
 	MxS16 m_location;      // 0x08
 	MxBool m_unk0x0a;      // 0x0a
@@ -42,7 +42,7 @@ struct AnimInfo {
 	float m_unk0x10[4];    // 0x10
 	MxU8 m_modelCount;     // 0x20
 	MxU16 m_unk0x22;       // 0x22
-	ModelInfo* m_models;   // 0x24
+	ModelInfo* models;     // 0x24
 	MxS8 m_characterIndex; // 0x28
 	MxBool m_unk0x29;      // 0x29
 	MxS8 m_unk0x2a[3];     // 0x2a
@@ -73,8 +73,8 @@ public:
 	MxBool Reset() override;                             // vtable+0x18
 	MxResult Serialize(LegoStorage* p_storage) override; // vtable+0x1c
 
-	void CopyToAnims(MxU32, AnimInfo* p_anims, MxU32& p_outExtraCharacterId);
-	void InitFromAnims(MxU32 p_animsLength, AnimInfo* p_anims, MxU32 p_extraCharacterId);
+	void CopyToAnims(MxU32 p_numAnims, AnimInfo* p_anims, MxU32& p_outExtraCharacterId);
+	void InitFromAnims(MxU32 p_numAnims, AnimInfo* p_anims, MxU32 p_extraCharacterId);
 
 	// SYNTHETIC: LEGO1 0x10065130
 	// AnimState::`scalar deleting destructor'
@@ -82,14 +82,14 @@ public:
 private:
 	MxU32 m_extraCharacterId; // 0x08
 
-	// appears to store the length of m_unk0x10
-	MxU32 m_unk0x0c; // 0x0c
+	// appears to store the length of m_animSaveInfo
+	MxU32 m_numAnims; // 0x0c
 	// dynamically sized array of MxU16, corresponding to AnimInfo::m_unk0x22
-	MxU16* m_unk0x10; // 0x10
+	MxU16* m_animSaveInfo; // 0x10
 
-	MxU32 m_locationsFlagsLength; // 0x14
+	MxU32 m_numCams; // 0x14
 	// dynamically sized array of bools, corresponding to LegoLocation.m_unk0x5c
-	MxBool* m_locationsFlags; // 0x18
+	MxBool* m_camAnimFired; // 0x18
 };
 
 // VTABLE: LEGO1 0x100d8c18
@@ -122,7 +122,7 @@ public:
 
 	// SIZE 0x18
 	struct Extra {
-		LegoROI* m_roi;      // 0x00
+		LegoROI* roi;        // 0x00
 		MxS32 m_characterId; // 0x04
 		MxLong m_unk0x08;    // 0x08
 		MxBool m_unk0x0c;    // 0x0c
@@ -239,7 +239,7 @@ private:
 	MxBool FUN_10063b90(LegoWorld* p_world, LegoExtraActor* p_actor, MxU8 p_mood, MxU32 p_characterId);
 	void FUN_10063d10();
 	void FUN_10063e40(LegoAnimPresenter* p_presenter);
-	MxBool FUN_10063fb0(LegoLocation::Boundary* p_boundary, LegoWorld* p_world);
+	MxBool FUN_10063fb0(LegoLocation::Boundary& p_hl, LegoWorld* p_world);
 	MxBool FUN_10064010(LegoPathBoundary* p_boundary, LegoOrientedEdge* p_edge, float p_destScale);
 	MxBool FUN_10064120(LegoLocation::Boundary* p_boundary, MxBool p_bool1, MxBool p_bool2);
 	MxResult FUN_10064380(

--- a/LEGO1/lego/legoomni/include/legoanimpresenter.h
+++ b/LEGO1/lego/legoomni/include/legoanimpresenter.h
@@ -13,11 +13,11 @@ class MxMatrix;
 class Vector3;
 
 struct LegoAnimStructComparator {
-	MxBool operator()(const char* const& p_a, const char* const& p_b) const { return strcmp(p_a, p_b) < 0; }
+	MxBool operator()(const char* p_a, const char* p_b) const { return strcmp(p_a, p_b) < 0; }
 };
 
 struct LegoAnimSubstComparator {
-	MxBool operator()(const char* const& p_a, const char* const& p_b) const { return strcmp(p_a, p_b) < 0; }
+	MxBool operator()(const char* p_a, const char* p_b) const { return strcmp(p_a, p_b) < 0; }
 };
 
 // SIZE 0x08
@@ -106,6 +106,7 @@ public:
 	// FUNCTION: BETA10 0x1005ab00
 	void SetRoiTransform(Matrix4* p_roiTransform) { m_roiTransform = p_roiTransform; }
 
+	// FUNCTION: BETA10 0x10028490
 	LegoAnim* GetAnimation() { return m_anim; }
 
 protected:
@@ -266,7 +267,7 @@ private:
 class LegoPathBoundary;
 
 struct LegoHideAnimStructComparator {
-	MxBool operator()(const char* const& p_a, const char* const& p_b) const { return strcmp(p_a, p_b) < 0; }
+	MxBool operator()(const char* p_a, const char* p_b) const { return strcmp(p_a, p_b) < 0; }
 };
 
 // SIZE 0x08
@@ -340,89 +341,89 @@ private:
 
 // clang-format off
 
-// TEMPLATE: LEGO1 0x100689c0
-// map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::~map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >
+// TEMPLATE: LEGO1 0x100689c0 SYMBOL
+// ??1?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10068a10
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::~_Tree<char const *,pair<char const * const,char const *>,map
+// TEMPLATE: LEGO1 0x10068a10 SYMBOL
+// ??1?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10068ae0
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10068ae0 SYMBOL
+// ?_Inc@iterator@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10068b20
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::erase
+// TEMPLATE: LEGO1 0x10068b20 SYMBOL
+// ?erase@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x10068f70
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::_Erase
+// TEMPLATE: LEGO1 0x10068f70 SYMBOL
+// ?_Erase@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@IAEXPAU_Node@1@@Z
 
-// TEMPLATE: LEGO1 0x10069d80
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::~_Tree<char const *,pair<char const * const,LegoAni
+// TEMPLATE: LEGO1 0x10069d80 SYMBOL
+// ??1?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x10069e50
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x10069e50 SYMBOL
+// ?_Inc@iterator@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x10069e90
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::erase
+// TEMPLATE: LEGO1 0x10069e90 SYMBOL
+// ?erase@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1006a2e0
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Erase
+// TEMPLATE: LEGO1 0x1006a2e0 SYMBOL
+// ?_Erase@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1006a320
 // Map<char const *,LegoAnimStruct,LegoAnimStructComparator>::~Map<char const *,LegoAnimStruct,LegoAnimStructComparator>
 
-// TEMPLATE: LEGO1 0x1006a370
-// map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::~map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >
+// TEMPLATE: LEGO1 0x1006a370 SYMBOL
+// ??1?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1006a750
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x1006a750 SYMBOL
+// ?_Dec@iterator@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006a7a0
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Insert
+// TEMPLATE: LEGO1 0x1006a7a0 SYMBOL
+// ?_Insert@?$_Tree@PBDU?$pair@QBDULegoAnimStruct@@@@U_Kfn@?$map@PBDULegoAnimStruct@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@ULegoAnimStructComparator@@V?$allocator@ULegoAnimStruct@@@@@@IAE?AViterator@1@PAU_Node@1@0ABU?$pair@QBDULegoAnim
 
-// TEMPLATE: LEGO1 0x1006c1b0
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x1006c1b0 SYMBOL
+// ?_Dec@iterator@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006c200
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::_Insert
+// TEMPLATE: LEGO1 0x1006c200 SYMBOL
+// ?_Insert@?$_Tree@PBDU?$pair@QBDPBD@@U_Kfn@?$map@PBDPBDULegoAnimSubstComparator@@V?$allocator@PBD@@@@ULegoAnimSubstComparator@@V?$allocator@PBD@@@@IAE?AViterator@1@PAU_Node@1@0ABU?$pair@QBDPBD@@@Z
 
-// TEMPLATE: LEGO1 0x1006c4b0
-// list<char *,allocator<char *> >::~list<char *,allocator<char *> >
+// TEMPLATE: LEGO1 0x1006c4b0 SYMBOL
+// ??1?$list@PADV?$allocator@PAD@@@@QAE@XZ
 
 // TEMPLATE: LEGO1 0x1006c520
 // List<char *>::~List<char *>
 
 // GLOBAL: LEGO1 0x100f7680
-// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *> >::_Kfn,LegoAnimSubstComparator,allocator<char const *> >::_Nil
+// _Tree<char const *,pair<char const * const,char const *>,map<char const *,char const *,LegoAnimSubstComparator,allocator<char const *>>::_Kfn,LegoAnimSubstComparator,allocator<char const *>>::_Nil
 
 // GLOBAL: LEGO1 0x100f7688
-// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct> >::_Nil
+// _Tree<char const *,pair<char const * const,LegoAnimStruct>,map<char const *,LegoAnimStruct,LegoAnimStructComparator,allocator<LegoAnimStruct>>::_Kfn,LegoAnimStructComparator,allocator<LegoAnimStruct>>::_Nil
 
-// TEMPLATE: LEGO1 0x1006ddb0
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::~_Tree<char const *,pair<ch
+// TEMPLATE: LEGO1 0x1006ddb0 SYMBOL
+// ??1?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1006de80
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::iterator::_Inc
+// TEMPLATE: LEGO1 0x1006de80 SYMBOL
+// ?_Inc@iterator@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006dec0
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::erase
+// TEMPLATE: LEGO1 0x1006dec0 SYMBOL
+// ?erase@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAE?AViterator@1@V21@@Z
 
-// TEMPLATE: LEGO1 0x1006e310
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Erase
+// TEMPLATE: LEGO1 0x1006e310 SYMBOL
+// ?_Erase@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@IAEXPAU_Node@1@@Z
 
 // TEMPLATE: LEGO1 0x1006e350
 // Map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator>::~Map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator>
 
-// TEMPLATE: LEGO1 0x1006e3a0
-// map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::~map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >
+// TEMPLATE: LEGO1 0x1006e3a0 SYMBOL
+// ??1?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAE@XZ
 
-// TEMPLATE: LEGO1 0x1006e6d0
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::iterator::_Dec
+// TEMPLATE: LEGO1 0x1006e6d0 SYMBOL
+// ?_Dec@iterator@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@QAEXXZ
 
-// TEMPLATE: LEGO1 0x1006e720
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Insert
+// TEMPLATE: LEGO1 0x1006e720 SYMBOL
+// ?_Insert@?$_Tree@PBDU?$pair@QBDULegoHideAnimStruct@@@@U_Kfn@?$map@PBDULegoHideAnimStruct@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@ULegoHideAnimStructComparator@@V?$allocator@ULegoHideAnimStruct@@@@@@IAE?AViterator@1@PAU_Node@1
 
 // GLOBAL: LEGO1 0x100f768c
-// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct> >::_Nil
+// _Tree<char const *,pair<char const * const,LegoHideAnimStruct>,map<char const *,LegoHideAnimStruct,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct>>::_Kfn,LegoHideAnimStructComparator,allocator<LegoHideAnimStruct>>::_Nil
 // clang-format on
 
 #endif // LEGOANIMPRESENTER_H

--- a/LEGO1/lego/legoomni/include/legocachsound.h
+++ b/LEGO1/lego/legoomni/include/legocachsound.h
@@ -63,20 +63,20 @@ private:
 	void CopyData(MxU8* p_data, MxU32 p_dataSize);
 	MxString GetBaseFilename(MxString& p_path);
 
-	LPDIRECTSOUNDBUFFER m_dsBuffer; // 0x08
-	undefined m_unk0x0c[4];         // 0x0c
-	Lego3DSound m_sound;            // 0x10
-	MxU8* m_data;                   // 0x40
-	MxU32 m_dataSize;               // 0x44
-	MxString m_unk0x48;             // 0x48
-	MxBool m_unk0x58;               // 0x58
-	PCMWAVEFORMAT m_wfx;            // 0x59
-	MxBool m_looping;               // 0x69
-	MxBool m_unk0x6a;               // 0x6a
-	MxS32 m_volume;                 // 0x6c
-	MxBool m_unk0x70;               // 0x70
-	MxString m_unk0x74;             // 0x74
-	MxBool m_muted;                 // 0x84
+	LPDIRECTSOUNDBUFFER m_directSoundBuffer; // 0x08
+	undefined m_unk0x0c[4];                  // 0x0c
+	Lego3DSound m_sound;                     // 0x10
+	MxU8* m_data;                            // 0x40
+	MxU32 m_dataSize;                        // 0x44
+	MxString m_unk0x48;                      // 0x48
+	MxBool m_unk0x58;                        // 0x58
+	PCMWAVEFORMAT m_wfx;                     // 0x59
+	MxBool m_looping;                        // 0x69
+	MxBool m_unk0x6a;                        // 0x6a
+	MxS32 m_volume;                          // 0x6c
+	MxBool m_unk0x70;                        // 0x70
+	MxString m_unk0x74;                      // 0x74
+	MxBool m_muted;                          // 0x84
 };
 
 #endif // LEGOCACHSOUND_H

--- a/LEGO1/lego/legoomni/include/legocarbuild.h
+++ b/LEGO1/lego/legoomni/include/legocarbuild.h
@@ -161,7 +161,7 @@ public:
 	void SetColorControlsEnabled(MxBool p_enabled);
 	void ToggleColorControlsEnabled();
 	void EnableDecalForSelectedPart(MxBool p_enabled);
-	void SetPartColor(MxS32 p_objectId);
+	void SetPartColor(MxU32 p_objectId);
 	void CalculateStartAndTargetTransforms();
 	void StartActorScriptByType(MxS32 p_actionType);
 	void StartActorScript(MxS32 p_streamId);
@@ -256,9 +256,9 @@ private:
 	MxU8 m_presentersEnabled;             // 0x348
 
 	static MxS16 g_lastTickleState;
-	static MxFloat g_selectedPartRotationAngleStepYAxis;
-	static MxFloat g_rotationAngleStepYAxis;
-	static LookupTableActions g_actorScripts[];
+	static const MxFloat g_selectedPartRotationAngleStepYAxis;
+	static const MxFloat g_rotationAngleStepYAxis;
+	static const LookupTableActions g_actorScripts[];
 };
 
 #endif // LEGOCARBUILD_H

--- a/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
+++ b/LEGO1/lego/legoomni/include/legocarbuildpresenter.h
@@ -88,6 +88,7 @@ public:
 	void MoveShelfForward();
 	MxBool StringEqualsPlatform(const LegoChar* p_string);
 	MxBool StringEqualsShelf(const LegoChar* p_string);
+	MxBool StringEqualsView(const LegoChar* p_string);
 	MxBool StringEndsOnY(const LegoChar* p_string);
 	MxBool StringDoesNotEndOnZero(const LegoChar* p_string);
 	const LegoChar* GetWiredNameByPartName(const LegoChar* p_name);

--- a/LEGO1/lego/legoomni/include/legogamestate.h
+++ b/LEGO1/lego/legoomni/include/legogamestate.h
@@ -192,7 +192,7 @@ public:
 	LegoGameState();
 	~LegoGameState();
 
-	void SetActor(MxU8 p_actorId);
+	void SetActor(MxU8 p_id);
 	void RemoveActor();
 	void ResetROI();
 
@@ -228,7 +228,7 @@ public:
 	Act GetLoadedAct() { return m_loadedAct; }
 
 	void SetActorId(MxU8 p_actorId) { m_actorId = p_actorId; }
-	LegoBackgroundColor* GetBackgroundColor() { return m_backgroundColor; }
+	LegoBackgroundColor* GetBackgroundColor() { return m_bgColorVar; }
 
 	void SetCurrentAct(Act p_currentAct);
 	void FindLoadedAct();
@@ -241,15 +241,15 @@ private:
 	void SetColors();
 	void SetROIColorOverride();
 
-	char* m_savePath;                           // 0x00
-	MxS16 m_stateCount;                         // 0x04
-	LegoState** m_stateArray;                   // 0x08
-	MxU8 m_actorId;                             // 0x0c
-	Act m_currentAct;                           // 0x10
-	Act m_loadedAct;                            // 0x14
-	LegoBackgroundColor* m_backgroundColor;     // 0x18
-	LegoBackgroundColor* m_tempBackgroundColor; // 0x1c
-	LegoFullScreenMovie* m_fullScreenMovie;     // 0x20
+	char* m_savePath;                    // 0x00
+	MxS16 m_stateCount;                  // 0x04
+	LegoState** m_states;                // 0x08
+	MxU8 m_actorId;                      // 0x0c
+	Act m_currentAct;                    // 0x10
+	Act m_loadedAct;                     // 0x14
+	LegoBackgroundColor* m_bgColorVar;   // 0x18
+	LegoBackgroundColor* m_tempColorVar; // 0x1c
+	LegoFullScreenMovie* m_fsMovieVar;   // 0x20
 
 public:
 	MxS16 m_currentPlayerId;              // 0x24

--- a/LEGO1/lego/legoomni/include/legotraninfo.h
+++ b/LEGO1/lego/legoomni/include/legotraninfo.h
@@ -1,13 +1,16 @@
 #ifndef LEGOTRANINFO_H
 #define LEGOTRANINFO_H
 
+#include "roi/legoroi.h"
+
 #include "decomp.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "mxgeometry/mxmatrix.h"
 #include "mxtypes.h"
 
 struct AnimInfo;
 class LegoAnimMMPresenter;
-class LegoROI;
 class MxPresenter;
 
 // SIZE 0x78

--- a/LEGO1/lego/legoomni/include/legotraninfolist.h
+++ b/LEGO1/lego/legoomni/include/legotraninfolist.h
@@ -19,6 +19,8 @@
 class LegoTranInfoList : public MxPtrList<LegoTranInfo> {
 public:
 	LegoTranInfoList() : MxPtrList<LegoTranInfo>(FALSE) {}
+
+	void Append(LegoTranInfo* p_obj);
 };
 
 // VTABLE: LEGO1 0x100d8cf0

--- a/LEGO1/lego/legoomni/include/legoutils.h
+++ b/LEGO1/lego/legoomni/include/legoutils.h
@@ -5,6 +5,7 @@
 #include "decomp.h"
 #include "extra.h"
 #include "mxtypes.h"
+#include "roi/legoroi.h"
 
 #include <windows.h>
 
@@ -34,7 +35,6 @@ class LegoEntity;
 class LegoAnimPresenter;
 class LegoNamedTexture;
 class LegoPathActor;
-class LegoROI;
 class LegoStorage;
 class LegoTreeNode;
 
@@ -54,6 +54,7 @@ Extra::ActionType MatchActionString(const char*);
 void InvokeAction(Extra::ActionType p_actionId, const MxAtomId& p_pAtom, MxS32 p_streamId, LegoEntity* p_sender);
 void SetCameraControllerFromIsle();
 void ConvertHSVToRGB(float p_h, float p_s, float p_v, float* p_rOut, float* p_gOut, float* p_bOut);
+void ConvertRGBToHSV(float p_r, float p_g, float p_b, float* p_hOut, float* p_sOut, float* p_vOut);
 void PlayCamAnim(LegoPathActor* p_actor, MxBool p_unused, MxU32 p_location, MxBool p_bool);
 void ResetViewVelocity();
 MxBool RemoveFromCurrentWorld(const MxAtomId& p_atomId, MxS32 p_id);

--- a/LEGO1/lego/legoomni/include/legovideomanager.h
+++ b/LEGO1/lego/legoomni/include/legovideomanager.h
@@ -92,7 +92,7 @@ private:
 	PALETTEENTRY m_paletteEntries[256];   // 0xe7
 	LegoPhonemeList* m_phonemeRefList;    // 0x4e8
 	MxBool m_isFullscreenMovie;           // 0x4ec
-	MxPalette* m_palette;                 // 0x4f0
+	MxPalette* m_savedPalette;            // 0x4f0
 	MxStopWatch* m_stopWatch;             // 0x4f4
 	double m_elapsedSeconds;              // 0x4f8
 	MxBool m_fullScreenMovie;             // 0x500

--- a/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
+++ b/LEGO1/lego/legoomni/include/mxbackgroundaudiomanager.h
@@ -47,7 +47,7 @@ public:
 	virtual MxResult Create(MxAtomId& p_script, MxU32 p_frequencyMS);
 
 	void Init();
-	void Update(MxS32 p_targetVolume, MxS32 p_speed, MxPresenter::TickleState p_tickleState);
+	void Update(MxS32 p_volume, MxS32 p_speed, MxPresenter::TickleState p_tickleState);
 	void Stop();
 	void LowerVolume();
 	void RaiseVolume();

--- a/LEGO1/lego/legoomni/src/audio/lego3dsound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/lego3dsound.cpp
@@ -7,6 +7,7 @@
 #include "misc.h"
 #include "mxmain.h"
 
+#include <assert.h>
 #include <vec.h>
 
 DECOMP_SIZE_ASSERT(Lego3DSound, 0x30)
@@ -108,6 +109,7 @@ MxResult Lego3DSound::Create(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const char
 }
 
 // FUNCTION: LEGO1 0x10011880
+// FUNCTION: BETA10 0x1003997e
 void Lego3DSound::Destroy()
 {
 	if (m_ds3dBuffer) {
@@ -131,6 +133,8 @@ void Lego3DSound::Destroy()
 // FUNCTION: BETA10 0x10039a2a
 MxU32 Lego3DSound::UpdatePosition(LPDIRECTSOUNDBUFFER p_directSoundBuffer)
 {
+	assert(p_directSoundBuffer);
+
 	MxU32 updated = FALSE;
 
 	if (m_positionROI != NULL) {
@@ -221,6 +225,8 @@ void Lego3DSound::FUN_10011a60(LPDIRECTSOUNDBUFFER p_directSoundBuffer, const ch
 		else {
 			m_positionROI = m_roi;
 		}
+
+		assert(m_positionROI);
 
 		if (m_ds3dBuffer != NULL) {
 			DWORD dwMode;

--- a/LEGO1/lego/legoomni/src/audio/legocachesoundmanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachesoundmanager.cpp
@@ -4,7 +4,7 @@
 #include "misc.h"
 
 DECOMP_SIZE_ASSERT(LegoCacheSoundEntry, 0x08)
-DECOMP_SIZE_ASSERT(LegoCacheSoundManager, 0x20)
+DECOMP_SIZE_ASSERT(LegoCacheSoundManager, 0x20);
 
 // FUNCTION: LEGO1 0x1003cf20
 // STUB: BETA10 0x100d0700
@@ -13,8 +13,9 @@ LegoCacheSoundManager::~LegoCacheSoundManager()
 	LegoCacheSound* sound;
 
 	while (!m_set.empty()) {
-		sound = (*m_set.begin()).GetSound();
-		m_set.erase(m_set.begin());
+		Set100d6b4c::iterator it = m_set.begin();
+		sound = (*it).GetSound();
+		m_set.erase(it);
 		sound->Stop();
 		delete sound;
 	}
@@ -44,9 +45,11 @@ MxResult LegoCacheSoundManager::Tickle()
 		}
 	}
 
+	LegoCacheSound* sound;
 	List100d6b4c::iterator listIter = m_list.begin();
+
 	while (listIter != m_list.end()) {
-		LegoCacheSound* sound = (*listIter).GetSound();
+		sound = (*listIter).GetSound();
 
 		if (sound->GetUnknown0x58()) {
 			sound->FUN_10006be0();
@@ -80,6 +83,7 @@ LegoCacheSound* LegoCacheSoundManager::FindSoundByKey(const char* p_key)
 }
 
 // FUNCTION: LEGO1 0x1003d290
+// FUNCTION: BETA10 0x100654db
 LegoCacheSound* LegoCacheSoundManager::ManageSoundEntry(LegoCacheSound* p_sound)
 {
 	Set100d6b4c::iterator it = m_set.find(LegoCacheSoundEntry(p_sound));

--- a/LEGO1/lego/legoomni/src/audio/legocachsound.cpp
+++ b/LEGO1/lego/legoomni/src/audio/legocachsound.cpp
@@ -1,6 +1,7 @@
 #include "legocachsound.h"
 
 #include "legosoundmanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "mxmain.h"
 
@@ -26,7 +27,7 @@ LegoCacheSound::~LegoCacheSound()
 // FUNCTION: BETA10 0x10066498
 void LegoCacheSound::Init()
 {
-	m_dsBuffer = NULL;
+	m_directSoundBuffer = NULL;
 	m_data = NULL;
 	m_unk0x58 = FALSE;
 	memset(&m_wfx, 0, sizeof(m_wfx));
@@ -73,7 +74,7 @@ MxResult LegoCacheSound::Create(
 	desc.dwBufferBytes = p_dataSize;
 	desc.lpwfxFormat = &wfx;
 
-	if (SoundManager()->GetDirectSound()->CreateSoundBuffer(&desc, &m_dsBuffer, NULL) != DS_OK) {
+	if (SoundManager()->GetDirectSound()->CreateSoundBuffer(&desc, &m_directSoundBuffer, NULL) != DS_OK) {
 		return FAILURE;
 	}
 
@@ -81,11 +82,11 @@ MxResult LegoCacheSound::Create(
 
 	MxS32 volume = m_volume * SoundManager()->GetVolume() / 100;
 	MxS32 attenuation = SoundManager()->GetAttenuation(volume);
-	m_dsBuffer->SetVolume(attenuation);
+	m_directSoundBuffer->SetVolume(attenuation);
 
-	if (m_sound.Create(m_dsBuffer, NULL, m_volume) != SUCCESS) {
-		m_dsBuffer->Release();
-		m_dsBuffer = NULL;
+	if (m_sound.Create(m_directSoundBuffer, NULL, m_volume) != SUCCESS) {
+		m_directSoundBuffer->Release();
+		m_directSoundBuffer = NULL;
 		return FAILURE;
 	}
 
@@ -115,10 +116,10 @@ void LegoCacheSound::CopyData(MxU8* p_data, MxU32 p_dataSize)
 // FUNCTION: BETA10 0x1006685b
 void LegoCacheSound::Destroy()
 {
-	if (m_dsBuffer) {
-		m_dsBuffer->Stop();
-		m_dsBuffer->Release();
-		m_dsBuffer = NULL;
+	if (m_directSoundBuffer) {
+		m_directSoundBuffer->Stop();
+		m_directSoundBuffer->Release();
+		m_directSoundBuffer = NULL;
 	}
 
 	delete[] m_data;
@@ -146,42 +147,43 @@ LegoCacheSound* LegoCacheSound::Clone()
 // FUNCTION: BETA10 0x10066a23
 MxResult LegoCacheSound::Play(const char* p_name, MxBool p_looping)
 {
-	assert(m_dsBuffer);
+	assert(m_directSoundBuffer);
 
 	if (m_data == NULL || m_dataSize == 0) {
 		return FAILURE;
 	}
 
 	m_unk0x6a = FALSE;
-	m_sound.FUN_10011a60(m_dsBuffer, p_name);
+	m_sound.FUN_10011a60(m_directSoundBuffer, p_name);
 
 	if (p_name != NULL) {
 		m_unk0x74 = p_name;
 	}
 
 	DWORD dwStatus;
-	m_dsBuffer->GetStatus(&dwStatus);
+	m_directSoundBuffer->GetStatus(&dwStatus);
 
 	if (dwStatus == DSBSTATUS_BUFFERLOST) {
-		m_dsBuffer->Restore();
-		m_dsBuffer->GetStatus(&dwStatus);
+		m_directSoundBuffer->Restore();
+		m_directSoundBuffer->GetStatus(&dwStatus);
 	}
 
 	if (dwStatus != DSBSTATUS_BUFFERLOST) {
 		LPVOID pvAudioPtr1, pvAudioPtr2;
 		DWORD dwAudioBytes1, dwAudioBytes2;
 
-		if (m_dsBuffer->Lock(0, m_dataSize, &pvAudioPtr1, &dwAudioBytes1, &pvAudioPtr2, &dwAudioBytes2, 0) == DS_OK) {
+		if (m_directSoundBuffer->Lock(0, m_dataSize, &pvAudioPtr1, &dwAudioBytes1, &pvAudioPtr2, &dwAudioBytes2, 0) ==
+			DS_OK) {
 			memcpy(pvAudioPtr1, m_data, dwAudioBytes1);
 
 			if (dwAudioBytes2 != 0) {
 				memcpy(pvAudioPtr2, m_data + dwAudioBytes1, dwAudioBytes2);
 			}
 
-			DWORD sts = m_dsBuffer->Unlock(pvAudioPtr1, dwAudioBytes1, pvAudioPtr2, dwAudioBytes2);
+			DWORD sts = m_directSoundBuffer->Unlock(pvAudioPtr1, dwAudioBytes1, pvAudioPtr2, dwAudioBytes2);
 			assert(!sts);
-			m_dsBuffer->SetCurrentPosition(0);
-			if (m_dsBuffer->Play(0, 0, p_looping)) {
+			m_directSoundBuffer->SetCurrentPosition(0);
+			if (m_directSoundBuffer->Play(0, 0, p_looping)) {
 				assert(0);
 			}
 		}
@@ -210,10 +212,10 @@ MxResult LegoCacheSound::Play(const char* p_name, MxBool p_looping)
 void LegoCacheSound::Stop()
 {
 	DWORD dwStatus;
-	m_dsBuffer->GetStatus(&dwStatus);
+	m_directSoundBuffer->GetStatus(&dwStatus);
 
 	if (dwStatus) {
-		m_dsBuffer->Stop();
+		m_directSoundBuffer->Stop();
 	}
 
 	m_unk0x58 = FALSE;
@@ -231,7 +233,7 @@ void LegoCacheSound::FUN_10006be0()
 {
 	if (!m_looping) {
 		DWORD dwStatus;
-		m_dsBuffer->GetStatus(&dwStatus);
+		m_directSoundBuffer->GetStatus(&dwStatus);
 
 		if (m_unk0x70) {
 			if (dwStatus == 0) {
@@ -242,7 +244,7 @@ void LegoCacheSound::FUN_10006be0()
 		}
 
 		if (dwStatus == 0) {
-			m_dsBuffer->Stop();
+			m_directSoundBuffer->Stop();
 			m_sound.Reset();
 			if (m_unk0x74.GetLength() != 0) {
 				m_unk0x74 = "";
@@ -258,14 +260,14 @@ void LegoCacheSound::FUN_10006be0()
 	}
 
 	if (!m_muted) {
-		if (!m_sound.UpdatePosition(m_dsBuffer)) {
+		if (!m_sound.UpdatePosition(m_directSoundBuffer)) {
 			if (!m_unk0x6a) {
-				m_dsBuffer->Stop();
+				m_directSoundBuffer->Stop();
 				m_unk0x6a = TRUE;
 			}
 		}
 		else if (m_unk0x6a) {
-			m_dsBuffer->Play(0, 0, m_looping);
+			m_directSoundBuffer->Play(0, 0, m_looping);
 			m_unk0x6a = FALSE;
 		}
 	}
@@ -291,12 +293,12 @@ void LegoCacheSound::MuteSilence(MxBool p_muted)
 		m_muted = p_muted;
 
 		if (m_muted) {
-			m_dsBuffer->SetVolume(-3000);
+			m_directSoundBuffer->SetVolume(-3000);
 		}
 		else {
 			MxS32 volume = m_volume * SoundManager()->GetVolume() / 100;
 			MxS32 attenuation = SoundManager()->GetAttenuation(volume);
-			m_dsBuffer->SetVolume(attenuation);
+			m_directSoundBuffer->SetVolume(attenuation);
 		}
 	}
 }
@@ -309,10 +311,10 @@ void LegoCacheSound::MuteStop(MxBool p_muted)
 		m_muted = p_muted;
 
 		if (m_muted) {
-			m_dsBuffer->Stop();
+			m_directSoundBuffer->Stop();
 		}
 		else {
-			m_dsBuffer->Play(0, 0, m_looping);
+			m_directSoundBuffer->Play(0, 0, m_looping);
 		}
 	}
 }
@@ -320,13 +322,13 @@ void LegoCacheSound::MuteStop(MxBool p_muted)
 // FUNCTION: BETA10 0x10066f4d
 MxResult LegoCacheSound::GetFrequency(LPDWORD p_freq)
 {
-	return m_dsBuffer->GetFrequency(p_freq);
+	return m_directSoundBuffer->GetFrequency(p_freq);
 }
 
 // FUNCTION: BETA10 0x10066f7b
 MxResult LegoCacheSound::SetFrequency(DWORD p_freq)
 {
-	return m_dsBuffer->SetFrequency(p_freq);
+	return m_directSoundBuffer->SetFrequency(p_freq);
 }
 
 // FUNCTION: BETA10 0x10066fa9

--- a/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/lego/legoomni/src/audio/mxbackgroundaudiomanager.cpp
@@ -29,6 +29,7 @@ MxBackgroundAudioManager::MxBackgroundAudioManager()
 }
 
 // FUNCTION: LEGO1 0x1007ec20
+// FUNCTION: BETA10 0x100e865e
 MxBackgroundAudioManager::~MxBackgroundAudioManager()
 {
 	TickleManager()->UnregisterClient(this);
@@ -37,6 +38,7 @@ MxBackgroundAudioManager::~MxBackgroundAudioManager()
 }
 
 // FUNCTION: LEGO1 0x1007ece0
+// FUNCTION: BETA10 0x100e874c
 MxResult MxBackgroundAudioManager::Create(MxAtomId& p_script, MxU32 p_frequencyMS)
 {
 	MxResult result = OpenMusic(p_script);
@@ -50,6 +52,7 @@ MxResult MxBackgroundAudioManager::Create(MxAtomId& p_script, MxU32 p_frequencyM
 }
 
 // FUNCTION: LEGO1 0x1007ed20
+// FUNCTION: BETA10 0x100e87cc
 MxResult MxBackgroundAudioManager::OpenMusic(MxAtomId& p_script)
 {
 	if (m_script.GetInternal()) {
@@ -67,6 +70,7 @@ MxResult MxBackgroundAudioManager::OpenMusic(MxAtomId& p_script)
 }
 
 // FUNCTION: LEGO1 0x1007ed70
+// FUNCTION: BETA10 0x100e8859
 void MxBackgroundAudioManager::DestroyMusic()
 {
 	if (m_script.GetInternal()) {
@@ -80,6 +84,7 @@ void MxBackgroundAudioManager::DestroyMusic()
 }
 
 // FUNCTION: LEGO1 0x1007ee40
+// FUNCTION: BETA10 0x100e8953
 MxResult MxBackgroundAudioManager::Tickle()
 {
 	switch (m_tickleState) {
@@ -97,6 +102,7 @@ MxResult MxBackgroundAudioManager::Tickle()
 }
 
 // FUNCTION: LEGO1 0x1007ee70
+// FUNCTION: BETA10 0x100e89e3
 void MxBackgroundAudioManager::MakePendingPresenterActive()
 {
 	if (m_activePresenter && m_activePresenter->GetAction()) {
@@ -114,6 +120,7 @@ void MxBackgroundAudioManager::MakePendingPresenterActive()
 }
 
 // FUNCTION: LEGO1 0x1007ef40
+// FUNCTION: BETA10 0x100e8afa
 void MxBackgroundAudioManager::FadeInPendingPresenter()
 {
 	MxS32 compare, volume;
@@ -213,6 +220,7 @@ MxLong MxBackgroundAudioManager::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1007f1b0
+// FUNCTION: BETA10 0x100e8f2e
 void MxBackgroundAudioManager::StartAction(MxParam& p_param)
 {
 	// TODO: the sender is most likely a MxAudioPresenter?
@@ -224,6 +232,7 @@ void MxBackgroundAudioManager::StartAction(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1007f200
+// FUNCTION: BETA10 0x100e8f8c
 void MxBackgroundAudioManager::StopAction(MxParam& p_param)
 {
 	if (((MxNotificationParam&) p_param).GetSender() == m_activePresenter) {
@@ -283,14 +292,14 @@ MxResult MxBackgroundAudioManager::PlayMusic(
 }
 
 // FUNCTION: BETA10 0x100e92ec
-void MxBackgroundAudioManager::Update(MxS32 p_targetVolume, MxS32 p_speed, MxPresenter::TickleState p_tickleState)
+void MxBackgroundAudioManager::Update(MxS32 p_volume, MxS32 p_speed, MxPresenter::TickleState p_tickleState)
 {
-	assert(p_targetVolume >= 0 && p_targetVolume <= 100);
+	assert(p_volume >= 0 && p_volume <= 100);
 	assert(p_speed > 0);
 
 	m_tickleState = p_tickleState;
 	m_speed = p_speed;
-	m_targetVolume = p_targetVolume;
+	m_targetVolume = p_volume;
 }
 
 // FUNCTION: LEGO1 0x1007f470
@@ -345,6 +354,7 @@ void MxBackgroundAudioManager::RaiseVolume()
 }
 
 // FUNCTION: LEGO1 0x1007f5f0
+// FUNCTION: BETA10 0x100e95a0
 void MxBackgroundAudioManager::Enable(MxBool p_enable)
 {
 	if (this->m_enabled != p_enable) {

--- a/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuild.cpp
@@ -46,9 +46,19 @@ DECOMP_SIZE_ASSERT(LegoCarBuild::LookupTableActions, 0x1c);
 
 // These four structs can be matched to the vehicle types using BETA10 0x10070520
 
+// GLOBAL: LEGO1 0x100d65a4
+const MxFloat LegoCarBuild::g_selectedPartRotationAngleStepYAxis = -0.1f;
+
+// GLOBAL: LEGO1 0x100d65a8
+const MxFloat LegoCarBuild::g_rotationAngleStepYAxis = 0.07;
+
+// GLOBAL: LEGO1 0x100d65ac
+// GLOBAL: BETA10 0x101bb7bc
+static const MxFloat g_unk0x100d65ac = 0.0f;
+
 // GLOBAL: LEGO1 0x100d65b0
 // GLOBAL: BETA10 0x101bb7c0
-LegoCarBuild::LookupTableActions LegoCarBuild::g_actorScripts[] = {
+const LegoCarBuild::LookupTableActions LegoCarBuild::g_actorScripts[] = {
 	{DunecarScript::c_igs001d3_RunAnim,
 	 DunecarScript::c_igs002d3_RunAnim,
 	 DunecarScript::c_igs003d3_RunAnim,
@@ -79,12 +89,6 @@ LegoCarBuild::LookupTableActions LegoCarBuild::g_actorScripts[] = {
 	 RacecarScript::c_irtxx4d1_RunAnim}
 };
 
-// GLOBAL: LEGO1 0x100d65a4
-MxFloat LegoCarBuild::g_selectedPartRotationAngleStepYAxis = -0.1f;
-
-// GLOBAL: LEGO1 0x100d65a8
-MxFloat LegoCarBuild::g_rotationAngleStepYAxis = 0.07;
-
 // GLOBAL: LEGO1 0x100f11cc
 MxS16 LegoCarBuild::g_lastTickleState = -1;
 
@@ -92,8 +96,8 @@ MxS16 LegoCarBuild::g_lastTickleState = -1;
 // FUNCTION: BETA10 0x1006ac10
 LegoCarBuild::LegoCarBuild()
 {
-	m_clickState = e_idle;
 	m_selectedPart = 0;
+	m_clickState = e_idle;
 	m_resetPlacedSelectedPart = c_disabled;
 	m_displayedPartIsPlaced = FALSE;
 	m_animPresenter = NULL;
@@ -160,62 +164,62 @@ MxResult LegoCarBuild::Create(MxDSAction& p_dsAction)
 {
 	MxResult result = LegoWorld::Create(p_dsAction);
 
-	if (!result) {
-		// TickleManager()->RegisterClient(this, 100);
-		InputManager()->SetWorld(this);
-		ControlManager()->Register(this);
-
-		SetIsWorldActive(FALSE);
-
-		InputManager()->Register(this);
-
-		// variable name verified by BETA10 0x1006b1a6
-		const char* buildStateClassName = NULL;
-
-		if (m_atomId == *g_copterScript) {
-			buildStateClassName = "LegoCopterBuildState";
-			GameState()->m_currentArea = LegoGameState::e_copterbuild;
-			m_carId = Helicopter_Actor;
-		}
-		else if (m_atomId == *g_dunecarScript) {
-			buildStateClassName = "LegoDuneCarBuildState";
-			GameState()->m_currentArea = LegoGameState::e_dunecarbuild;
-			m_carId = DuneBugy_Actor;
-		}
-		else if (m_atomId == *g_jetskiScript) {
-			buildStateClassName = "LegoJetskiBuildState";
-			GameState()->m_currentArea = LegoGameState::e_jetskibuild;
-			m_carId = Jetski_Actor;
-		}
-		else if (m_atomId == *g_racecarScript) {
-			buildStateClassName = "LegoRaceCarBuildState";
-			GameState()->m_currentArea = LegoGameState::e_racecarbuild;
-			m_carId = RaceCar_Actor;
-		}
-
-		LegoGameState* gameState = GameState();
-
-		LegoVehicleBuildState* buildState = (LegoVehicleBuildState*) gameState->GetState(buildStateClassName);
-
-		if (!buildState) {
-			buildState = (LegoVehicleBuildState*) gameState->CreateState(buildStateClassName);
-		}
-
-		m_buildState = buildState;
-		m_alreadyFinished = m_buildState->m_finishedBuild;
-
-		GameState()->StopArea(LegoGameState::e_previousArea);
-
-		m_buildState->m_animationState = LegoVehicleBuildState::e_entering;
-		m_clickState = e_idle;
-
-		BackgroundAudioManager()->Stop();
-		EnableAnimations(FALSE);
-
-		result = SUCCESS;
+	if (result != SUCCESS) {
+		return result;
 	}
 
-	return result;
+	// TickleManager()->RegisterClient(this, 100);
+	InputManager()->SetWorld(this);
+	ControlManager()->Register(this);
+
+	SetIsWorldActive(FALSE);
+
+	InputManager()->Register(this);
+
+	// variable name verified by BETA10 0x1006b1a6
+	const char* buildStateClassName = NULL;
+
+	if (m_atomId == *g_copterScript) {
+		buildStateClassName = "LegoCopterBuildState";
+		GameState()->m_currentArea = LegoGameState::e_copterbuild;
+		m_carId = Helicopter_Actor;
+	}
+	else if (m_atomId == *g_dunecarScript) {
+		buildStateClassName = "LegoDuneCarBuildState";
+		GameState()->m_currentArea = LegoGameState::e_dunecarbuild;
+		m_carId = DuneBugy_Actor;
+	}
+	else if (m_atomId == *g_jetskiScript) {
+		buildStateClassName = "LegoJetskiBuildState";
+		GameState()->m_currentArea = LegoGameState::e_jetskibuild;
+		m_carId = Jetski_Actor;
+	}
+	else if (m_atomId == *g_racecarScript) {
+		buildStateClassName = "LegoRaceCarBuildState";
+		GameState()->m_currentArea = LegoGameState::e_racecarbuild;
+		m_carId = RaceCar_Actor;
+	}
+
+	LegoGameState* gameState = GameState();
+
+	LegoVehicleBuildState* buildState = (LegoVehicleBuildState*) gameState->GetState(buildStateClassName);
+
+	if (!buildState) {
+		buildState = (LegoVehicleBuildState*) gameState->CreateState(buildStateClassName);
+	}
+
+	m_buildState = buildState;
+	m_alreadyFinished = m_buildState->m_finishedBuild;
+
+	GameState()->StopArea(LegoGameState::e_previousArea);
+
+	m_buildState->m_animationState = LegoVehicleBuildState::e_entering;
+	m_clickState = e_idle;
+
+	BackgroundAudioManager()->Stop();
+	EnableAnimations(FALSE);
+
+	return SUCCESS;
 }
 
 // FUNCTION: LEGO1 0x10022cd0
@@ -286,6 +290,7 @@ void LegoCarBuild::InitPresenters()
 }
 
 // FUNCTION: LEGO1 0x10022f00
+// FUNCTION: BETA10 0x1006b7e7
 void LegoCarBuild::DisplaySelectedPart()
 {
 	if (m_selectedPart) {
@@ -352,7 +357,7 @@ void LegoCarBuild::CalculateStartAndTargetScreenPositions()
 	m_selectedPartTargetScreenPosition[1] = screenPos[1] / screenPos[3];
 
 	m_normalizedDistance =
-		sqrt((MxDouble) DISTSQRD2(m_selectedPartStartScreenPosition, m_selectedPartTargetScreenPosition));
+		sqrt((MxDouble) DISTSQRD2(m_selectedPartTargetScreenPosition, m_selectedPartStartScreenPosition));
 
 	m_draggingQuarternionTransformer.SetStartEnd(m_selectedPartStartTransform, m_selectedPartTargetTransform);
 }
@@ -372,45 +377,47 @@ void LegoCarBuild::CalculateSelectedPartMatrix(MxLong p_x, MxLong p_y)
 		screenCoordinatesForRay[0] = p_x;
 		screenCoordinatesForRay[1] = p_y;
 
-		if (CalculateRayOriginDirection(screenCoordinatesForRay, local30, local84)) {
-			MxFloat positionOffset[3];
-			MxFloat screenPosition[2];
-
-			screenPosition[0] = p_x;
-			screenPosition[1] = p_y;
-
-			positionOffset[0] = 0;
-			positionOffset[1] = 0;
-			positionOffset[2] = 0;
-
-			MxMatrix transform;
-
-			if (p_y < m_selectedPartStartScreenPosition[1]) {
-				CalculateDragPositionAbove(screenPosition, positionOffset);
-			}
-			else if (p_y > m_selectedPartTargetScreenPosition[1]) {
-				CalculateDragPositionOnGround(screenPosition, positionOffset);
-			}
-			else if (p_y >= m_selectedPartStartScreenPosition[1]) {
-				CalculateDragPositionBetween(screenPosition, positionOffset);
-			}
-
-			MxS32 currentDistance[2];
-
-			currentDistance[0] = p_x - m_selectedPartStartScreenPosition[0];
-			currentDistance[1] = p_y - m_selectedPartStartScreenPosition[1];
-
-			MxFloat distanceRatio = sqrt((double) (NORMSQRD2(currentDistance))) / m_normalizedDistance;
-
-			m_draggingQuarternionTransformer.InterpolateToMatrix(transform, distanceRatio);
-
-			transform[3][0] = m_selectedPartStartTransform[3][0] + positionOffset[0];
-			transform[3][1] = m_selectedPartStartTransform[3][1] + positionOffset[1];
-			transform[3][2] = m_selectedPartStartTransform[3][2] + positionOffset[2];
-			transform[3][3] = 1.0;
-
-			m_selectedPart->WrappedSetLocal2WorldWithWorldDataUpdate(transform);
+		if (!CalculateRayOriginDirection(screenCoordinatesForRay, local30, local84)) {
+			return;
 		}
+
+		MxFloat positionOffset[3];
+		MxFloat screenPosition[2];
+
+		screenPosition[0] = p_x;
+		screenPosition[1] = p_y;
+
+		positionOffset[0] = 0;
+		positionOffset[1] = 0;
+		positionOffset[2] = 0;
+
+		MxMatrix transform;
+
+		if (p_y < m_selectedPartStartScreenPosition[1]) {
+			CalculateDragPositionAbove(screenPosition, positionOffset);
+		}
+		else if (p_y > m_selectedPartTargetScreenPosition[1]) {
+			CalculateDragPositionOnGround(screenPosition, positionOffset);
+		}
+		else if (p_y >= m_selectedPartStartScreenPosition[1]) {
+			CalculateDragPositionBetween(screenPosition, positionOffset);
+		}
+
+		MxS32 currentDistance[2];
+
+		currentDistance[0] = p_x - m_selectedPartStartScreenPosition[0];
+		currentDistance[1] = p_y - m_selectedPartStartScreenPosition[1];
+
+		MxFloat distanceRatio = sqrt((double) (NORMSQRD2(currentDistance))) / m_normalizedDistance;
+
+		m_draggingQuarternionTransformer.InterpolateToMatrix(transform, distanceRatio);
+
+		transform[3][0] = m_selectedPartStartTransform[3][0] + positionOffset[0];
+		transform[3][1] = m_selectedPartStartTransform[3][1] + positionOffset[1];
+		transform[3][2] = m_selectedPartStartTransform[3][2] + positionOffset[2];
+		transform[3][3] = 1.0;
+
+		m_selectedPart->WrappedSetLocal2WorldWithWorldDataUpdate(transform);
 	}
 }
 
@@ -425,8 +432,8 @@ void LegoCarBuild::CalculateDragPositionAbove(MxFloat p_coordinates[2], MxFloat 
 	CalculateRayOriginDirection(p_coordinates, direction, origin);
 
 	planeFactor = (m_selectedPartStartPosition[2] - origin[2]) / direction[2];
-	p_position[0] = (planeFactor * direction[0] + origin[0]) - m_selectedPartStartPosition[0];
-	p_position[1] = (planeFactor * direction[1] + origin[1]) - m_selectedPartStartPosition[1];
+	p_position[0] = planeFactor * direction[0] - m_selectedPartStartPosition[0] + origin[0];
+	p_position[1] = planeFactor * direction[1] - m_selectedPartStartPosition[1] + origin[1];
 	p_position[2] = 0.0;
 }
 
@@ -468,7 +475,7 @@ void LegoCarBuild::CalculateDragPositionOnGround(MxFloat p_coordinates[2], MxFlo
 // FUNCTION: BETA10 0x100701f0
 void LegoCarBuild::VTable0x80(MxFloat p_param1[2], MxFloat p_param2[2], MxFloat p_param3, MxFloat p_param4[2])
 {
-	if (p_param1[1] == 0.0f) {
+	if (p_param1[1] == 0.0) {
 		return;
 	}
 	p_param4[0] = ((p_param3 - p_param2[1]) / p_param1[1]) * p_param1[0] + p_param2[0];
@@ -1355,7 +1362,7 @@ void LegoCarBuild::EnableDecalForSelectedPart(MxBool p_enabled)
 
 // FUNCTION: LEGO1 0x10025350
 // FUNCTION: BETA10 0x1006e3c0
-void LegoCarBuild::SetPartColor(MxS32 p_objectId)
+void LegoCarBuild::SetPartColor(MxU32 p_objectId)
 {
 	const LegoChar* color;
 	LegoChar buffer[256];

--- a/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/build/legocarbuildpresenter.cpp
@@ -302,12 +302,13 @@ MxResult LegoCarBuildAnimPresenter::Serialize(LegoStorage* p_storage)
 		}
 	}
 	else if (p_storage->IsWriteMode()) {
-		p_storage->WriteS16(m_placedPartCount);
-		p_storage->WriteFloat(m_shelfFrame);
+		LegoStorage* storage = p_storage;
+		storage->WriteS16(m_placedPartCount);
+		storage->WriteFloat(m_shelfFrame);
 		for (MxS16 i = 0; i < m_numberOfParts; i++) {
-			p_storage->WriteString(m_parts[i].m_name);
-			p_storage->WriteString(m_parts[i].m_wiredName);
-			p_storage->WriteS16(m_parts[i].m_objectId);
+			storage->WriteString(m_parts[i].m_name);
+			storage->WriteString(m_parts[i].m_wiredName);
+			storage->WriteS16(m_parts[i].m_objectId);
 		}
 	}
 
@@ -642,6 +643,12 @@ MxBool LegoCarBuildAnimPresenter::StringEqualsShelf(const LegoChar* p_string)
 	return strnicmp(p_string, "SHELF", strlen("SHELF")) == 0;
 }
 
+// FUNCTION: BETA10 0x1007266c
+MxBool LegoCarBuildAnimPresenter::StringEqualsView(const LegoChar* p_string)
+{
+	return stricmp(p_string, "VIEW") == 0;
+}
+
 // FUNCTION: LEGO1 0x10079c30
 // FUNCTION: BETA10 0x100726a6
 MxBool LegoCarBuildAnimPresenter::IsNextPartToPlace(const LegoChar* p_name)
@@ -699,7 +706,7 @@ const LegoChar* LegoCarBuildAnimPresenter::GetWiredNameByPartName(const LegoChar
 void LegoCarBuildAnimPresenter::SetPartObjectIdByName(const LegoChar* p_name, MxS16 p_objectId)
 {
 	for (MxS16 i = 0; i < m_numberOfParts; i++) {
-		if (strcmpi(p_name, m_parts[i].m_name) == 0) {
+		if (strcmpi(m_parts[i].m_name, p_name) == 0) {
 			m_parts[i].m_objectId = p_objectId;
 			return;
 		}

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1,3 +1,4 @@
+
 #include "legoanimationmanager.h"
 
 #include "3dmanager/lego3dmanager.h"
@@ -31,6 +32,22 @@
 #include <io.h>
 #include <vec.h>
 
+inline void LegoTranInfoList::Append(LegoTranInfo* p_obj)
+{
+	MxListEntry<LegoTranInfo*>* last = this->m_last;
+	MxListEntry<LegoTranInfo*>* newEntry = new MxListEntry<LegoTranInfo*>(p_obj, last);
+
+	if (last) {
+		last->SetNext(newEntry);
+	}
+	else {
+		this->m_first = newEntry;
+	}
+
+	this->m_last = newEntry;
+	this->m_count++;
+}
+
 DECOMP_SIZE_ASSERT(LegoAnimationManager, 0x500)
 DECOMP_SIZE_ASSERT(LegoAnimationManager::Character, 0x18)
 DECOMP_SIZE_ASSERT(LegoAnimationManager::Vehicle, 0x08)
@@ -41,7 +58,7 @@ DECOMP_SIZE_ASSERT(AnimInfo, 0x30)
 DECOMP_SIZE_ASSERT(ModelInfo, 0x30)
 
 // GLOBAL: LEGO1 0x100d8b28
-MxU8 g_unk0x100d8b28[] = {0, 1, 2, 4, 8, 16};
+const MxU8 g_unk0x100d8b28[] = {0, 1, 2, 4, 8, 16};
 
 // GLOBAL: LEGO1 0x100f6d20
 LegoAnimationManager::Vehicle g_vehicles[] = {
@@ -310,6 +327,10 @@ float g_unk0x100f74b0[6][3] = {
 // GLOBAL: LEGO1 0x100f74f8
 MxS32 g_legoAnimationManagerConfig = 1;
 
+// GLOBAL: LEGO1 0x100f74fc
+// GLOBAL: BETA10 0x101e2398
+undefined4 g_unk0x100f74fc = 0;
+
 // GLOBAL: LEGO1 0x100f7500
 float g_unk0x100f7500 = 0.1f;
 
@@ -345,7 +366,7 @@ LegoAnimationManager::~LegoAnimationManager()
 	FUN_10061010(FALSE);
 
 	for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-		LegoROI* roi = m_extras[i].m_roi;
+		LegoROI* roi = m_extras[i].roi;
 
 		if (roi != NULL) {
 			LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
@@ -431,7 +452,7 @@ void LegoAnimationManager::Suspend()
 
 		MxS32 i;
 		for (i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-			LegoROI* roi = m_extras[i].m_roi;
+			LegoROI* roi = m_extras[i].roi;
 
 			if (roi != NULL) {
 				LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
@@ -458,7 +479,7 @@ void LegoAnimationManager::Suspend()
 				}
 			}
 
-			m_extras[i].m_roi = NULL;
+			m_extras[i].roi = NULL;
 			m_extras[i].m_characterId = -1;
 			m_extras[i].m_speed = -1.0f;
 		}
@@ -511,7 +532,7 @@ void LegoAnimationManager::Init()
 	}
 
 	for (i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-		m_extras[i].m_roi = NULL;
+		m_extras[i].roi = NULL;
 		m_extras[i].m_characterId = -1;
 		m_extras[i].m_speed = -1.0f;
 		m_extras[i].m_unk0x14 = FALSE;
@@ -580,6 +601,7 @@ void LegoAnimationManager::EnableCamAnims(MxBool p_enableCamAnims)
 }
 
 // FUNCTION: LEGO1 0x1005f720
+// FUNCTION: BETA10 0x10040291
 MxResult LegoAnimationManager::LoadWorldInfo(LegoOmni::World p_worldId)
 {
 	MxResult result = FAILURE;
@@ -672,6 +694,7 @@ MxResult LegoAnimationManager::LoadWorldInfo(LegoOmni::World p_worldId)
 		}
 
 		m_anims = new AnimInfo[m_animCount];
+		assert(m_anims);
 		memset(m_anims, 0, m_animCount * sizeof(*m_anims));
 
 		for (j = 0; j < m_animCount; j++) {
@@ -679,7 +702,7 @@ MxResult LegoAnimationManager::LoadWorldInfo(LegoOmni::World p_worldId)
 				goto done;
 			}
 
-			m_anims[j].m_characterIndex = GetCharacterIndex(m_anims[j].m_name + strlen(m_anims[j].m_name) - 2);
+			m_anims[j].m_characterIndex = GetCharacterIndex(m_anims[j].animName + strlen(m_anims[j].animName) - 2);
 			m_anims[j].m_unk0x29 = FALSE;
 
 			for (k = 0; k < 3; k++) {
@@ -688,7 +711,7 @@ MxResult LegoAnimationManager::LoadWorldInfo(LegoOmni::World p_worldId)
 
 			if (m_anims[j].m_location == -1) {
 				for (MxS32 l = 0; l < m_anims[j].m_modelCount; l++) {
-					MxS32 index = GetCharacterIndex(m_anims[j].m_models[l].m_name);
+					MxS32 index = GetCharacterIndex(m_anims[j].models[l].modelName);
 
 					if (index >= 0) {
 						g_characters[index].m_active = TRUE;
@@ -700,7 +723,7 @@ MxResult LegoAnimationManager::LoadWorldInfo(LegoOmni::World p_worldId)
 			for (MxS32 m = 0; m < m_anims[j].m_modelCount; m++) {
 				MxU32 n;
 
-				if (FindVehicle(m_anims[j].m_models[m].m_name, n) && m_anims[j].m_models[m].m_unk0x2c) {
+				if (FindVehicle(m_anims[j].models[m].modelName, n) && m_anims[j].models[m].m_unk0x2c) {
 					m_anims[j].m_unk0x2a[count++] = n;
 					if (count > 3) {
 						break;
@@ -710,6 +733,7 @@ MxResult LegoAnimationManager::LoadWorldInfo(LegoOmni::World p_worldId)
 		}
 
 		m_worldId = p_worldId;
+		assert(!m_tranInfoList);
 		m_tranInfoList = new LegoTranInfoList();
 		m_tranInfoList2 = new LegoTranInfoList();
 
@@ -741,6 +765,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10060140
+// FUNCTION: BETA10 0x10040c2e
 MxBool LegoAnimationManager::FindVehicle(const char* p_name, MxU32& p_index)
 {
 	for (MxS32 i = 0; i < sizeOfArray(g_vehicles); i++) {
@@ -754,6 +779,7 @@ MxBool LegoAnimationManager::FindVehicle(const char* p_name, MxU32& p_index)
 }
 
 // FUNCTION: LEGO1 0x10060180
+// FUNCTION: BETA10 0x10040c94
 MxResult LegoAnimationManager::ReadAnimInfo(LegoStorage* p_storage, AnimInfo* p_info)
 {
 	MxResult result = FAILURE;
@@ -764,12 +790,14 @@ MxResult LegoAnimationManager::ReadAnimInfo(LegoStorage* p_storage, AnimInfo* p_
 		goto done;
 	}
 
-	p_info->m_name = new char[length + 1];
-	if (p_storage->Read(p_info->m_name, length) == FAILURE) {
+	p_info->animName = new char[length + 1];
+	assert(p_info->animName);
+
+	if (p_storage->Read(p_info->animName, length) == FAILURE) {
 		goto done;
 	}
 
-	p_info->m_name[length] = 0;
+	p_info->animName[length] = 0;
 	if (p_storage->Read(&p_info->m_objectId, sizeof(MxU32)) == FAILURE) {
 		goto done;
 	}
@@ -800,11 +828,11 @@ MxResult LegoAnimationManager::ReadAnimInfo(LegoStorage* p_storage, AnimInfo* p_
 		goto done;
 	}
 
-	p_info->m_models = new ModelInfo[p_info->m_modelCount];
-	memset(p_info->m_models, 0, p_info->m_modelCount * sizeof(*p_info->m_models));
+	p_info->models = new ModelInfo[p_info->m_modelCount];
+	memset(p_info->models, 0, p_info->m_modelCount * sizeof(*p_info->models));
 
 	for (j = 0; j < p_info->m_modelCount; j++) {
-		if (ReadModelInfo(p_storage, &p_info->m_models[j]) == FAILURE) {
+		if (ReadModelInfo(p_storage, &p_info->models[j]) == FAILURE) {
 			goto done;
 		}
 	}
@@ -816,6 +844,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10060310
+// FUNCTION: BETA10 0x10040fad
 MxResult LegoAnimationManager::ReadModelInfo(LegoStorage* p_storage, ModelInfo* p_info)
 {
 	MxResult result = FAILURE;
@@ -825,12 +854,14 @@ MxResult LegoAnimationManager::ReadModelInfo(LegoStorage* p_storage, ModelInfo* 
 		goto done;
 	}
 
-	p_info->m_name = new char[length + 1];
-	if (p_storage->Read(p_info->m_name, length) == FAILURE) {
+	p_info->modelName = new char[length + 1];
+	assert(p_info->modelName);
+
+	if (p_storage->Read(p_info->modelName, length) == FAILURE) {
 		goto done;
 	}
 
-	p_info->m_name[length] = 0;
+	p_info->modelName[length] = 0;
 	if (p_storage->Read(&p_info->m_unk0x04, sizeof(MxU8)) == FAILURE) {
 		goto done;
 	}
@@ -855,20 +886,21 @@ done:
 }
 
 // FUNCTION: LEGO1 0x100603c0
+// FUNCTION: BETA10 0x10041156
 void LegoAnimationManager::DeleteAnimations()
 {
 	MxBool suspended = m_suspended;
 
 	if (m_anims != NULL) {
 		for (MxS32 i = 0; i < m_animCount; i++) {
-			delete[] m_anims[i].m_name;
+			delete[] m_anims[i].animName;
 
-			if (m_anims[i].m_models != NULL) {
+			if (m_anims[i].models != NULL) {
 				for (MxS32 j = 0; j < m_anims[i].m_modelCount; j++) {
-					delete[] m_anims[i].m_models[j].m_name;
+					delete[] m_anims[i].models[j].modelName;
 				}
 
-				delete[] m_anims[i].m_models;
+				delete[] m_anims[i].models;
 			}
 		}
 
@@ -1094,10 +1126,12 @@ MxResult LegoAnimationManager::FUN_100609f0(MxU32 p_objectId, MxMatrix* p_matrix
 }
 
 // FUNCTION: LEGO1 0x10060d00
+// FUNCTION: BETA10 0x10041d6a
 MxResult LegoAnimationManager::StartEntityAction(MxDSAction& p_dsAction, LegoEntity* p_entity)
 {
 	MxResult result = FAILURE;
 	LegoROI* roi = p_entity->GetROI();
+	assert(roi);
 
 	if (p_entity->GetType() == LegoEntity::e_actor) {
 		LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
@@ -1110,7 +1144,7 @@ MxResult LegoAnimationManager::StartEntityAction(MxDSAction& p_dsAction, LegoEnt
 				actor->SetController(NULL);
 
 				for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-					if (m_extras[i].m_roi == roi) {
+					if (m_extras[i].roi == roi) {
 						MxS32 characterId = m_extras[i].m_characterId;
 						g_characters[characterId].m_unk0x07 = TRUE;
 						MxS32 vehicleId = g_characters[characterId].m_vehicleId;
@@ -1202,15 +1236,16 @@ void LegoAnimationManager::CameraTriggerFire(LegoPathActor* p_actor, MxBool, MxU
 		MxU16 unk0x0e, unk0x10;
 		if (FUN_100617c0(p_location, unk0x0e, unk0x10) == SUCCESS) {
 			MxU16 index = unk0x0e;
-			MxU32 unk0x22 = -1;
 			MxBool success = FALSE;
+			MxU16 i;
+			MxU32 unk0x22 = -1;
 
-			for (MxU16 i = unk0x0e; i <= unk0x10; i++) {
+			for (i = unk0x0e; i <= unk0x10; i++) {
 				AnimInfo& animInfo = m_anims[i];
 
 				if ((p_bool || !FUN_100623a0(animInfo)) && !FUN_10062710(animInfo) && animInfo.m_unk0x29 &&
-					animInfo.m_unk0x22 < unk0x22 && (animInfo.m_unk0x22 == 0 || *animInfo.m_name != 'i') &&
-					*animInfo.m_name != 'I') {
+					animInfo.m_unk0x22 < unk0x22 && (animInfo.m_unk0x22 == 0 || *animInfo.animName != 'i') &&
+					*animInfo.animName != 'I') {
 					index = i;
 					unk0x22 = animInfo.m_unk0x22;
 					success = TRUE;
@@ -1259,6 +1294,12 @@ void LegoAnimationManager::FUN_10061010(MxBool p_und)
 	m_unk0x404 = Timer()->GetTime();
 }
 #else
+inline void RestoreBackgroundVolume(MxBool p_lowered)
+{
+	MxBool& lowered = p_lowered;
+	BackgroundAudioManager()->RaiseVolume();
+}
+
 // FUNCTION: LEGO1 0x10061010
 void LegoAnimationManager::FUN_10061010(MxBool p_und)
 {
@@ -1271,14 +1312,18 @@ void LegoAnimationManager::FUN_10061010(MxBool p_und)
 
 		while (cursor.Next(tranInfo)) {
 			if (tranInfo->m_presenter) {
+				MxU32* flagsPtr = &tranInfo->m_flags;
+				MxU32 flags = *flagsPtr;
+				MxBool flags2 = (MxBool) (*flagsPtr & LegoTranInfo::c_bit2);
+
 				// LINE: LEGO1 0x100610e6
 				if (tranInfo->m_unk0x14 && tranInfo->m_location != -1 && p_und) {
 					if (tranInfo->m_presenter->GetPresenter() &&
 						tranInfo->m_presenter->GetPresenter()->GetAnimation() &&
 						tranInfo->m_presenter->GetPresenter()->GetAnimation()->GetCamAnim()) {
-						if (tranInfo->m_flags & LegoTranInfo::c_bit2) {
-							BackgroundAudioManager()->RaiseVolume();
-							tranInfo->m_flags &= ~LegoTranInfo::c_bit2;
+						if (flags & LegoTranInfo::c_bit2) {
+							RestoreBackgroundVolume(flags2);
+							*flagsPtr &= ~LegoTranInfo::c_bit2;
 						}
 
 						tranInfo->m_presenter->FUN_1004b840();
@@ -1293,10 +1338,10 @@ void LegoAnimationManager::FUN_10061010(MxBool p_und)
 					}
 				}
 				else {
-					if (tranInfo->m_flags & LegoTranInfo::c_bit2) {
+					if (flags & LegoTranInfo::c_bit2) {
 						// LINE: LEGO1 0x10061150
-						BackgroundAudioManager()->RaiseVolume();
-						tranInfo->m_flags &= ~LegoTranInfo::c_bit2;
+						RestoreBackgroundVolume(flags2);
+						*flagsPtr &= ~LegoTranInfo::c_bit2;
 					}
 
 					MxTrace("Stopping %d\n", tranInfo->m_objectId);
@@ -1307,8 +1352,6 @@ void LegoAnimationManager::FUN_10061010(MxBool p_und)
 				if (m_tranInfoList2 != NULL) {
 					LegoTranInfoListCursor cursor(m_tranInfoList2);
 					if (!cursor.Find(tranInfo)) {
-						// TODO: For some reason, the embedded `MxListEntry` constructor is not inlined.
-						// This may be the key for getting this function to match correctly.
 						m_tranInfoList2->Append(tranInfo);
 					}
 				}
@@ -1456,7 +1499,7 @@ MxLong LegoAnimationManager::Notify(MxParam& p_param)
 				delete tranInfo;
 
 				for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-					LegoROI* roi = m_extras[i].m_roi;
+					LegoROI* roi = m_extras[i].roi;
 
 					if (roi != NULL) {
 						LegoExtraActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
@@ -1505,7 +1548,7 @@ MxResult LegoAnimationManager::Tickle()
 
 	if (m_unk0x401) {
 		for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-			LegoROI* roi = m_extras[i].m_roi;
+			LegoROI* roi = m_extras[i].roi;
 
 			if (roi != NULL && m_extras[i].m_unk0x0d) {
 				LegoPathActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
@@ -1531,7 +1574,7 @@ MxResult LegoAnimationManager::Tickle()
 					}
 				}
 
-				m_extras[i].m_roi = NULL;
+				m_extras[i].roi = NULL;
 				g_characters[m_extras[i].m_characterId].m_inExtras = FALSE;
 				g_characters[m_extras[i].m_characterId].m_unk0x07 = FALSE;
 				m_extras[i].m_characterId = -1;
@@ -1562,7 +1605,7 @@ MxResult LegoAnimationManager::Tickle()
 		}
 
 		for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-			LegoROI* roi = m_extras[i].m_roi;
+			LegoROI* roi = m_extras[i].roi;
 
 			if (roi != NULL) {
 				MxU16 result = FUN_10062110(roi, direction, position, boundary, speed, unk0x0c, m_extras[i].m_unk0x14);
@@ -1742,12 +1785,12 @@ MxBool LegoAnimationManager::FUN_100623a0(AnimInfo& p_info)
 // FUNCTION: BETA10 0x100434bf
 MxBool LegoAnimationManager::ModelExists(AnimInfo& p_info, const char* p_name)
 {
-	ModelInfo* models = p_info.m_models;
+	ModelInfo* models = p_info.models;
 	MxU8 modelCount = p_info.m_modelCount;
 
 	if (models != NULL && modelCount) {
 		for (MxU8 i = 0; i < modelCount; i++) {
-			if (!strcmpi(models[i].m_name, p_name)) {
+			if (!strcmpi(models[i].modelName, p_name)) {
 				return TRUE;
 			}
 		}
@@ -1760,12 +1803,12 @@ MxBool LegoAnimationManager::ModelExists(AnimInfo& p_info, const char* p_name)
 // FUNCTION: BETA10 0x10043552
 void LegoAnimationManager::FUN_10062580(AnimInfo& p_info)
 {
-	ModelInfo* models = p_info.m_models;
+	ModelInfo* models = p_info.models;
 	MxU8 modelCount = p_info.m_modelCount;
 
 	if (models != NULL && modelCount) {
 		for (MxU8 i = 0; i < modelCount; i++) {
-			LegoPathActor* actor = CharacterManager()->GetExtraActor(models[i].m_name);
+			LegoPathActor* actor = CharacterManager()->GetExtraActor(models[i].modelName);
 
 			if (actor) {
 				LegoPathController* controller = actor->GetController();
@@ -1775,7 +1818,7 @@ void LegoAnimationManager::FUN_10062580(AnimInfo& p_info)
 					actor->SetController(NULL);
 
 					for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-						if (m_extras[i].m_roi == actor->GetROI()) {
+						if (m_extras[i].roi == actor->GetROI()) {
 							MxS32 characterId = m_extras[i].m_characterId;
 							g_characters[characterId].m_unk0x07 = TRUE;
 							MxS32 vehicleId = g_characters[characterId].m_vehicleId;
@@ -1863,7 +1906,7 @@ void LegoAnimationManager::PurgeExtra(MxBool p_und)
 		MxLong time = Timer()->GetTime();
 
 		for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-			LegoROI* roi = m_extras[i].m_roi;
+			LegoROI* roi = m_extras[i].roi;
 
 			if (roi != NULL) {
 				MxU16 prefix = *(MxU16*) roi->GetName();
@@ -1898,7 +1941,7 @@ void LegoAnimationManager::PurgeExtra(MxBool p_und)
 						}
 					}
 
-					m_extras[i].m_roi = NULL;
+					m_extras[i].roi = NULL;
 					g_characters[m_extras[i].m_characterId].m_inExtras = FALSE;
 					g_characters[m_extras[i].m_characterId].m_unk0x07 = FALSE;
 					m_extras[i].m_characterId = -1;
@@ -1923,7 +1966,7 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 			LegoPathActor* actor = UserActor();
 			if (actor == NULL || actor->GetWorldSpeed() <= 20.0f) {
 				MxU32 i;
-				for (i = 0; i < m_numAllowedExtras && m_extras[i].m_roi != NULL; i++) {
+				for (i = 0; i < m_numAllowedExtras && m_extras[i].roi != NULL; i++) {
 				}
 
 				if (i != m_numAllowedExtras) {
@@ -1957,10 +2000,10 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 						LegoLocation* location = LegoNavController::GetLocation(p_location);
 
 						if (location != NULL) {
-							if (location->m_boundaryA.m_unk0x10 || FUN_10063fb0(&location->m_boundaryA, world)) {
+							if (location->m_boundaryA.m_unk0x10 || FUN_10063fb0(location->m_boundaryA, world)) {
 								boundary = &location->m_boundaryA;
 							}
-							else if (location->m_boundaryB.m_unk0x10 || FUN_10063fb0(&location->m_boundaryB, world)) {
+							else if (location->m_boundaryB.m_unk0x10 || FUN_10063fb0(location->m_boundaryB, world)) {
 								boundary = &location->m_boundaryB;
 							}
 						}
@@ -1970,7 +2013,7 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 
 					if (boundary != NULL) {
 						for (i = 0; i < m_numAllowedExtras; i++) {
-							if (m_extras[i].m_roi == NULL) {
+							if (m_extras[i].roi == NULL) {
 								m_lastExtraCharacterId++;
 
 								if (m_lastExtraCharacterId >= sizeOfArray(g_characters)) {
@@ -1993,10 +2036,11 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 									!g_characters[m_lastExtraCharacterId].m_inExtras &&
 									g_characters[m_lastExtraCharacterId].m_active == active) {
 									if (!CharacterManager()->Exists(g_characters[m_lastExtraCharacterId].m_name)) {
-										m_extras[i].m_roi = CharacterManager()->GetActorROI(
+										m_extras[i].roi = CharacterManager()->GetActorROI(
 											g_characters[m_lastExtraCharacterId].m_name,
 											TRUE
 										);
+										assert(m_extras[i].roi);
 
 										LegoExtraActor* actor = CharacterManager()->GetExtraActor(
 											g_characters[m_lastExtraCharacterId].m_name
@@ -2035,7 +2079,7 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 											if (FUN_10063b90(
 													world,
 													actor,
-													CharacterManager()->GetMood(m_extras[i].m_roi),
+													CharacterManager()->GetMood(m_extras[i].roi),
 													m_lastExtraCharacterId
 												)) {
 												m_extras[i].m_unk0x14 = TRUE;
@@ -2064,8 +2108,8 @@ void LegoAnimationManager::AddExtra(MxS32 p_location, MxBool p_und)
 											return;
 										}
 										else {
-											CharacterManager()->ReleaseActor(m_extras[i].m_roi);
-											m_extras[i].m_roi = NULL;
+											CharacterManager()->ReleaseActor(m_extras[i].roi);
+											m_extras[i].roi = NULL;
 											continue;
 										}
 									}
@@ -2122,8 +2166,8 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 
 		if (!g_characters[characterId].m_inExtras) {
 			for (i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-				if (m_extras[i].m_roi == NULL) {
-					m_extras[i].m_roi = p_roi;
+				if (m_extras[i].roi == NULL) {
+					m_extras[i].roi = p_roi;
 					break;
 				}
 			}
@@ -2136,7 +2180,7 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 			inExtras = TRUE;
 
 			for (i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-				if (m_extras[i].m_roi == p_roi) {
+				if (m_extras[i].roi == p_roi) {
 					break;
 				}
 			}
@@ -2160,7 +2204,7 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 					g_characters[characterId].m_unk0x10 = 0;
 				}
 
-				m_extras[i].m_roi = NULL;
+				m_extras[i].roi = NULL;
 				g_characters[characterId].m_unk0x07 = FALSE;
 				g_characters[characterId].m_inExtras = FALSE;
 				return FALSE;
@@ -2230,7 +2274,7 @@ MxBool LegoAnimationManager::FUN_10062e20(LegoROI* p_roi, LegoAnimPresenter* p_p
 		g_characters[characterId].m_unk0x07 = FALSE;
 
 		if (result != SUCCESS) {
-			m_extras[i].m_roi = NULL;
+			m_extras[i].roi = NULL;
 			g_characters[characterId].m_inExtras = FALSE;
 		}
 		else {
@@ -2282,7 +2326,7 @@ void LegoAnimationManager::FUN_10063270(LegoROIList* p_list, LegoAnimPresenter* 
 
 				if (actor != NULL) {
 					for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-						if (m_extras[i].m_roi == roi) {
+						if (m_extras[i].roi == roi) {
 							if (actor->GetController() != NULL) {
 								actor->GetController()->RemoveActor(actor);
 								actor->SetController(NULL);
@@ -2302,7 +2346,7 @@ void LegoAnimationManager::FUN_10063270(LegoROIList* p_list, LegoAnimPresenter* 
 								}
 							}
 
-							m_extras[i].m_roi = NULL;
+							m_extras[i].roi = NULL;
 							g_characters[m_extras[i].m_characterId].m_inExtras = FALSE;
 							g_characters[m_extras[i].m_characterId].m_unk0x07 = FALSE;
 							m_extras[i].m_characterId = -1;
@@ -2376,6 +2420,7 @@ void LegoAnimationManager::FUN_10063aa0()
 MxBool LegoAnimationManager::FUN_10063b90(LegoWorld* p_world, LegoExtraActor* p_actor, MxU8 p_mood, MxU32 p_characterId)
 {
 	const char** cycles = g_cycles[g_characters[p_characterId].m_unk0x16];
+	assert(cycles);
 	const char* vehicleWC;
 	LegoLocomotionAnimPresenter* presenter;
 
@@ -2435,11 +2480,13 @@ MxBool LegoAnimationManager::FUN_10063b90(LegoWorld* p_world, LegoExtraActor* p_
 // FUNCTION: BETA10 0x10045034
 void LegoAnimationManager::FUN_10063d10()
 {
-	if (CurrentWorld() != NULL) {
+	LegoWorld* world = CurrentWorld();
+
+	if (world != NULL) {
 		MxLong time = Timer()->GetTime();
 
 		for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-			LegoROI* roi = m_extras[i].m_roi;
+			LegoROI* roi = m_extras[i].roi;
 
 			if (roi != NULL) {
 				if (m_extras[i].m_unk0x0c && g_characters[m_extras[i].m_characterId].m_unk0x0c >= 0 &&
@@ -2447,7 +2494,8 @@ void LegoAnimationManager::FUN_10063d10()
 
 					m_extras[i].m_unk0x0c = FALSE;
 
-					LegoExtraActor* actor = CharacterManager()->GetExtraActor(roi->GetName());
+					const char* name = roi->GetName();
+					LegoExtraActor* actor = CharacterManager()->GetExtraActor(name);
 					if (actor != NULL) {
 						float speed = m_extras[i].m_speed;
 
@@ -2493,13 +2541,17 @@ void LegoAnimationManager::FUN_10063e40(LegoAnimPresenter* p_presenter)
 
 // FUNCTION: LEGO1 0x10063fb0
 // FUNCTION: BETA10 0x100452a7
-MxBool LegoAnimationManager::FUN_10063fb0(LegoLocation::Boundary* p_boundary, LegoWorld* p_world)
+MxBool LegoAnimationManager::FUN_10063fb0(LegoLocation::Boundary& p_hl, LegoWorld* p_world)
 {
-	if (p_boundary->m_name != NULL) {
+	if (p_hl.m_name != NULL) {
 		Mx3DPointFloat vec;
-		LegoPathBoundary* boundary = p_world->FindPathBoundary(p_boundary->m_name);
-		LegoOrientedEdge* pSrcE = (LegoOrientedEdge*) boundary->GetEdges()[p_boundary->src];
-		return FUN_10064010(boundary, pSrcE, p_boundary->m_srcScale);
+		LegoPathBoundary* boundary = p_world->FindPathBoundary(p_hl.m_name);
+		assert(boundary);
+		assert(p_hl.src < boundary->GetNumEdges());
+
+		LegoOrientedEdge* pSrcE = (LegoOrientedEdge*) boundary->GetEdges()[p_hl.src];
+		assert(pSrcE);
+		return FUN_10064010(boundary, pSrcE, p_hl.m_srcScale);
 	}
 
 	return FALSE;
@@ -2563,6 +2615,7 @@ MxBool LegoAnimationManager::FUN_10064120(LegoLocation::Boundary* p_boundary, Mx
 
 	for (i = 0; i < numEdges; i++) {
 		e = (LegoOrientedEdge*) boundary->GetEdges()[i];
+		assert(e);
 		e->GetFaceNormal(*boundary, vec);
 		float dot = vec.Dot(direction, vec);
 
@@ -2620,9 +2673,9 @@ MxBool LegoAnimationManager::FUN_10064120(LegoLocation::Boundary* p_boundary, Mx
 				else {
 					local34 = (LegoOrientedEdge*) local34->GetClockwiseEdge(*boundary);
 				}
-			} while (!local34->GetMask0x03() && local34 != local50);
+			} while (!local34->GetMask0x03() && local50 != local34);
 
-			if (local34 == local50) {
+			if (local50 == local34) {
 				return FALSE;
 			}
 		}
@@ -2648,12 +2701,14 @@ MxResult LegoAnimationManager::FUN_10064380(
 )
 {
 	LegoWorld* world = CurrentWorld();
+	assert(world);
+
 	MxS32 extraIndex = -1;
 	LegoExtraActor* actor = NULL;
 	MxS32 i;
 
 	for (i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-		LegoROI* roi = m_extras[i].m_roi;
+		LegoROI* roi = m_extras[i].roi;
 
 		if (roi == NULL && extraIndex == -1) {
 			extraIndex = i;
@@ -2686,7 +2741,7 @@ MxResult LegoAnimationManager::FUN_10064380(
 			return FAILURE;
 		}
 
-		m_extras[extraIndex].m_roi = CharacterManager()->GetActorROI(p_name, TRUE);
+		m_extras[extraIndex].roi = CharacterManager()->GetActorROI(p_name, TRUE);
 		m_extras[extraIndex].m_characterId = characterId;
 		m_extras[extraIndex].m_speed = p_speed;
 
@@ -2700,8 +2755,8 @@ MxResult LegoAnimationManager::FUN_10064380(
 		actor->SetWorldSpeed(0.0f);
 
 		if (world->PlaceActor(actor, p_boundaryName, p_src, p_srcScale, p_dest, p_destScale) != SUCCESS) {
-			CharacterManager()->ReleaseActor(m_extras[i].m_roi);
-			m_extras[i].m_roi = NULL;
+			CharacterManager()->ReleaseActor(m_extras[i].roi);
+			m_extras[i].roi = NULL;
 			m_unk0x414--;
 			return FAILURE;
 		}
@@ -2794,7 +2849,7 @@ MxResult LegoAnimationManager::FUN_10064740(Vector3* p_position)
 MxResult LegoAnimationManager::FUN_10064880(const char* p_name, MxS32 p_unk0x0c, MxS32 p_unk0x10)
 {
 	for (MxS32 i = 0; i < (MxS32) sizeOfArray(m_extras); i++) {
-		LegoROI* roi = m_extras[i].m_roi;
+		LegoROI* roi = m_extras[i].roi;
 
 		if (roi != NULL) {
 			if (!strcmpi(roi->GetName(), p_name)) {
@@ -2875,7 +2930,9 @@ void LegoAnimationManager::FUN_10064b50(MxLong p_time)
 
 			m_unk0x4cc.InterpolateToMatrix(mat, (float) (p_time - m_unk0x434) / 1000.0f);
 
-			VPV3(mat[3], m_unk0x43c[3], sub);
+			mat[3][0] = m_unk0x43c[3][0] + sub[0];
+			mat[3][1] = m_unk0x43c[3][1] + sub[1];
+			mat[3][2] = m_unk0x43c[3][2] + sub[2];
 			mat[3][3] = 1.0f;
 		}
 
@@ -2893,6 +2950,7 @@ void LegoAnimationManager::FUN_10064b50(MxLong p_time)
 }
 
 // FUNCTION: LEGO1 0x10064ee0
+// FUNCTION: BETA10 0x100461a3
 MxBool LegoAnimationManager::FUN_10064ee0(MxU32 p_objectId)
 {
 	if (m_tranInfoList != NULL) {
@@ -2915,61 +2973,73 @@ MxBool LegoAnimationManager::FUN_10064ee0(MxU32 p_objectId)
 }
 
 // FUNCTION: LEGO1 0x10064ff0
+// FUNCTION: BETA10 0x10046227
 AnimState::AnimState()
 {
-	m_unk0x0c = 0;
-	m_unk0x10 = NULL;
-	m_locationsFlagsLength = 0;
-	m_locationsFlags = NULL;
+	m_numAnims = 0;
+	m_animSaveInfo = NULL;
+	m_numCams = 0;
+	m_camAnimFired = NULL;
 }
 
 // FUNCTION: LEGO1 0x10065150
+// FUNCTION: BETA10 0x100462be
 AnimState::~AnimState()
 {
-	delete[] m_unk0x10;
-	delete[] m_locationsFlags;
+	delete[] m_animSaveInfo;
+	delete[] m_camAnimFired;
 }
 
 // FUNCTION: LEGO1 0x100651d0
-void AnimState::CopyToAnims(MxU32, AnimInfo* p_anims, MxU32& p_outExtraCharacterId)
+// FUNCTION: BETA10 0x1004635c
+void AnimState::CopyToAnims(MxU32 p_numAnims, AnimInfo* p_anims, MxU32& p_outExtraCharacterId)
 {
-	if (m_unk0x10 != NULL) {
-		for (MxS32 i = 0; i < m_unk0x0c; i++) {
-			p_anims[i].m_unk0x22 = m_unk0x10[i];
+	assert(p_numAnims == m_numAnims);
+
+	if (m_animSaveInfo != NULL) {
+		for (MxS32 i = 0; i < m_numAnims; i++) {
+			p_anims[i].m_unk0x22 = m_animSaveInfo[i];
 		}
+
+		assert(m_camAnimFired && (m_numCams == LegoNavController::GetNumCameras()));
 
 		p_outExtraCharacterId = m_extraCharacterId;
 
-		for (MxS32 j = 0; j < m_locationsFlagsLength; j++) {
+		for (MxS32 j = 0; j < m_numCams; j++) {
 			LegoLocation* location = LegoNavController::GetLocation(j);
 			if (location != NULL) {
-				location->m_unk0x5c = m_locationsFlags[j];
+				location->m_unk0x5c = m_camAnimFired[j];
 			}
 		}
 	}
 }
 
 // FUNCTION: LEGO1 0x10065240
-void AnimState::InitFromAnims(MxU32 p_animsLength, AnimInfo* p_anims, MxU32 p_extraCharacterId)
+// FUNCTION: BETA10 0x1004648a
+void AnimState::InitFromAnims(MxU32 p_numAnims, AnimInfo* p_anims, MxU32 p_extraCharacterId)
 {
-	if (m_unk0x10 == NULL) {
-		m_unk0x0c = p_animsLength;
-		m_unk0x10 = new MxU16[p_animsLength];
-		MxS32 numLocations = LegoNavController::GetNumCameras();
-		m_locationsFlagsLength = numLocations;
-		m_locationsFlags = new MxBool[numLocations];
+	if (m_animSaveInfo == NULL) {
+		m_numAnims = p_numAnims;
+		m_animSaveInfo = new MxU16[p_numAnims];
+		assert(m_animSaveInfo);
+		MxS32 numCams = LegoNavController::GetNumCameras();
+		m_numCams = numCams;
+		m_camAnimFired = new MxBool[numCams];
+		assert(m_camAnimFired);
 	}
+
+	assert((p_numAnims == m_numAnims) && (m_numCams == LegoNavController::GetNumCameras()));
 
 	m_extraCharacterId = p_extraCharacterId;
 
-	for (MxS32 i = 0; i < m_unk0x0c; i++) {
-		m_unk0x10[i] = p_anims[i].m_unk0x22;
+	for (MxS32 i = 0; i < m_numAnims; i++) {
+		m_animSaveInfo[i] = p_anims[i].m_unk0x22;
 	}
 
-	for (MxS32 j = 0; j < m_locationsFlagsLength; j++) {
+	for (MxS32 j = 0; j < m_numCams; j++) {
 		LegoLocation* location = LegoNavController::GetLocation(j);
 		if (location != NULL) {
-			m_locationsFlags[j] = location->m_unk0x5c;
+			m_camAnimFired[j] = location->m_unk0x5c;
 		}
 	}
 }
@@ -2986,62 +3056,62 @@ MxResult AnimState::Serialize(LegoStorage* p_storage)
 
 			p_storage->ReadU32(m_extraCharacterId);
 
-			if (m_unk0x10) {
-				delete[] m_unk0x10;
+			if (m_animSaveInfo) {
+				delete[] m_animSaveInfo;
 			}
 
-			p_storage->ReadU32(m_unk0x0c);
+			p_storage->ReadU32(m_numAnims);
 
 #ifndef BETA10
-			if (m_unk0x0c != 0) {
-				m_unk0x10 = new MxU16[m_unk0x0c];
+			if (m_numAnims != 0) {
+				m_animSaveInfo = new MxU16[m_numAnims];
 			}
 			else {
-				m_unk0x10 = NULL;
+				m_animSaveInfo = NULL;
 			}
 #else
-			m_unk0x10 = new MxU16[m_unk0x0c];
+			m_animSaveInfo = new MxU16[m_numAnims];
 #endif
 
-			for (i = 0; i < m_unk0x0c; i++) {
-				p_storage->ReadU16(m_unk0x10[i]);
+			for (i = 0; i < m_numAnims; i++) {
+				p_storage->ReadU16(m_animSaveInfo[i]);
 			}
 
 			// Note that here we read first and then free memory in contrast to above
-			p_storage->ReadU32(m_locationsFlagsLength);
+			p_storage->ReadU32(m_numCams);
 
 #ifndef BETA10
-			if (m_locationsFlags) {
-				delete[] m_locationsFlags;
+			if (m_camAnimFired) {
+				delete[] m_camAnimFired;
 			}
 
-			if (m_locationsFlagsLength != 0) {
-				m_locationsFlags = new MxBool[m_locationsFlagsLength];
+			if (m_numCams != 0) {
+				m_camAnimFired = new MxBool[m_numCams];
 			}
 			else {
-				m_locationsFlags = NULL;
+				m_camAnimFired = NULL;
 			}
 #else
-			m_locationsFlags = new MxBool[m_locationsFlagsLength];
+			m_camAnimFired = new MxBool[m_numCams];
 #endif
 
-			for (i = 0; i < m_locationsFlagsLength; i++) {
-				p_storage->ReadU8(m_locationsFlags[i]);
+			for (i = 0; i < m_numCams; i++) {
+				p_storage->ReadU8(m_camAnimFired[i]);
 			}
 		}
 		else if (p_storage->IsWriteMode()) {
 			MxS32 i;
 
 			p_storage->WriteU32(m_extraCharacterId);
-			p_storage->WriteU32(m_unk0x0c);
+			p_storage->WriteU32(m_numAnims);
 
-			for (i = 0; i < m_unk0x0c; i++) {
-				p_storage->WriteU16(m_unk0x10[i]);
+			for (i = 0; i < m_numAnims; i++) {
+				p_storage->WriteU16(m_animSaveInfo[i]);
 			}
 
-			p_storage->WriteU32(m_locationsFlagsLength);
-			for (i = 0; i < m_locationsFlagsLength; i++) {
-				p_storage->WriteU8(m_locationsFlags[i]);
+			p_storage->WriteU32(m_numCams);
+			for (i = 0; i < m_numCams; i++) {
+				p_storage->WriteU8(m_camAnimFired[i]);
 			}
 		}
 	}
@@ -3052,16 +3122,16 @@ MxResult AnimState::Serialize(LegoStorage* p_storage)
 // FUNCTION: LEGO1 0x100654f0
 MxBool AnimState::Reset()
 {
-	if (m_unk0x10 != NULL) {
+	if (m_animSaveInfo != NULL) {
 		m_extraCharacterId = 0;
 
-		for (MxS32 i = 0; i < m_unk0x0c; i++) {
-			m_unk0x10[i] = 0;
+		for (MxS32 i = 0; i < m_numAnims; i++) {
+			m_animSaveInfo[i] = 0;
 		}
 
-		for (MxS32 j = 0; j < m_locationsFlagsLength; j++) {
+		for (MxS32 j = 0; j < m_numCams; j++) {
 			if (LegoNavController::GetLocation(j) != NULL) {
-				m_locationsFlags[j] = 0;
+				m_camAnimFired[j] = 0;
 			}
 		}
 

--- a/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimmmpresenter.cpp
@@ -3,6 +3,8 @@
 #include "3dmanager/lego3dmanager.h"
 #include "decomp.h"
 #include "define.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "islepathactor.h"
 #include "legoanimationmanager.h"
 #include "legoanimpresenter.h"
@@ -19,6 +21,8 @@
 #include "mxstreamer.h"
 #include "mxtimer.h"
 #include "mxutilities.h"
+
+#include <assert.h>
 
 DECOMP_SIZE_ASSERT(LegoAnimMMPresenter, 0x74)
 
@@ -110,6 +114,7 @@ MxResult LegoAnimMMPresenter::StartAction(MxStreamController* p_controller, MxDS
 		result = SUCCESS;
 	}
 
+	assert(result == SUCCESS);
 	return result;
 }
 
@@ -225,6 +230,7 @@ MxLong LegoAnimMMPresenter::Notify(MxParam& p_param)
 }
 
 // FUNCTION: LEGO1 0x1004b360
+// FUNCTION: BETA10 0x1004c560
 void LegoAnimMMPresenter::AdvanceSerialAction(MxPresenter* p_presenter)
 {
 	if (m_presenter == p_presenter && ((MxU8) p_presenter->GetCurrentTickleState() == MxPresenter::e_streaming ||
@@ -249,6 +255,7 @@ void LegoAnimMMPresenter::ParseExtra()
 		char output[1024];
 		if (KeyValueStringParse(output, g_strANIMMAN_ID, extraCopy)) {
 			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
 			m_animmanId = atoi(token);
 			m_tranInfo = AnimationManager()->GetTranInfo(m_animmanId);
 
@@ -318,6 +325,8 @@ MxBool LegoAnimMMPresenter::FUN_1004b530(MxLong p_time)
 	if (m_presenter != NULL) {
 		m_presenter->GetTransforms(m_unk0x68, 0);
 		m_roiMap = m_presenter->GetROIMap(m_roiMapSize);
+		assert(m_roiMap);
+		assert(m_roiMapSize);
 		m_roiMapSize++;
 	}
 

--- a/LEGO1/lego/legoomni/src/common/legogamestate.cpp
+++ b/LEGO1/lego/legoomni/src/common/legogamestate.cpp
@@ -82,6 +82,10 @@ const char* g_playersGSI = "Players.gsi";
 // STRING: LEGO1 0x100f3e24
 const char* g_historyGSI = "History.gsi";
 
+// GLOBAL: LEGO1 0x100f3e4c
+// STRING: LEGO1 0x100f3e14
+const char* g_texturesGST = "Textures.gst";
+
 // This is a pointer to the end of the global variable name table, which has
 // the text "END_OF_VARIABLES" in it.
 // TODO: make g_endOfVariables reference the actual end of the variable array.
@@ -121,6 +125,9 @@ ColorStringStruct g_colorSaveData[43] = {
 // in that table is a special entry, the string "END_OF_VARIABLES"
 extern const char* g_endOfVariables;
 
+// STRING: LEGO1 0x100f3bf4
+const char* const g_disable = "disable";
+
 // GLOBAL: LEGO1 0x100f3fb0
 // STRING: LEGO1 0x100f3a18
 const char* g_delimiter = " \t";
@@ -138,7 +145,6 @@ const char* g_reset = "reset";
 const char* g_strEnable = "enable";
 
 // GLOBAL: LEGO1 0x100f3fc0
-// STRING: LEGO1 0x100f3bf4
 const char* g_strDisable = "disable";
 
 // FUNCTION: LEGO1 0x10039550
@@ -150,7 +156,7 @@ LegoGameState::LegoGameState()
 	m_stateCount = 0;
 	m_actorId = 0;
 	m_savePath = NULL;
-	m_stateArray = NULL;
+	m_states = NULL;
 	m_jukeboxMusic = JukeboxScript::c_noneJukebox;
 	m_currentArea = e_undefined;
 	m_previousArea = e_undefined;
@@ -160,14 +166,17 @@ LegoGameState::LegoGameState()
 	m_loadedAct = e_actNotFound;
 	SetCurrentAct(e_act1);
 
-	m_backgroundColor = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
-	VariableTable()->SetVariable(m_backgroundColor);
+	m_bgColorVar = new LegoBackgroundColor("backgroundcolor", "set 56 54 68");
+	assert(m_bgColorVar);
+	VariableTable()->SetVariable(m_bgColorVar);
 
-	m_tempBackgroundColor = new LegoBackgroundColor("tempBackgroundColor", "set 56 54 68");
-	VariableTable()->SetVariable(m_tempBackgroundColor);
+	m_tempColorVar = new LegoBackgroundColor("tempBackgroundColor", "set 56 54 68");
+	assert(m_tempColorVar);
+	VariableTable()->SetVariable(m_tempColorVar);
 
-	m_fullScreenMovie = new LegoFullScreenMovie("fsmovie", "disable");
-	VariableTable()->SetVariable(m_fullScreenMovie);
+	m_fsMovieVar = new LegoFullScreenMovie("fsmovie", "disable");
+	assert(m_fsMovieVar);
+	VariableTable()->SetVariable(m_fsMovieVar);
 
 	VariableTable()->SetVariable("lightposition", "2");
 	SerializeScoreHistory(LegoFile::c_read);
@@ -180,13 +189,13 @@ LegoGameState::~LegoGameState()
 
 	if (m_stateCount) {
 		for (MxS16 i = 0; i < m_stateCount; i++) {
-			LegoState* state = m_stateArray[i];
+			LegoState* state = m_states[i];
 			if (state) {
 				delete state;
 			}
 		}
 
-		delete[] m_stateArray;
+		delete[] m_states;
 	}
 
 	delete[] m_savePath;
@@ -194,34 +203,39 @@ LegoGameState::~LegoGameState()
 
 // FUNCTION: LEGO1 0x10039780
 // FUNCTION: BETA10 0x10083d43
-void LegoGameState::SetActor(MxU8 p_actorId)
+void LegoGameState::SetActor(MxU8 p_id)
 {
-	if (p_actorId) {
-		m_actorId = p_actorId;
+	assert(p_id != LegoActor::e_none);
+
+	if (p_id) {
+		m_actorId = p_id;
 	}
 
 	LegoPathActor* oldActor = UserActor();
 	SetUserActor(NULL);
 
-	IslePathActor* newActor = new IslePathActor();
-	const char* actorName = LegoActor::GetActorName(m_actorId);
-	LegoROI* roi = CharacterManager()->GetActorROI(actorName, FALSE);
+	IslePathActor* userCharacter = new IslePathActor();
+	assert(userCharacter);
+	const char* name = LegoActor::GetActorName(m_actorId);
+	assert(name);
+	LegoROI* roi = CharacterManager()->GetActorROI(name, FALSE);
+	assert(roi);
 	MxDSAction action;
 
 	action.SetAtomId(*g_isleScript);
 	action.SetObjectId(100000);
-	newActor->Create(action);
-	newActor->SetActorId(p_actorId);
-	newActor->SetROI(roi, FALSE, FALSE);
+	userCharacter->Create(action);
+	userCharacter->SetActorId(p_id);
+	userCharacter->SetROI(roi, FALSE, FALSE);
 
 	if (oldActor) {
-		newActor->GetROI()->SetLocal2World(oldActor->GetROI()->GetLocal2World());
-		newActor->SetBoundary(oldActor->GetBoundary());
+		userCharacter->GetROI()->SetLocal2World(oldActor->GetROI()->GetLocal2World());
+		userCharacter->SetBoundary(oldActor->GetBoundary());
 		delete oldActor;
 	}
 
-	newActor->ClearFlag(LegoEntity::c_managerOwned);
-	SetUserActor(newActor);
+	userCharacter->ClearFlag(LegoEntity::c_managerOwned);
+	SetUserActor(userCharacter);
 }
 
 // FUNCTION: LEGO1 0x10039910
@@ -262,11 +276,11 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	}
 
 	MxResult result = FAILURE;
+	MxS32 j;
 	LegoFile storage;
 	MxVariableTable* variableTable = VariableTable();
 	MxS16 count = 0;
 	MxU32 i;
-	MxS32 j;
 	MxU16 area;
 
 	MxString savePath;
@@ -300,7 +314,7 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	result = BuildingManager()->Write(&storage);
 
 	for (j = 0; j < m_stateCount; j++) {
-		if (m_stateArray[j]->IsSerializable()) {
+		if (m_states[j]->IsSerializable()) {
 			count++;
 		}
 	}
@@ -308,8 +322,8 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	storage.WriteS16(count);
 
 	for (j = 0; j < m_stateCount; j++) {
-		if (m_stateArray[j]->IsSerializable()) {
-			m_stateArray[j]->Serialize(&storage);
+		if (m_states[j]->IsSerializable()) {
+			m_states[j]->Serialize(&storage);
 		}
 	}
 
@@ -326,10 +340,10 @@ done:
 MxResult LegoGameState::DeleteState()
 {
 	MxS16 stateCount = m_stateCount;
-	LegoState** stateArray = m_stateArray;
+	LegoState** stateArray = m_states;
 
 	m_stateCount = 0;
-	m_stateArray = NULL;
+	m_states = NULL;
 
 	for (MxS32 count = 0; count < stateCount; count++) {
 		if (!stateArray[count]->Reset() && stateArray[count]->IsSerializable()) {
@@ -362,7 +376,7 @@ MxResult LegoGameState::Load(MxULong p_slot)
 
 	MxS32 version;
 	MxU32 status;
-	MxS16 count, actArea;
+	MxS16 i, count, actArea;
 	const char* lightPosition;
 
 	storage.ReadS32(version);
@@ -388,7 +402,7 @@ MxResult LegoGameState::Load(MxULong p_slot)
 		}
 	} while (status != 2);
 
-	m_backgroundColor->SetLightColor();
+	m_bgColorVar->SetLightColor();
 	lightPosition = VariableTable()->GetVariable("lightposition");
 
 	if (lightPosition) {
@@ -412,7 +426,7 @@ MxResult LegoGameState::Load(MxULong p_slot)
 	storage.ReadS16(count);
 
 	if (count) {
-		for (MxS16 i = 0; i < count; i++) {
+		for (i = 0; i < count; i++) {
 			storage.ReadString(stateName);
 
 			LegoState* state = GetState(stateName);
@@ -449,6 +463,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10039f00
+// FUNCTION: BETA10 0x100847b8
 void LegoGameState::SetSavePath(char* p_savePath)
 {
 	if (m_savePath != NULL) {
@@ -573,6 +588,7 @@ void LegoGameState::GetFileSavePath(MxString* p_outPath, MxS16 p_slotn)
 }
 
 // FUNCTION: LEGO1 0x1003a2e0
+// FUNCTION: BETA10 0x10084c68
 void LegoGameState::SerializePlayersInfo(MxS16 p_flags)
 {
 	LegoFile storage;
@@ -596,6 +612,7 @@ void LegoGameState::SerializePlayersInfo(MxS16 p_flags)
 }
 
 // FUNCTION: LEGO1 0x1003a3f0
+// FUNCTION: BETA10 0x10084db7
 MxResult LegoGameState::AddPlayer(Username& p_player)
 {
 	MxString from, to;
@@ -655,6 +672,7 @@ void LegoGameState::SwitchPlayer(MxS16 p_playerId)
 }
 
 // FUNCTION: LEGO1 0x1003a6e0
+// FUNCTION: BETA10 0x1008519b
 MxS16 LegoGameState::FindPlayer(Username& p_player)
 {
 	for (MxS16 i = 0; i < m_playerCount; i++) {
@@ -949,10 +967,11 @@ void LegoGameState::SwitchArea(Area p_area)
 		InvokeAction(Extra::ActionType::e_start, *g_isleScript, IsleScript::c_GaraDoor, NULL);
 		break;
 	case e_garageExited: {
-		Act1State* state = (Act1State*) GameState()->GetState("Act1State");
+		Act1State* act1State = (Act1State*) GameState()->GetState("Act1State");
+		assert(act1State);
 		LoadIsle();
 
-		if (state->GetState() == Act1State::e_transitionToTowtrack) {
+		if (act1State->GetState() == Act1State::e_transitionToTowtrack) {
 			VideoManager()->Get3DManager()->SetFrustrum(90, 0.1f, 250.0f);
 		}
 		else {
@@ -1045,6 +1064,7 @@ void LegoGameState::SwitchArea(Area p_area)
 		InvokeAction(Extra::ActionType::e_opendisk, *g_histbookScript, HistbookScript::c__StartUp, NULL);
 		break;
 	default:
+		assert("Wrong destination location" == NULL);
 		break;
 	}
 }
@@ -1091,8 +1111,8 @@ MxBool ROIColorOverride(const char* p_input, char* p_output, MxU32 p_copyLen)
 LegoState* LegoGameState::GetState(const char* p_stateName)
 {
 	for (MxS32 i = 0; i < m_stateCount; ++i) {
-		if (m_stateArray[i]->IsA(p_stateName)) {
-			return m_stateArray[i];
+		if (m_states[i]->IsA(p_stateName)) {
+			return m_states[i];
 		}
 	}
 	return NULL;
@@ -1115,36 +1135,39 @@ LegoState* LegoGameState::CreateState(const char* p_stateName)
 // FUNCTION: BETA10 0x1008636e
 void LegoGameState::RegisterState(LegoState* p_state)
 {
+	assert(p_state);
+
 	MxS32 targetIndex;
 	for (targetIndex = 0; targetIndex < m_stateCount; ++targetIndex) {
-		if (m_stateArray[targetIndex]->IsA(p_state->ClassName())) {
+		if (m_states[targetIndex]->IsA(p_state->ClassName())) {
 			break;
 		}
 	}
 
 	if (targetIndex == m_stateCount) {
-		LegoState** newBuffer = new LegoState*[m_stateCount + 1];
+		LegoState** states = new LegoState*[m_stateCount + 1];
+		assert(states);
 
 		if (m_stateCount != 0) {
-			memcpy(newBuffer, m_stateArray, m_stateCount * sizeof(LegoState*));
-			delete[] m_stateArray;
+			memcpy(states, m_states, m_stateCount * sizeof(LegoState*));
+			delete[] m_states;
 		}
 
-		newBuffer[m_stateCount++] = p_state;
-		m_stateArray = newBuffer;
+		states[m_stateCount++] = p_state;
+		m_states = states;
 	}
 	else {
-		delete m_stateArray[targetIndex];
-		m_stateArray[targetIndex] = p_state;
+		delete m_states[targetIndex];
+		m_states[targetIndex] = p_state;
 	}
 }
 
 // FUNCTION: LEGO1 0x1003bd00
 void LegoGameState::Init()
 {
-	m_backgroundColor->SetValue("set 56 54 68");
-	m_backgroundColor->SetLightColor();
-	m_tempBackgroundColor->SetValue("set 56 54 68");
+	m_bgColorVar->SetValue("set 56 54 68");
+	m_bgColorVar->SetLightColor();
+	m_tempColorVar->SetValue("set 56 54 68");
 	VariableTable()->SetVariable("lightposition", "2");
 	SetLightPosition(2);
 	PlantManager()->Init();

--- a/LEGO1/lego/legoomni/src/common/legotesttimer.cpp
+++ b/LEGO1/lego/legoomni/src/common/legotesttimer.cpp
@@ -2,9 +2,12 @@
 
 #include "legoeventnotificationparam.h"
 #include "legoinputmanager.h"
+#include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "misc.h"
 #include "mxnotificationparam.h"
 
+#include <conio.h>
 #include <stdio.h>
 
 // FUNCTION: BETA10 0x100d1030
@@ -153,4 +156,23 @@ MxLong LegoTestTimer::Notify(MxParam& p_param)
 	}
 
 	return 0;
+}
+
+// Reconstruction: not in BETA10 or the 1996 source. Retail's .reloc reservation (sized before
+// /OPT:REF) accounts for a discarded function with this switch table. Keys mirror Notify.
+void LegoTestTimerConsoleControl(LegoTestTimer* p_timer)
+{
+	while (!_kbhit()) {
+	}
+
+	switch (_getch()) {
+	case 's':
+	case 'S':
+		p_timer->ResetAtNextTick();
+		break;
+	case 'p':
+	case 'P':
+		p_timer->Print();
+		break;
+	}
 }

--- a/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp
+++ b/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp
@@ -1,4 +1,5 @@
 #include "legotextureinfo.h"
+#include "realtime/matrix4d.inl.h"
 
 #include "legovideomanager.h"
 #include "misc.h"
@@ -8,6 +9,13 @@
 #include "tgl/d3drm/tglimpl.h"
 
 DECOMP_SIZE_ASSERT(LegoTextureInfo, 0x10)
+
+inline void GetMeshData(IDirect3DRMMesh** p_mesh, D3DRMGROUPINDEX& p_index, Tgl::Mesh* p_tglElem)
+{
+	TglImpl::MeshImpl* meshImpl = (TglImpl::MeshImpl*) p_tglElem;
+	*p_mesh = meshImpl->ImplementationData()->groupMesh;
+	p_index = meshImpl->ImplementationData()->groupIndex;
+}
 
 // FUNCTION: LEGO1 0x10065bf0
 LegoTextureInfo::LegoTextureInfo()
@@ -58,6 +66,7 @@ LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_text
 
 	LPDIRECTDRAW pDirectDraw = VideoManager()->GetDirect3D()->DirectDraw();
 	LegoImage* image = p_texture->GetImage();
+	MxS32 i;
 
 	DDSURFACEDESC desc;
 	memset(&desc, 0, sizeof(desc));
@@ -70,7 +79,6 @@ LegoTextureInfo* LegoTextureInfo::Create(const char* p_name, LegoTexture* p_text
 	desc.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_PALETTEINDEXED8;
 	desc.ddpfPixelFormat.dwRGBBitCount = 8;
 
-	MxS32 i;
 	const LegoU8* bits;
 	MxU8* surface;
 
@@ -156,18 +164,21 @@ done:
 // FUNCTION: LEGO1 0x10065f60
 BOOL LegoTextureInfo::SetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo* p_textureInfo)
 {
-	TglImpl::MeshImpl::MeshData* data = ((TglImpl::MeshImpl*) pMesh)->ImplementationData();
-	data->groupMesh->SetGroupTexture(data->groupIndex, p_textureInfo->m_texture);
+	IDirect3DRMMesh* mesh;
+	D3DRMGROUPINDEX id;
+	GetMeshData(&mesh, id, pMesh);
+
+	mesh->SetGroupTexture(id, p_textureInfo->m_texture);
 	return TRUE;
 }
 
 // FUNCTION: LEGO1 0x10065f90
 BOOL LegoTextureInfo::GetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo*& p_textureInfo)
 {
-	TglImpl::MeshImpl::MeshData* data = ((TglImpl::MeshImpl*) pMesh)->ImplementationData();
+	IDirect3DRMMesh* mesh;
+	D3DRMGROUPINDEX id;
+	GetMeshData(&mesh, id, pMesh);
 
-	IDirect3DRMMesh* mesh = data->groupMesh;
-	D3DRMGROUPINDEX id = data->groupIndex;
 	LPDIRECT3DRMTEXTURE returnPtr = NULL;
 	LPDIRECT3DRMTEXTURE2 texture = NULL;
 
@@ -189,6 +200,7 @@ BOOL LegoTextureInfo::GetGroupTexture(Tgl::Mesh* pMesh, LegoTextureInfo*& p_text
 LegoResult LegoTextureInfo::LoadBits(const LegoU8* p_bits)
 {
 	if (m_surface != NULL && m_texture != NULL) {
+		MxS32 i;
 		DDSURFACEDESC desc;
 		memset(&desc, 0, sizeof(desc));
 		desc.dwSize = sizeof(desc);
@@ -201,7 +213,7 @@ LegoResult LegoTextureInfo::LoadBits(const LegoU8* p_bits)
 				memcpy(desc.lpSurface, p_bits, desc.dwWidth * desc.dwHeight);
 			}
 			else {
-				for (MxS32 i = 0; i < desc.dwHeight; i++) {
+				for (i = 0; i < desc.dwHeight; i++) {
 					memcpy(surface, bits, desc.dwWidth);
 					surface += desc.lPitch;
 					bits += desc.dwWidth;

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -30,6 +30,7 @@
 #include "realtime/realtime.h"
 #include "scripts.h"
 
+#include <assert.h>
 #include <process.h>
 #include <string.h>
 #include <vec.h>
@@ -42,6 +43,9 @@ LegoROI* PickROI(MxLong p_x, MxLong p_y)
 	Lego3DView* view = videoManager->Get3DManager()->GetLego3DView();
 	return (LegoROI*) view->Pick(p_x, p_y);
 }
+
+// GLOBAL: LEGO1 0x100f407c
+undefined4 g_unk0x100f407c = 2;
 
 // FUNCTION: LEGO1 0x1003dd90
 // FUNCTION: BETA10 0x100d3449
@@ -179,23 +183,23 @@ void CalculateViewFromAnimation(LegoAnimPresenter* p_presenter)
 {
 	MxMatrix viewMatrix;
 	LegoTreeNode* rootNode = p_presenter->GetAnimation()->GetRoot();
-	LegoAnimNodeData* camData = NULL;
+	LegoAnimNodeData* cameraData = NULL;
 	LegoAnimNodeData* targetData = NULL;
 	MxS16 nodesCount = CountTotalTreeNodes(rootNode);
 
 	MxFloat fov;
 	for (MxS16 i = 0; i < nodesCount; i++) {
-		if (camData && targetData) {
+		if (cameraData && targetData) {
 			break;
 		}
 
 		LegoAnimNodeData* data = (LegoAnimNodeData*) GetTreeNode(rootNode, i)->GetData();
 
 		if (!strnicmp(data->GetName(), "CAM", strlen("CAM"))) {
-			camData = data;
+			cameraData = data;
 			fov = atof(&data->GetName()[strlen(data->GetName()) - 2]);
 		}
-		else if (!strcmpi(data->GetName(), "TARGET")) {
+		else if (!_strcmpi(data->GetName(), "TARGET")) {
 			targetData = data;
 		}
 	}
@@ -205,7 +209,10 @@ void CalculateViewFromAnimation(LegoAnimPresenter* p_presenter)
 	matrixCam.SetIdentity();
 	matrixTarget.SetIdentity();
 
-	camData->CreateLocalTransform(0.0f, matrixCam);
+	assert(cameraData);
+	assert(targetData);
+
+	cameraData->CreateLocalTransform(0.0f, matrixCam);
 	targetData->CreateLocalTransform(0.0f, matrixTarget);
 
 	Mx3DPointFloat dir;
@@ -227,38 +234,39 @@ void CalculateViewFromAnimation(LegoAnimPresenter* p_presenter)
 }
 
 // FUNCTION: LEGO1 0x1003e300
+// FUNCTION: BETA10 0x100d3e50
 Extra::ActionType MatchActionString(const char* p_str)
 {
 	Extra::ActionType result = Extra::ActionType::e_unknown;
 
-	if (!strcmpi("openram", p_str)) {
+	if (!_strcmpi("openram", p_str)) {
 		result = Extra::ActionType::e_openram;
 	}
-	else if (!strcmpi("opendisk", p_str)) {
+	else if (!_strcmpi("opendisk", p_str)) {
 		result = Extra::ActionType::e_opendisk;
 	}
-	else if (!strcmpi("close", p_str)) {
+	else if (!_strcmpi("close", p_str)) {
 		result = Extra::ActionType::e_close;
 	}
-	else if (!strcmpi("start", p_str)) {
+	else if (!_strcmpi("start", p_str)) {
 		result = Extra::ActionType::e_start;
 	}
-	else if (!strcmpi("stop", p_str)) {
+	else if (!_strcmpi("stop", p_str)) {
 		result = Extra::ActionType::e_stop;
 	}
-	else if (!strcmpi("run", p_str)) {
+	else if (!_strcmpi("run", p_str)) {
 		result = Extra::ActionType::e_run;
 	}
-	else if (!strcmpi("exit", p_str)) {
+	else if (!_strcmpi("exit", p_str)) {
 		result = Extra::ActionType::e_exit;
 	}
-	else if (!strcmpi("enable", p_str)) {
+	else if (!_strcmpi("enable", p_str)) {
 		result = Extra::ActionType::e_enable;
 	}
-	else if (!strcmpi("disable", p_str)) {
+	else if (!_strcmpi("disable", p_str)) {
 		result = Extra::ActionType::e_disable;
 	}
-	else if (!strcmpi("notify", p_str)) {
+	else if (!_strcmpi("notify", p_str)) {
 		result = Extra::ActionType::e_notify;
 	}
 
@@ -383,7 +391,9 @@ void NotifyEntity(const char* p_filename, MxS32 p_entityId, LegoEntity* p_sender
 // FUNCTION: LEGO1 0x1003eab0
 void SetCameraControllerFromIsle()
 {
-	InputManager()->SetCamera(FindWorld(*g_isleScript, IsleScript::c__Isle)->GetCameraController());
+	Isle* isle = (Isle*) FindWorld(*g_isleScript, IsleScript::c__Isle);
+	assert(isle);
+	InputManager()->SetCamera(isle->GetCameraController());
 }
 
 // FUNCTION: LEGO1 0x1003eae0
@@ -398,7 +408,7 @@ void ConvertHSVToRGB(float p_h, float p_s, float p_v, float* p_rOut, float* p_gO
 
 	double sDbl = p_s;
 
-	if (p_s > 0.5f) {
+	if (p_s > 0.5) {
 		calc = (1.0f - p_v) * p_s + p_v;
 	}
 	else {
@@ -454,6 +464,81 @@ void ConvertHSVToRGB(float p_h, float p_s, float p_v, float* p_rOut, float* p_gO
 	default:
 		return;
 	}
+}
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+// FUNCTION: BETA10 0x100d4801
+void ConvertRGBToHSV(float p_r, float p_g, float p_b, float* p_hOut, float* p_sOut, float* p_vOut)
+{
+	double h, min, delta, s, max, gc, l, rc, bc;
+
+	h = 0.0;
+	l = 0.0;
+	s = 0.0;
+
+	max = MAX(max = MAX(p_g, p_r), p_b);
+
+	if ((l = ((min = MIN(p_b, min = MIN(p_r, p_g))) + max) / 2.0) <= 0.0) {
+		l = 0.0;
+		goto done;
+	}
+
+	delta = max - min;
+	s = delta;
+
+	if (s > 0.0) {
+		if (l > 0.5) {
+			s = s / (2.0 - max - min);
+		}
+		else {
+			s = s / (min + max);
+		}
+	}
+	else {
+		goto done;
+	}
+
+	rc = (max - p_r) / delta;
+	gc = (max - p_g) / delta;
+	bc = (max - p_b) / delta;
+
+	if (max == p_r) {
+		h = (min == p_g) ? bc + 5.0 : 1.0 - gc;
+	}
+	else if (max == p_g) {
+		h = (min == p_b) ? rc + 1.0 : 3.0 - bc;
+	}
+	else {
+		h = (min == p_r) ? gc + 3.0 : 5.0 - rc;
+	}
+
+	h = h * (1.0 / 6.0); // BETA10 (1996) still divides: h = h / 6.0;
+
+done:
+	if (h < 0.0) {
+		h += 1.0;
+	}
+	if (h > 1.0) {
+		h -= 1.0;
+	}
+	if (l < 0.0) {
+		l = 0.0;
+	}
+	if (l > 1.0) {
+		l = 1.0;
+	}
+	if (s < 0.0) {
+		s = 0.0;
+	}
+	if (s > 1.0) {
+		s = 1.0;
+	}
+
+	*p_hOut = h;
+	*p_sOut = l;
+	*p_vOut = s;
 }
 
 // FUNCTION: LEGO1 0x1003ecc0
@@ -716,11 +801,14 @@ void WriteDefaultTexture(LegoStorage* p_storage, const char* p_name)
 					memcpy(image->GetBits(), desc.lpSurface, desc.dwWidth * desc.dwHeight);
 				}
 				else {
-					MxU8* surface = (MxU8*) desc.lpSurface;
 					LegoU8* bits = image->GetBits();
+					MxU8* surface = (MxU8*) desc.lpSurface;
 
 					for (MxS32 i = 0; i < desc.dwHeight; i++) {
-						memcpy(bits, surface, desc.dwWidth);
+						// Note: this appears to be a bug. The copy runs the wrong way round -
+						// the branch above reads the surface into the image, while this one
+						// writes the still-uninitialized image into the locked surface.
+						memcpy(surface, bits, desc.dwWidth);
 						surface += desc.lPitch;
 						bits += desc.dwWidth;
 					}
@@ -744,8 +832,8 @@ void WriteDefaultTexture(LegoStorage* p_storage, const char* p_name)
 					image->SetCount(i);
 
 					if (i > 0) {
-						// Note: this appears to be a bug. size should be i * sizeof(LegoPaletteEntry)
-						memcpy(image->GetPalette(), paletteEntries, i);
+						LegoPaletteEntry* palette = image->GetPalette();
+						memcpy(palette, paletteEntries, i);
 					}
 
 					LegoTexture texture;

--- a/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxcontrolpresenter.cpp
@@ -2,6 +2,8 @@
 
 #include "define.h"
 #include "legocontrolmanager.h"
+#include "legoutils.h"
+#include "realtime/matrix4d.inl.h"
 #include "mxdsmultiaction.h"
 #include "mxmisc.h"
 #include "mxstillpresenter.h"
@@ -144,6 +146,7 @@ MxBool MxControlPresenter::CheckButtonDown(MxS32 p_x, MxS32 p_y, MxPresenter* p_
 }
 
 // FUNCTION: LEGO1 0x10044480
+// FUNCTION: BETA10 0x100eb1ae
 MxBool MxControlPresenter::Notify(LegoControlManagerNotificationParam* p_param, MxPresenter* p_presenter)
 {
 	if (IsEnabled()) {
@@ -175,6 +178,7 @@ MxBool MxControlPresenter::Notify(LegoControlManagerNotificationParam* p_param, 
 }
 
 // FUNCTION: LEGO1 0x10044540
+// FUNCTION: BETA10 0x100eb3ba
 void MxControlPresenter::UpdateEnabledChild(MxS16 p_enabledChild)
 {
 	if (p_enabledChild == -1) {
@@ -199,6 +203,7 @@ void MxControlPresenter::UpdateEnabledChild(MxS16 p_enabledChild)
 }
 
 // FUNCTION: LEGO1 0x10044610
+// FUNCTION: BETA10 0x100eb59b
 void MxControlPresenter::ReadyTickle()
 {
 	MxPresenter::ParseExtra();

--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -32,6 +32,7 @@ MxTransitionManager::MxTransitionManager()
 }
 
 // FUNCTION: LEGO1 0x1004ba00
+// FUNCTION: BETA10 0x100ec34c
 MxTransitionManager::~MxTransitionManager()
 {
 	delete[] m_copyBuffer;
@@ -45,6 +46,7 @@ MxTransitionManager::~MxTransitionManager()
 }
 
 // FUNCTION: LEGO1 0x1004baa0
+// FUNCTION: BETA10 0x100ec3d1
 MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 {
 	LegoVideoManager* videoManager = VideoManager();
@@ -53,10 +55,10 @@ MxResult MxTransitionManager::GetDDrawSurfaceFromVideoManager() // vtable+0x14
 }
 
 // FUNCTION: LEGO1 0x1004bac0
+// FUNCTION: BETA10 0x100ec402
 MxResult MxTransitionManager::Tickle()
 {
-	MxULong time = m_animationSpeed + m_systemTime;
-	if (time > timeGetTime()) {
+	if (m_animationSpeed + m_systemTime > timeGetTime()) {
 		return SUCCESS;
 	}
 
@@ -199,6 +201,7 @@ void MxTransitionManager::DissolveTransition()
 	}
 
 	// Run one tick of the animation
+	MxS32 col;
 	DDSURFACEDESC ddsd;
 	memset(&ddsd, 0, sizeof(ddsd));
 	ddsd.dwSize = sizeof(ddsd);
@@ -212,7 +215,7 @@ void MxTransitionManager::DissolveTransition()
 	if (res == DD_OK) {
 		SubmitCopyRect(&ddsd);
 
-		for (MxS32 col = 0; col < 640; col++) {
+		for (col = 0; col < 640; col++) {
 			// Select 16 columns on each tick
 			if (m_animationTimer * 16 > m_columnOrder[col]) {
 				continue;
@@ -319,7 +322,7 @@ void MxTransitionManager::MosaicTransition()
 					MxS32 bytesPerPixel = ddsd.ddpfPixelFormat.dwRGBBitCount / 8;
 
 					// Seek to the sample position.
-					MxU8* source = (MxU8*) ddsd.lpSurface + 10 * row * ddsd.lPitch + bytesPerPixel * xShift;
+					MxU8* source = (MxU8*) ddsd.lpSurface + 10 * row * ddsd.lPitch + xShift * bytesPerPixel;
 
 					// Sample byte or word depending on display mode.
 					MxU32 sample = bytesPerPixel == 1 ? *source : *(MxU16*) source;
@@ -529,6 +532,8 @@ void MxTransitionManager::SubmitCopyRect(LPDDSURFACEDESC p_ddsc)
 // FUNCTION: LEGO1 0x1004c580
 void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 {
+	MxS32 i;
+	MxS32 y;
 	// Check if the copy rect is setup
 	if (m_copyFlags.m_bit0 == FALSE || m_waitIndicator == NULL) {
 		return;
@@ -540,24 +545,29 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 	// Check if wait indicator has started
 	if (m_waitIndicator->GetCurrentTickleState() >= MxPresenter::e_streaming) {
 		// Setup the copy rect
-		MxU32 copyPitch = (p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8) *
-						  (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
 		MxU32 bytesPerPixel = p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8;
+		MxS32 copyPitch = (p_ddsc->ddpfPixelFormat.dwRGBBitCount / 8) *
+						  (m_copyRect.right - m_copyRect.left + 1); // This uses m_copyRect, seemingly erroneously
 
-		m_copyRect.left = m_waitIndicator->GetLocation().GetX();
-		m_copyRect.top = m_waitIndicator->GetLocation().GetY();
+		MxPoint32 loc;
+		loc = m_waitIndicator->GetLocation();
+		y = loc.GetY();
 
 		MxS32 height = m_waitIndicator->GetHeight();
 		MxS32 width = m_waitIndicator->GetWidth();
+		MxU32 x = loc.GetX();
 
-		m_copyRect.right = m_copyRect.left + width - 1;
-		m_copyRect.bottom = m_copyRect.top + height - 1;
+		m_copyRect.left = x;
+		m_copyRect.top = y;
+		m_copyRect.right = x + width - 1;
+		m_copyRect.bottom = y + height - 1;
 
 		// Allocate the copy buffer
 		const MxU8* src =
 			(const MxU8*) p_ddsc->lpSurface + m_copyRect.top * p_ddsc->lPitch + bytesPerPixel * m_copyRect.left;
 
-		m_copyBuffer = new MxU8[bytesPerPixel * width * height];
+		m_copyBuffer = new MxU8
+			[(m_copyRect.bottom - m_copyRect.top + 1) * (m_copyRect.right - m_copyRect.left + 1) * bytesPerPixel];
 		if (!m_copyBuffer) {
 			return;
 		}
@@ -565,7 +575,7 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 		// Copy into the copy buffer
 		MxU8* dst = m_copyBuffer;
 
-		for (MxS32 i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++) {
+		for (i = 0; i < (m_copyRect.bottom - m_copyRect.top + 1); i++) {
 			memcpy(dst, src, copyPitch);
 			src += p_ddsc->lPitch;
 			dst += copyPitch;
@@ -574,29 +584,27 @@ void MxTransitionManager::SetupCopyRect(LPDDSURFACEDESC p_ddsc)
 
 	// Setup display surface
 	if ((m_waitIndicator->GetAction()->GetFlags() & MxDSAction::c_bit5) != 0) {
-		MxDisplaySurface* displaySurface = VideoManager()->GetDisplaySurface();
 		MxBool und = FALSE;
-		displaySurface->VTable0x2c(
+		VideoManager()->GetDisplaySurface()->VTable0x2c(
 			p_ddsc,
 			m_waitIndicator->GetBitmap(),
 			0,
 			0,
-			m_waitIndicator->GetLocation().GetX(),
-			m_waitIndicator->GetLocation().GetY(),
+			m_waitIndicator->GetX(),
+			m_waitIndicator->GetY(),
 			m_waitIndicator->GetWidth(),
 			m_waitIndicator->GetHeight(),
 			und
 		);
 	}
 	else {
-		MxDisplaySurface* displaySurface = VideoManager()->GetDisplaySurface();
-		displaySurface->VTable0x24(
+		VideoManager()->GetDisplaySurface()->VTable0x24(
 			p_ddsc,
 			m_waitIndicator->GetBitmap(),
 			0,
 			0,
-			m_waitIndicator->GetLocation().GetX(),
-			m_waitIndicator->GetLocation().GetY(),
+			m_waitIndicator->GetX(),
+			m_waitIndicator->GetY(),
 			m_waitIndicator->GetWidth(),
 			m_waitIndicator->GetHeight()
 		);

--- a/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
+++ b/LEGO1/lego/legoomni/src/control/legocontrolmanager.cpp
@@ -2,6 +2,8 @@
 
 #include "legoeventnotificationparam.h"
 #include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "misc.h"
 #include "mxcontrolpresenter.h"
 #include "mxdsaction.h"
@@ -12,6 +14,12 @@
 DECOMP_SIZE_ASSERT(LegoControlManager, 0x60)
 DECOMP_SIZE_ASSERT(LegoControlManagerNotificationParam, 0x2c)
 DECOMP_SIZE_ASSERT(LegoEventNotificationParam, 0x20)
+
+// GLOBAL: LEGO1 0x100f31b0
+MxS32 g_clickedObjectId = -1;
+
+// GLOBAL: LEGO1 0x100f31b4
+const char* g_clickedAtom = NULL;
 
 // FUNCTION: LEGO1 0x10028520
 // STUB: BETA10 0x1008ae50
@@ -57,6 +65,7 @@ void LegoControlManager::Unregister(MxCore* p_listener)
 }
 
 // FUNCTION: LEGO1 0x10029210
+// FUNCTION: BETA10 0x1007c406
 MxBool LegoControlManager::HandleButtonDown(LegoEventNotificationParam& p_param, MxPresenter* p_presenter)
 {
 	if (m_presenterList != NULL && m_presenterList->GetNumElements() != 0) {
@@ -109,6 +118,7 @@ MxBool LegoControlManager::HandleButtonDown(LegoEventNotificationParam& p_param,
 }
 
 // FUNCTION: LEGO1 0x100292e0
+// FUNCTION: BETA10 0x1007c772
 void LegoControlManager::Notify()
 {
 	LegoNotifyListCursor cursor(&m_notifyList);
@@ -122,8 +132,10 @@ void LegoControlManager::Notify()
 }
 
 // FUNCTION: LEGO1 0x100293c0
+// FUNCTION: BETA10 0x1007c81b
 void LegoControlManager::UpdateEnabledChild(MxU32 p_objectId, const char* p_atom, MxS16 p_enabledChild)
 {
+	const char* const& atom = p_atom;
 	if (m_presenterList) {
 		MxPresenterListCursor cursor(m_presenterList);
 		MxPresenter* control;
@@ -131,7 +143,7 @@ void LegoControlManager::UpdateEnabledChild(MxU32 p_objectId, const char* p_atom
 		while (cursor.Next(control)) {
 			MxDSAction* action = control->GetAction();
 
-			if (action->GetObjectId() == p_objectId && action->GetAtomId().GetInternal() == p_atom) {
+			if (action->GetObjectId() == p_objectId && action->GetAtomId().GetInternal() == atom) {
 				((MxControlPresenter*) control)->UpdateEnabledChild(p_enabledChild);
 
 				if (((MxControlPresenter*) control)->GetEnabledChild() == 0) {

--- a/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/control/legometerpresenter.cpp
@@ -8,6 +8,10 @@
 #include "mxutilities.h"
 #include "mxvariabletable.h"
 
+#include "roi/legoroi.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
+
 #include <assert.h>
 
 DECOMP_SIZE_ASSERT(LegoMeterPresenter, 0x94)
@@ -110,9 +114,13 @@ void LegoMeterPresenter::RepeatingTickle()
 // FUNCTION: BETA10 0x10097a40
 void LegoMeterPresenter::DrawMeter()
 {
-	const char* strval = VariableTable()->GetVariable(m_variable.GetData());
-	MxFloat percent = atof(strval);
-	MxS16 row, leftRightCol, bottomTopCol, leftRightEnd, bottomTopEnd;
+	MxFloat percent;
+	const char* strval;
+	MxU8* line;
+	MxS16 leftRightEnd, leftRightRow, leftRightCol, bottomTopEnd, bottomTopRow, bottomTopCol;
+
+	strval = VariableTable()->GetVariable(m_variable.GetData());
+	percent = atof(strval);
 
 	if (strval != NULL && m_curPercent != percent) {
 		m_curPercent = percent;
@@ -132,8 +140,8 @@ void LegoMeterPresenter::DrawMeter()
 		case e_leftToRight:
 			leftRightEnd = m_meterRect.GetWidth() * m_curPercent;
 
-			for (row = m_meterRect.GetTop(); row < m_meterRect.GetBottom(); row++) {
-				MxU8* line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), row);
+			for (leftRightRow = m_meterRect.GetTop(); leftRightRow < m_meterRect.GetBottom(); leftRightRow++) {
+				line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), leftRightRow);
 
 				for (leftRightCol = 0; leftRightCol < leftRightEnd; leftRightCol++, line++) {
 					if (*line) {
@@ -145,8 +153,8 @@ void LegoMeterPresenter::DrawMeter()
 		case e_bottomToTop:
 			bottomTopEnd = m_meterRect.GetBottom() - (MxS16) (m_meterRect.GetHeight() * m_curPercent);
 
-			for (row = m_meterRect.GetBottom(); row > bottomTopEnd; row--) {
-				MxU8* line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), row);
+			for (bottomTopRow = m_meterRect.GetBottom(); bottomTopRow > bottomTopEnd; bottomTopRow--) {
+				line = m_frameBitmap->GetStart(m_meterRect.GetLeft(), bottomTopRow);
 
 				for (bottomTopCol = 0; bottomTopCol < m_meterRect.GetWidth(); bottomTopCol++, line++) {
 					if (*line) {

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -16,12 +16,6 @@ DECOMP_SIZE_ASSERT(LegoNotifyList, 0x18)
 DECOMP_SIZE_ASSERT(LegoNotifyListCursor, 0x10)
 DECOMP_SIZE_ASSERT(LegoEventQueue, 0x18)
 
-// GLOBAL: LEGO1 0x100f31b0
-MxS32 g_clickedObjectId = -1;
-
-// GLOBAL: LEGO1 0x100f31b4
-const char* g_clickedAtom = NULL;
-
 // GLOBAL: LEGO1 0x100f67b8
 MxBool g_unk0x100f67b8 = TRUE;
 
@@ -54,6 +48,7 @@ LegoInputManager::LegoInputManager()
 }
 
 // FUNCTION: LEGO1 0x1005b8f0
+// FUNCTION: BETA10 0x10088c10
 LegoInputManager::~LegoInputManager()
 {
 	Destroy();
@@ -66,7 +61,6 @@ MxResult LegoInputManager::Create(HWND p_hwnd)
 	MxResult result = SUCCESS;
 
 	m_controlManager = new LegoControlManager;
-	assert(m_controlManager);
 
 	if (!m_keyboardNotifyList) {
 		m_keyboardNotifyList = new LegoNotifyList;
@@ -88,6 +82,7 @@ MxResult LegoInputManager::Create(HWND p_hwnd)
 }
 
 // FUNCTION: LEGO1 0x1005bfe0
+// FUNCTION: BETA10 0x10088e8f
 void LegoInputManager::Destroy()
 {
 	ReleaseDX();
@@ -126,6 +121,7 @@ void LegoInputManager::CreateAndAcquireKeyboard(HWND p_hwnd)
 }
 
 // FUNCTION: LEGO1 0x1005c0a0
+// FUNCTION: BETA10 0x1008904e
 void LegoInputManager::ReleaseDX()
 {
 	if (m_directInputDevice != NULL) {
@@ -141,6 +137,7 @@ void LegoInputManager::ReleaseDX()
 }
 
 // FUNCTION: LEGO1 0x1005c0f0
+// FUNCTION: BETA10 0x100890e6
 void LegoInputManager::GetKeyboardState()
 {
 	m_kbStateSuccess = FALSE;
@@ -161,6 +158,7 @@ void LegoInputManager::GetKeyboardState()
 }
 
 // FUNCTION: LEGO1 0x1005c160
+// FUNCTION: BETA10 0x100891b6
 MxResult LegoInputManager::GetNavigationKeyStates(MxU32& p_keyFlags)
 {
 	GetKeyboardState();
@@ -207,6 +205,7 @@ MxResult LegoInputManager::GetNavigationKeyStates(MxU32& p_keyFlags)
 }
 
 // FUNCTION: LEGO1 0x1005c240
+// FUNCTION: BETA10 0x10089298
 MxResult LegoInputManager::GetJoystickId()
 {
 	JOYINFOEX joyinfoex;
@@ -239,6 +238,7 @@ MxResult LegoInputManager::GetJoystickId()
 }
 
 // FUNCTION: LEGO1 0x1005c320
+// FUNCTION: BETA10 0x100893ae
 MxResult LegoInputManager::GetJoystickState(
 	MxU32* p_joystickX,
 	MxU32* p_joystickY,
@@ -294,6 +294,7 @@ MxResult LegoInputManager::GetJoystickState(
 }
 
 // FUNCTION: LEGO1 0x1005c470
+// FUNCTION: BETA10 0x10089529
 void LegoInputManager::Register(MxCore* p_notify)
 {
 	AUTOLOCK(m_criticalSection);
@@ -305,6 +306,7 @@ void LegoInputManager::Register(MxCore* p_notify)
 }
 
 // FUNCTION: LEGO1 0x1005c5c0
+// FUNCTION: BETA10 0x100895b2
 void LegoInputManager::UnRegister(MxCore* p_notify)
 {
 	AUTOLOCK(m_criticalSection);
@@ -316,12 +318,14 @@ void LegoInputManager::UnRegister(MxCore* p_notify)
 }
 
 // FUNCTION: LEGO1 0x1005c700
+// FUNCTION: BETA10 0x10089671
 void LegoInputManager::SetCamera(LegoCameraController* p_camera)
 {
 	m_camera = p_camera;
 }
 
 // FUNCTION: LEGO1 0x1005c710
+// FUNCTION: BETA10 0x10089695
 void LegoInputManager::ClearCamera()
 {
 	m_camera = NULL;
@@ -342,6 +346,7 @@ void LegoInputManager::ClearWorld()
 }
 
 // FUNCTION: LEGO1 0x1005c740
+// FUNCTION: BETA10 0x100896ff
 void LegoInputManager::QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p_x, MxLong p_y, MxU8 p_key)
 {
 	LegoEventNotificationParam param = LegoEventNotificationParam(p_id, NULL, p_modifier, p_x, p_y, p_key);
@@ -353,6 +358,7 @@ void LegoInputManager::QueueEvent(NotificationId p_id, MxU8 p_modifier, MxLong p
 }
 
 // FUNCTION: LEGO1 0x1005c820
+// FUNCTION: BETA10 0x100897bf
 void LegoInputManager::ProcessEvents()
 {
 	AUTOLOCK(m_criticalSection);
@@ -366,6 +372,7 @@ void LegoInputManager::ProcessEvents()
 }
 
 // FUNCTION: LEGO1 0x1005c9c0
+// FUNCTION: BETA10 0x10089892
 MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 {
 	MxBool processRoi;
@@ -426,6 +433,7 @@ MxBool LegoInputManager::ProcessOneEvent(LegoEventNotificationParam& p_param)
 			}
 
 			if (p_param.GetNotification() == c_notificationButtonDown) {
+				assert(VideoManager());
 				MxPresenter* presenter = VideoManager()->GetPresenterAt(p_param.GetX(), p_param.GetY());
 
 				if (presenter) {

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -33,6 +33,9 @@ DECOMP_SIZE_ASSERT(LegoLocomotionAnimPresenter, 0xd8)
 DECOMP_SIZE_ASSERT(LegoHideAnimPresenter, 0xc4)
 DECOMP_SIZE_ASSERT(LegoHideAnimStruct, 0x08)
 
+// GLOBAL: LEGO1 0x100f767c
+undefined4 g_unk0x100f767c = 1;
+
 // FUNCTION: LEGO1 0x10068420
 // FUNCTION: BETA10 0x1004e5f0
 LegoAnimPresenter::LegoAnimPresenter()
@@ -41,12 +44,14 @@ LegoAnimPresenter::LegoAnimPresenter()
 }
 
 // FUNCTION: LEGO1 0x10068670
+// FUNCTION: BETA10 0x1004e696
 LegoAnimPresenter::~LegoAnimPresenter()
 {
 	Destroy(TRUE);
 }
 
 // FUNCTION: LEGO1 0x100686f0
+// FUNCTION: BETA10 0x1004e724
 void LegoAnimPresenter::Init()
 {
 	m_anim = NULL;
@@ -139,6 +144,7 @@ void LegoAnimPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x10068fb0
+// FUNCTION: BETA10 0x1004ebde
 MxResult LegoAnimPresenter::CreateAnim(MxStreamChunk* p_chunk)
 {
 	MxResult result = FAILURE;
@@ -190,6 +196,7 @@ done:
 }
 
 // FUNCTION: LEGO1 0x10069150
+// FUNCTION: BETA10 0x1004eeaf
 LegoChar* LegoAnimPresenter::GetActorName(const LegoChar* p_name)
 {
 	LegoChar* str;
@@ -217,6 +224,7 @@ LegoChar* LegoAnimPresenter::GetActorName(const LegoChar* p_name)
 }
 
 // FUNCTION: LEGO1 0x100692b0
+// FUNCTION: BETA10 0x1004efb6
 void LegoAnimPresenter::CreateManagedActors()
 {
 	m_managedActors = new LegoROIList();
@@ -224,7 +232,7 @@ void LegoAnimPresenter::CreateManagedActors()
 	if (m_managedActors) {
 		LegoU32 numActors = m_anim->GetNumActors();
 
-		for (LegoU32 i = 0; i < numActors; i++) {
+		for (LegoS32 i = 0; i < numActors; i++) {
 			LegoChar* str = GetVariableOrIdentity(m_anim->GetActorName(i), NULL);
 			LegoU32 actorType = m_anim->GetActorType(i);
 			LegoROI* roi = NULL;
@@ -247,6 +255,7 @@ void LegoAnimPresenter::CreateManagedActors()
 			else if (actorType == LegoAnimActorEntry::e_managedInvisibleRoi) {
 				LegoChar* baseName = new LegoChar[strlen(str)];
 				strcpy(baseName, str + 1);
+				assert(*baseName);
 				strlwr(baseName);
 
 				LegoChar* roiName = GetActorName(str);
@@ -262,6 +271,7 @@ void LegoAnimPresenter::CreateManagedActors()
 			else if (actorType == LegoAnimActorEntry::e_managedInvisibleRoiTrimmed) {
 				LegoChar* lodName = new LegoChar[strlen(str)];
 				strcpy(lodName, str + 1);
+				assert(*lodName);
 
 				for (LegoChar* c = &lodName[strlen(lodName) - 1]; c > lodName; c--) {
 					if ((*c < '0' || *c > '9') && *c != '_') {
@@ -312,6 +322,7 @@ void LegoAnimPresenter::CreateSceneROIs()
 					const LegoChar* actorName = m_anim->GetActorName(i);
 
 					LegoU32 len = strlen(actorName);
+					assert(len < sizeof(lodName));
 					strcpy(lodName, actorName);
 
 					for (LegoChar* i = &lodName[len - 1]; isdigit(*i) || *i == '_'; i--) {
@@ -329,6 +340,7 @@ void LegoAnimPresenter::CreateSceneROIs()
 }
 
 // FUNCTION: LEGO1 0x100697c0
+// FUNCTION: BETA10 0x1004f62c
 LegoChar* LegoAnimPresenter::GetVariableOrIdentity(const LegoChar* p_varName, const LegoChar* p_prefix)
 {
 	const LegoChar* str = p_varName;
@@ -356,6 +368,7 @@ LegoChar* LegoAnimPresenter::GetVariableOrIdentity(const LegoChar* p_varName, co
 }
 
 // FUNCTION: LEGO1 0x100698b0
+// FUNCTION: BETA10 0x1004f704
 LegoBool LegoAnimPresenter::AppendROIToScene(const CompoundObject& p_rois, const LegoChar* p_varName)
 {
 	LegoBool result = FALSE;
@@ -368,7 +381,9 @@ LegoBool LegoAnimPresenter::AppendROIToScene(const CompoundObject& p_rois, const
 	}
 
 	if (str != NULL && *str != '\0' && p_rois.size() > 0) {
-		for (CompoundObject::const_iterator it = p_rois.begin(); it != p_rois.end(); it++) {
+		CompoundObject::const_iterator it;
+
+		for (it = p_rois.begin(); it != p_rois.end(); it++) {
 			LegoROI* roi = (LegoROI*) *it;
 			const char* name = roi->GetName();
 
@@ -387,6 +402,7 @@ LegoBool LegoAnimPresenter::AppendROIToScene(const CompoundObject& p_rois, const
 }
 
 // FUNCTION: LEGO1 0x100699e0
+// FUNCTION: BETA10 0x1004f857
 LegoROI* LegoAnimPresenter::FindROI(const LegoChar* p_name)
 {
 	LegoROIListCursor cursor(m_sceneROIs);
@@ -407,6 +423,7 @@ LegoROI* LegoAnimPresenter::FindROI(const LegoChar* p_name)
 }
 
 // FUNCTION: LEGO1 0x10069b10
+// FUNCTION: BETA10 0x1004f976
 void LegoAnimPresenter::BuildROIMap()
 {
 	LegoAnimStructMap anims;
@@ -426,7 +443,7 @@ void LegoAnimPresenter::BuildROIMap()
 	m_roiMap = new LegoROI*[anims.size() + 1];
 	memset(m_roiMap, 0, (anims.size() + 1) * sizeof(*m_roiMap));
 
-	for (LegoAnimStructMap::iterator it = anims.begin(); it != anims.end();) {
+	for (LegoAnimStructMap::iterator it = anims.begin(); it != anims.end(); ++it, m_roiMapSize++) {
 		MxU32 index = (*it).second.m_index;
 		m_roiMap[index] = (*it).second.m_roi;
 
@@ -442,12 +459,11 @@ void LegoAnimPresenter::BuildROIMap()
 		}
 
 		delete[] const_cast<char*>((*it).first);
-		it++;
-		m_roiMapSize++;
 	}
 }
 
 // FUNCTION: LEGO1 0x1006a3c0
+// FUNCTION: BETA10 0x1004fc10
 void LegoAnimPresenter::UpdateStructMapAndROIIndex(LegoAnimStructMap& p_map, LegoTreeNode* p_node, LegoROI* p_roi)
 {
 	LegoROI* roi = p_roi;
@@ -500,6 +516,7 @@ void LegoAnimPresenter::UpdateStructMapAndROIIndex(LegoAnimStructMap& p_map, Leg
 }
 
 // FUNCTION: LEGO1 0x1006a4f0
+// FUNCTION: BETA10 0x1004fe1f
 void LegoAnimPresenter::UpdateStructMapAndROIIndexForNode(
 	LegoAnimStructMap& p_map,
 	LegoAnimNodeData* p_data,
@@ -544,6 +561,7 @@ void LegoAnimPresenter::ReleaseManagedActors()
 }
 
 // FUNCTION: LEGO1 0x1006ab70
+// FUNCTION: BETA10 0x10050012
 void LegoAnimPresenter::AppendManagedActors()
 {
 	if (m_localActors) {
@@ -555,18 +573,21 @@ void LegoAnimPresenter::AppendManagedActors()
 }
 
 // FUNCTION: LEGO1 0x1006aba0
+// FUNCTION: BETA10 0x10050042
 LegoBool LegoAnimPresenter::VerifyAnimationTree()
 {
 	return VerifyAnimationNode(m_anim->GetRoot(), NULL);
 }
 
 // FUNCTION: LEGO1 0x1006abb0
+// FUNCTION: BETA10 0x10050071
 MxBool LegoAnimPresenter::VerifyAnimationNode(LegoTreeNode* p_node, LegoROI* p_roi)
 {
 	MxBool result = FALSE;
 	LegoROI* roi = p_roi;
 	LegoChar* varOrName = NULL;
-	const LegoChar* name = ((LegoAnimNodeData*) p_node->GetData())->GetName();
+	LegoAnimNodeData* data = (LegoAnimNodeData*) p_node->GetData();
+	const LegoChar* name = data->GetName();
 	MxS32 i, count;
 
 	if (name != NULL && *name != '-') {
@@ -625,6 +646,7 @@ void LegoAnimPresenter::SubstituteVariables()
 }
 
 // FUNCTION: LEGO1 0x1006ad30
+// FUNCTION: BETA10 0x100502c2
 void LegoAnimPresenter::PutFrame()
 {
 	if (m_currentTickleState == e_streaming) {
@@ -734,19 +756,20 @@ MxResult LegoAnimPresenter::CopyTransform(LegoROI* p_roi)
 		}
 	}
 
-	{
-		mn->Product(inverse, local2world);
-		SetRoiTransform(mn);
-		delete[] roiTransforms;
-		SetRoiTransformApplied();
+	mn->Product(inverse, local2world);
+	SetRoiTransform(mn);
+	delete[] roiTransforms;
+	SetRoiTransformApplied();
 
+	{
 		MxMatrix originalTransform(*m_transform);
 		MxMatrix newTransform;
 
 		newTransform.Product(originalTransform, *m_roiTransform);
 		*m_transform = newTransform;
-		return SUCCESS;
 	}
+
+	return SUCCESS;
 
 done:
 	if (mn != NULL) {
@@ -843,10 +866,12 @@ done:
 }
 
 // FUNCTION: LEGO1 0x1006b840
+// FUNCTION: BETA10 0x10050f1b
 void LegoAnimPresenter::StreamingTickle()
 {
 	if (m_subscriber->PeekData()) {
 		MxStreamChunk* chunk = m_subscriber->PopData();
+		assert(chunk->GetChunkFlags() & DS_CHUNK_END_OF_STREAM);
 		m_subscriber->FreeDataChunk(chunk);
 	}
 
@@ -866,24 +891,28 @@ void LegoAnimPresenter::StreamingTickle()
 }
 
 // FUNCTION: LEGO1 0x1006b8c0
+// FUNCTION: BETA10 0x1005105b
 void LegoAnimPresenter::DoneTickle()
 {
 	MxVideoPresenter::DoneTickle();
 }
 
 // FUNCTION: LEGO1 0x1006b8d0
+// FUNCTION: BETA10 0x10051079
 MxResult LegoAnimPresenter::AddToManager()
 {
 	return MxVideoPresenter::AddToManager();
 }
 
 // FUNCTION: LEGO1 0x1006b8e0
+// FUNCTION: BETA10 0x10051097
 void LegoAnimPresenter::Destroy()
 {
 	Destroy(FALSE);
 }
 
 // FUNCTION: LEGO1 0x1006b8f0
+// FUNCTION: BETA10 0x100510b7
 const char* LegoAnimPresenter::GetActionObjectName()
 {
 	return m_action->GetObjectName();
@@ -981,6 +1010,7 @@ void LegoAnimPresenter::ParseExtra()
 
 		if (KeyValueStringParse(output, g_strSUBST, extraCopy)) {
 			m_substMap = new LegoAnimSubstMap();
+			assert(m_substMap);
 
 			char* substToken = output;
 			char *key, *value;
@@ -1000,9 +1030,11 @@ void LegoAnimPresenter::ParseExtra()
 
 		if (KeyValueStringParse(output, g_strWORLD, extraCopy)) {
 			char* token = strtok(output, g_parseExtraTokens);
+			assert(token);
 			m_worldAtom = MxAtomId(token, e_lowerCase2);
 
 			token = strtok(NULL, g_parseExtraTokens);
+			assert(token);
 			m_worldId = atoi(token);
 		}
 
@@ -1159,6 +1191,7 @@ void LegoAnimPresenter::RemoveFromWorld()
 }
 
 // FUNCTION: LEGO1 0x1006c8a0
+// FUNCTION: BETA10 0x10051fc7
 void LegoAnimPresenter::SetDisabled(MxBool p_disabled)
 {
 	if (m_roiMapSize != 0 && m_roiMap != NULL) {
@@ -1236,6 +1269,7 @@ void LegoLoopingAnimPresenter::StreamingTickle()
 {
 	if (m_subscriber->PeekData()) {
 		MxStreamChunk* chunk = m_subscriber->PopData();
+		assert(chunk->GetChunkFlags() & DS_CHUNK_END_OF_STREAM);
 		m_subscriber->FreeDataChunk(chunk);
 	}
 
@@ -1304,18 +1338,21 @@ void LegoLoopingAnimPresenter::PutFrame()
 }
 
 // FUNCTION: LEGO1 0x1006cdd0
+// FUNCTION: BETA10 0x10052672
 LegoLocomotionAnimPresenter::LegoLocomotionAnimPresenter()
 {
 	Init();
 }
 
 // FUNCTION: LEGO1 0x1006d050
+// FUNCTION: BETA10 0x100526e9
 LegoLocomotionAnimPresenter::~LegoLocomotionAnimPresenter()
 {
 	Destroy(TRUE);
 }
 
 // FUNCTION: LEGO1 0x1006d0b0
+// FUNCTION: BETA10 0x1005275b
 void LegoLocomotionAnimPresenter::Init()
 {
 	m_unk0xc0 = 0;
@@ -1327,6 +1364,7 @@ void LegoLocomotionAnimPresenter::Init()
 }
 
 // FUNCTION: LEGO1 0x1006d0e0
+// FUNCTION: BETA10 0x100527be
 void LegoLocomotionAnimPresenter::Destroy(MxBool p_fromDestructor)
 {
 	ENTER(m_criticalSection);
@@ -1350,6 +1388,7 @@ void LegoLocomotionAnimPresenter::Destroy(MxBool p_fromDestructor)
 }
 
 // FUNCTION: LEGO1 0x1006d140
+// FUNCTION: BETA10 0x1005288c
 MxResult LegoLocomotionAnimPresenter::CreateAnim(MxStreamChunk* p_chunk)
 {
 	MxResult result = LegoAnimPresenter::CreateAnim(p_chunk);
@@ -1370,18 +1409,21 @@ MxResult LegoLocomotionAnimPresenter::AddToManager()
 }
 
 // FUNCTION: LEGO1 0x1006d5b0
+// FUNCTION: BETA10 0x1005297d
 void LegoLocomotionAnimPresenter::Destroy()
 {
 	Destroy(FALSE);
 }
 
 // FUNCTION: LEGO1 0x1006d5c0
+// FUNCTION: BETA10 0x1005299d
 void LegoLocomotionAnimPresenter::PutFrame()
 {
 	// Empty
 }
 
 // FUNCTION: LEGO1 0x1006d5d0
+// FUNCTION: BETA10 0x100529b3
 void LegoLocomotionAnimPresenter::ReadyTickle()
 {
 	LegoLoopingAnimPresenter::ReadyTickle();
@@ -1402,6 +1444,7 @@ void LegoLocomotionAnimPresenter::StartingTickle()
 {
 	if (m_subscriber->PeekData()) {
 		MxStreamChunk* chunk = m_subscriber->PopData();
+		assert(chunk->GetChunkFlags() & DS_CHUNK_END_OF_STREAM);
 		m_subscriber->FreeDataChunk(chunk);
 	}
 
@@ -1411,6 +1454,7 @@ void LegoLocomotionAnimPresenter::StartingTickle()
 }
 
 // FUNCTION: LEGO1 0x1006d660
+// FUNCTION: BETA10 0x10052adf
 void LegoLocomotionAnimPresenter::StreamingTickle()
 {
 	if (m_worldRefCounter == 0) {
@@ -1419,6 +1463,7 @@ void LegoLocomotionAnimPresenter::StreamingTickle()
 }
 
 // FUNCTION: LEGO1 0x1006d670
+// FUNCTION: BETA10 0x10052b12
 void LegoLocomotionAnimPresenter::EndAction()
 {
 	if (m_action) {
@@ -1594,7 +1639,7 @@ void LegoHideAnimPresenter::AssignIndiciesWithMap()
 	m_boundaryMap = new LegoPathBoundary*[anims.size() + 1];
 	m_boundaryMap[0] = NULL;
 
-	for (LegoHideAnimStructMap::iterator it = anims.begin(); !(it == anims.end()); it++) {
+	for (LegoHideAnimStructMap::iterator it = anims.begin(); !(it == anims.end()); ++it) {
 		m_boundaryMap[(*it).second.m_index] = (*it).second.m_boundary;
 		delete[] const_cast<char*>((*it).first);
 	}

--- a/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legophonemepresenter.cpp
@@ -1,11 +1,14 @@
 #include "legophonemepresenter.h"
 
 #include "legocharactermanager.h"
+#include "realtime/matrix4d.inl.h"
 #include "legovideomanager.h"
 #include "misc.h"
 #include "misc/legocontainer.h"
 #include "mxcompositepresenter.h"
 #include "mxdsaction.h"
+
+#include <assert.h>
 
 DECOMP_SIZE_ASSERT(LegoPhonemePresenter, 0x88)
 
@@ -114,6 +117,7 @@ void LegoPhonemePresenter::LoadFrame(MxStreamChunk* p_chunk)
 void LegoPhonemePresenter::PutFrame()
 {
 	if (m_textureInfo != NULL && m_rectCount != 0) {
+		assert(m_frameBitmap->GetImage());
 		m_textureInfo->LoadBits(m_frameBitmap->GetImage());
 		m_rectCount = 0;
 	}

--- a/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp
@@ -1,6 +1,8 @@
 #include "legotexturepresenter.h"
 
 #include "legovideomanager.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "misc.h"
 #include "misc/legocontainer.h"
 #include "misc/legoimage.h"
@@ -57,7 +59,7 @@ MxResult LegoTexturePresenter::Read(MxDSChunk& p_chunk)
 		}
 
 		textureName[textureNameLength] = '\0';
-		strlwr(textureName);
+		_strlwr(textureName);
 
 		texture = new LegoTexture();
 		if (texture->Read(&storage, hardwareMode) != SUCCESS) {

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -8,6 +8,8 @@
 #include "mxdirectx/mxdirect3d.h"
 #include "mxdirectx/mxstopwatch.h"
 #include "mxdisplaysurface.h"
+#include "realtime/matrix4d.inl.h"
+#include "realtime/vectorlength.inl.h"
 #include "mxgeometry/mxmatrix.h"
 #include "mxmisc.h"
 #include "mxpalette.h"
@@ -19,6 +21,7 @@
 #include "tgl/d3drm/tglimpl.h"
 #include "viewmanager/viewroi.h"
 
+#include <assert.h>
 #include <stdio.h>
 
 DECOMP_SIZE_ASSERT(LegoVideoManager, 0x590)
@@ -38,7 +41,7 @@ LegoVideoManager::LegoVideoManager()
 	m_unk0x78[0] = 0x6c;
 	m_phonemeRefList = NULL;
 	m_isFullscreenMovie = FALSE;
-	m_palette = NULL;
+	m_savedPalette = NULL;
 	m_stopWatch = NULL;
 	m_drawCursor = FALSE;
 	m_cursorX = m_cursorY;
@@ -55,13 +58,15 @@ LegoVideoManager::LegoVideoManager()
 }
 
 // FUNCTION: LEGO1 0x1007ab40
+// FUNCTION: BETA10 0x100d5b57
 LegoVideoManager::~LegoVideoManager()
 {
 	Destroy();
-	delete m_palette;
+	delete m_savedPalette;
 }
 
 // FUNCTION: LEGO1 0x1007abb0
+// FUNCTION: BETA10 0x100d5c31
 MxResult LegoVideoManager::CreateDirect3D()
 {
 	if (!m_direct3d) {
@@ -77,9 +82,9 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 {
 	MxResult result = FAILURE;
 	MxBool paletteCreated = FALSE;
-	MxS32 deviceNum = -1;
-	Direct3DDeviceInfo* device = NULL;
-	MxDriver* driver = NULL;
+	MxS32 r = -1;
+	MxDriver* pdd = NULL;
+	Direct3DDeviceInfo* pd3d = NULL;
 	LegoDeviceEnumerate deviceEnumerate;
 	Mx3DPointFloat posVec(0.0, 1.25, -50.0);
 	Mx3DPointFloat dirVec(0.0, 0.0, 1.0);
@@ -110,23 +115,25 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	}
 
 	if (p_videoParam.GetDeviceName()) {
-		deviceNum = deviceEnumerate.ParseDeviceName(p_videoParam.GetDeviceName());
-		if (deviceNum >= 0) {
-			if ((deviceNum = deviceEnumerate.GetDevice(deviceNum, driver, device)) != SUCCESS) {
-				deviceNum = -1;
+		r = deviceEnumerate.ParseDeviceName(p_videoParam.GetDeviceName());
+		if (r >= 0) {
+			if ((r = deviceEnumerate.GetDevice(r, pdd, pd3d)) != SUCCESS) {
+				r = -1;
 			}
 		}
 	}
 
-	if (deviceNum < 0) {
+	if (r < 0) {
 		deviceEnumerate.FUN_1009d210();
-		deviceNum = deviceEnumerate.GetBestDevice();
-		deviceNum = deviceEnumerate.GetDevice(deviceNum, driver, device);
+		r = deviceEnumerate.GetBestDevice();
+		assert(r >= 0);
+		r = deviceEnumerate.GetDevice(r, pdd, pd3d);
+		assert(r >= 0 && pdd && pd3d);
 	}
 
-	m_direct3d->SetDevice(deviceEnumerate, driver, device);
+	m_direct3d->SetDevice(deviceEnumerate, pdd, pd3d);
 
-	if (!driver->m_ddCaps.dwCaps2 && driver->m_ddCaps.dwSVBRops[7] != 2) {
+	if (!pd3d->m_HWDesc.dcmColorModel && pd3d->m_HELDesc.dcmColorModel != D3DCOLOR_RGB) {
 		p_videoParam.Flags().SetLacksLightSupport(TRUE);
 	}
 	else {
@@ -207,6 +214,7 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	m_3dManager->SetPointOfView(*m_viewROI);
 
 	m_phonemeRefList = new LegoPhonemeList;
+	assert(m_phonemeRefList);
 	SetRender3D(FALSE);
 	m_stopWatch = new MxStopWatch;
 	m_stopWatch->Start();
@@ -347,7 +355,6 @@ MxResult LegoVideoManager::Tickle()
 		}
 	}
 	else if (m_fullScreenMovie) {
-		MxPresenter* presenter;
 		MxPresenterListCursor cursor(m_presenters);
 
 		if (cursor.Last(presenter)) {
@@ -448,10 +455,9 @@ void LegoVideoManager::DrawFPS()
 			m_arialFont = NULL;
 		}
 		else {
-			DWORD i;
 			char* ptr = (char*) surfaceDesc.lpSurface;
 
-			for (i = 0; i < surfaceDesc.dwHeight; i++) {
+			for (DWORD i = 0; i < surfaceDesc.dwHeight; i++) {
 				memset(ptr, 0, surfaceDesc.dwWidth * surfaceDesc.ddpfPixelFormat.dwRGBBitCount / 8);
 				ptr += surfaceDesc.lPitch;
 			}
@@ -473,10 +479,9 @@ void LegoVideoManager::DrawFPS()
 			surfaceDesc.dwSize = sizeof(surfaceDesc);
 
 			if (m_unk0x528->Lock(NULL, &surfaceDesc, DDLOCK_WAIT, NULL) == DD_OK) {
-				DWORD i;
 				char* ptr = (char*) surfaceDesc.lpSurface;
 
-				for (i = 0; i < surfaceDesc.dwHeight; i++) {
+				for (DWORD i = 0; i < surfaceDesc.dwHeight; i++) {
 					memset(ptr, 0, surfaceDesc.dwWidth * surfaceDesc.ddpfPixelFormat.dwRGBBitCount / 8);
 					ptr += surfaceDesc.lPitch;
 				}
@@ -595,7 +600,8 @@ void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable, MxBool p_scale)
 		m_isFullscreenMovie = p_enable;
 
 		if (p_enable) {
-			m_palette = m_videoParam.GetPalette()->Clone();
+			assert(!m_savedPalette);
+			m_savedPalette = m_videoParam.GetPalette()->Clone();
 			OverrideSkyColor(FALSE);
 
 			m_displaySurface->GetVideoParam().Flags().SetDoubleScaling(p_scale);
@@ -608,9 +614,10 @@ void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable, MxBool p_scale)
 			m_displaySurface->GetVideoParam().Flags().SetDoubleScaling(FALSE);
 
 			// restore previous pallete
-			RealizePalette(m_palette);
-			delete m_palette;
-			m_palette = NULL;
+			assert(m_savedPalette);
+			RealizePalette(m_savedPalette);
+			delete m_savedPalette;
+			m_savedPalette = NULL;
 
 			// update region where video used to be
 			MxRect32 rect(


### PR DESCRIPTION
Asserts and names restored from BETA10, unused code recovered from BETA10 (`ConvertRGBToHSV`), a reconstructed `LegoTestTimerConsoleControl` that stands in for code the shipped link discarded (explained in a comment), and small logic and member-initialization fixes confirmed by the byte-identical build. Covers the manager, presenter, audio, video, control and build sources.

Part of a stacked series that makes the build of LEGO1.DLL, ISLE.EXE and CONFIG.EXE byte-identical to the retail binaries. CI on this PR checks that everything still builds and passes the usual lints; the last PR in the series proves the byte-identical result.